### PR TITLE
fix(issue-19): enforce io returns at gateway boundary

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, Semaphore};
 
 /// Ensures `close_session` runs when `execute_with_history` fails so session report / digest finalize.
@@ -1760,32 +1761,46 @@ impl GatewayExecutionService {
         // Response validation gate: check the result against the response contract declared
         // in spawn metadata; run bounded repair loop when repair_enabled is set.
         // Fallback: when the caller supplies no metadata contract, use the contract declared
-        // in the agent's own SKILL.md frontmatter (loaded via AgentRepository).
+        // in the agent's own SKILL.md frontmatter. If neither provides an output schema,
+        // manifest `io.returns` becomes the default output_schema for the final reply.
         // Validation is skipped for suspended sessions (they haven't finished producing output).
-        if self.config.response_validation.enabled
-            && result.suspended_for_approval.is_none()
+        let gateway_dir = crate::execution::gateway_root_dir(&self.config);
+        let manifest_loaded = {
+            let repo = AgentRepository::from_config(&self.config);
+            repo.get_sync_from_store(agent_id, &gateway_dir, self.gateway_store.as_deref())
+                .ok()
+                .map(|loaded| loaded.manifest)
+        };
+        let manifest_returns_schema = manifest_loaded
+            .as_ref()
+            .and_then(|manifest| manifest.io.as_ref())
+            .and_then(|io| io.returns.clone());
+        let metadata_has_output_schema = metadata
+            .and_then(|value| value.get("response_contract"))
+            .and_then(|value| value.get("output_schema"))
+            .is_some();
+        let manifest_contract_has_output_schema = manifest_loaded
+            .as_ref()
+            .and_then(|manifest| manifest.response_contract.as_ref())
+            .and_then(|value| value.get("output_schema"))
+            .is_some();
+        let enforcing_manifest_returns = manifest_returns_schema.is_some()
+            && !metadata_has_output_schema
+            && !manifest_contract_has_output_schema;
+
+        if result.suspended_for_approval.is_none()
             && !result.suspended_for_user_input
+            && (self.config.response_validation.enabled || enforcing_manifest_returns)
         {
-            // Resolve effective contract: caller-supplied metadata first, then manifest default.
-            let manifest_contract: Option<serde_json::Value> =
-                if metadata.and_then(|m| m.get("response_contract")).is_none() {
-                    let repo = AgentRepository::from_config(&self.config);
-                    let gateway_dir = crate::execution::gateway_root_dir(&self.config);
-                    repo.get_sync_from_store(agent_id, &gateway_dir, self.gateway_store.as_deref())
-                        .ok()
-                        .and_then(|loaded| loaded.manifest.response_contract)
-                } else {
-                    None
-                };
-            let effective_metadata: Option<serde_json::Value> = if manifest_contract.is_some() {
-                Some(serde_json::json!({ "response_contract": manifest_contract }))
-            } else {
-                None
-            };
+            let effective_metadata = build_effective_response_contract_metadata(
+                metadata,
+                manifest_loaded.as_ref(),
+            );
             let metadata_ref: Option<&serde_json::Value> = effective_metadata.as_ref().or(metadata);
             match crate::runtime::response_validation::parse_response_contract(metadata_ref) {
                 Ok(Some(contract)) => {
-                    result = self
+                    let validation_session_id = result.session_id.clone();
+                    match self
                         .validate_and_maybe_repair(
                             agent_id,
                             result,
@@ -1794,7 +1809,54 @@ impl GatewayExecutionService {
                             workflow_id,
                             task_id,
                         )
-                        .await?;
+                        .await
+                    {
+                        Ok(validated) => {
+                            if enforcing_manifest_returns {
+                                if let Some(expected_schema) = manifest_returns_schema.as_ref() {
+                                    log_contract_enforcement_event_to_gateway(
+                                        self.gateway_store.as_deref(),
+                                        agent_id,
+                                        &validated.session_id,
+                                        "io.returns",
+                                        EntryStatus::Success,
+                                        source_agent_id,
+                                        serde_json::json!({
+                                            "contract": "io.returns",
+                                            "result": "pass",
+                                            "expected_schema": expected_schema,
+                                            "source_agent_id": source_agent_id,
+                                            "enforcer": "response_validation"
+                                        }),
+                                    );
+                                }
+                            }
+                            result = validated;
+                        }
+                        Err(error) => {
+                            if enforcing_manifest_returns {
+                                if let Some(expected_schema) = manifest_returns_schema.as_ref() {
+                                    log_contract_enforcement_event_to_gateway(
+                                        self.gateway_store.as_deref(),
+                                        agent_id,
+                                        &validation_session_id,
+                                        "io.returns",
+                                        EntryStatus::Denied,
+                                        source_agent_id,
+                                        serde_json::json!({
+                                            "contract": "io.returns",
+                                            "result": "rejected",
+                                            "expected_schema": expected_schema,
+                                            "source_agent_id": source_agent_id,
+                                            "reason": error.to_string(),
+                                            "enforcer": "response_validation"
+                                        }),
+                                    );
+                                }
+                            }
+                            return Err(error);
+                        }
+                    }
                 }
                 Ok(None) => {} // no contract in metadata — skip validation
                 Err(e) => {
@@ -2683,6 +2745,108 @@ fn log_input_schema_validation_to_gateway(
 ) -> anyhow::Result<()> {
     // No-op: gateway causal chain events are now captured in gateway.db
     Ok(())
+}
+
+fn build_effective_response_contract_metadata(
+    metadata: Option<&serde_json::Value>,
+    manifest: Option<&AgentManifest>,
+) -> Option<serde_json::Value> {
+    let manifest_contract = manifest.and_then(|loaded| loaded.response_contract.clone());
+    let manifest_returns_schema = manifest
+        .and_then(|loaded| loaded.io.as_ref())
+        .and_then(|io| io.returns.clone());
+
+    let mut response_contract = metadata
+        .and_then(|value| value.get("response_contract"))
+        .cloned()
+        .or(manifest_contract)
+        .and_then(|value| match value {
+            serde_json::Value::Object(map) => Some(map),
+            _ => None,
+        });
+
+    match (response_contract.as_mut(), manifest_returns_schema) {
+        (Some(contract), Some(schema)) => {
+            contract
+                .entry("output_schema".to_string())
+                .or_insert(schema);
+        }
+        (Some(_), None) => {}
+        (None, Some(schema)) => {
+            let mut contract = serde_json::Map::new();
+            contract.insert("output_schema".to_string(), schema);
+            response_contract = Some(contract);
+        }
+        (None, None) => return metadata.cloned(),
+    }
+
+    let mut effective = metadata.cloned().unwrap_or_else(|| serde_json::json!({}));
+    if !effective.is_object() {
+        effective = serde_json::json!({});
+    }
+    if let Some(contract) = response_contract {
+        if let Some(object) = effective.as_object_mut() {
+            object.insert(
+                "response_contract".to_string(),
+                serde_json::Value::Object(contract),
+            );
+            return Some(effective);
+        }
+    }
+    None
+}
+
+fn contract_event_seq() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn log_contract_enforcement_event_to_gateway(
+    gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
+    agent_id: &str,
+    session_id: &str,
+    action: &str,
+    status: EntryStatus,
+    target_agent_id: Option<&str>,
+    payload: serde_json::Value,
+) {
+    let Some(store) = gateway_store else {
+        return;
+    };
+
+    let payload_str = serde_json::to_string(&payload).ok();
+    let reason = payload
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned);
+
+    if let Err(error) = store.create_causal_event(&CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: agent_id.to_string(),
+        session_id: session_id.to_string(),
+        turn_id: None,
+        event_seq: contract_event_seq(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        category: "contract".to_string(),
+        action: action.to_string(),
+        status: status.to_string(),
+        target: target_agent_id.map(ToOwned::to_owned),
+        payload: payload_str,
+        payload_ref: None,
+        evidence_ref: None,
+        reason,
+    }) {
+        tracing::warn!(
+            target: "response_validation",
+            error = %error,
+            action = action,
+            agent_id = agent_id,
+            session_id = session_id,
+            "Failed to persist contract enforcement event"
+        );
+    }
 }
 
 pub fn gateway_actor_id() -> String {

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -2751,6 +2751,16 @@ fn build_effective_response_contract_metadata(
     metadata: Option<&serde_json::Value>,
     manifest: Option<&AgentManifest>,
 ) -> Option<serde_json::Value> {
+    // Preserve caller metadata unchanged when response_contract is present but not an object,
+    // so parse_response_contract can surface the invalid contract instead of masking it.
+    if let Some(incoming) = metadata {
+        if let Some(contract_value) = incoming.get("response_contract") {
+            if !contract_value.is_object() {
+                return metadata.cloned();
+            }
+        }
+    }
+
     let manifest_contract = manifest.and_then(|loaded| loaded.response_contract.clone());
     let manifest_returns_schema = manifest
         .and_then(|loaded| loaded.io.as_ref())

--- a/autonoetic-gateway/src/runtime/tools/agent.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent.rs
@@ -6,6 +6,7 @@ use crate::runtime::tools::{
 };
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
+use autonoetic_types::causal_chain::{CausalEventRecord, EntryStatus};
 use autonoetic_types::config::{GatewayConfig, SchemaEnforcementConfig, SchemaEnforcementMode};
 use autonoetic_types::schema_enforcement::{default_enforcer, EnforcementResult, SchemaEnforcer};
 use autonoetic_types::workflow::{TaskRun, TaskRunStatus, WorkflowEventRecord};
@@ -173,6 +174,12 @@ impl NativeTool for AgentSpawnTool {
             .map(|c| &c.schema_enforcement)
             .unwrap_or(&default_enforcement_config);
 
+        let resolved_session_id = args
+            .session_id
+            .clone()
+            .or_else(|| session_id.map(ToOwned::to_owned))
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
         if enforcement_config.mode != SchemaEnforcementMode::Disabled {
             let agents_dir = config.map(|c| &c.agents_dir).ok_or_else(|| {
                 anyhow::anyhow!("config is required for agent.spawn schema enforcement")
@@ -192,7 +199,23 @@ impl NativeTool for AgentSpawnTool {
                                         &args.message,
                                         accepts,
                                     ) {
-                                        SpawnSchemaOutcome::Pass => {}
+                                        SpawnSchemaOutcome::Pass => {
+                                            log_io_contract_enforcement(
+                                                gateway_store.as_deref(),
+                                                &manifest.agent.id,
+                                                &resolved_session_id,
+                                                Some(&args.agent_id),
+                                                "io.accepts",
+                                                EntryStatus::Success,
+                                                serde_json::json!({
+                                                    "contract": "io.accepts",
+                                                    "result": "pass",
+                                                    "target_agent_id": args.agent_id,
+                                                    "expected_schema": accepts,
+                                                    "enforcer": "deterministic"
+                                                }),
+                                            );
+                                        }
                                         SpawnSchemaOutcome::Coerced {
                                             new_message,
                                             transformations,
@@ -205,9 +228,45 @@ impl NativeTool for AgentSpawnTool {
                                                     "Schema enforcement: payload coerced"
                                                 );
                                             }
+                                            log_io_contract_enforcement(
+                                                gateway_store.as_deref(),
+                                                &manifest.agent.id,
+                                                &resolved_session_id,
+                                                Some(&args.agent_id),
+                                                "io.accepts",
+                                                EntryStatus::Success,
+                                                serde_json::json!({
+                                                    "contract": "io.accepts",
+                                                    "result": "coerced",
+                                                    "target_agent_id": args.agent_id,
+                                                    "expected_schema": accepts,
+                                                    "transformations": transformations,
+                                                    "enforcer": "deterministic"
+                                                }),
+                                            );
                                             args.message = new_message;
                                         }
                                         SpawnSchemaOutcome::Reject(body) => {
+                                            let payload = serde_json::from_str::<serde_json::Value>(&body)
+                                                .unwrap_or_else(|_| {
+                                                    serde_json::json!({
+                                                        "contract": "io.accepts",
+                                                        "result": "rejected",
+                                                        "target_agent_id": args.agent_id,
+                                                        "reason": body,
+                                                        "expected_schema": accepts,
+                                                        "enforcer": "deterministic"
+                                                    })
+                                                });
+                                            log_io_contract_enforcement(
+                                                gateway_store.as_deref(),
+                                                &manifest.agent.id,
+                                                &resolved_session_id,
+                                                Some(&args.agent_id),
+                                                "io.accepts",
+                                                EntryStatus::Denied,
+                                                payload,
+                                            );
                                             return Ok(body);
                                         }
                                     }
@@ -218,12 +277,6 @@ impl NativeTool for AgentSpawnTool {
                 }
             }
         }
-
-        let resolved_session_id = args
-            .session_id
-            .clone()
-            .or_else(|| session_id.map(ToOwned::to_owned))
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         let agents_dir = config
             .map(|c| &c.agents_dir)
@@ -1190,6 +1243,52 @@ pub(crate) fn enforce_spawn_message_schema(
             })
             .to_string(),
         ),
+    }
+}
+
+fn log_io_contract_enforcement(
+    gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
+    agent_id: &str,
+    session_id: &str,
+    target: Option<&str>,
+    action: &str,
+    status: EntryStatus,
+    payload: serde_json::Value,
+) {
+    let Some(store) = gateway_store else {
+        return;
+    };
+
+    let payload_str = serde_json::to_string(&payload).ok();
+    let reason = payload
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned);
+
+    if let Err(error) = store.create_causal_event(&CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: agent_id.to_string(),
+        session_id: session_id.to_string(),
+        turn_id: None,
+        event_seq: Utc::now().timestamp_millis().max(0) as u64,
+        timestamp: Utc::now().to_rfc3339(),
+        category: "contract".to_string(),
+        action: action.to_string(),
+        status: status.to_string(),
+        target: target.map(ToOwned::to_owned),
+        payload: payload_str,
+        payload_ref: None,
+        evidence_ref: None,
+        reason,
+    }) {
+        tracing::warn!(
+            target: "schema_enforcement",
+            error = %error,
+            action = action,
+            agent_id = agent_id,
+            session_id = session_id,
+            "Failed to persist contract enforcement event"
+        );
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/agent.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent.rs
@@ -210,7 +210,7 @@ impl NativeTool for AgentSpawnTool {
                                                 serde_json::json!({
                                                     "contract": "io.accepts",
                                                     "result": "pass",
-                                                    "target_agent_id": args.agent_id,
+                                                    "target_agent_id": &args.agent_id,
                                                     "expected_schema": accepts,
                                                     "enforcer": "deterministic"
                                                 }),
@@ -238,7 +238,7 @@ impl NativeTool for AgentSpawnTool {
                                                 serde_json::json!({
                                                     "contract": "io.accepts",
                                                     "result": "coerced",
-                                                    "target_agent_id": args.agent_id,
+                                                    "target_agent_id": &args.agent_id,
                                                     "expected_schema": accepts,
                                                     "transformations": transformations,
                                                     "enforcer": "deterministic"
@@ -252,8 +252,8 @@ impl NativeTool for AgentSpawnTool {
                                                     serde_json::json!({
                                                         "contract": "io.accepts",
                                                         "result": "rejected",
-                                                        "target_agent_id": args.agent_id,
-                                                        "reason": body,
+                                                        "target_agent_id": &args.agent_id,
+                                                        "reason": &body,
                                                         "expected_schema": accepts,
                                                         "enforcer": "deterministic"
                                                     })

--- a/autonoetic-gateway/tests/response_validation_integration.rs
+++ b/autonoetic-gateway/tests/response_validation_integration.rs
@@ -47,6 +47,54 @@ You are a validation test agent. Produce the requested output.
     Ok(dir)
 }
 
+fn install_validation_agent_with_returns(
+    agent_dir: &std::path::Path,
+    agent_id: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    let dir = agent_dir.join(agent_id);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            r#"---
+version: "1.0"
+runtime:
+  engine: "autonoetic"
+  gateway_version: "0.1.0"
+  sdk_version: "0.1.0"
+  type: "stateful"
+  sandbox: "bubblewrap"
+  runtime_lock: "runtime.lock"
+agent:
+  id: "{agent_id}"
+  name: "{agent_id}"
+  description: "Validation test agent with output schema"
+io:
+  returns:
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+llm_config:
+  provider: "openai"
+  model: "gpt-4o"
+  temperature: 0.0
+capabilities:
+  - type: "WriteAccess"
+    scopes: ["*"]
+  - type: "ReadAccess"
+    scopes: ["*"]
+---
+# Instructions
+You are a validation test agent. Produce the requested output.
+"#,
+        ),
+    )?;
+    Ok(dir)
+}
+
 fn setup_store_and_seed(
     config: &autonoetic_types::config::GatewayConfig,
     agents_dir: &std::path::Path,
@@ -336,6 +384,113 @@ async fn test_response_validation_fails_on_non_json_reply_when_schema_declared(
         "error should mention JSON requirement, got: {}",
         msg
     );
+
+    Ok(())
+}
+
+#[serial_test::serial]
+#[tokio::test]
+async fn test_manifest_io_returns_passes_without_explicit_response_contract(
+) -> anyhow::Result<()> {
+    let workspace = TestWorkspace::new()?;
+    let config = workspace.gateway_config();
+
+    install_validation_agent_with_returns(&workspace.agents_dir, "returns.pass.agent")?;
+    let store = setup_store_and_seed(&config, &workspace.agents_dir, "returns.pass.agent")?;
+
+    let stub = OpenAiStub::spawn(move |_raw, _body| async move {
+        serde_json::json!({
+            "choices": [{"message": {"content": "{\"status\":\"ok\"}"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+        })
+    })
+    .await?;
+    let _url = EnvGuard::set("AUTONOETIC_LLM_BASE_URL", stub.completion_url());
+    let _key = EnvGuard::set("AUTONOETIC_LLM_API_KEY", "test-key");
+
+    let execution = GatewayExecutionService::new(config, Some(store));
+    let result = execution
+        .spawn_agent_once(
+            "returns.pass.agent",
+            "return structured json",
+            "sess-returns-pass-1",
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await?;
+
+    assert_eq!(result.assistant_reply.as_deref(), Some("{\"status\":\"ok\"}"));
+
+    Ok(())
+}
+
+#[serial_test::serial]
+#[tokio::test]
+async fn test_manifest_io_returns_rejects_and_logs_without_explicit_response_contract(
+) -> anyhow::Result<()> {
+    let workspace = TestWorkspace::new()?;
+    let config = workspace.gateway_config();
+
+    install_validation_agent_with_returns(&workspace.agents_dir, "returns.fail.agent")?;
+    let store = setup_store_and_seed(&config, &workspace.agents_dir, "returns.fail.agent")?;
+
+    let stub = OpenAiStub::spawn(move |_raw, _body| async move {
+        serde_json::json!({
+            "choices": [{"message": {"content": "plain text output"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4}
+        })
+    })
+    .await?;
+    let _url = EnvGuard::set("AUTONOETIC_LLM_BASE_URL", stub.completion_url());
+    let _key = EnvGuard::set("AUTONOETIC_LLM_API_KEY", "test-key");
+
+    let execution = GatewayExecutionService::new(config, Some(store.clone()));
+    let err = execution
+        .spawn_agent_once(
+            "returns.fail.agent",
+            "return structured json",
+            "sess-returns-fail-1",
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("output_schema"),
+        "error should mention output_schema, got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("valid JSON"),
+        "error should mention JSON requirement, got: {}",
+        msg
+    );
+
+    let events = store.search_causal_events(Some("sess-returns-fail-1"), Some("returns.fail.agent"), 100)?;
+    let event = events
+        .iter()
+        .find(|event| event.category == "contract" && event.action == "io.returns")
+        .expect("expected io.returns contract event");
+    assert_eq!(event.status, "DENIED");
+    let payload = event
+        .payload
+        .as_ref()
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+        .expect("payload should be valid json");
+    assert_eq!(payload["contract"], "io.returns");
+    assert_eq!(payload["result"], "rejected");
 
     Ok(())
 }

--- a/autonoetic-gateway/tests/response_validation_integration.rs
+++ b/autonoetic-gateway/tests/response_validation_integration.rs
@@ -426,6 +426,22 @@ async fn test_manifest_io_returns_passes_without_explicit_response_contract(
 
     assert_eq!(result.assistant_reply.as_deref(), Some("{\"status\":\"ok\"}"));
 
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+    let events = store.search_causal_events(Some("sess-returns-pass-1"), Some("returns.pass.agent"), 100)?;
+    let event = events
+        .iter()
+        .find(|event| event.category == "contract" && event.action == "io.returns")
+        .expect("expected io.returns contract event");
+    assert_eq!(event.status, "SUCCESS");
+    let payload = event
+        .payload
+        .as_ref()
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+        .expect("payload should be valid json");
+    assert_eq!(payload["contract"], "io.returns");
+    assert_eq!(payload["result"], "pass");
+
     Ok(())
 }
 

--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -130,6 +130,7 @@ print(json.dumps({"result": input_data}))
 **Input schema contract:**
 - The agent author declares `io.accepts` (and optionally `io.returns`) in the manifest. The gateway surfaces these through `agent.list` so callers can shape `message` correctly before calling `agent.spawn`.
 - When `io.accepts` is present, the gateway parses the caller's `message` and validates it against the schema. On mismatch, `agent.spawn` returns `{ "ok": false, "error": "schema_validation_failed", "expected_schema": ..., "fields_with_errors": [...], "hint": ... }` — the calling LLM reads this and retries with a corrected payload. Type coercion (default values, type defaults for required fields) is applied silently.
+- When `io.returns` is present, the gateway validates the child agent's final reply before returning the `SpawnResult` to the caller. If no explicit `response_contract.output_schema` overrides it, `io.returns` becomes the default output schema. Mismatches are rejected at the gateway boundary and recorded as contract events so drift is visible in traces.
 - When `io.accepts` is absent, `message` is passed through unchanged. The script is responsible for parsing it.
 - The gateway does **not** invent a default schema: `create_from_intent` without an explicit `io` installs the agent with `io: None`.
 

--- a/docs/response-validation-gate.md
+++ b/docs/response-validation-gate.md
@@ -4,6 +4,8 @@ Autonoetic can validate an agent's final response after execution and before ret
 
 When a response contract is declared, the gateway validates the produced `SpawnResult`. If validation fails and repair is enabled, the gateway gives the same agent a bounded chance to repair the actual outputs and try again.
 
+When no explicit `response_contract.output_schema` is supplied, manifest `io.returns` is treated as the gateway-owned default output schema for the final reply. That keeps output-shape ownership in the gateway instead of leaving it as advisory SKILL prose.
+
 ## What The Gateway Validates
 
 The response contract is declared as `metadata.autonoetic.response_contract` and currently supports these fields:
@@ -36,7 +38,7 @@ Validation uses authoritative runtime state, not natural-language assertions:
 - `max_artifacts`: limits the number of returned files.
 - `max_total_size_mb`: sums authoritative byte sizes for returned content handles from the content store.
 - `max_reply_length_chars`: validates the final reply string length.
-- `output_schema`: validates the final reply text when it is JSON.
+- `output_schema`: validates the final reply text when it is JSON. This may come from an explicit response contract or from manifest `io.returns` when no explicit output schema overrides it.
 - `prohibited_text_patterns`: rejects replies that match forbidden regex patterns.
 - `min_artifact_builds`: checks durable execution-trace evidence for successful `artifact.build` calls in the current session branch.
 


### PR DESCRIPTION
## Summary

This closes the main output-contract gap from issue #19 by making manifest `io.returns` gateway-enforced instead of advisory.

Changes in this PR:
- treat manifest `io.returns` as the default `response_contract.output_schema` when no explicit output schema is provided
- validate child-agent final replies at the execution boundary before returning `SpawnResult` to the caller
- persist `io.accepts` and `io.returns` enforcement outcomes to `causal_events` as contract events
- document that `io.returns` is gateway-owned when no explicit response contract overrides it
- add integration coverage for both the pass and reject paths

## Why

Issue #19 is about making the gateway the single source of truth for inter-agent I/O contracts.

Before this change:
- `io.accepts` was enforced on ingress
- `io.returns` was only observational / advisory unless a caller explicitly injected `response_contract.output_schema`

After this change:
- output-shape enforcement is symmetric by default
- agents cannot silently drift away from declared `io.returns`
- contract decisions are visible in durable runtime observability, not just in caller-facing failures

## Implementation Notes

- caller-supplied `response_contract.output_schema` still takes precedence
- manifest `response_contract.output_schema` also still takes precedence
- manifest `io.returns` fills the gap only when no explicit output schema is already present
- rejected `io.returns` validations are recorded as `contract` events with action `io.returns`
- ingress `io.accepts` decisions are also mirrored into `causal_events`

## Testing

Ran:

```bash
cargo test -p autonoetic-gateway --test response_validation_integration -- --nocapture