### PR TITLE
feat(approval): HMAC-sign continuation files + action-equality on resume

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -974,7 +974,42 @@ impl GatewayExecutionService {
             // 2) Session checkpoint (hibernation/budget/max-turns/manual/error)
             // 3) Fresh start
             let (outcome, resume_initial_message, consumed_checkpoint_turn_id) = if let Some(t_id) = task_id {
-                if let Ok(Some(cont)) = crate::runtime::continuation::load_continuation(&self.config, t_id) {
+                let load_result = crate::runtime::continuation::load_continuation(&self.config, t_id);
+                if let Err(e) = &load_result {
+                    tracing::error!(
+                        target: "continuation",
+                        task_id = %t_id,
+                        error = %e,
+                        "Continuation integrity violation — tampering suspected"
+                    );
+                    if let Ok(logger) = init_gateway_causal_logger(&self.config) {
+                        let _ = logger.log(
+                            "gateway",
+                            "",
+                            None,
+                            0,
+                            "background",
+                            "continuation_tampered",
+                            autonoetic_types::causal_chain::EntryStatus::Error,
+                            Some(serde_json::json!({
+                                "task_id": t_id,
+                                "error": e.to_string(),
+                            })),
+                        );
+                    }
+                    if let Some(store) = self.gateway_store.as_ref() {
+                        let pending = store.get_pending_approvals().unwrap_or_default();
+                        if let Some(p) = pending.iter().find(|p| p.task_id.as_deref() == Some(t_id)) {
+                            let _ = store.cancel_approval(
+                                &p.request_id,
+                                "gateway",
+                                &chrono::Utc::now().to_rfc3339(),
+                            );
+                        }
+                    }
+                    anyhow::bail!("continuation integrity violation for task '{}': {}", t_id, e);
+                }
+                if let Some(cont) = load_result.unwrap() {
                     tracing::info!(
                         target: "continuation",
                         task_id = %t_id,
@@ -986,6 +1021,28 @@ impl GatewayExecutionService {
                     let approval_req = self.gateway_store
                         .as_ref()
                         .and_then(|store| store.get_approval(&cont.approval_request_id).ok().flatten());
+
+                    // Action-equality check: if the continuation carries a pending_action,
+                    // verify it structurally equals the action from the approval row.
+                    // This prevents TOCTOU substitution where the approval row is somehow
+                    // swapped to a different action between suspension and resume.
+                    if let Some(ref req) = approval_req {
+                        if let Some(ref pending) = cont.pending_action {
+                            if pending != &req.action {
+                                tracing::error!(
+                                    target: "continuation",
+                                    task_id = %t_id,
+                                    approval_request_id = %cont.approval_request_id,
+                                    "Action mismatch between continuation and approval row — possible substitution attack"
+                                );
+                                let _ = crate::runtime::continuation::delete_continuation(&self.config, t_id);
+                                anyhow::bail!(
+                                    "continuation action mismatch: the action stored in the continuation does not match the approved action (task '{}')",
+                                    t_id
+                                );
+                            }
+                        }
+                    }
 
                     let approved_result = match approval_req {
                         Some(ref req) if req.status == Some(autonoetic_types::background::ApprovalStatus::Approved) => {

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -975,39 +975,58 @@ impl GatewayExecutionService {
             // 3) Fresh start
             let (outcome, resume_initial_message, consumed_checkpoint_turn_id) = if let Some(t_id) = task_id {
                 let load_result = crate::runtime::continuation::load_continuation(&self.config, t_id);
-                if let Err(e) = &load_result {
-                    tracing::error!(
-                        target: "continuation",
-                        task_id = %t_id,
-                        error = %e,
-                        "Continuation integrity violation — tampering suspected"
-                    );
-                    if let Ok(logger) = init_gateway_causal_logger(&self.config) {
-                        let _ = logger.log(
-                            "gateway",
-                            "",
-                            None,
-                            0,
-                            "background",
-                            "continuation_tampered",
-                            autonoetic_types::causal_chain::EntryStatus::Error,
-                            Some(serde_json::json!({
-                                "task_id": t_id,
-                                "error": e.to_string(),
-                            })),
+                if let Err(ref e) = load_result {
+                    if crate::runtime::continuation::is_integrity_error(e) {
+                        tracing::error!(
+                            target: "continuation",
+                            task_id = %t_id,
+                            error = %e,
+                            "Continuation integrity violation — tampering suspected"
                         );
-                    }
-                    if let Some(store) = self.gateway_store.as_ref() {
-                        let pending = store.get_pending_approvals().unwrap_or_default();
-                        if let Some(p) = pending.iter().find(|p| p.task_id.as_deref() == Some(t_id)) {
-                            let _ = store.cancel_approval(
-                                &p.request_id,
-                                "gateway",
-                                &chrono::Utc::now().to_rfc3339(),
-                            );
+                        if let Some(store) = self.gateway_store.as_ref() {
+                            let pending = store.get_pending_approvals().unwrap_or_default();
+                            let matching: Vec<String> = pending
+                                .iter()
+                                .filter(|p| p.task_id.as_deref() == Some(t_id))
+                                .map(|p| p.request_id.clone())
+                                .collect();
+                            if !matching.is_empty() {
+                                let cancelled_at = chrono::Utc::now().to_rfc3339();
+                                for rid in &matching {
+                                    let _ = store.cancel_approval(rid, "gateway", &cancelled_at);
+                                }
+                                let _ = store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+                                    event_id: uuid::Uuid::new_v4().to_string(),
+                                    agent_id: "gateway".to_string(),
+                                    session_id: String::new(),
+                                    turn_id: None,
+                                    event_seq: 0,
+                                    timestamp: cancelled_at.clone(),
+                                    category: "background".to_string(),
+                                    action: "continuation_tampered".to_string(),
+                                    status: "error".to_string(),
+                                    target: None,
+                                    payload: Some(serde_json::json!({
+                                        "task_id": t_id,
+                                        "reason": "integrity_violation",
+                                        "approval_request_ids": matching,
+                                    }).to_string()),
+                                    payload_ref: None,
+                                    evidence_ref: None,
+                                    reason: Some("HMAC mismatch on continuation load".to_string()),
+                                });
+                            }
                         }
+                        anyhow::bail!("{}", e);
+                    } else {
+                        tracing::error!(
+                            target: "continuation",
+                            task_id = %t_id,
+                            error = %e,
+                            "Failed to load continuation"
+                        );
+                        anyhow::bail!("failed to load continuation for task '{}': {}", t_id, e);
                     }
-                    anyhow::bail!("continuation integrity violation for task '{}': {}", t_id, e);
                 }
                 if let Some(cont) = load_result.unwrap() {
                     tracing::info!(
@@ -1022,24 +1041,34 @@ impl GatewayExecutionService {
                         .as_ref()
                         .and_then(|store| store.get_approval(&cont.approval_request_id).ok().flatten());
 
-                    // Action-equality check: if the continuation carries a pending_action,
-                    // verify it structurally equals the action from the approval row.
-                    // This prevents TOCTOU substitution where the approval row is somehow
-                    // swapped to a different action between suspension and resume.
+                    // Action-equality check: signed continuations must carry a pending_action
+                    // that structurally equals the action from the approval row.  This prevents
+                    // TOCTOU substitution where the approval row is swapped to a different action
+                    // between suspension and resume.  Legacy unsigned continuations (no
+                    // pending_action) are still accepted.
                     if let Some(ref req) = approval_req {
-                        if let Some(ref pending) = cont.pending_action {
-                            if pending != &req.action {
-                                tracing::error!(
+                        match cont.pending_action.as_ref() {
+                            None => {
+                                tracing::warn!(
                                     target: "continuation",
                                     task_id = %t_id,
-                                    approval_request_id = %cont.approval_request_id,
-                                    "Action mismatch between continuation and approval row — possible substitution attack"
+                                    "Continuation missing pending_action — skipping action-equality check (legacy?)"
                                 );
-                                let _ = crate::runtime::continuation::delete_continuation(&self.config, t_id);
-                                anyhow::bail!(
-                                    "continuation action mismatch: the action stored in the continuation does not match the approved action (task '{}')",
-                                    t_id
-                                );
+                            }
+                            Some(pending) => {
+                                if pending != &req.action {
+                                    tracing::error!(
+                                        target: "continuation",
+                                        task_id = %t_id,
+                                        approval_request_id = %cont.approval_request_id,
+                                        "Action mismatch between continuation and approval row — possible substitution attack"
+                                    );
+                                    let _ = crate::runtime::continuation::delete_continuation(&self.config, t_id);
+                                    anyhow::bail!(
+                                        "continuation action mismatch: the action stored in the continuation does not match the approved action (task '{}')",
+                                        t_id
+                                    );
+                                }
                             }
                         }
                     }

--- a/autonoetic-gateway/src/runtime/continuation.rs
+++ b/autonoetic-gateway/src/runtime/continuation.rs
@@ -18,16 +18,41 @@ use crate::runtime::guard::LoopGuardState;
 use crate::server::ofp;
 use autonoetic_types::background::{ApprovalDecision, ScheduledAction};
 use autonoetic_types::config::GatewayConfig;
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-
-type HmacSha256 = Hmac<Sha256>;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/// Error returned when a continuation file fails HMAC integrity verification.
+/// Used to distinguish tamper-detection errors from ordinary I/O or parse
+/// failures, so callers can emit the appropriate causal event and cancel the
+/// bound approval.
+#[derive(Debug)]
+pub struct ContinuationIntegrityError {
+    pub task_id: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for ContinuationIntegrityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "continuation integrity violation for task '{}': {}",
+            self.task_id, self.message
+        )
+    }
+}
+
+impl std::error::Error for ContinuationIntegrityError {}
+
+/// Returns `true` if the error is a `ContinuationIntegrityError` (HMAC
+/// mismatch / tamper detection).  Used by callers to decide whether to cancel
+/// approvals and emit a tamper causal event.
+pub fn is_integrity_error(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<ContinuationIntegrityError>().is_some()
+}
 
 /// HMAC-signed envelope wrapping a serialised `TurnContinuation` payload.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -109,7 +134,10 @@ pub struct PendingApprovalToolCall {
 
 /// Resolve the HMAC key for continuation signing.  Uses the explicit
 /// `continuation_key` config value when set, otherwise derives a key from
-/// `node_id` so every gateway instance has a unique default.
+/// `node_id`.  **Warning:** the `node_id`-derived default is not a secret and
+/// only provides detection of accidental corruption, not protection against a
+/// local attacker who can read the config.  Production deployments should set
+/// `continuation_key` to a high-entropy secret.
 pub fn continuation_hmac_key(config: &GatewayConfig) -> String {
     config
         .continuation_key
@@ -203,10 +231,10 @@ pub fn load_continuation(
                 task_id = %task_id,
                 "HMAC verification failed — continuation file may have been tampered with"
             );
-            anyhow::bail!(
-                "continuation integrity violation: HMAC mismatch for task '{}'",
-                task_id
-            );
+            return Err(ContinuationIntegrityError {
+                task_id: task_id.to_string(),
+                message: "HMAC mismatch".to_string(),
+            }.into());
         }
         let cont: TurnContinuation = serde_json::from_str(&envelope.payload_json)?;
         return Ok(Some(cont));

--- a/autonoetic-gateway/src/runtime/continuation.rs
+++ b/autonoetic-gateway/src/runtime/continuation.rs
@@ -6,20 +6,37 @@
 //! approved action directly, reconstructs the conversation history, and resumes
 //! `execute_with_history` — the LLM sees the real tool result and continues normally.
 //!
-//! This replaces the previous "kill turn + notify agent + agent retries with
-//! approval_ref" pattern, eliminating the source of context loss and the complex
-//! resume message / checkpoint dance.
+//! # Integrity
+//!
+//! Continuation files are HMAC-SHA256 signed using a per-gateway key derived from
+//! `GatewayConfig::continuation_key` (or `node_id` as fallback). On load, the
+//! signature is verified before the payload is deserialized. Tampered files are
+//! rejected, a causal event is emitted, and the bound approval is cancelled.
 
 use crate::llm::{Message, ToolCall};
 use crate::runtime::guard::LoopGuardState;
+use crate::server::ofp;
 use autonoetic_types::background::{ApprovalDecision, ScheduledAction};
 use autonoetic_types::config::GatewayConfig;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+type HmacSha256 = Hmac<Sha256>;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/// HMAC-signed envelope wrapping a serialised `TurnContinuation` payload.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SignedContinuation {
+    /// Canonical-JSON serialised `TurnContinuation`.
+    pub payload_json: String,
+    /// HMAC-SHA256 hex digest over `payload_json` bytes using the gateway key.
+    pub hmac_hex: String,
+}
 
 /// Serializable snapshot of an agent turn that has been suspended at an
 /// approval boundary.  Saved to disk; loaded on resume to seamlessly continue
@@ -49,6 +66,12 @@ pub struct TurnContinuation {
 
     /// Approval request ID stored in `GatewayStore`.
     pub approval_request_id: String,
+
+    /// The `ScheduledAction` that is pending approval.  Stored so the gateway
+    /// can verify structural equality against the approval row at resume,
+    /// preventing TOCTOU substitution attacks.
+    #[serde(default)]
+    pub pending_action: Option<ScheduledAction>,
 
     /// Workflow / task context — populated by `spawn_task_execution`.
     pub workflow_id: Option<String>,
@@ -81,6 +104,38 @@ pub struct PendingApprovalToolCall {
 }
 
 // ---------------------------------------------------------------------------
+// Key derivation
+// ---------------------------------------------------------------------------
+
+/// Resolve the HMAC key for continuation signing.  Uses the explicit
+/// `continuation_key` config value when set, otherwise derives a key from
+/// `node_id` so every gateway instance has a unique default.
+pub fn continuation_hmac_key(config: &GatewayConfig) -> String {
+    config
+        .continuation_key
+        .clone()
+        .unwrap_or_else(|| format!("autonoetic-continuation-{}", config.node_id))
+}
+
+// ---------------------------------------------------------------------------
+// Canonical JSON helper
+// ---------------------------------------------------------------------------
+
+/// Produce a deterministic JSON representation.  `serde_json` with sorted keys
+/// ensures the same struct always serialises to the same bytes.
+fn canonical_json<T: serde::Serialize>(value: &T) -> anyhow::Result<String> {
+    let mut buf = serde_json::Serializer::with_formatter(
+        Vec::new(),
+        serde_json::ser::CompactFormatter,
+    );
+    serde::Serialize::serialize(value, &mut buf)?;
+    // Re-parse and re-serialize with sorted keys for determinism
+    let v: serde_json::Value = serde_json::from_slice(&buf.into_inner())?;
+    let sorted = serde_json::to_string(&v)?;
+    Ok(sorted)
+}
+
+// ---------------------------------------------------------------------------
 // Storage helpers
 // ---------------------------------------------------------------------------
 
@@ -93,7 +148,8 @@ fn continuation_path(config: &GatewayConfig, task_id: &str) -> PathBuf {
     continuations_dir(config).join(format!("{}.json", task_id))
 }
 
-/// Persist a `TurnContinuation` for the given task.
+/// Persist a `TurnContinuation` for the given task, wrapped in a signed
+/// envelope.
 pub fn save_continuation(
     config: &GatewayConfig,
     task_id: &str,
@@ -102,18 +158,32 @@ pub fn save_continuation(
     let dir = continuations_dir(config);
     std::fs::create_dir_all(&dir)?;
     let path = continuation_path(config, task_id);
-    let json = serde_json::to_string_pretty(cont)?;
+
+    let payload_json = canonical_json(cont)?;
+    let key = continuation_hmac_key(config);
+    let hmac_hex = ofp::hmac_sign(&key, payload_json.as_bytes());
+
+    let envelope = SignedContinuation {
+        payload_json,
+        hmac_hex,
+    };
+    let json = serde_json::to_string_pretty(&envelope)?;
     std::fs::write(&path, json)?;
+
     tracing::debug!(
         target: "continuation",
         task_id = %task_id,
         path = %path.display(),
-        "Saved turn continuation"
+        "Saved signed turn continuation"
     );
     Ok(())
 }
 
-/// Load a previously saved `TurnContinuation`, returning `None` if not found.
+/// Load a previously saved `TurnContinuation`, verifying HMAC integrity.
+///
+/// Returns `Ok(None)` if the file does not exist.
+/// Returns `Err` on HMAC verification failure (tampering detected) or
+/// deserialization errors.
 pub fn load_continuation(
     config: &GatewayConfig,
     task_id: &str,
@@ -123,7 +193,33 @@ pub fn load_continuation(
         return Ok(None);
     }
     let json = std::fs::read_to_string(&path)?;
+
+    // Try signed envelope format first.
+    if let Ok(envelope) = serde_json::from_str::<SignedContinuation>(&json) {
+        let key = continuation_hmac_key(config);
+        if !ofp::hmac_verify(&key, envelope.payload_json.as_bytes(), &envelope.hmac_hex) {
+            tracing::error!(
+                target: "continuation",
+                task_id = %task_id,
+                "HMAC verification failed — continuation file may have been tampered with"
+            );
+            anyhow::bail!(
+                "continuation integrity violation: HMAC mismatch for task '{}'",
+                task_id
+            );
+        }
+        let cont: TurnContinuation = serde_json::from_str(&envelope.payload_json)?;
+        return Ok(Some(cont));
+    }
+
+    // Legacy unsigned format — still accepted for existing continuations
+    // written before the signing feature was deployed.
     let cont: TurnContinuation = serde_json::from_str(&json)?;
+    tracing::warn!(
+        target: "continuation",
+        task_id = %task_id,
+        "Loaded unsigned (legacy) continuation — consider re-saving to sign"
+    );
     Ok(Some(cont))
 }
 
@@ -192,8 +288,6 @@ pub fn execute_approved_action(
             dependencies,
             ..
         } => {
-            // Build args JSON with approval_ref set so the handler skips
-            // remote-access detection and proceeds directly to execution.
             let deps_json = match dependencies {
                 Some(d) => serde_json::json!({
                     "runtime": d.runtime,

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1980,6 +1980,12 @@ impl AgentExecutor {
                             .find(|tc| tc.id == pending_call_id)
                             .expect("pending call id must match a tool call in the response");
 
+                        let pending_action = self
+                            .gateway_store
+                            .as_ref()
+                            .and_then(|store| store.get_approval(&request_id).ok().flatten())
+                            .map(|req| req.action);
+
                         let continuation = crate::runtime::continuation::TurnContinuation {
                             history: history.clone(), // snapshot BEFORE assistant_msg
                             assistant_message: assistant_msg,
@@ -1993,6 +1999,7 @@ impl AgentExecutor {
                                 },
                             remaining_tool_calls: remaining_calls,
                             approval_request_id: request_id.clone(),
+                            pending_action,
                             workflow_id: self.workflow_id.clone(),
                             task_id: self.task_id.clone(),
                             session_id: session_id.clone(),

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1980,11 +1980,21 @@ impl AgentExecutor {
                             .find(|tc| tc.id == pending_call_id)
                             .expect("pending call id must match a tool call in the response");
 
-                        let pending_action = self
-                            .gateway_store
-                            .as_ref()
-                            .and_then(|store| store.get_approval(&request_id).ok().flatten())
-                            .map(|req| req.action);
+                        let pending_action = match self.gateway_store.as_ref() {
+                            Some(store) => {
+                                let approval = store.get_approval(&request_id)
+                                    .map_err(|e| anyhow::anyhow!(
+                                        "failed to fetch approval {} while saving continuation: {}",
+                                        request_id, e
+                                    ))?;
+                                let approval = approval.ok_or_else(|| anyhow::anyhow!(
+                                    "missing approval {} while saving continuation",
+                                    request_id
+                                ))?;
+                                Some(approval.action)
+                            }
+                            None => None,
+                        };
 
                         let continuation = crate::runtime::continuation::TurnContinuation {
                             history: history.clone(), // snapshot BEFORE assistant_msg

--- a/autonoetic-gateway/tests/continuation_hmac_integrity_integration.rs
+++ b/autonoetic-gateway/tests/continuation_hmac_integrity_integration.rs
@@ -1,0 +1,225 @@
+//! Integration tests for continuation file HMAC integrity and action-equality.
+//!
+//! Verifies:
+//!   1. HMAC-signed continuations load and verify correctly.
+//!   2. Tampered continuation files are rejected with an error.
+//!   3. Action mismatch between continuation and approval is detected.
+
+mod support;
+
+use autonoetic_gateway::runtime::continuation::{
+    continuation_hmac_key, continuations_dir, load_continuation, save_continuation,
+    PendingApprovalToolCall, SignedContinuation, TurnContinuation,
+};
+use autonoetic_gateway::runtime::guard::LoopGuardState;
+use autonoetic_gateway::llm::{Message, Role, ToolCall};
+use autonoetic_types::background::ScheduledAction;
+use autonoetic_types::config::GatewayConfig;
+
+fn default_guard_state() -> LoopGuardState {
+    LoopGuardState {
+        max_loops_without_progress: 10,
+        max_tool_failures: 5,
+        max_consecutive_same_progress: 2,
+        max_child_failures: 3,
+        current_loops: 0,
+        tool_failure_counts: std::collections::HashMap::new(),
+        last_progress_fingerprint: None,
+        consecutive_progress_count: 0,
+        child_failure_count: 0,
+    }
+}
+
+fn make_test_continuation(request_id: &str) -> TurnContinuation {
+    TurnContinuation {
+        history: vec![Message {
+            role: Role::User,
+            content: "test prompt".to_string(),
+            tool_calls: vec![],
+            tool_call_id: None,
+        }],
+        assistant_message: Message {
+            role: Role::Assistant,
+            content: "".to_string(),
+            tool_calls: vec![ToolCall {
+                id: "call_test".to_string(),
+                name: "sandbox_exec".to_string(),
+                arguments: "{}".to_string(),
+            }],
+            tool_call_id: None,
+        },
+        completed_tool_results: vec![],
+        pending_tool_call: PendingApprovalToolCall {
+            call_id: "call_test".to_string(),
+            tool_name: "sandbox_exec".to_string(),
+            arguments: "{}".to_string(),
+            approval_response: "{}".to_string(),
+        },
+        remaining_tool_calls: vec![],
+        approval_request_id: request_id.to_string(),
+        pending_action: Some(ScheduledAction::SandboxExec {
+            command: "echo hello".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        }),
+        workflow_id: None,
+        task_id: Some("task-001".to_string()),
+        session_id: "sess-001".to_string(),
+        turn_id: "turn-001".to_string(),
+        suspended_at: chrono::Utc::now().to_rfc3339(),
+        loop_guard_state: default_guard_state(),
+    }
+}
+
+fn make_test_config(dir: &std::path::Path) -> GatewayConfig {
+    let mut config = GatewayConfig::default();
+    config.agents_dir = dir.to_path_buf();
+    config
+}
+
+#[test]
+#[serial_test::serial]
+fn test_hmac_signed_continuation_roundtrips() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+    let cont = make_test_continuation("req-001");
+
+    save_continuation(&config, "task-001", &cont).expect("save");
+
+    let loaded = load_continuation(&config, "task-001")
+        .expect("load")
+        .expect("some");
+
+    assert_eq!(loaded.approval_request_id, "req-001");
+    assert_eq!(loaded.session_id, "sess-001");
+    assert!(loaded.pending_action.is_some());
+}
+
+#[test]
+#[serial_test::serial]
+fn test_tampered_payload_rejected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+    let cont = make_test_continuation("req-001");
+
+    save_continuation(&config, "task-001", &cont).expect("save");
+
+    let dir = continuations_dir(&config);
+    let path = dir.join("task-001.json");
+    let raw = std::fs::read_to_string(&path).expect("read");
+
+    let mut envelope: SignedContinuation = serde_json::from_str(&raw).expect("parse envelope");
+    envelope.payload_json = envelope.payload_json.replace("echo hello", "rm -rf /");
+    std::fs::write(&path, serde_json::to_string_pretty(&envelope).expect("serialize"))
+        .expect("write tampered");
+
+    let result = load_continuation(&config, "task-001");
+    assert!(result.is_err(), "tampered continuation should be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("integrity violation"),
+        "error should mention integrity violation, got: {}",
+        err
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn test_tampered_hmac_rejected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+    let cont = make_test_continuation("req-002");
+
+    save_continuation(&config, "task-002", &cont).expect("save");
+
+    let dir = continuations_dir(&config);
+    let path = dir.join("task-002.json");
+    let raw = std::fs::read_to_string(&path).expect("read");
+
+    let mut envelope: SignedContinuation = serde_json::from_str(&raw).expect("parse envelope");
+    envelope.hmac_hex = "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+    std::fs::write(&path, serde_json::to_string_pretty(&envelope).expect("serialize"))
+        .expect("write tampered hmac");
+
+    let result = load_continuation(&config, "task-002");
+    assert!(result.is_err(), "tampered HMAC should be rejected");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_unsigned_legacy_continuation_still_loads() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+
+    let cont = make_test_continuation("req-legacy");
+    let raw_payload = serde_json::to_string_pretty(&cont).expect("serialize");
+
+    let dir = continuations_dir(&config);
+    std::fs::create_dir_all(&dir).expect("dir");
+    let path = dir.join("task-legacy.json");
+    std::fs::write(&path, &raw_payload).expect("write unsigned");
+
+    let loaded = load_continuation(&config, "task-legacy")
+        .expect("load legacy")
+        .expect("some");
+
+    assert_eq!(loaded.approval_request_id, "req-legacy");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_continuation_key_derivation_uses_node_id() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config1 = make_test_config(tmp.path());
+    config1.node_id = "node-alpha".to_string();
+
+    let mut config2 = make_test_config(tmp.path());
+    config2.node_id = "node-beta".to_string();
+
+    let key1 = continuation_hmac_key(&config1);
+    let key2 = continuation_hmac_key(&config2);
+
+    assert_ne!(key1, key2, "different node_id should produce different keys");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_continuation_key_explicit_overrides_default() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config = make_test_config(tmp.path());
+    config.node_id = "default-node".to_string();
+    config.continuation_key = Some("my-explicit-key".to_string());
+
+    let key = continuation_hmac_key(&config);
+    assert_eq!(key, "my-explicit-key");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_missing_continuation_returns_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+
+    let result = load_continuation(&config, "nonexistent").expect("load");
+    assert!(result.is_none());
+}
+
+#[test]
+#[serial_test::serial]
+fn test_different_key_rejects_continuation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let mut config_save = make_test_config(tmp.path());
+    config_save.continuation_key = Some("save-key".to_string());
+
+    let mut config_load = make_test_config(tmp.path());
+    config_load.continuation_key = Some("different-key".to_string());
+
+    let cont = make_test_continuation("req-key-001");
+    save_continuation(&config_save, "task-key-001", &cont).expect("save");
+
+    let result = load_continuation(&config_load, "task-key-001");
+    assert!(result.is_err(), "different key should reject");
+}

--- a/autonoetic-gateway/tests/continuation_hmac_integrity_integration.rs
+++ b/autonoetic-gateway/tests/continuation_hmac_integrity_integration.rs
@@ -8,8 +8,9 @@
 mod support;
 
 use autonoetic_gateway::runtime::continuation::{
-    continuation_hmac_key, continuations_dir, load_continuation, save_continuation,
-    PendingApprovalToolCall, SignedContinuation, TurnContinuation,
+    continuation_hmac_key, continuations_dir, is_integrity_error, load_continuation,
+    save_continuation, ContinuationIntegrityError, PendingApprovalToolCall, SignedContinuation,
+    TurnContinuation,
 };
 use autonoetic_gateway::runtime::guard::LoopGuardState;
 use autonoetic_gateway::llm::{Message, Role, ToolCall};
@@ -222,4 +223,42 @@ fn test_different_key_rejects_continuation() {
 
     let result = load_continuation(&config_load, "task-key-001");
     assert!(result.is_err(), "different key should reject");
+    assert!(is_integrity_error(&result.unwrap_err()), "should be typed integrity error");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_tamper_returns_typed_integrity_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+    let cont = make_test_continuation("req-typed");
+
+    save_continuation(&config, "task-typed", &cont).expect("save");
+
+    let dir = continuations_dir(&config);
+    let path = dir.join("task-typed.json");
+    let raw = std::fs::read_to_string(&path).expect("read");
+    let mut envelope: SignedContinuation = serde_json::from_str(&raw).expect("parse");
+    envelope.hmac_hex = "deadbeef".to_string();
+    std::fs::write(&path, serde_json::to_string_pretty(&envelope).expect("ser")).expect("write");
+
+    let err = load_continuation(&config, "task-typed").unwrap_err();
+    assert!(is_integrity_error(&err), "should be integrity error");
+    let ie = err.downcast_ref::<ContinuationIntegrityError>().expect("downcast");
+    assert_eq!(ie.task_id, "task-typed");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_io_error_is_not_treated_as_tampering() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = make_test_config(tmp.path());
+
+    let dir = continuations_dir(&config);
+    std::fs::create_dir_all(&dir).expect("dir");
+    let path = dir.join("task-bad-json.json");
+    std::fs::write(&path, "this is not valid json{{{").expect("write");
+
+    let err = load_continuation(&config, "task-bad-json").unwrap_err();
+    assert!(!is_integrity_error(&err), "parse error should not be integrity error");
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -496,10 +496,16 @@ pub struct GatewayConfig {
     #[serde(default = "default_approval_timeout_secs")]
     pub approval_timeout_secs: u64,
 
-    /// HMAC-SHA256 key for signing turn continuation files.  When unset the
-    /// gateway derives a deterministic key from `node_id`.  Rotate by
-    /// changing this value (existing continuations will fail integrity
-    /// verification and be rejected).
+    /// HMAC-SHA256 key for signing turn continuation files.
+    /// This value should be a secret, high-entropy key provided from a secret
+    /// source (environment secret or vault); do not derive it from `node_id`
+    /// or any other identifier. Rotate by changing this value (existing
+    /// continuations will fail integrity verification and be rejected).
+    ///
+    /// When unset the gateway derives a deterministic key from `node_id`.
+    /// This is a development convenience only — it does **not** protect
+    /// against a local attacker who can read the config and edit the
+    /// continuation file.  Production deployments should set this field.
     #[serde(default)]
     pub continuation_key: Option<String>,
 

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -496,6 +496,13 @@ pub struct GatewayConfig {
     #[serde(default = "default_approval_timeout_secs")]
     pub approval_timeout_secs: u64,
 
+    /// HMAC-SHA256 key for signing turn continuation files.  When unset the
+    /// gateway derives a deterministic key from `node_id`.  Rotate by
+    /// changing this value (existing continuations will fail integrity
+    /// verification and be rejected).
+    #[serde(default)]
+    pub continuation_key: Option<String>,
+
     /// Heartbeat interval (seconds) for workflow tasks in `Running` state.
     ///
     /// Used by both scheduler-driven async runs and synchronous `agent.spawn` waits to
@@ -1161,6 +1168,7 @@ impl Default for GatewayConfig {
             code_analysis: CodeAnalysisConfig::default(),
             session_budget: SessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),
+            continuation_key: None,
             workflow_task_heartbeat_secs: default_workflow_task_heartbeat_secs_val(),
             stuck_task_timeout_secs: default_stuck_task_timeout_secs_val(),
             evidence_mode: default_evidence_mode(),


### PR DESCRIPTION
## Summary

Closes the TOCTOU integrity window between operator approval decision and continuation resume (Phase 1 of approval-system hardening plan #80, closes #81).

- **HMAC-signed continuations**: `save_continuation` wraps the payload in a `SignedContinuation { payload_json, hmac_hex }` envelope using HMAC-SHA256. `load_continuation` verifies the HMAC before returning; tampered files are rejected with an error.
- **Action-equality check on resume**: `TurnContinuation` now carries `pending_action: Option<ScheduledAction>` populated at save time from the approval row. On resume, `execution.rs` structurally compares it against the approval's action — mismatch refuses execution.
- **Tamper detection with causal event + approval cancellation**: HMAC verification failure emits a `continuation_tampered` causal event and cancels the bound approval.
- **Config**: `GatewayConfig::continuation_key` (optional; defaults to key derived from `node_id`).
- **Backward compat**: Legacy unsigned continuation files (pre-existing on disk) still load with a warning.

## Tests

- 8 new integration tests in `continuation_hmac_integrity_integration.rs`:
  - Signed round-trip
  - Tampered payload rejected
  - Tampered HMAC rejected
  - Legacy unsigned still loads
  - Key derivation uses node_id
  - Explicit key overrides default
  - Missing continuation returns None
  - Different key rejects
- All 7 existing `turn_continuation_approval_integration` tests pass unchanged.
- 615/616 gateway tests pass (1 pre-existing flaky failure unrelated to changes).

## Acceptance criteria (#81)

- [x] HMAC verification failures cannot execute the action.
- [x] Action-mismatch failures cannot execute the action.
- [x] Tamper produces a causal event and cancels the approval.
- [x] Existing tests still pass on unmodified continuations.