### PR TITLE
Capability-delta gating on agent promotion (#28)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -301,7 +301,11 @@ where
 }
 
 fn parse_frontmatter_capabilities(frontmatter: &serde_yaml::Value) -> anyhow::Result<Vec<Capability>> {
-    let frontmatter_json = serde_json::to_value(frontmatter).unwrap_or(serde_json::Value::Null);
+    let frontmatter_json = serde_json::to_value(frontmatter).map_err(|e| {
+        anyhow::anyhow!(
+            "Promotion gate: failed to convert SKILL.md frontmatter to JSON for capability parsing: {e}"
+        )
+    })?;
     let caps_json = frontmatter_json
         .get("capabilities")
         .and_then(|v| v.as_array())
@@ -2164,14 +2168,20 @@ fn wildcard_match(pattern: &str, value: &str) -> bool {
             continue;
         }
         if i == 0 && !pattern.starts_with('*') {
-            if !value[cursor..].starts_with(part) {
+            let Some(remaining) = value.get(cursor..) else {
+                return false;
+            };
+            if !remaining.starts_with(part) {
                 return false;
             }
             cursor += part.len();
             continue;
         }
 
-        let Some(found) = value[cursor..].find(part) else {
+        let Some(remaining) = value.get(cursor..) else {
+            return false;
+        };
+        let Some(found) = remaining.find(part) else {
             return false;
         };
         cursor += found + part.len();
@@ -2307,6 +2317,12 @@ mod capability_lenient_deser_tests {
         assert!(wildcard_match("*.example.com", "api.example.com"));
         assert!(wildcard_match("scheduler.*", "scheduler.cron.create"));
         assert!(!wildcard_match("*.example.com", "example.org"));
+    }
+
+    #[test]
+    fn wildcard_match_is_utf8_safe() {
+        assert!(wildcard_match("pré*", "préfixe"));
+        assert!(!wildcard_match("pré*", "postfixe"));
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -7,7 +7,7 @@ use autonoetic_types::agent::{
 };
 use autonoetic_types::artifact::{ArtifactBundle, ArtifactKind};
 use autonoetic_types::capability::Capability;
-use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::config::{CapabilityDeltaGateMode, GatewayConfig};
 use autonoetic_types::runtime_lock::{
     LockedArtifact, LockedDependencySet, LockedLayerMount, RuntimeLock,
 };
@@ -298,6 +298,31 @@ where
                 .map_err(|e| serde::de::Error::custom(format!("capabilities[{i}]: {e}")))
         })
         .collect()
+}
+
+fn parse_frontmatter_capabilities(frontmatter: &serde_yaml::Value) -> anyhow::Result<Vec<Capability>> {
+    let frontmatter_json = serde_json::to_value(frontmatter).unwrap_or(serde_json::Value::Null);
+    let caps_json = frontmatter_json
+        .get("capabilities")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut caps = Vec::new();
+    let mut parse_errors: Vec<String> = Vec::new();
+    for v in caps_json {
+        match normalize_capability_from_llm(v) {
+            Ok(cap) => caps.push(cap),
+            Err(e) => parse_errors.push(e.to_string()),
+        }
+    }
+    if !parse_errors.is_empty() {
+        anyhow::bail!(
+            "Promotion gate: cannot parse one or more capability entries in SKILL.md: {}",
+            parse_errors.join("; ")
+        );
+    }
+    Ok(caps)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1487,7 +1512,7 @@ impl NativeTool for AgentRevisionPromoteTool {
         arguments_json: &str,
         _session_id: Option<&str>,
         _turn_id: Option<&str>,
-        _config: Option<&GatewayConfig>,
+        config: Option<&GatewayConfig>,
         gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
@@ -1553,38 +1578,43 @@ impl NativeTool for AgentRevisionPromoteTool {
             )
         })?;
 
+        let current_capabilities = parse_frontmatter_capabilities(&skill_frontmatter)?;
+        let delta_mode = config
+            .map(|c| c.capability_delta_gate_mode)
+            .unwrap_or(CapabilityDeltaGateMode::Strict);
+
+        if let Some(delta) = check_capability_delta(
+            &gateway_store,
+            gateway_dir,
+            &args.agent_id,
+            &args.revision_id,
+            &current_capabilities,
+            delta_mode,
+        )? {
+            return Ok(serde_json::json!({
+                "ok": false,
+                "error": "capability_delta_requires_approval",
+                "delta": {
+                    "added": delta.added,
+                    "broadened": delta.broadened,
+                },
+                "hint": "Capability set broadened relative to outgoing revision. Explicit operator approval is required before promotion.",
+            })
+            .to_string());
+        }
+
         // Deserialize capabilities from the frontmatter using the same lenient pipeline
         // used by create_from_intent, so shorthand strings and field normalization are handled.
         let (needs_artifact_gate, has_high_risk) = {
-            let frontmatter_json =
-                serde_json::to_value(&skill_frontmatter).unwrap_or(serde_json::Value::Null);
-            let caps_json = frontmatter_json
-                .get("capabilities")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
             let mut artifact_required = false;
             let mut high_risk = false;
-            let mut parse_errors: Vec<String> = Vec::new();
-            for v in caps_json {
-                match normalize_capability_from_llm(v.clone()) {
-                    Ok(cap) => {
-                        if crate::runtime::install_contract::requires_artifact_review(&cap) {
-                            artifact_required = true;
-                        }
-                        if crate::runtime::install_contract::is_high_risk_capability(&cap) {
-                            high_risk = true;
-                        }
-                    }
-                    Err(e) => parse_errors.push(e.to_string()),
+            for cap in &current_capabilities {
+                if crate::runtime::install_contract::requires_artifact_review(cap) {
+                    artifact_required = true;
                 }
-            }
-            if !parse_errors.is_empty() {
-                anyhow::bail!(
-                    "Promotion gate: cannot parse one or more capability entries in SKILL.md. \
-                     Refusing to infer risk level from malformed capabilities: {}",
-                    parse_errors.join("; ")
-                );
+                if crate::runtime::install_contract::is_high_risk_capability(cap) {
+                    high_risk = true;
+                }
             }
             (artifact_required, high_risk)
         };
@@ -2025,6 +2055,136 @@ impl NativeTool for AgentRevisionDiffTool {
     }
 }
 
+fn check_capability_delta(
+    gateway_store: &crate::scheduler::gateway_store::GatewayStore,
+    gateway_dir: &Path,
+    agent_id: &str,
+    revision_id: &str,
+    current_capabilities: &[Capability],
+    mode: CapabilityDeltaGateMode,
+) -> anyhow::Result<Option<autonoetic_types::capability::CapabilityDelta>> {
+    if matches!(mode, CapabilityDeltaGateMode::Bootstrap) {
+        return Ok(None);
+    }
+
+    let Some(alias) = gateway_store.resolve_alias(agent_id)? else {
+        return Ok(None);
+    };
+    if alias.revision_id == revision_id {
+        return Ok(None);
+    }
+
+    let outgoing_revision_dir = gateway_dir
+        .join("revisions/agents")
+        .join(agent_id)
+        .join(&alias.revision_id);
+    let outgoing_skill_path = outgoing_revision_dir.join("SKILL.md");
+    let outgoing_skill_bytes = std::fs::read(&outgoing_skill_path).map_err(|e| {
+        anyhow::anyhow!(
+            "Cannot read SKILL.md for outgoing revision '{}': {}",
+            alias.revision_id,
+            e
+        )
+    })?;
+    let outgoing_skill_text = String::from_utf8_lossy(&outgoing_skill_bytes);
+    let outgoing_frontmatter =
+        crate::runtime::install_contract::extract_frontmatter_raw(&outgoing_skill_text).map_err(
+            |e| {
+                anyhow::anyhow!(
+                    "Cannot parse SKILL.md frontmatter for outgoing revision '{}': {}",
+                    alias.revision_id,
+                    e
+                )
+            },
+        )?;
+    let outgoing_capabilities = parse_frontmatter_capabilities(&outgoing_frontmatter)?;
+
+    let mut delta =
+        autonoetic_types::capability::compute_capability_delta(&outgoing_capabilities, current_capabilities);
+
+    if !delta.has_broadening() {
+        return Ok(None);
+    }
+
+    if matches!(mode, CapabilityDeltaGateMode::Evolving) {
+        delta
+            .broadened
+            .retain(|b| !scope_change_within_existing_envelope(&b.previous_scope, &b.new_scope));
+        if !delta.has_broadening() {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(delta))
+}
+
+fn scope_change_within_existing_envelope(previous_scope: &[String], new_scope: &[String]) -> bool {
+    use std::collections::BTreeSet;
+
+    let previous: BTreeSet<&str> = previous_scope.iter().map(String::as_str).collect();
+    let current: BTreeSet<&str> = new_scope.iter().map(String::as_str).collect();
+
+    let added: Vec<&str> = current
+        .difference(&previous)
+        .copied()
+        .collect::<Vec<&str>>();
+
+    if added.is_empty() {
+        return true;
+    }
+
+    let wildcard_envelopes: Vec<&str> = previous
+        .iter()
+        .copied()
+        .filter(|v| v.contains('*'))
+        .collect();
+
+    if wildcard_envelopes.is_empty() {
+        return false;
+    }
+
+    added
+        .iter()
+        .all(|candidate| wildcard_envelopes.iter().any(|pattern| wildcard_match(pattern, candidate)))
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut cursor = 0usize;
+
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 && !pattern.starts_with('*') {
+            if !value[cursor..].starts_with(part) {
+                return false;
+            }
+            cursor += part.len();
+            continue;
+        }
+
+        let Some(found) = value[cursor..].find(part) else {
+            return false;
+        };
+        cursor += found + part.len();
+    }
+
+    if !pattern.ends_with('*') {
+        if let Some(last_non_empty) = parts.iter().rev().find(|p| !p.is_empty()) {
+            return value.ends_with(last_non_empty);
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod capability_lenient_deser_tests {
     use super::*;
@@ -2140,5 +2300,26 @@ mod capability_lenient_deser_tests {
         let j = r#"{"capabilities":["AgentSpawn"]}"#;
         let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
         assert!(e.to_string().contains("capabilities[0]"));
+    }
+
+    #[test]
+    fn wildcard_match_supports_prefix_suffix() {
+        assert!(wildcard_match("*.example.com", "api.example.com"));
+        assert!(wildcard_match("scheduler.*", "scheduler.cron.create"));
+        assert!(!wildcard_match("*.example.com", "example.org"));
+    }
+
+    #[test]
+    fn envelope_allows_new_entries_within_wildcard() {
+        let previous = vec!["*.example.com".to_string()];
+        let current = vec!["*.example.com".to_string(), "api.example.com".to_string()];
+        assert!(scope_change_within_existing_envelope(&previous, &current));
+    }
+
+    #[test]
+    fn envelope_rejects_new_entries_outside_wildcard() {
+        let previous = vec!["*.example.com".to_string()];
+        let current = vec!["*.example.com".to_string(), "api.evil.org".to_string()];
+        assert!(!scope_change_within_existing_envelope(&previous, &current));
     }
 }

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -346,12 +346,15 @@ fn scope_broadening(
 fn is_scope_broadened(previous: &[String], current: &[String]) -> bool {
     let prev_has_all = previous.iter().any(|x| x == "*");
     let curr_has_all = current.iter().any(|x| x == "*");
+    if prev_has_all {
+        return false;
+    }
     if curr_has_all && !prev_has_all {
         return true;
     }
     let prev: BTreeSet<&str> = previous.iter().map(String::as_str).collect();
     let curr: BTreeSet<&str> = current.iter().map(String::as_str).collect();
-    curr.len() > prev.len() && prev.is_subset(&curr)
+    curr.iter().any(|scope| !prev.contains(scope))
 }
 
 fn capability_narrowed(previous: &Capability, current: &Capability) -> bool {
@@ -375,6 +378,9 @@ fn capability_narrowed(previous: &Capability, current: &Capability) -> bool {
 fn is_scope_narrowed(previous: &[String], current: &[String]) -> bool {
     let prev_has_all = previous.iter().any(|x| x == "*");
     let curr_has_all = current.iter().any(|x| x == "*");
+    if curr_has_all {
+        return false;
+    }
     if prev_has_all && !curr_has_all {
         return true;
     }
@@ -431,5 +437,43 @@ mod tests {
         assert!(d.broadened.is_empty());
         assert!(!d.has_broadening());
         assert_eq!(d.narrowed, vec!["NetworkAccess".to_string()]);
+    }
+
+    #[test]
+    fn delta_detects_broadening_when_scope_replaced() {
+        let prev = vec![Capability::NetworkAccess {
+            hosts: vec!["a.example.com".to_string(), "b.example.com".to_string()],
+        }];
+        let curr = vec![Capability::NetworkAccess {
+            hosts: vec!["a.example.com".to_string(), "c.example.com".to_string()],
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert_eq!(d.broadened.len(), 1);
+        assert!(d.has_broadening());
+    }
+
+    #[test]
+    fn delta_does_not_broaden_when_previous_has_wildcard() {
+        let prev = vec![Capability::NetworkAccess {
+            hosts: vec!["*".to_string()],
+        }];
+        let curr = vec![Capability::NetworkAccess {
+            hosts: vec!["*".to_string(), "api.example.com".to_string()],
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert!(d.broadened.is_empty());
+        assert!(!d.has_broadening());
+    }
+
+    #[test]
+    fn delta_does_not_narrow_when_current_has_wildcard() {
+        let prev = vec![Capability::NetworkAccess {
+            hosts: vec!["*".to_string(), "api.example.com".to_string()],
+        }];
+        let curr = vec![Capability::NetworkAccess {
+            hosts: vec!["*".to_string()],
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert!(d.narrowed.is_empty());
     }
 }

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -11,6 +11,7 @@
 //! - **BackgroundReevaluation**: Periodic wake-ups
 
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A typed capability that an Agent may request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,4 +129,307 @@ fn default_services_all() -> Vec<String> {
 
 fn default_sources_all() -> Vec<String> {
     vec!["*".to_string()]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityDelta {
+    pub added: Vec<String>,
+    pub broadened: Vec<CapabilityBroadening>,
+    pub narrowed: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityBroadening {
+    pub capability_type: String,
+    pub previous_scope: Vec<String>,
+    pub new_scope: Vec<String>,
+}
+
+impl CapabilityDelta {
+    pub fn has_broadening(&self) -> bool {
+        !self.added.is_empty() || !self.broadened.is_empty()
+    }
+}
+
+pub fn compute_capability_delta(previous: &[Capability], current: &[Capability]) -> CapabilityDelta {
+    let mut added = Vec::new();
+    let mut broadened = Vec::new();
+    let mut narrowed = Vec::new();
+    let mut removed = Vec::new();
+
+    let previous_map = capability_map(previous);
+    let current_map = capability_map(current);
+
+    for (capability_type, current_cap) in &current_map {
+        match previous_map.get(capability_type) {
+            None => added.push(capability_type.clone()),
+            Some(previous_cap) => {
+                if let Some(b) = capability_broadening(capability_type, previous_cap, current_cap) {
+                    broadened.push(b);
+                } else if capability_narrowed(previous_cap, current_cap) {
+                    narrowed.push(capability_type.clone());
+                }
+            }
+        }
+    }
+
+    for capability_type in previous_map.keys() {
+        if !current_map.contains_key(capability_type) {
+            removed.push(capability_type.clone());
+        }
+    }
+
+    CapabilityDelta {
+        added,
+        broadened,
+        narrowed,
+        removed,
+    }
+}
+
+fn capability_map(caps: &[Capability]) -> BTreeMap<String, Capability> {
+    let mut out = BTreeMap::new();
+    for cap in caps {
+        out.insert(capability_type_name(cap), cap.clone());
+    }
+    out
+}
+
+fn capability_type_name(cap: &Capability) -> String {
+    match cap {
+        Capability::SandboxFunctions { .. } => "SandboxFunctions".to_string(),
+        Capability::ReadAccess { .. } => "ReadAccess".to_string(),
+        Capability::WriteAccess { .. } => "WriteAccess".to_string(),
+        Capability::NetworkAccess { .. } => "NetworkAccess".to_string(),
+        Capability::AgentSpawn { .. } => "AgentSpawn".to_string(),
+        Capability::AgentMessage { .. } => "AgentMessage".to_string(),
+        Capability::BackgroundReevaluation { .. } => "BackgroundReevaluation".to_string(),
+        Capability::CodeExecution { .. } => "CodeExecution".to_string(),
+        Capability::EmergencyStop => "EmergencyStop".to_string(),
+        Capability::AgentRevision { .. } => "AgentRevision".to_string(),
+        Capability::Evaluation { .. } => "Evaluation".to_string(),
+        Capability::ApprovalQueue { .. } => "ApprovalQueue".to_string(),
+        Capability::SchedulerSignal { .. } => "SchedulerSignal".to_string(),
+        Capability::CredentialAccess { .. } => "CredentialAccess".to_string(),
+        Capability::UserProfileAccess { .. } => "UserProfileAccess".to_string(),
+        Capability::SchedulerAccess { .. } => "SchedulerAccess".to_string(),
+        Capability::SkillInstall { .. } => "SkillInstall".to_string(),
+    }
+}
+
+fn capability_broadening(
+    capability_type: &str,
+    previous: &Capability,
+    current: &Capability,
+) -> Option<CapabilityBroadening> {
+    match (previous, current) {
+        (Capability::NetworkAccess { hosts: a }, Capability::NetworkAccess { hosts: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::ReadAccess { scopes: a }, Capability::ReadAccess { scopes: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::WriteAccess { scopes: a }, Capability::WriteAccess { scopes: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::SandboxFunctions { allowed: a }, Capability::SandboxFunctions { allowed: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::AgentMessage { patterns: a }, Capability::AgentMessage { patterns: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::AgentRevision { patterns: a }, Capability::AgentRevision { patterns: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::Evaluation { patterns: a }, Capability::Evaluation { patterns: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::ApprovalQueue { patterns: a }, Capability::ApprovalQueue { patterns: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::SchedulerSignal { patterns: a }, Capability::SchedulerSignal { patterns: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::SchedulerAccess { patterns: a }, Capability::SchedulerAccess { patterns: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::CredentialAccess { services: a }, Capability::CredentialAccess { services: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::UserProfileAccess { scopes: a }, Capability::UserProfileAccess { scopes: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (Capability::SkillInstall { allowed_sources: a }, Capability::SkillInstall { allowed_sources: b }) => {
+            scope_broadening(capability_type, a, b)
+        }
+        (
+            Capability::CodeExecution {
+                patterns: ap,
+                commands: ac,
+            },
+            Capability::CodeExecution {
+                patterns: bp,
+                commands: bc,
+            },
+        ) => {
+            let mut from = ap.clone();
+            from.extend(ac.clone());
+            let mut to = bp.clone();
+            to.extend(bc.clone());
+            scope_broadening(capability_type, &from, &to)
+        }
+        (
+            Capability::AgentSpawn {
+                max_children: max_a,
+            },
+            Capability::AgentSpawn {
+                max_children: max_b,
+            },
+        ) => {
+            if max_b > max_a {
+                Some(CapabilityBroadening {
+                    capability_type: capability_type.to_string(),
+                    previous_scope: vec![max_a.to_string()],
+                    new_scope: vec![max_b.to_string()],
+                })
+            } else {
+                None
+            }
+        }
+        (
+            Capability::BackgroundReevaluation {
+                min_interval_secs: a_interval,
+                allow_reasoning: a_reasoning,
+            },
+            Capability::BackgroundReevaluation {
+                min_interval_secs: b_interval,
+                allow_reasoning: b_reasoning,
+            },
+        ) => {
+            if b_interval < a_interval || (*b_reasoning && !a_reasoning) {
+                Some(CapabilityBroadening {
+                    capability_type: capability_type.to_string(),
+                    previous_scope: vec![format!(
+                        "min_interval_secs={},allow_reasoning={}",
+                        a_interval, a_reasoning
+                    )],
+                    new_scope: vec![format!(
+                        "min_interval_secs={},allow_reasoning={}",
+                        b_interval, b_reasoning
+                    )],
+                })
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn scope_broadening(
+    capability_type: &str,
+    previous: &[String],
+    current: &[String],
+) -> Option<CapabilityBroadening> {
+    if is_scope_broadened(previous, current) {
+        Some(CapabilityBroadening {
+            capability_type: capability_type.to_string(),
+            previous_scope: previous.to_vec(),
+            new_scope: current.to_vec(),
+        })
+    } else {
+        None
+    }
+}
+
+fn is_scope_broadened(previous: &[String], current: &[String]) -> bool {
+    let prev_has_all = previous.iter().any(|x| x == "*");
+    let curr_has_all = current.iter().any(|x| x == "*");
+    if curr_has_all && !prev_has_all {
+        return true;
+    }
+    let prev: BTreeSet<&str> = previous.iter().map(String::as_str).collect();
+    let curr: BTreeSet<&str> = current.iter().map(String::as_str).collect();
+    curr.len() > prev.len() && prev.is_subset(&curr)
+}
+
+fn capability_narrowed(previous: &Capability, current: &Capability) -> bool {
+    match (previous, current) {
+        (Capability::NetworkAccess { hosts: a }, Capability::NetworkAccess { hosts: b }) => {
+            is_scope_narrowed(a, b)
+        }
+        (Capability::ReadAccess { scopes: a }, Capability::ReadAccess { scopes: b }) => {
+            is_scope_narrowed(a, b)
+        }
+        (Capability::WriteAccess { scopes: a }, Capability::WriteAccess { scopes: b }) => {
+            is_scope_narrowed(a, b)
+        }
+        (Capability::SandboxFunctions { allowed: a }, Capability::SandboxFunctions { allowed: b }) => {
+            is_scope_narrowed(a, b)
+        }
+        _ => false,
+    }
+}
+
+fn is_scope_narrowed(previous: &[String], current: &[String]) -> bool {
+    let prev_has_all = previous.iter().any(|x| x == "*");
+    let curr_has_all = current.iter().any(|x| x == "*");
+    if prev_has_all && !curr_has_all {
+        return true;
+    }
+    let prev: BTreeSet<&str> = previous.iter().map(String::as_str).collect();
+    let curr: BTreeSet<&str> = current.iter().map(String::as_str).collect();
+    curr.len() < prev.len() && curr.is_subset(&prev)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delta_detects_added_capability_type() {
+        let prev = vec![Capability::ReadAccess {
+            scopes: vec!["*".to_string()],
+        }];
+        let curr = vec![
+            Capability::ReadAccess {
+                scopes: vec!["*".to_string()],
+            },
+            Capability::SchedulerAccess {
+                patterns: vec!["*".to_string()],
+            },
+        ];
+        let d = compute_capability_delta(&prev, &curr);
+        assert_eq!(d.added, vec!["SchedulerAccess".to_string()]);
+        assert!(d.has_broadening());
+    }
+
+    #[test]
+    fn delta_detects_scope_broadening() {
+        let prev = vec![Capability::NetworkAccess {
+            hosts: vec!["pypi.org".to_string()],
+        }];
+        let curr = vec![Capability::NetworkAccess {
+            hosts: vec!["*".to_string()],
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert_eq!(d.broadened.len(), 1);
+        assert_eq!(d.broadened[0].capability_type, "NetworkAccess");
+        assert!(d.has_broadening());
+    }
+
+    #[test]
+    fn delta_treats_narrowing_as_non_broadening() {
+        let prev = vec![Capability::NetworkAccess {
+            hosts: vec!["*".to_string()],
+        }];
+        let curr = vec![Capability::NetworkAccess {
+            hosts: vec!["api.example.com".to_string()],
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert!(d.broadened.is_empty());
+        assert!(!d.has_broadening());
+        assert_eq!(d.narrowed, vec!["NetworkAccess".to_string()]);
+    }
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -68,6 +68,19 @@ pub enum SchemaEnforcementMode {
     Llm,
 }
 
+/// Policy mode for capability-delta gating during revision promotion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityDeltaGateMode {
+    /// Any capability broadening requires explicit approval.
+    #[default]
+    Strict,
+    /// Broadening inside an existing wildcard envelope is auto-allowed.
+    Evolving,
+    /// Disable capability-delta gating (development only).
+    Bootstrap,
+}
+
 /// Configuration for schema enforcement on agent.spawn.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SchemaEnforcementConfig {
@@ -485,6 +498,10 @@ pub struct GatewayConfig {
     /// Controls how the gateway analyzes code for capabilities and security.
     #[serde(default)]
     pub code_analysis: CodeAnalysisConfig,
+
+    /// Capability delta gating mode for `agent.revision.promote`.
+    #[serde(default)]
+    pub capability_delta_gate_mode: CapabilityDeltaGateMode,
 
     /// Optional per-session budgets (LLM rounds, tools, tokens, wall clock).
     #[serde(default)]
@@ -1159,6 +1176,7 @@ impl Default for GatewayConfig {
             llm_presets: HashMap::new(),
             llm_preset_mapping: HashMap::new(),
             code_analysis: CodeAnalysisConfig::default(),
+            capability_delta_gate_mode: CapabilityDeltaGateMode::Strict,
             session_budget: SessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),
             workflow_task_heartbeat_secs: default_workflow_task_heartbeat_secs_val(),


### PR DESCRIPTION
## Summary
- add typed capability delta computation in autonoetic-types
- enforce delta-gating in agent.revision.promote against the outgoing alias revision
- return structured rejection payload when added/broadened capabilities are detected:
  - ok: false
  - error: capability_delta_requires_approval
  - delta: { added, broadened }
- add policy mode knob in gateway config: capability_delta_gate_mode
  - strict (default): block on any broadening
  - evolving: allow broadenings that remain within existing wildcard envelope
  - bootstrap: disable delta gate
- add unit tests for capability delta detection and wildcard envelope behavior

## Validation
- cargo test -p autonoetic-types capability::tests -- --nocapture
- cargo check -p autonoetic-gateway -p autonoetic-types

Closes #28