### PR TITLE
feat(approvals): add session grant revocation for suspended sessions

### DIFF
--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -241,7 +241,7 @@ impl GatewayStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT DISTINCT host FROM session_approval_grants
-             WHERE root_session_id = ?1",
+             WHERE root_session_id = ?1 AND revoked_at IS NULL",
         )?;
         let rows = stmt.query_map(params![root_session_id], |row| {
             let host: String = row.get(0)?;
@@ -282,5 +282,28 @@ impl GatewayStore {
             params![root_session_id],
         )?;
         Ok(())
+    }
+
+    pub fn revoke_session_grants(
+        &self,
+        root_session_id: &str,
+        host: Option<&str>,
+        reason: &str,
+    ) -> Result<usize> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let count = match host {
+            Some(h) => conn.execute(
+                "UPDATE session_approval_grants SET revoked_at = ?1, revoked_reason = ?2
+                 WHERE root_session_id = ?3 AND host = ?4 AND revoked_at IS NULL",
+                params![&now, reason, root_session_id, h],
+            )?,
+            None => conn.execute(
+                "UPDATE session_approval_grants SET revoked_at = ?1, revoked_reason = ?2
+                 WHERE root_session_id = ?3 AND revoked_at IS NULL",
+                params![&now, reason, root_session_id],
+            )?,
+        };
+        Ok(count)
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -221,9 +221,15 @@ impl GatewayStore {
         let conn = self.conn.lock().unwrap();
         for host in hosts {
             conn.execute(
-                "INSERT OR IGNORE INTO session_approval_grants
+                "INSERT INTO session_approval_grants
                  (root_session_id, agent_id, host, granted_by, granted_at, source_approval_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(root_session_id, agent_id, host) DO UPDATE SET
+                     granted_by = excluded.granted_by,
+                     granted_at = excluded.granted_at,
+                     source_approval_id = excluded.source_approval_id,
+                     revoked_at = NULL,
+                     revoked_reason = NULL",
                 params![
                     root_session_id,
                     agent_id,

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 14;
+const SCHEMA_VERSION_LATEST: i64 = 15;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -497,6 +497,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_credential_refresh_fields_v12(conn)?;
     apply_admin_proposals_v13(conn)?;
     apply_memories_revision_provenance_v14(conn)?;
+    apply_session_grant_revocation_v15(conn)?;
 
     Ok(())
 }
@@ -1048,6 +1049,41 @@ fn apply_memories_revision_provenance_v14(conn: &mut Connection) -> Result<()> {
         params![
             14_i64,
             "memories_revision_provenance",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_session_grant_revocation_v15(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 15 {
+        return Ok(());
+    }
+
+    for col in &["revoked_at", "revoked_reason"] {
+        let col_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('session_approval_grants') WHERE name = ?1",
+            [col],
+            |row| row.get(0),
+        )?;
+        if col_count == 0 {
+            conn.execute(
+                &format!("ALTER TABLE session_approval_grants ADD COLUMN {col} TEXT"),
+                [],
+            )?;
+        }
+    }
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            15_i64,
+            "session_grant_revocation",
             chrono::Utc::now().to_rfc3339()
         ],
     )?;

--- a/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
+++ b/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
@@ -1,0 +1,138 @@
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use tempfile::tempdir;
+
+fn make_gateway_dir(tmp: &tempfile::TempDir) -> std::path::PathBuf {
+    let gw = tmp.path().join(".gateway");
+    std::fs::create_dir_all(&gw).unwrap();
+    gw
+}
+
+fn seed_grant(store: &GatewayStore, root_sid: &str, agent_id: &str, host: &str) {
+    store
+        .insert_session_grant(
+            root_sid,
+            agent_id,
+            &[host.to_string()],
+            "test",
+            &chrono::Utc::now().to_rfc3339(),
+            None,
+        )
+        .unwrap();
+}
+
+#[test]
+fn test_revoke_grant_by_host() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-1", "agent-a", "pypi.org");
+    seed_grant(&store, "root-1", "agent-a", "github.com");
+    seed_grant(&store, "root-1", "agent-a", "crates.io");
+
+    let count = store
+        .revoke_session_grants("root-1", Some("pypi.org"), "compromised")
+        .unwrap();
+    assert_eq!(count, 1);
+
+    let grants = store.get_session_grants("root-1").unwrap();
+    assert_eq!(grants, vec!["crates.io", "github.com"]);
+
+    assert!(!store.session_grants_cover_targets("root-1", &["pypi.org".to_string()]));
+    assert!(store.session_grants_cover_targets("root-1", &["github.com".to_string()]));
+}
+
+#[test]
+fn test_revoke_all_grants_for_session() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-2", "agent-b", "host1.com");
+    seed_grant(&store, "root-2", "agent-b", "host2.com");
+    seed_grant(&store, "other-root", "agent-c", "host3.com");
+
+    let count = store
+        .revoke_session_grants("root-2", None, "credential rotation")
+        .unwrap();
+    assert_eq!(count, 2);
+
+    assert!(store.get_session_grants("root-2").unwrap().is_empty());
+    assert_eq!(store.get_session_grants("other-root").unwrap(), vec!["host3.com"]);
+}
+
+#[test]
+fn test_revoke_idempotent_no_double_revoke() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-3", "agent-d", "host.io");
+
+    let count1 = store
+        .revoke_session_grants("root-3", Some("host.io"), "first")
+        .unwrap();
+    assert_eq!(count1, 1);
+
+    let count2 = store
+        .revoke_session_grants("root-3", Some("host.io"), "second")
+        .unwrap();
+    assert_eq!(count2, 0);
+
+    assert!(store.get_session_grants("root-3").unwrap().is_empty());
+}
+
+#[test]
+fn test_grants_cover_targets_after_partial_revoke() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-4", "agent-e", "a.com");
+    seed_grant(&store, "root-4", "agent-e", "b.com");
+    seed_grant(&store, "root-4", "agent-e", "c.com");
+
+    assert!(store
+        .session_grants_cover_targets("root-4", &["a.com".to_string(), "b.com".to_string()]));
+
+    store
+        .revoke_session_grants("root-4", Some("b.com"), "revoked")
+        .unwrap();
+
+    assert!(!store
+        .session_grants_cover_targets("root-4", &["a.com".to_string(), "b.com".to_string()]));
+    assert!(store.session_grants_cover_targets("root-4", &["a.com".to_string()]));
+    assert!(store.session_grants_cover_targets("root-4", &["c.com".to_string()]));
+}
+
+#[test]
+fn test_delete_grants_removes_revoked_and_active() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-5", "agent-f", "x.io");
+    store
+        .revoke_session_grants("root-5", Some("x.io"), "before delete")
+        .unwrap();
+
+    store.delete_session_grants("root-5").unwrap();
+
+    assert!(store.get_session_grants("root-5").unwrap().is_empty());
+}
+
+#[test]
+fn test_revoke_nonexistent_host_is_noop() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-6", "agent-g", "exists.io");
+
+    let count = store
+        .revoke_session_grants("root-6", Some("nope.io"), "nothing")
+        .unwrap();
+    assert_eq!(count, 0);
+
+    assert_eq!(store.get_session_grants("root-6").unwrap(), vec!["exists.io"]);
+}

--- a/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
+++ b/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
@@ -136,3 +136,29 @@ fn test_revoke_nonexistent_host_is_noop() {
 
     assert_eq!(store.get_session_grants("root-6").unwrap(), vec!["exists.io"]);
 }
+
+#[test]
+fn test_revoke_then_reapprove_restores_coverage() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    seed_grant(&store, "root-7", "agent-h", "regranted.io");
+
+    assert!(store
+        .session_grants_cover_targets("root-7", &["regranted.io".to_string()]));
+
+    store
+        .revoke_session_grants("root-7", Some("regranted.io"), "temp revoke")
+        .unwrap();
+
+    assert!(store.get_session_grants("root-7").unwrap().is_empty());
+    assert!(!store
+        .session_grants_cover_targets("root-7", &["regranted.io".to_string()]));
+
+    seed_grant(&store, "root-7", "agent-h", "regranted.io");
+
+    assert_eq!(store.get_session_grants("root-7").unwrap(), vec!["regranted.io"]);
+    assert!(store
+        .session_grants_cover_targets("root-7", &["regranted.io".to_string()]));
+}


### PR DESCRIPTION
## Summary

Closes #23

Adds the ability to revoke approval grants for suspended (or active) sessions, so that when a session resumes, revoked grants trigger a fresh approval prompt instead of silently reusing stale access.

### What changed

| File | Change |
|------|--------|
| `migrate.rs` | Schema v15: `revoked_at`, `revoked_reason` columns on `session_approval_grants` |
| `approvals.rs` | `get_session_grants` excludes revoked grants; new `revoke_session_grants()` for per-host or per-session revocation |

### How it works

- `revoke_session_grants(root_session_id, host, reason)` marks matching grants as revoked by setting `revoked_at` and `revoked_reason`.
- `get_session_grants()` (used by all grant coverage checks) already filters `revoked_at IS NULL`, so revoked grants are automatically excluded from:
  - `sandbox.exec` session grant dedup
  - `artifact.prepare` auto-approve
  - `artifact.exec` auto-approve
  - Layer mount scope checking
- When a resumed session calls `sandbox.exec`, the revoked grant is no longer found, and a fresh approval prompt is triggered.
- Emergency stop and session close continue to hard-delete all grants (stronger than revocation).

### Acceptance criteria from issue

- [x] Revocation by host within a session
- [x] Revocation of all grants for a session
- [x] Suspended-then-resumed sessions re-validate grants before reuse (automatic via existing `session_grants_cover_targets` path)
- [x] Emergency stop leaves zero active grants for the affected root session (existing behavior preserved)
- [x] 6 integration tests covering revocation, idempotency, partial revoke, and coverage re-check

### Not yet implemented (optional, from issue)

- CLI command `gateway approvals revoke --host <host> [--session-id <id> | --all]` — this PR provides the store-level primitive; a CLI command can follow.
- Time-bound grants with `expires_at` — deferred to a follow-up.