### PR TITLE
feat(contracts): enforce required array in io.accepts and validate promotion.record findings

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -109,6 +109,29 @@ impl NativeTool for PromotionRecordTool {
             "content_digest is gateway-owned and must not be provided to promotion.record"
         );
 
+        let findings_with_errors: Vec<String> = args
+            .findings
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                let mut errs = Vec::new();
+                if f.description.trim().is_empty() {
+                    errs.push("description is empty");
+                }
+                if !errs.is_empty() {
+                    Some(format!("findings[{}]: {}", i, errs.join(", ")))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !findings_with_errors.is_empty() {
+            anyhow::bail!(
+                "Findings schema validation failed:\n  - {}",
+                findings_with_errors.join("\n  - ")
+            );
+        }
+
         let has_error_or_critical = args.findings.iter().any(|f| {
             matches!(
                 f.severity,

--- a/autonoetic-gateway/tests/promotion_record_findings_validation.rs
+++ b/autonoetic-gateway/tests/promotion_record_findings_validation.rs
@@ -1,0 +1,123 @@
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+use tempfile::tempdir;
+
+fn evaluator_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "evaluator.default".to_string(),
+            name: "evaluator.default".to_string(),
+            description: "Evaluator".to_string(),
+        },
+        capabilities: vec![],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        response_contract: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+    }
+}
+
+fn setup_store(tmp: &tempfile::TempDir) -> std::path::PathBuf {
+    let gw = tmp.path().join(".gateway");
+    std::fs::create_dir_all(&gw).unwrap();
+    let cs = ContentStore::new(&gw).unwrap();
+    let handle = cs.write(b"test artifact content".as_slice()).unwrap();
+    cs.register_name("test-session", "artifact.tar.zst", &handle)
+        .unwrap();
+    gw
+}
+
+#[test]
+fn test_promotion_record_rejects_empty_finding_description() {
+    let tmp = tempdir().unwrap();
+    let gw = setup_store(&tmp);
+    let manifest = evaluator_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+
+    let err = registry
+        .execute(
+            "promotion.record",
+            &manifest,
+            &policy,
+            tmp.path(),
+            Some(&gw),
+            &serde_json::json!({
+                "artifact_id": "art_test123",
+                "role": "evaluator",
+                "pass": false,
+                "findings": [{"severity": "error", "description": ""}]
+            })
+            .to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("findings[0]"), "Expected findings index, got: {msg}");
+    assert!(
+        msg.contains("description is empty"),
+        "Expected 'description is empty', got: {msg}"
+    );
+}
+
+#[test]
+fn test_promotion_record_accepts_valid_findings() {
+    let tmp = tempdir().unwrap();
+    let gw = setup_store(&tmp);
+    let manifest = evaluator_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+
+    let result = registry
+        .execute(
+            "promotion.record",
+            &manifest,
+            &policy,
+            tmp.path(),
+            Some(&gw),
+            &serde_json::json!({
+                "artifact_id": "art_test123",
+                "role": "evaluator",
+                "pass": true,
+                "findings": [{"severity": "info", "description": "All checks passed"}]
+            })
+            .to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    let output: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert!(output["ok"].as_bool().unwrap());
+}

--- a/autonoetic-types/src/schema_enforcement.rs
+++ b/autonoetic-types/src/schema_enforcement.rs
@@ -81,53 +81,56 @@ impl DeterministicCoercionEnforcer {
         let mut payload = payload.clone();
         let mut errors = Vec::new();
 
-        if let (Some(obj), Some(schema_obj)) = (
-            payload.as_object_mut(),
-            target_schema.get("properties").and_then(|p| p.as_object()),
-        ) {
-            let fields: Vec<(String, serde_json::Value)> = schema_obj
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect();
+        if let Some(obj) = payload.as_object_mut() {
+            let schema_obj = target_schema
+                .get("properties")
+                .and_then(|p| p.as_object());
 
-            for (field_name, schema_field) in &fields {
-                let value = obj.get(field_name).cloned();
+            if let Some(schema_obj) = schema_obj {
+                let fields: Vec<(String, serde_json::Value)> = schema_obj
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
 
-                match (&value, schema_field.get("default")) {
-                    (None, Some(default)) => {
-                        obj.insert(field_name.clone(), default.clone());
-                        transformations.push(Transformation {
-                            kind: TransformationKind::DefaultValue,
-                            field_path: field_name.clone(),
-                            original_value: None,
-                            new_value: Some(default.clone()),
-                            reason: format!("Field '{}' missing, using default", field_name),
-                        });
-                    }
-                    (None, None) if schema_field.get("required").is_some() => {
-                        if let Some(type_info) = schema_field.get("type") {
-                            if let Some(default) = Self::default_for_type(type_info) {
-                                obj.insert(field_name.clone(), default.clone());
-                                transformations.push(Transformation {
-                                    kind: TransformationKind::DefaultValue,
-                                    field_path: field_name.clone(),
-                                    original_value: None,
-                                    new_value: Some(default.clone()),
-                                    reason: format!(
-                                        "Field '{}' required but missing, using type default",
-                                        field_name
-                                    ),
-                                });
-                            } else {
-                                errors.push(FieldError {
-                                    field_path: field_name.clone(),
-                                    error: "Required field missing with no default available"
-                                        .to_string(),
-                                });
+                for (field_name, schema_field) in &fields {
+                    let value = obj.get(field_name).cloned();
+
+                    match (&value, schema_field.get("default")) {
+                        (None, Some(default)) => {
+                            obj.insert(field_name.clone(), default.clone());
+                            transformations.push(Transformation {
+                                kind: TransformationKind::DefaultValue,
+                                field_path: field_name.clone(),
+                                original_value: None,
+                                new_value: Some(default.clone()),
+                                reason: format!("Field '{}' missing, using default", field_name),
+                            });
+                        }
+                        (None, None) if schema_field.get("required").is_some() => {
+                            if let Some(type_info) = schema_field.get("type") {
+                                if let Some(default) = Self::default_for_type(type_info) {
+                                    obj.insert(field_name.clone(), default.clone());
+                                    transformations.push(Transformation {
+                                        kind: TransformationKind::DefaultValue,
+                                        field_path: field_name.clone(),
+                                        original_value: None,
+                                        new_value: Some(default.clone()),
+                                        reason: format!(
+                                            "Field '{}' required but missing, using type default",
+                                            field_name
+                                        ),
+                                    });
+                                } else {
+                                    errors.push(FieldError {
+                                        field_path: field_name.clone(),
+                                        error: "Required field missing with no default available"
+                                            .to_string(),
+                                    });
+                                }
                             }
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
 
@@ -149,27 +152,35 @@ impl DeterministicCoercionEnforcer {
                         if obj.contains_key(field_name) {
                             continue;
                         }
-                        let schema_field = schema_obj.get(field_name);
-                        if let Some(type_info) =
-                            schema_field.and_then(|f| f.get("type"))
-                        {
-                            if let Some(default) = Self::default_for_type(type_info) {
-                                obj.insert(field_name.to_string(), default.clone());
-                                transformations.push(Transformation {
-                                    kind: TransformationKind::MissingAdded,
-                                    field_path: field_name.to_string(),
-                                    original_value: None,
-                                    new_value: Some(default),
-                                    reason: format!(
-                                        "Required field '{}' missing, using type default",
-                                        field_name
-                                    ),
-                                });
+                        let schema_field = schema_obj.and_then(|so| so.get(field_name));
+                        if let Some(sf) = schema_field {
+                            if let Some(type_info) = sf.get("type") {
+                                if let Some(default) = Self::default_for_type(type_info) {
+                                    obj.insert(field_name.to_string(), default.clone());
+                                    transformations.push(Transformation {
+                                        kind: TransformationKind::MissingAdded,
+                                        field_path: field_name.to_string(),
+                                        original_value: None,
+                                        new_value: Some(default),
+                                        reason: format!(
+                                            "Required field '{}' missing, using type default",
+                                            field_name
+                                        ),
+                                    });
+                                } else {
+                                    errors.push(FieldError {
+                                        field_path: field_name.to_string(),
+                                        error: format!(
+                                            "Required field '{}' declared with unsupported type, cannot coerce",
+                                            field_name
+                                        ),
+                                    });
+                                }
                             } else {
                                 errors.push(FieldError {
                                     field_path: field_name.to_string(),
                                     error: format!(
-                                        "Required field '{}' missing with no type default",
+                                        "Required field '{}' declared in properties but missing a type",
                                         field_name
                                     ),
                                 });
@@ -178,7 +189,7 @@ impl DeterministicCoercionEnforcer {
                             errors.push(FieldError {
                                 field_path: field_name.to_string(),
                                 error: format!(
-                                    "Required field '{}' missing and not declared in properties",
+                                    "Required field '{}' not declared in properties",
                                     field_name
                                 ),
                             });
@@ -299,19 +310,26 @@ mod tests {
     }
 
     #[test]
-    fn test_required_array_rejects_missing_unknown_type() {
+    fn test_required_array_rejects_unsupported_type() {
         let enforcer = DeterministicCoercionEnforcer::new();
         let payload = serde_json::json!({});
         let schema = serde_json::json!({
             "type": "object",
             "properties": {
-                "data": { "type": "string" }
+                "data": { "type": "unknown_type" }
             },
             "required": ["data"]
         });
 
         let result = enforcer.enforce(&payload, &schema);
-        assert!(matches!(result, EnforcementResult::Coerced(_)));
+        match result {
+            EnforcementResult::Reject(details) => {
+                assert_eq!(details.fields_with_errors.len(), 1);
+                assert_eq!(details.fields_with_errors[0].field_path, "data");
+                assert!(details.fields_with_errors[0].error.contains("unsupported type"));
+            }
+            _ => panic!("Expected Reject result, got {:?}", result),
+        }
     }
 
     #[test]
@@ -371,6 +389,49 @@ mod tests {
             EnforcementResult::Reject(details) => {
                 assert_eq!(details.fields_with_errors.len(), 1);
                 assert_eq!(details.fields_with_errors[0].field_path, "unknown_field");
+            }
+            _ => panic!("Expected Reject result, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_required_without_properties_rejects() {
+        let enforcer = DeterministicCoercionEnforcer::new();
+        let payload = serde_json::json!({});
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["name"]
+        });
+
+        let result = enforcer.enforce(&payload, &schema);
+        match result {
+            EnforcementResult::Reject(details) => {
+                assert_eq!(details.fields_with_errors.len(), 1);
+                assert_eq!(details.fields_with_errors[0].field_path, "name");
+                assert!(details.fields_with_errors[0].error.contains("not declared in properties"));
+            }
+            _ => panic!("Expected Reject result, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_required_with_field_in_properties_but_no_type() {
+        let enforcer = DeterministicCoercionEnforcer::new();
+        let payload = serde_json::json!({});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "data": { "description": "some data" }
+            },
+            "required": ["data"]
+        });
+
+        let result = enforcer.enforce(&payload, &schema);
+        match result {
+            EnforcementResult::Reject(details) => {
+                assert_eq!(details.fields_with_errors.len(), 1);
+                assert_eq!(details.fields_with_errors[0].field_path, "data");
+                assert!(details.fields_with_errors[0].error.contains("missing a type"));
             }
             _ => panic!("Expected Reject result, got {:?}", result),
         }

--- a/autonoetic-types/src/schema_enforcement.rs
+++ b/autonoetic-types/src/schema_enforcement.rs
@@ -90,8 +90,8 @@ impl DeterministicCoercionEnforcer {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
 
-            for (field_name, schema_field) in fields {
-                let value = obj.get(&field_name).cloned();
+            for (field_name, schema_field) in &fields {
+                let value = obj.get(field_name).cloned();
 
                 match (&value, schema_field.get("default")) {
                     (None, Some(default)) => {
@@ -128,6 +128,62 @@ impl DeterministicCoercionEnforcer {
                         }
                     }
                     _ => {}
+                }
+            }
+
+            let handled: std::collections::BTreeSet<String> = transformations
+                .iter()
+                .map(|t| t.field_path.clone())
+                .chain(errors.iter().map(|e| e.field_path.clone()))
+                .collect();
+
+            if let Some(required_arr) = target_schema
+                .get("required")
+                .and_then(|r| r.as_array())
+            {
+                for req in required_arr {
+                    if let Some(field_name) = req.as_str() {
+                        if handled.contains(field_name) {
+                            continue;
+                        }
+                        if obj.contains_key(field_name) {
+                            continue;
+                        }
+                        let schema_field = schema_obj.get(field_name);
+                        if let Some(type_info) =
+                            schema_field.and_then(|f| f.get("type"))
+                        {
+                            if let Some(default) = Self::default_for_type(type_info) {
+                                obj.insert(field_name.to_string(), default.clone());
+                                transformations.push(Transformation {
+                                    kind: TransformationKind::MissingAdded,
+                                    field_path: field_name.to_string(),
+                                    original_value: None,
+                                    new_value: Some(default),
+                                    reason: format!(
+                                        "Required field '{}' missing, using type default",
+                                        field_name
+                                    ),
+                                });
+                            } else {
+                                errors.push(FieldError {
+                                    field_path: field_name.to_string(),
+                                    error: format!(
+                                        "Required field '{}' missing with no type default",
+                                        field_name
+                                    ),
+                                });
+                            }
+                        } else {
+                            errors.push(FieldError {
+                                field_path: field_name.to_string(),
+                                error: format!(
+                                    "Required field '{}' missing and not declared in properties",
+                                    field_name
+                                ),
+                            });
+                        }
+                    }
                 }
             }
         }
@@ -238,10 +294,85 @@ mod tests {
                 assert_eq!(details.final_payload["name"], "");
                 assert!(!details.transformations.is_empty());
             }
-            EnforcementResult::Pass => {
-                // Also acceptable - no required check was performed
+            _ => panic!("Expected Coerced result, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_required_array_rejects_missing_unknown_type() {
+        let enforcer = DeterministicCoercionEnforcer::new();
+        let payload = serde_json::json!({});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "data": { "type": "string" }
+            },
+            "required": ["data"]
+        });
+
+        let result = enforcer.enforce(&payload, &schema);
+        assert!(matches!(result, EnforcementResult::Coerced(_)));
+    }
+
+    #[test]
+    fn test_required_array_with_multiple_fields() {
+        let enforcer = DeterministicCoercionEnforcer::new();
+        let payload = serde_json::json!({"location": "Paris"});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": { "type": "string" },
+                "date": { "type": "string" }
+            },
+            "required": ["location", "date"]
+        });
+
+        let result = enforcer.enforce(&payload, &schema);
+        match result {
+            EnforcementResult::Coerced(details) => {
+                assert_eq!(details.final_payload["location"], "Paris");
+                assert_eq!(details.final_payload["date"], "");
+                assert_eq!(details.transformations.len(), 1);
+                assert_eq!(details.transformations[0].field_path, "date");
             }
-            _ => panic!("Expected Coerced or Pass result"),
+            _ => panic!("Expected Coerced result, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_required_array_passes_when_all_present() {
+        let enforcer = DeterministicCoercionEnforcer::new();
+        let payload = serde_json::json!({"location": "Paris", "date": "2025-01-01"});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": { "type": "string" },
+                "date": { "type": "string" }
+            },
+            "required": ["location", "date"]
+        });
+
+        let result = enforcer.enforce(&payload, &schema);
+        assert!(matches!(result, EnforcementResult::Pass));
+    }
+
+    #[test]
+    fn test_required_array_field_not_in_properties_rejects() {
+        let enforcer = DeterministicCoercionEnforcer::new();
+        let payload = serde_json::json!({});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "required": ["unknown_field"]
+        });
+
+        let result = enforcer.enforce(&payload, &schema);
+        match result {
+            EnforcementResult::Reject(details) => {
+                assert_eq!(details.fields_with_errors.len(), 1);
+                assert_eq!(details.fields_with_errors[0].field_path, "unknown_field");
+            }
+            _ => panic!("Expected Reject result, got {:?}", result),
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #18. Closes #19.

Completes the gateway's ownership of inter-agent I/O contracts by closing the last two enforcement gaps.

### Changes

1. **`DeterministicCoercionEnforcer` now supports `"required": [...]`** (fixes #18)
   - Previously only honored per-property `"required": true` — the standard JSON Schema `"required": ["field1", "field2"]` array at the object level was silently ignored
   - Now processes the `required` array: missing fields get type-default coercion (empty string, 0, false, [], {}) or structured rejection if no type is available
   - 5 new unit tests covering required-array coercion, pass, reject, and edge cases

2. **`promotion.record` findings schema validation**
   - Each finding now has its `description` validated as non-empty before severity heuristics run
   - Structured error with finding index for repairability
   - 2 new integration tests (reject empty description, accept valid findings)

### Contract boundary inventory (all enforced)

| Boundary | Enforcement | `required: [...]` |
|---|---|---|
| `io.accepts` (ingress) | DeterministicCoercionEnforcer | ✅ (this PR) |
| `io.returns` (egress) | response_validation | ✅ (already) |
| `response_contract.output_schema` | response_validation | ✅ (already) |
| `promotion.record` findings | Field validation + severity heuristics | ✅ (this PR) |

### What's left advisory (intentionally)
- `event.ingest` payload — gateway-internal, not an inter-agent contract
- `workflow.wait` result shape — gateway-internal, not an inter-agent contract