### PR TITLE
feat(approval): session-scoped grants, pattern-based targets, grant expiry (Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "autonoetic-gateway",
  "autonoetic-mcp",
  "autonoetic-types",
+ "chrono",
  "clap",
  "crossterm",
  "dirs",

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -142,6 +142,14 @@ pub fn pending_approval_requests_for_session(
     Ok(v)
 }
 
+/// Optional parameters for approving a request with Phase 2 grant options.
+#[derive(Default)]
+pub struct ApproveOptions {
+    pub grant_scope: Option<autonoetic_types::background::GrantScope>,
+    pub grant_targets: Vec<autonoetic_types::background::GrantTarget>,
+    pub grant_expires_at: Option<String>,
+}
+
 pub fn approve_request(
     config: &GatewayConfig,
     gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
@@ -151,6 +159,23 @@ pub fn approve_request(
     secrets: Option<Vec<(String, String)>>,
     approver_level: Option<&ApprovalLevel>,
     hook_executor: Option<&crate::scheduler::hooks::HookExecutor>,
+) -> anyhow::Result<ApprovalDecision> {
+    approve_request_with_options(
+        config, gateway_store, request_id, decided_by, reason, secrets,
+        approver_level, hook_executor, ApproveOptions::default(),
+    )
+}
+
+pub fn approve_request_with_options(
+    config: &GatewayConfig,
+    gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
+    request_id: &str,
+    decided_by: &str,
+    reason: Option<String>,
+    secrets: Option<Vec<(String, String)>>,
+    approver_level: Option<&ApprovalLevel>,
+    hook_executor: Option<&crate::scheduler::hooks::HookExecutor>,
+    options: ApproveOptions,
 ) -> anyhow::Result<ApprovalDecision> {
     let store = gateway_store
         .ok_or_else(|| anyhow::anyhow!("GatewayStore is required to approve requests"))?;
@@ -277,13 +302,14 @@ pub fn approve_request(
         );
     }
 
-    let decision = decide_request(
+    let decision = decide_request_with_options(
         config,
         gateway_store,
         request_id,
         decided_by,
         reason,
         ApprovalStatus::Approved,
+        options,
     )?;
 
     // Dumb Gate model: notify the waiting session, do not auto-execute.
@@ -865,6 +891,21 @@ fn decide_request(
     reason: Option<String>,
     status: ApprovalStatus,
 ) -> anyhow::Result<ApprovalDecision> {
+    decide_request_with_options(
+        config, gateway_store, request_id, decided_by, reason, status,
+        ApproveOptions::default(),
+    )
+}
+
+fn decide_request_with_options(
+    config: &GatewayConfig,
+    gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
+    request_id: &str,
+    decided_by: &str,
+    reason: Option<String>,
+    status: ApprovalStatus,
+    options: ApproveOptions,
+) -> anyhow::Result<ApprovalDecision> {
     let request = if let Some(store) = gateway_store {
         store
             .get_approval(request_id)?
@@ -934,13 +975,26 @@ fn decide_request(
             if !hosts.is_empty() {
                 if let Some(root_sid) = &decision.root_session_id {
                     if let Some(store) = gateway_store {
+                        let scope = options.grant_scope.clone()
+                            .unwrap_or(autonoetic_types::background::GrantScope::RootSession);
+                        let targets = if options.grant_targets.is_empty() {
+                            hosts.iter()
+                                .map(|h| autonoetic_types::background::GrantTarget::ExactHost(h.clone()))
+                                .collect()
+                        } else {
+                            options.grant_targets.clone()
+                        };
+                        let session_id = decision.session_id.as_str();
                         if let Err(e) = store.insert_session_grant(
                             root_sid,
+                            session_id,
                             &decision.agent_id,
-                            &hosts,
+                            &scope,
+                            &targets,
                             &decision.decided_by,
                             &decision.decided_at,
                             Some(&decision.request_id),
+                            options.grant_expires_at.as_deref(),
                         ) {
                             tracing::warn!(
                                 target: "approval",
@@ -954,7 +1008,8 @@ fn decide_request(
                                 request_id = %decision.request_id,
                                 agent_id = %decision.agent_id,
                                 root_session_id = %root_sid,
-                                hosts = ?hosts,
+                                scope = %scope.as_str(),
+                                targets = ?targets,
                                 "Inserted session approval grants for approved sandbox exec"
                             );
                         }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use autonoetic_types::background::{ApprovalLevel, ApprovalRequest};
+use autonoetic_types::background::{
+    ApprovalLevel, ApprovalRequest, GrantScope, GrantTarget, SessionApprovalGrant,
+};
 use rusqlite::{params, Connection, OptionalExtension};
 
 use super::GatewayStore;
@@ -212,32 +214,92 @@ impl GatewayStore {
     pub fn insert_session_grant(
         &self,
         root_session_id: &str,
+        session_id: &str,
+        agent_id: &str,
+        scope: &GrantScope,
+        targets: &[GrantTarget],
+        granted_by: &str,
+        granted_at: &str,
+        source_approval_id: Option<&str>,
+        expires_at: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+
+        let primary_host = targets.iter().find_map(|t| match t {
+            GrantTarget::ExactHost(h) => Some(h.clone()),
+            _ => None,
+        }).unwrap_or_else(|| "_multi_target_".to_string());
+
+        conn.execute(
+            "INSERT INTO session_approval_grants
+             (root_session_id, session_id, agent_id, host, scope, granted_by, granted_at, source_approval_id, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(root_session_id, agent_id, host) DO UPDATE SET
+                 session_id = excluded.session_id,
+                 scope = excluded.scope,
+                 granted_by = excluded.granted_by,
+                 granted_at = excluded.granted_at,
+                 source_approval_id = excluded.source_approval_id,
+                 expires_at = excluded.expires_at,
+                 revoked_at = NULL,
+                 revoked_reason = NULL",
+            params![
+                root_session_id,
+                session_id,
+                agent_id,
+                primary_host,
+                scope.as_str(),
+                granted_by,
+                granted_at,
+                source_approval_id,
+                expires_at,
+            ],
+        )?;
+
+        let grant_id: i64 = conn.query_row(
+            "SELECT id FROM session_approval_grants WHERE root_session_id = ?1 AND agent_id = ?2 AND host = ?3",
+            params![root_session_id, agent_id, primary_host],
+            |row| row.get(0),
+        )?;
+
+        conn.execute(
+            "DELETE FROM session_approval_grant_targets WHERE grant_id = ?1",
+            params![grant_id],
+        )?;
+
+        for target in targets {
+            let value = serde_json::to_string(target)?;
+            conn.execute(
+                "INSERT INTO session_approval_grant_targets (grant_id, kind, value) VALUES (?1, ?2, ?3)",
+                params![grant_id, target.kind_str(), value],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Backward-compatible wrapper: inserts ExactHost grants with RootSession scope.
+    pub fn insert_session_grant_hosts(
+        &self,
+        root_session_id: &str,
         agent_id: &str,
         hosts: &[String],
         granted_by: &str,
         granted_at: &str,
         source_approval_id: Option<&str>,
     ) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
         for host in hosts {
-            conn.execute(
-                "INSERT INTO session_approval_grants
-                 (root_session_id, agent_id, host, granted_by, granted_at, source_approval_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                 ON CONFLICT(root_session_id, agent_id, host) DO UPDATE SET
-                     granted_by = excluded.granted_by,
-                     granted_at = excluded.granted_at,
-                     source_approval_id = excluded.source_approval_id,
-                     revoked_at = NULL,
-                     revoked_reason = NULL",
-                params![
-                    root_session_id,
-                    agent_id,
-                    host,
-                    granted_by,
-                    granted_at,
-                    source_approval_id
-                ],
+            let targets = vec![GrantTarget::ExactHost(host.clone())];
+            self.insert_session_grant(
+                root_session_id,
+                root_session_id,
+                agent_id,
+                &GrantScope::RootSession,
+                &targets,
+                granted_by,
+                granted_at,
+                source_approval_id,
+                None,
             )?;
         }
         Ok(())
@@ -262,27 +324,137 @@ impl GatewayStore {
         Ok(results)
     }
 
+    pub fn get_session_grants_structured(
+        &self,
+        root_session_id: &str,
+    ) -> Result<Vec<SessionApprovalGrant>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, root_session_id, session_id, agent_id, scope, granted_by, granted_at,
+                    source_approval_id, expires_at
+             FROM session_approval_grants
+             WHERE root_session_id = ?1 AND revoked_at IS NULL",
+        )?;
+        let rows = stmt.query_map(params![root_session_id], |row| {
+            let id: i64 = row.get(0)?;
+            let root_session_id: String = row.get(1)?;
+            let session_id: String = row.get(2)?;
+            let agent_id: String = row.get(3)?;
+            let scope_str: String = row.get(4)?;
+            let granted_by: String = row.get(5)?;
+            let granted_at: String = row.get(6)?;
+            let source_approval_id: Option<String> = row.get(7)?;
+            let expires_at: Option<String> = row.get(8)?;
+            Ok((id, root_session_id, session_id, agent_id, scope_str, granted_by, granted_at, source_approval_id, expires_at))
+        })?;
+
+        let mut results = Vec::new();
+        for row_result in rows {
+            let (id, root_sid, sess_id, agent_id, scope_str, granted_by, granted_at, source_approval_id, expires_at) = row_result?;
+            let targets = self.get_grant_targets_with_conn(&conn, id)?;
+            results.push(SessionApprovalGrant {
+                id,
+                root_session_id: root_sid,
+                session_id: sess_id,
+                agent_id,
+                scope: GrantScope::from_str_lossy(&scope_str),
+                granted_by,
+                granted_at,
+                source_approval_id,
+                expires_at,
+                targets,
+            });
+        }
+        Ok(results)
+    }
+
+    fn get_grant_targets_with_conn(&self, conn: &Connection, grant_id: i64) -> Result<Vec<GrantTarget>> {
+        let mut stmt = conn.prepare(
+            "SELECT value FROM session_approval_grant_targets WHERE grant_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![grant_id], |row| {
+            let value: String = row.get(0)?;
+            Ok(value)
+        })?;
+        let mut targets = Vec::new();
+        for row in rows {
+            let value = row?;
+            if let Ok(t) = serde_json::from_str::<GrantTarget>(&value) {
+                targets.push(t);
+            }
+        }
+        Ok(targets)
+    }
+
     pub fn session_grants_cover_targets(
         &self,
+        root_session_id: &str,
+        required_targets: &[String],
+    ) -> bool {
+        self.grants_cover_targets(root_session_id, root_session_id, required_targets)
+    }
+
+    /// Scope-aware grant coverage check.  A request is covered when every
+    /// required target is matched by at least one active (non-revoked,
+    /// non-expired) grant whose scope covers the requesting session.
+    pub fn grants_cover_targets(
+        &self,
+        session_id: &str,
         root_session_id: &str,
         required_targets: &[String],
     ) -> bool {
         if required_targets.is_empty() {
             return false;
         }
-        let granted = match self.get_session_grants(root_session_id) {
+
+        let grants = match self.get_session_grants_structured(root_session_id) {
             Ok(g) => g,
             Err(_) => return false,
         };
-        if granted.is_empty() {
+
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let active: Vec<&SessionApprovalGrant> = grants
+            .iter()
+            .filter(|g| {
+                if let Some(ref exp) = g.expires_at {
+                    if exp < &now {
+                        return false;
+                    }
+                }
+                match g.scope {
+                    GrantScope::RootSession => true,
+                    GrantScope::Session => g.session_id == session_id,
+                }
+            })
+            .collect();
+
+        if active.is_empty() {
             return false;
         }
-        let granted_set: std::collections::BTreeSet<String> = granted.into_iter().collect();
-        required_targets.iter().all(|t| granted_set.contains(t))
+
+        required_targets.iter().all(|req| {
+            active.iter().any(|grant| {
+                grant.targets.iter().any(|t| t.matches(req))
+            })
+        })
     }
 
     pub fn delete_session_grants(&self, root_session_id: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
+        let grant_ids: Vec<i64> = {
+            let mut stmt = conn.prepare(
+                "SELECT id FROM session_approval_grants WHERE root_session_id = ?1",
+            )?;
+            let rows = stmt.query_map(params![root_session_id], |row| row.get(0))?;
+            rows.filter_map(|r| r.ok()).collect()
+        };
+        for gid in &grant_ids {
+            let _ = conn.execute(
+                "DELETE FROM session_approval_grant_targets WHERE grant_id = ?1",
+                params![gid],
+            );
+        }
         conn.execute(
             "DELETE FROM session_approval_grants WHERE root_session_id = ?1",
             params![root_session_id],
@@ -310,6 +482,29 @@ impl GatewayStore {
                 params![&now, reason, root_session_id],
             )?,
         };
+        Ok(count)
+    }
+
+    pub fn prune_expired_grants(&self) -> Result<usize> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let expired_ids: Vec<i64> = {
+            let mut stmt = conn.prepare(
+                "SELECT id FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",
+            )?;
+            let rows = stmt.query_map(params![&now], |row| row.get(0))?;
+            rows.filter_map(|r| r.ok()).collect()
+        };
+        for gid in &expired_ids {
+            let _ = conn.execute(
+                "DELETE FROM session_approval_grant_targets WHERE grant_id = ?1",
+                params![gid],
+            );
+        }
+        let count = conn.execute(
+            "DELETE FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",
+            params![&now],
+        )?;
         Ok(count)
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -234,9 +234,7 @@ impl GatewayStore {
             "INSERT INTO session_approval_grants
              (root_session_id, session_id, agent_id, host, scope, granted_by, granted_at, source_approval_id, expires_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-             ON CONFLICT(root_session_id, agent_id, host) DO UPDATE SET
-                 session_id = excluded.session_id,
-                 scope = excluded.scope,
+             ON CONFLICT(root_session_id, session_id, agent_id, scope, host) DO UPDATE SET
                  granted_by = excluded.granted_by,
                  granted_at = excluded.granted_at,
                  source_approval_id = excluded.source_approval_id,
@@ -257,8 +255,8 @@ impl GatewayStore {
         )?;
 
         let grant_id: i64 = conn.query_row(
-            "SELECT id FROM session_approval_grants WHERE root_session_id = ?1 AND agent_id = ?2 AND host = ?3",
-            params![root_session_id, agent_id, primary_host],
+            "SELECT id FROM session_approval_grants WHERE root_session_id = ?1 AND session_id = ?2 AND agent_id = ?3 AND scope = ?4 AND host = ?5",
+            params![root_session_id, session_id, agent_id, scope.as_str(), primary_host],
             |row| row.get(0),
         )?;
 
@@ -370,20 +368,50 @@ impl GatewayStore {
 
     fn get_grant_targets_with_conn(&self, conn: &Connection, grant_id: i64) -> Result<Vec<GrantTarget>> {
         let mut stmt = conn.prepare(
-            "SELECT value FROM session_approval_grant_targets WHERE grant_id = ?1",
+            "SELECT kind, value FROM session_approval_grant_targets WHERE grant_id = ?1",
         )?;
         let rows = stmt.query_map(params![grant_id], |row| {
-            let value: String = row.get(0)?;
-            Ok(value)
+            let kind: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((kind, value))
         })?;
         let mut targets = Vec::new();
         for row in rows {
-            let value = row?;
-            if let Ok(t) = serde_json::from_str::<GrantTarget>(&value) {
+            let (kind, value) = row?;
+            if let Some(t) = Self::parse_grant_target(&kind, &value) {
                 targets.push(t);
+            } else {
+                eprintln!(
+                    "warning: failed to parse session_approval_grant_targets row for grant_id={} (kind={}, value={})",
+                    grant_id, kind, value
+                );
             }
         }
         Ok(targets)
+    }
+
+    fn parse_grant_target(kind: &str, value: &str) -> Option<GrantTarget> {
+        if let Ok(t) = serde_json::from_str::<GrantTarget>(value) {
+            return Some(t);
+        }
+        let tagged = serde_json::json!({"kind": kind, "value": value});
+        if let Ok(t) = serde_json::from_value::<GrantTarget>(tagged) {
+            return Some(t);
+        }
+        match kind {
+            "exact_host" => Some(GrantTarget::ExactHost(value.to_string())),
+            "host_suffix" => Some(GrantTarget::HostSuffix(value.to_string())),
+            "host_and_port" => {
+                if let Some((h, p)) = value.rsplit_once(':') {
+                    if let Ok(port) = p.parse::<u16>() {
+                        return Some(GrantTarget::HostAndPort { host: h.to_string(), port });
+                    }
+                }
+                None
+            }
+            "url_prefix" => Some(GrantTarget::UrlPrefix(value.to_string())),
+            _ => None,
+        }
     }
 
     pub fn session_grants_cover_targets(
@@ -412,13 +440,17 @@ impl GatewayStore {
             Err(_) => return false,
         };
 
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now();
 
         let active: Vec<&SessionApprovalGrant> = grants
             .iter()
             .filter(|g| {
                 if let Some(ref exp) = g.expires_at {
-                    if exp < &now {
+                    let expires_at = match chrono::DateTime::parse_from_rfc3339(exp) {
+                        Ok(dt) => dt.with_timezone(&chrono::Utc),
+                        Err(_) => return false,
+                    };
+                    if expires_at < now {
                         return false;
                     }
                 }
@@ -486,14 +518,25 @@ impl GatewayStore {
     }
 
     pub fn prune_expired_grants(&self) -> Result<usize> {
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now();
         let conn = self.conn.lock().unwrap();
         let expired_ids: Vec<i64> = {
             let mut stmt = conn.prepare(
-                "SELECT id FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",
+                "SELECT id, expires_at FROM session_approval_grants WHERE expires_at IS NOT NULL",
             )?;
-            let rows = stmt.query_map(params![&now], |row| row.get(0))?;
-            rows.filter_map(|r| r.ok()).collect()
+            let rows = stmt.query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                let expires_at: String = row.get(1)?;
+                Ok((id, expires_at))
+            })?;
+            rows.filter_map(|r| r.ok())
+                .filter(|(_, exp)| {
+                    chrono::DateTime::parse_from_rfc3339(exp)
+                        .map(|dt| dt.with_timezone(&chrono::Utc) < now)
+                        .unwrap_or(false)
+                })
+                .map(|(id, _)| id)
+                .collect()
         };
         for gid in &expired_ids {
             let _ = conn.execute(
@@ -501,10 +544,13 @@ impl GatewayStore {
                 params![gid],
             );
         }
-        let count = conn.execute(
-            "DELETE FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",
-            params![&now],
-        )?;
+        let count = expired_ids.len();
+        for gid in &expired_ids {
+            let _ = conn.execute(
+                "DELETE FROM session_approval_grants WHERE id = ?1",
+                params![gid],
+            );
+        }
         Ok(count)
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 15;
+const SCHEMA_VERSION_LATEST: i64 = 18;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -498,6 +498,9 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_admin_proposals_v13(conn)?;
     apply_memories_revision_provenance_v14(conn)?;
     apply_session_grant_revocation_v15(conn)?;
+    apply_grant_scope_and_session_v16(conn)?;
+    apply_grant_targets_table_v17(conn)?;
+    apply_grant_expiry_v18(conn)?;
 
     Ok(())
 }
@@ -1084,6 +1087,134 @@ fn apply_session_grant_revocation_v15(conn: &mut Connection) -> Result<()> {
         params![
             15_i64,
             "session_grant_revocation",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_grant_scope_and_session_v16(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 16 {
+        return Ok(());
+    }
+
+    for (col, default) in &[
+        ("session_id", "TEXT NOT NULL DEFAULT ''"),
+        ("scope", "TEXT NOT NULL DEFAULT 'root_session'"),
+    ] {
+        let col_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('session_approval_grants') WHERE name = ?1",
+            [col],
+            |row| row.get(0),
+        )?;
+        if col_count == 0 {
+            conn.execute(
+                &format!("ALTER TABLE session_approval_grants ADD COLUMN {col} {default}"),
+                [],
+            )?;
+        }
+    }
+
+    conn.execute(
+        "UPDATE session_approval_grants SET session_id = root_session_id WHERE session_id = ''",
+        [],
+    )?;
+
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_session_grants_session_agent
+          ON session_approval_grants(session_id, agent_id);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            16_i64,
+            "grant_scope_and_session",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_grant_targets_table_v17(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 17 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS session_approval_grant_targets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            grant_id INTEGER NOT NULL REFERENCES session_approval_grants(id) ON DELETE CASCADE,
+            kind TEXT NOT NULL,
+            value TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_grant_targets_grant_id
+          ON session_approval_grant_targets(grant_id);",
+    )?;
+
+    let mut stmt = conn.prepare(
+        "SELECT id, host FROM session_approval_grants",
+    )?;
+    let rows: Vec<(i64, String)> = stmt.query_map([], |row| {
+        Ok((row.get(0)?, row.get(1)?))
+    })?.filter_map(|r| r.ok()).collect();
+    drop(stmt);
+
+    for (grant_id, host) in &rows {
+        conn.execute(
+            "INSERT OR IGNORE INTO session_approval_grant_targets (grant_id, kind, value) VALUES (?1, 'exact_host', ?2)",
+            params![grant_id, host],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            17_i64,
+            "grant_targets_table",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_grant_expiry_v18(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 18 {
+        return Ok(());
+    }
+
+    let col_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('session_approval_grants') WHERE name = 'expires_at'",
+        [],
+        |row| row.get(0),
+    )?;
+    if col_count == 0 {
+        conn.execute(
+            "ALTER TABLE session_approval_grants ADD COLUMN expires_at TEXT",
+            [],
+        )?;
+    }
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            18_i64,
+            "grant_expiry",
             chrono::Utc::now().to_rfc3339()
         ],
     )?;

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -1103,22 +1103,28 @@ fn apply_grant_scope_and_session_v16(conn: &mut Connection) -> Result<()> {
         return Ok(());
     }
 
-    for (col, default) in &[
-        ("session_id", "TEXT NOT NULL DEFAULT ''"),
-        ("scope", "TEXT NOT NULL DEFAULT 'root_session'"),
-    ] {
-        let col_count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM pragma_table_info('session_approval_grants') WHERE name = ?1",
-            [col],
-            |row| row.get(0),
-        )?;
-        if col_count == 0 {
-            conn.execute(
-                &format!("ALTER TABLE session_approval_grants ADD COLUMN {col} {default}"),
-                [],
-            )?;
-        }
-    }
+    conn.execute_batch(
+        "CREATE TABLE session_approval_grants_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            root_session_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            host TEXT NOT NULL,
+            granted_by TEXT NOT NULL,
+            granted_at TEXT NOT NULL,
+            source_approval_id TEXT,
+            revoked_at TEXT,
+            revoked_reason TEXT,
+            session_id TEXT NOT NULL DEFAULT '',
+            scope TEXT NOT NULL DEFAULT 'root_session',
+            UNIQUE(root_session_id, session_id, agent_id, scope, host)
+        );
+        INSERT INTO session_approval_grants_new
+            (id, root_session_id, agent_id, host, granted_by, granted_at, source_approval_id, revoked_at, revoked_reason)
+            SELECT id, root_session_id, agent_id, host, granted_by, granted_at, source_approval_id, revoked_at, revoked_reason
+            FROM session_approval_grants;
+        DROP TABLE session_approval_grants;
+        ALTER TABLE session_approval_grants_new RENAME TO session_approval_grants;",
+    )?;
 
     conn.execute(
         "UPDATE session_approval_grants SET session_id = root_session_id WHERE session_id = ''",
@@ -1126,7 +1132,11 @@ fn apply_grant_scope_and_session_v16(conn: &mut Connection) -> Result<()> {
     )?;
 
     conn.execute_batch(
-        "CREATE INDEX IF NOT EXISTS idx_session_grants_session_agent
+        "CREATE INDEX IF NOT EXISTS idx_session_grants_root_agent
+          ON session_approval_grants(root_session_id, agent_id);
+         CREATE INDEX IF NOT EXISTS idx_session_grants_root
+          ON session_approval_grants(root_session_id);
+         CREATE INDEX IF NOT EXISTS idx_session_grants_session_agent
           ON session_approval_grants(session_id, agent_id);",
     )?;
 
@@ -1171,9 +1181,10 @@ fn apply_grant_targets_table_v17(conn: &mut Connection) -> Result<()> {
     drop(stmt);
 
     for (grant_id, host) in &rows {
+        let value = serde_json::json!({"kind": "exact_host", "value": host}).to_string();
         conn.execute(
             "INSERT OR IGNORE INTO session_approval_grant_targets (grant_id, kind, value) VALUES (?1, 'exact_host', ?2)",
-            params![grant_id, host],
+            params![grant_id, value],
         )?;
     }
 

--- a/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
+++ b/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
@@ -9,7 +9,7 @@ fn make_gateway_dir(tmp: &tempfile::TempDir) -> std::path::PathBuf {
 
 fn seed_grant(store: &GatewayStore, root_sid: &str, agent_id: &str, host: &str) {
     store
-        .insert_session_grant(
+        .insert_session_grant_hosts(
             root_sid,
             agent_id,
             &[host.to_string()],

--- a/autonoetic-gateway/tests/approval_scope_targets_integration.rs
+++ b/autonoetic-gateway/tests/approval_scope_targets_integration.rs
@@ -5,9 +5,8 @@
 //!   2. Root-scoped grants cover all children.
 //!   3. GrantTarget pattern matching works for all four kinds.
 //!   4. Expired grants are excluded from coverage.
-//!   5. Migration preserves existing grants.
-//!   6. Emergency stop cleans up all scopes.
-//!   7. Janitor prunes expired grants.
+//!   5. Emergency stop cleans up all scopes.
+//!   6. Janitor prunes expired grants.
 
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::background::{GrantScope, GrantTarget};

--- a/autonoetic-gateway/tests/approval_scope_targets_integration.rs
+++ b/autonoetic-gateway/tests/approval_scope_targets_integration.rs
@@ -1,0 +1,334 @@
+//! Integration tests for Phase 2 approval hardening: grant scope, targets, expiry.
+//!
+//! Verifies:
+//!   1. Session-scoped grants only cover the specific child session.
+//!   2. Root-scoped grants cover all children.
+//!   3. GrantTarget pattern matching works for all four kinds.
+//!   4. Expired grants are excluded from coverage.
+//!   5. Migration preserves existing grants.
+//!   6. Emergency stop cleans up all scopes.
+//!   7. Janitor prunes expired grants.
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::background::{GrantScope, GrantTarget};
+
+fn make_gateway_dir(tmp: &tempfile::TempDir) -> std::path::PathBuf {
+    let gw = tmp.path().join(".gateway");
+    std::fs::create_dir_all(&gw).unwrap();
+    gw
+}
+
+fn seed_grant(
+    store: &GatewayStore,
+    root_sid: &str,
+    session_id: &str,
+    agent_id: &str,
+    scope: &GrantScope,
+    targets: &[GrantTarget],
+    expires_at: Option<&str>,
+) {
+    store
+        .insert_session_grant(
+            root_sid,
+            session_id,
+            agent_id,
+            scope,
+            targets,
+            "test",
+            &chrono::Utc::now().to_rfc3339(),
+            None,
+            expires_at,
+        )
+        .unwrap();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_session_scoped_grant_covers_only_own_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![GrantTarget::ExactHost("api.example.com".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "child-A",
+        "agent-1",
+        &GrantScope::Session,
+        &targets,
+        None,
+    );
+
+    assert!(store.grants_cover_targets("child-A", "root-1", &["api.example.com".to_string()]));
+    assert!(!store.grants_cover_targets("child-B", "root-1", &["api.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_root_scoped_grant_covers_all_children() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![GrantTarget::ExactHost("api.example.com".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "child-A",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        None,
+    );
+
+    assert!(store.grants_cover_targets("child-A", "root-1", &["api.example.com".to_string()]));
+    assert!(store.grants_cover_targets("child-B", "root-1", &["api.example.com".to_string()]));
+    assert!(store.grants_cover_targets("root-1", "root-1", &["api.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_host_suffix_matches_subdomain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![GrantTarget::HostSuffix("*.github.com".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        None,
+    );
+
+    assert!(store.grants_cover_targets("root-1", "root-1", &["api.github.com".to_string()]));
+    assert!(store.grants_cover_targets("root-1", "root-1", &["v2.api.github.com".to_string()]));
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["github.com.evil.example".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_host_and_port_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![GrantTarget::HostAndPort {
+        host: "api.example.com".to_string(),
+        port: 443,
+    }];
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        None,
+    );
+
+    assert!(store.grants_cover_targets("root-1", "root-1", &["api.example.com:443".to_string()]));
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["api.example.com".to_string()]));
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["api.example.com:8080".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_url_prefix_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![GrantTarget::UrlPrefix("https://api.example.com/public/".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        None,
+    );
+
+    assert!(store.grants_cover_targets("root-1", "root-1", &["https://api.example.com/public/x".to_string()]));
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["https://api.example.com/admin".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_expired_grant_excluded() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let past = "2000-01-01T00:00:00+00:00";
+    let targets = vec![GrantTarget::ExactHost("api.example.com".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        Some(past),
+    );
+
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["api.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_future_expiry_still_covers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let future = "2099-01-01T00:00:00+00:00";
+    let targets = vec![GrantTarget::ExactHost("api.example.com".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        Some(future),
+    );
+
+    assert!(store.grants_cover_targets("root-1", "root-1", &["api.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_prune_expired_grants() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let past = "2000-01-01T00:00:00+00:00";
+    let targets = vec![GrantTarget::ExactHost("expired.example.com".to_string())];
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets,
+        Some(past),
+    );
+
+    let targets2 = vec![GrantTarget::ExactHost("active.example.com".to_string())];
+    let future = "2099-01-01T00:00:00+00:00";
+    seed_grant(
+        &store,
+        "root-1",
+        "root-1",
+        "agent-1",
+        &GrantScope::RootSession,
+        &targets2,
+        Some(future),
+    );
+
+    let pruned = store.prune_expired_grants().unwrap();
+    assert_eq!(pruned, 1);
+
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["expired.example.com".to_string()]));
+    assert!(store.grants_cover_targets("root-1", "root-1", &["active.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_emergency_stop_cleans_up_all_scopes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![GrantTarget::ExactHost("api.example.com".to_string())];
+    seed_grant(&store, "root-1", "child-A", "agent-1", &GrantScope::Session, &targets, None);
+    seed_grant(&store, "root-1", "root-1", "agent-1", &GrantScope::RootSession, &targets, None);
+
+    store.delete_session_grants("root-1").unwrap();
+
+    assert!(!store.grants_cover_targets("child-A", "root-1", &["api.example.com".to_string()]));
+    assert!(!store.grants_cover_targets("root-1", "root-1", &["api.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_two_children_one_root_session_vs_root_scope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets_a = vec![GrantTarget::ExactHost("host-a.example.com".to_string())];
+    seed_grant(&store, "root-1", "child-A", "agent-1", &GrantScope::Session, &targets_a, None);
+
+    let targets_b = vec![GrantTarget::ExactHost("host-b.example.com".to_string())];
+    seed_grant(&store, "root-1", "child-B", "agent-1", &GrantScope::Session, &targets_b, None);
+
+    assert!(store.grants_cover_targets("child-A", "root-1", &["host-a.example.com".to_string()]));
+    assert!(!store.grants_cover_targets("child-A", "root-1", &["host-b.example.com".to_string()]));
+    assert!(store.grants_cover_targets("child-B", "root-1", &["host-b.example.com".to_string()]));
+    assert!(!store.grants_cover_targets("child-B", "root-1", &["host-a.example.com".to_string()]));
+}
+
+#[test]
+#[serial_test::serial]
+fn test_multi_target_grant() {
+    let tmp = tempfile::tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+
+    let targets = vec![
+        GrantTarget::ExactHost("api.example.com".to_string()),
+        GrantTarget::ExactHost("cdn.example.com".to_string()),
+    ];
+    seed_grant(&store, "root-1", "root-1", "agent-1", &GrantScope::RootSession, &targets, None);
+
+    assert!(store.grants_cover_targets("root-1", "root-1", &[
+        "api.example.com".to_string(),
+        "cdn.example.com".to_string(),
+    ]));
+    assert!(!store.grants_cover_targets("root-1", "root-1", &[
+        "api.example.com".to_string(),
+        "other.example.com".to_string(),
+    ]));
+}
+
+#[test]
+fn test_grant_target_exact_host_matches() {
+    assert!(GrantTarget::ExactHost("api.github.com".to_string()).matches("api.github.com"));
+    assert!(!GrantTarget::ExactHost("api.github.com".to_string()).matches("other.com"));
+}
+
+#[test]
+fn test_grant_target_host_suffix_rejects_evil() {
+    let t = GrantTarget::HostSuffix("*.github.com".to_string());
+    assert!(t.matches("api.github.com"));
+    assert!(t.matches("v2.api.github.com"));
+    assert!(t.matches("github.com"));
+    assert!(!t.matches("github.com.evil.example"));
+}
+
+#[test]
+fn test_grant_target_host_and_port() {
+    let t = GrantTarget::HostAndPort {
+        host: "api.example.com".to_string(),
+        port: 443,
+    };
+    assert!(t.matches("api.example.com:443"));
+    assert!(!t.matches("api.example.com:80"));
+    assert!(!t.matches("api.example.com"));
+}
+
+#[test]
+fn test_grant_target_url_prefix() {
+    let t = GrantTarget::UrlPrefix("https://api.example.com/public/".to_string());
+    assert!(t.matches("https://api.example.com/public/x"));
+    assert!(t.matches("https://api.example.com/public/"));
+    assert!(!t.matches("https://api.example.com/admin"));
+}

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -652,16 +652,36 @@ impl GrantTarget {
                     return true;
                 }
                 request.ends_with(&format!(".{}", suffix))
-                    && !request.ends_with(&format!(".{}.evil", suffix))
             }
             Self::HostAndPort { host, port } => {
                 let expected = format!("{}:{}", host.to_ascii_lowercase(), port);
                 request_target.eq_ignore_ascii_case(&expected)
             }
             Self::UrlPrefix(prefix) => {
-                let request = request_target.to_ascii_lowercase();
-                let prefix = prefix.to_ascii_lowercase();
-                request.starts_with(&prefix)
+                fn lower_authority(url: &str) -> std::borrow::Cow<'_, str> {
+                    let scheme_end = url.find("://").map(|p| p + 3).unwrap_or(0);
+                    let rest = &url[scheme_end..];
+                    if let Some(pos) = rest.find('/') {
+                        let authority = &rest[..pos];
+                        let path = &rest[pos..];
+                        if authority.chars().any(|c| c.is_ascii_uppercase()) {
+                            format!(
+                                "{}{}{}",
+                                &url[..scheme_end].to_ascii_lowercase(),
+                                authority.to_ascii_lowercase(),
+                                path
+                            )
+                            .into()
+                        } else {
+                            std::borrow::Cow::Borrowed(url)
+                        }
+                    } else {
+                        url.to_ascii_lowercase().into()
+                    }
+                }
+                let norm_req = lower_authority(request_target);
+                let norm_pre = lower_authority(prefix);
+                norm_req.starts_with(&*norm_pre)
             }
         }
     }

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -575,3 +575,109 @@ pub struct UserInteractionResumePayload {
     #[serde(default)]
     pub answer_text: Option<String>,
 }
+
+// ---------------------------------------------------------------------------
+// Grant scope & targets (Phase 2 — approval hardening)
+// ---------------------------------------------------------------------------
+
+/// Scope of a session approval grant.
+///
+/// `RootSession` (default): the grant covers all children/siblings under the
+/// root session — the current behaviour.  `Session`: the grant is limited to
+/// the specific child session that was active when the approval was decided.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantScope {
+    #[default]
+    RootSession,
+    Session,
+}
+
+impl GrantScope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RootSession => "root_session",
+            Self::Session => "session",
+        }
+    }
+
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s {
+            "session" => Self::Session,
+            _ => Self::RootSession,
+        }
+    }
+}
+
+/// A structured grant target describing what network host/path a grant covers.
+///
+/// Each approved `SandboxExec` produces one or more grant targets.  By default
+/// these are `ExactHost` entries derived from the detected hosts, preserving
+/// current behaviour.  Operators can narrow at approval time via `--target`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum GrantTarget {
+    /// Exact hostname match, e.g. `"api.github.com"`.
+    ExactHost(String),
+    /// Matches any subdomain of the suffix, e.g. `"*.github.com"` matches
+    /// `api.github.com` but NOT `github.com.evil.example`.
+    HostSuffix(String),
+    /// Exact host + port, e.g. `"api.github.com:443"`.
+    HostAndPort { host: String, port: u16 },
+    /// Matches URLs starting with this prefix, e.g.
+    /// `"https://api.github.com/public/"`.
+    UrlPrefix(String),
+}
+
+impl GrantTarget {
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::ExactHost(_) => "exact_host",
+            Self::HostSuffix(_) => "host_suffix",
+            Self::HostAndPort { .. } => "host_and_port",
+            Self::UrlPrefix(_) => "url_prefix",
+        }
+    }
+
+    /// Check whether a request target (lowercased host or full URL) is covered
+    /// by this grant target.
+    pub fn matches(&self, request_target: &str) -> bool {
+        match self {
+            Self::ExactHost(host) => request_target.eq_ignore_ascii_case(host),
+            Self::HostSuffix(suffix) => {
+                let suffix = suffix.trim_start_matches("*.");
+                let request = request_target.to_ascii_lowercase();
+                let suffix = suffix.to_ascii_lowercase();
+                if request == suffix {
+                    return true;
+                }
+                request.ends_with(&format!(".{}", suffix))
+                    && !request.ends_with(&format!(".{}.evil", suffix))
+            }
+            Self::HostAndPort { host, port } => {
+                let expected = format!("{}:{}", host.to_ascii_lowercase(), port);
+                request_target.eq_ignore_ascii_case(&expected)
+            }
+            Self::UrlPrefix(prefix) => {
+                let request = request_target.to_ascii_lowercase();
+                let prefix = prefix.to_ascii_lowercase();
+                request.starts_with(&prefix)
+            }
+        }
+    }
+}
+
+/// A structured grant row returned from the store for display and matching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionApprovalGrant {
+    pub id: i64,
+    pub root_session_id: String,
+    pub session_id: String,
+    pub agent_id: String,
+    pub scope: GrantScope,
+    pub granted_by: String,
+    pub granted_at: String,
+    pub source_approval_id: Option<String>,
+    pub expires_at: Option<String>,
+    pub targets: Vec<GrantTarget>,
+}

--- a/autonoetic/Cargo.toml
+++ b/autonoetic/Cargo.toml
@@ -26,6 +26,7 @@ crossterm = "0.28"
 unicode-width = "0.2"
 arboard = "3.4"
 rpassword = "7.3"
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -59,6 +59,11 @@ impl CliGrantScope {
 pub fn parse_grant_target_spec(spec: &str) -> anyhow::Result<autonoetic_types::background::GrantTarget> {
     use autonoetic_types::background::GrantTarget;
     if let Some(val) = spec.strip_prefix("host:") {
+        if let Some((h, port_str)) = val.rsplit_once(':') {
+            if let Ok(port) = port_str.parse::<u16>() {
+                return Ok(GrantTarget::HostAndPort { host: h.to_ascii_lowercase(), port });
+            }
+        }
         Ok(GrantTarget::ExactHost(val.to_ascii_lowercase()))
     } else if let Some(val) = spec.strip_prefix("suffix:") {
         Ok(GrantTarget::HostSuffix(val.to_ascii_lowercase()))

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -41,6 +41,54 @@ impl CliApprovalLevel {
     }
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CliGrantScope {
+    Root,
+    Session,
+}
+
+impl CliGrantScope {
+    pub fn to_runtime(self) -> autonoetic_types::background::GrantScope {
+        match self {
+            Self::Root => autonoetic_types::background::GrantScope::RootSession,
+            Self::Session => autonoetic_types::background::GrantScope::Session,
+        }
+    }
+}
+
+pub fn parse_grant_target_spec(spec: &str) -> anyhow::Result<autonoetic_types::background::GrantTarget> {
+    use autonoetic_types::background::GrantTarget;
+    if let Some(val) = spec.strip_prefix("host:") {
+        Ok(GrantTarget::ExactHost(val.to_ascii_lowercase()))
+    } else if let Some(val) = spec.strip_prefix("suffix:") {
+        Ok(GrantTarget::HostSuffix(val.to_ascii_lowercase()))
+    } else if let Some(val) = spec.strip_prefix("hostport:") {
+        let (host, port_str) = val.rsplit_once(':')
+            .ok_or_else(|| anyhow::anyhow!("hostport spec must be 'hostport:host:port', got: {}", spec))?;
+        let port: u16 = port_str.parse()
+            .map_err(|_| anyhow::anyhow!("invalid port in hostport spec: {}", port_str))?;
+        Ok(GrantTarget::HostAndPort { host: host.to_ascii_lowercase(), port })
+    } else if let Some(val) = spec.strip_prefix("url:") {
+        Ok(GrantTarget::UrlPrefix(val.to_ascii_lowercase()))
+    } else {
+        Ok(GrantTarget::ExactHost(spec.to_ascii_lowercase()))
+    }
+}
+
+pub fn parse_ttl(ttl: &str) -> anyhow::Result<String> {
+    let secs = if ttl.ends_with('s') {
+        ttl.trim_end_matches('s').parse::<i64>()?
+    } else if ttl.ends_with('m') {
+        ttl.trim_end_matches('m').parse::<i64>()? * 60
+    } else if ttl.ends_with('h') {
+        ttl.trim_end_matches('h').parse::<i64>()? * 3600
+    } else {
+        ttl.parse::<i64>()? * 60
+    };
+    let expires = chrono::Utc::now() + chrono::Duration::seconds(secs);
+    Ok(expires.to_rfc3339())
+}
+
 pub fn apply_response_validation_override(
     config: &mut GatewayConfig,
     mode: Option<ResponseValidationMode>,
@@ -176,6 +224,21 @@ pub enum GatewayApprovalCommands {
         /// Approver level used to authorize this decision.
         #[arg(long = "approval-level", value_enum, default_value_t = CliApprovalLevel::Operator)]
         approval_level: CliApprovalLevel,
+        /// Grant scope: `root` (default) shares with all children/siblings;
+        /// `session` limits the grant to the specific child session.
+        #[arg(long, value_enum, default_value_t = CliGrantScope::Root)]
+        scope: CliGrantScope,
+        /// Narrow the grant to specific targets (repeatable).
+        /// Syntax: `host:api.github.com`, `suffix:*.github.com`,
+        /// `hostport:api.github.com:443`, `url:https://api.github.com/public/`
+        #[arg(long = "target", value_name = "SPEC")]
+        targets: Vec<String>,
+        /// Time-to-live for the grant (e.g. `10m`, `1h`, `30s`).
+        #[arg(long)]
+        ttl: Option<String>,
+        /// Absolute expiry timestamp (RFC3339).
+        #[arg(long)]
+        until: Option<String>,
     },
     /// Reject one pending request.
     Reject {

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -255,9 +255,16 @@ pub async fn handle_gateway_approvals(
             };
 
             let expires_at = if let Some(ttl) = ttl {
+                if until.is_some() {
+                    anyhow::bail!("--ttl and --until are mutually exclusive; provide one or the other");
+                }
                 Some(super::common::parse_ttl(&ttl)?)
-            } else {
+            } else if let Some(ref until_str) = until {
+                let _ = chrono::DateTime::parse_from_rfc3339(until_str)
+                    .map_err(|e| anyhow::anyhow!("invalid --until timestamp (expected RFC3339): {}", e))?;
                 until.clone()
+            } else {
+                None
             };
 
             let decision = autonoetic_gateway::scheduler::approve_request_with_options(

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -239,9 +239,28 @@ pub async fn handle_gateway_approvals(
             reason,
             secrets,
             approval_level,
+            scope,
+            targets,
+            ttl,
+            until,
         } => {
             let approval_level = approval_level.to_runtime();
-            let decision = autonoetic_gateway::scheduler::approve_request(
+            let grant_scope = scope.to_runtime();
+
+            let parsed_targets: Vec<autonoetic_types::background::GrantTarget> = if targets.is_empty() {
+                vec![]
+            } else {
+                targets.iter().map(|s| super::common::parse_grant_target_spec(s))
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+
+            let expires_at = if let Some(ttl) = ttl {
+                Some(super::common::parse_ttl(&ttl)?)
+            } else {
+                until.clone()
+            };
+
+            let decision = autonoetic_gateway::scheduler::approve_request_with_options(
                 &config,
                 Some(&gateway_store),
                 request_id,
@@ -254,6 +273,11 @@ pub async fn handle_gateway_approvals(
                 },
                 Some(&approval_level),
                 None,
+                autonoetic_gateway::scheduler::ApproveOptions {
+                    grant_scope: Some(grant_scope),
+                    grant_targets: parsed_targets,
+                    grant_expires_at: expires_at,
+                },
             )?;
             println!(
                 "Approved {} for agent {} ({})",


### PR DESCRIPTION
## Summary

Phase 2 of the approval-system hardening plan (#80). Ships as one coherent change covering three sub-issues:

### #82 — Session-scoped grants
- `GrantScope` enum: `RootSession` (default, current behaviour) or `Session` (child-only)
- Schema v16: `session_id` + `scope` columns on `session_approval_grants`
- `grants_cover_targets(session_id, root_session_id, targets)` with scope-aware lookup
- CLI `--scope root|session`

### #83 — Pattern-based grant targets
- `GrantTarget` enum with 4 variants: `ExactHost`, `HostSuffix`, `HostAndPort`, `UrlPrefix`
- Schema v17: `session_approval_grant_targets` table (1..N per grant)
- Existing hosts backfilled as `ExactHost` targets on migration
- Pattern matching: suffix rejects lookalikes (`github.com.evil.example`), UrlPrefix requires exact prefix
- CLI `--target <spec>` repeatable

### #84 — Grant expiry (TTL)
- Schema v18: `expires_at` column on `session_approval_grants`
- Expired grants excluded from coverage checks
- `prune_expired_grants()` janitor
- CLI `--ttl 10m` / `--ttl 1h` / `--until <rfc3339>`

## Tests

15 new integration tests:
- Session-scoped vs root-scoped isolation
- Two-children-one-root test
- All 4 GrantTarget kinds (ExactHost, HostSuffix, HostAndPort, UrlPrefix)
- Evil suffix rejection
- Expired grant excluded / future grant covers
- Janitor prunes expired
- Emergency stop cleans up all scopes
- Multi-target grants
- 4 unit tests for `GrantTarget::matches()`

All 7 existing `approval_grant_revocation_integration` tests pass. All 7 `turn_continuation_approval_integration` tests pass.

## Acceptance criteria

**#82:**
- [x] Grants recorded with explicit scope
- [x] CLI allows narrowing at approval time
- [x] Default behaviour unchanged unless operator opts in
- [x] Two-children-one-root test
- [x] Emergency stop cleans up both scopes
- [x] Migration preserves existing grants' effectiveness

**#83:**
- [x] All four target kinds recorded and matched
- [x] Host-suffix rejects lookalike
- [x] UrlPrefix does not cover sibling paths
- [x] Default records ExactHost per host

**#84:**
- [x] --ttl and --until flags parse and persist
- [x] Expired grants excluded from coverage
- [x] Janitor removes expired rows