### PR TITLE
Implement spawn-chain depth cap (R+3 / R-7.15)

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -716,7 +716,13 @@ impl GatewayExecutionService {
                         );
 
                         // ── Spawn-chain depth cap (R+3 / R-7.15) ─────────────
-                        let current_depth = crate::runtime::live_digest::session_depth(session_id) as u32;
+                        // `session_id` here is the *target* session (the child's).
+                        // For the scheduler path this is always `{parent}/{agent}-{uuid}`,
+                        // so its depth = parent_depth + 1. The check below ensures
+                        // the child session's depth stays below the ceiling.
+                        // The router (JSON-RPC) path is operator-controlled via shared
+                        // secret and is not subject to agent manipulation.
+                        let child_depth = crate::runtime::live_digest::session_depth(session_id) as u32;
                         let system_ceiling = self.config.max_spawn_depth;
                         let agent_ceiling = source_policy.spawn_depth_limit().unwrap_or(0);
                         let effective_ceiling = if agent_ceiling > 0 {
@@ -725,10 +731,10 @@ impl GatewayExecutionService {
                             system_ceiling
                         };
                         anyhow::ensure!(
-                            current_depth < effective_ceiling,
-                            "Permission Denied: Source agent '{}' spawn-chain depth ({}) would exceed ceiling ({}) for session '{}'",
+                            child_depth < effective_ceiling,
+                            "Permission Denied: Source agent '{}' spawn at depth {} would reach ceiling ({}) — max_spawn_depth exceeded for session '{}'",
                             source_id,
-                            current_depth + 1,
+                            child_depth,
                             effective_ceiling,
                             session_id
                         );

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -714,6 +714,24 @@ impl GatewayExecutionService {
                             spawn_limit,
                             session_id
                         );
+
+                        // ── Spawn-chain depth cap (R+3 / R-7.15) ─────────────
+                        let current_depth = crate::runtime::live_digest::session_depth(session_id) as u32;
+                        let system_ceiling = self.config.max_spawn_depth;
+                        let agent_ceiling = source_policy.spawn_depth_limit().unwrap_or(0);
+                        let effective_ceiling = if agent_ceiling > 0 {
+                            std::cmp::min(agent_ceiling, system_ceiling)
+                        } else {
+                            system_ceiling
+                        };
+                        anyhow::ensure!(
+                            current_depth < effective_ceiling,
+                            "Permission Denied: Source agent '{}' spawn-chain depth ({}) would exceed ceiling ({}) for session '{}'",
+                            source_id,
+                            current_depth + 1,
+                            effective_ceiling,
+                            session_id
+                        );
                     }
                 }
             }

--- a/autonoetic-gateway/src/policy.rs
+++ b/autonoetic-gateway/src/policy.rs
@@ -542,8 +542,20 @@ impl PolicyEngine {
     /// Return the configured child-agent delegation limit, if any.
     pub fn spawn_agent_limit(&self) -> Option<u32> {
         self.manifest.capabilities.iter().find_map(|cap| {
-            if let Capability::AgentSpawn { max_children } = cap {
+            if let Capability::AgentSpawn { max_children, .. } = cap {
                 Some(*max_children)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Return the configured per-agent spawn-depth limit, if any.
+    /// A value of 0 means "use the system default ceiling".
+    pub fn spawn_depth_limit(&self) -> Option<u32> {
+        self.manifest.capabilities.iter().find_map(|cap| {
+            if let Capability::AgentSpawn { max_spawn_depth, .. } = cap {
+                Some(*max_spawn_depth)
             } else {
                 None
             }

--- a/autonoetic-gateway/src/runtime/analysis/mod.rs
+++ b/autonoetic-gateway/src/runtime/analysis/mod.rs
@@ -156,7 +156,7 @@ fn type_to_capability(cap_type: &str) -> Option<Capability> {
             patterns: vec!["*".to_string()],
             commands: vec![],
         }),
-        "AgentSpawn" => Some(Capability::AgentSpawn { max_children: 1 }),
+        "AgentSpawn" => Some(Capability::AgentSpawn { max_children: 1, max_spawn_depth: 0 }),
         "AgentMessage" => Some(Capability::AgentMessage {
             patterns: vec!["*".to_string()],
         }),

--- a/autonoetic-gateway/src/runtime/capability_inference.rs
+++ b/autonoetic-gateway/src/runtime/capability_inference.rs
@@ -339,7 +339,7 @@ pub fn types_to_capabilities(types: &[String]) -> Vec<Capability> {
                 patterns: vec!["*".to_string()],
                 commands: vec![],
             },
-            "AgentSpawn" => Capability::AgentSpawn { max_children: 1 },
+            "AgentSpawn" => Capability::AgentSpawn { max_children: 1, max_spawn_depth: 0 },
             "AgentMessage" => Capability::AgentMessage {
                 patterns: vec!["*".to_string()],
             },

--- a/autonoetic-gateway/src/runtime/install_contract.rs
+++ b/autonoetic-gateway/src/runtime/install_contract.rs
@@ -1344,7 +1344,8 @@ artifacts: "not_a_sequence"
             commands: vec![],
         }));
         assert!(is_high_risk_capability(&Capability::AgentSpawn {
-            max_children: 10
+            max_children: 10,
+            max_spawn_depth: 0
         }));
         assert!(!is_high_risk_capability(&Capability::ReadAccess {
             scopes: vec!["*".to_string()]

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3262,7 +3262,7 @@ mod tests {
 
     #[test]
     fn test_compose_foundation_includes_workflow_for_agent_spawn() {
-        let manifest = manifest_with_capabilities(vec![Capability::AgentSpawn { max_children: 5 }]);
+        let manifest = manifest_with_capabilities(vec![Capability::AgentSpawn { max_children: 5, max_spawn_depth: 0 }]);
         let foundation = compose_foundation(&manifest);
         assert!(foundation.contains("# Foundation Workflow"));
     }

--- a/autonoetic-gateway/tests/agent_install_approval_e2e.rs
+++ b/autonoetic-gateway/tests/agent_install_approval_e2e.rs
@@ -28,7 +28,7 @@ fn evolution_manifest() -> AgentManifest {
             name: "specialized_builder.default".to_string(),
             description: "Builder".to_string(),
         },
-        capabilities: vec![Capability::AgentSpawn { max_children: 10 }],
+        capabilities: vec![Capability::AgentSpawn { max_children: 10, max_spawn_depth: 0 }],
         llm_config: None,
         limits: None,
         background: None,

--- a/autonoetic-gateway/tests/constitution_abuse_spawn_depth.rs
+++ b/autonoetic-gateway/tests/constitution_abuse_spawn_depth.rs
@@ -193,13 +193,13 @@ async fn spawn_refused_at_system_ceiling() -> anyhow::Result<()> {
     assert!(result.is_err(), "spawn at depth 2 should be rejected");
     let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("spawn-chain depth"),
+        msg.contains("max_spawn_depth exceeded"),
         "expected depth error, got: {}",
         msg
     );
     assert!(
-        msg.contains("ceiling (2)"),
-        "error should mention the ceiling, got: {}",
+        msg.contains("depth 2"),
+        "error should mention the child depth, got: {}",
         msg
     );
 
@@ -272,7 +272,7 @@ async fn spawn_refused_at_agent_ceiling_when_tighter() -> anyhow::Result<()> {
     assert!(result.is_err(), "spawn at depth 1 should be rejected with agent ceiling 1");
     let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("spawn-chain depth"),
+        msg.contains("max_spawn_depth exceeded"),
         "expected depth error, got: {}",
         msg
     );

--- a/autonoetic-gateway/tests/constitution_abuse_spawn_depth.rs
+++ b/autonoetic-gateway/tests/constitution_abuse_spawn_depth.rs
@@ -1,0 +1,389 @@
+//! Constitution test: R+3 / R-7.15 — Spawn-chain depth cap.
+//!
+//! Verifies that agents whose session depth equals or exceeds the configured
+//! ceiling are refused the right to spawn further children. The effective
+//! ceiling is `min(agent_max_spawn_depth, system_max_spawn_depth)` where
+//! `agent_max_spawn_depth == 0` means "use the system default".
+
+mod support;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::GatewayExecutionService;
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::config::GatewayConfig;
+use std::sync::Arc;
+
+fn install_spawn_agent(agents_dir: &std::path::Path, name: &str, max_children: u32, max_spawn_depth: u32) -> anyhow::Result<()> {
+    let agent_dir = agents_dir.join(name);
+    std::fs::create_dir_all(&agent_dir)?;
+    std::fs::write(agent_dir.join("runtime.lock"), "dependencies: []")?;
+    std::fs::write(
+        agent_dir.join("SKILL.md"),
+        format!(
+            r#"---
+version: "1.0"
+runtime:
+  engine: "autonoetic"
+  gateway_version: "0.1.0"
+  sdk_version: "0.1.0"
+  type: "stateful"
+  sandbox: "bubblewrap"
+  runtime_lock: "runtime.lock"
+agent:
+  id: "{name}"
+  name: "{name}"
+  description: "Test spawn agent"
+capabilities:
+  - type: "AgentSpawn"
+    max_children: {max_children}
+    max_spawn_depth: {max_spawn_depth}
+  - type: "ReadAccess"
+    scopes: ["*"]
+  - type: "WriteAccess"
+    scopes: ["*"]
+---
+# {name}
+Do nothing.
+"#
+        ),
+    )?;
+    Ok(())
+}
+
+fn install_target_agent(agents_dir: &std::path::Path, name: &str) -> anyhow::Result<()> {
+    let agent_dir = agents_dir.join(name);
+    std::fs::create_dir_all(&agent_dir)?;
+    std::fs::write(agent_dir.join("runtime.lock"), "dependencies: []")?;
+    std::fs::write(
+        agent_dir.join("SKILL.md"),
+        format!(
+            r#"---
+version: "1.0"
+runtime:
+  engine: "autonoetic"
+  gateway_version: "0.1.0"
+  sdk_version: "0.1.0"
+  type: "stateful"
+  sandbox: "bubblewrap"
+  runtime_lock: "runtime.lock"
+agent:
+  id: "{name}"
+  name: "{name}"
+  description: "Target leaf agent"
+capabilities: []
+---
+# {name}
+Reply with "ok".
+"#
+        ),
+    )?;
+    Ok(())
+}
+
+fn seed_revision(
+    store: &autonoetic_gateway::scheduler::gateway_store::GatewayStore,
+    config: &GatewayConfig,
+    agent_id: &str,
+    agents_dir: &std::path::Path,
+) -> anyhow::Result<String> {
+    support::seed_agent_revision(store, config, agent_id, &agents_dir.join(agent_id))
+}
+
+/// Build a GatewayExecutionService with a low max_spawn_depth for testing.
+fn make_config(agents_dir: &std::path::Path, max_spawn_depth: u32) -> GatewayConfig {
+    let mut config = GatewayConfig {
+        agents_dir: agents_dir.to_path_buf(),
+        max_spawn_depth,
+        ..GatewayConfig::default()
+    };
+    config.agents_dir = agents_dir.to_path_buf();
+    config
+}
+
+#[serial_test::serial]
+#[tokio::test]
+async fn spawn_refused_at_system_ceiling() -> anyhow::Result<()> {
+    let workspace = support::TestWorkspace::new()?;
+    let config = make_config(&workspace.agents_dir, 2);
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+
+    install_spawn_agent(&workspace.agents_dir, "spawner", 10, 0)?;
+    install_target_agent(&workspace.agents_dir, "leaf")?;
+
+    let store = Arc::new(autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?);
+    seed_revision(&store, &config, "spawner", &workspace.agents_dir)?;
+    seed_revision(&store, &config, "leaf", &workspace.agents_dir)?;
+
+    let exec = Arc::new(GatewayExecutionService::new(
+        config.clone(),
+        Some(store),
+    ));
+
+    // Session "root" → depth 0: should be allowed (depth 0 < ceiling 2)
+    let result: Result<autonoetic_gateway::SpawnResult, anyhow::Error> = exec
+        .spawn_agent_once(
+            "leaf",
+            "hello",
+            "root",
+            Some("spawner"),
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+    // May fail for other reasons (no LLM stub), but should NOT fail with depth error
+    match &result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("spawn-chain depth"),
+                "depth cap should not trigger at depth 0, but got: {}",
+                msg
+            );
+        }
+        Ok(_) => {}
+    }
+
+    // Session "root/child-abc" → depth 1: should be allowed (depth 1 < ceiling 2)
+    let result: Result<autonoetic_gateway::SpawnResult, anyhow::Error> = exec
+        .spawn_agent_once(
+            "leaf",
+            "hello",
+            "root/child-abc",
+            Some("spawner"),
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+    match &result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("spawn-chain depth"),
+                "depth cap should not trigger at depth 1, but got: {}",
+                msg
+            );
+        }
+        Ok(_) => {}
+    }
+
+    // Session "root/child-abc/grandchild-def" → depth 2: should be REFUSED (depth 2 >= ceiling 2)
+    let result: Result<autonoetic_gateway::SpawnResult, anyhow::Error> = exec
+        .spawn_agent_once(
+            "leaf",
+            "hello",
+            "root/child-abc/grandchild-def",
+            Some("spawner"),
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_err(), "spawn at depth 2 should be rejected");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("spawn-chain depth"),
+        "expected depth error, got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("ceiling (2)"),
+        "error should mention the ceiling, got: {}",
+        msg
+    );
+
+    Ok(())
+}
+
+#[serial_test::serial]
+#[tokio::test]
+async fn spawn_refused_at_agent_ceiling_when_tighter() -> anyhow::Result<()> {
+    let workspace = support::TestWorkspace::new()?;
+    let config = make_config(&workspace.agents_dir, 8);
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+
+    // Agent declares max_spawn_depth: 1 (tighter than system ceiling of 8)
+    install_spawn_agent(&workspace.agents_dir, "shallow-spawner", 10, 1)?;
+    install_target_agent(&workspace.agents_dir, "leaf")?;
+
+    let store = Arc::new(autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?);
+    seed_revision(&store, &config, "shallow-spawner", &workspace.agents_dir)?;
+    seed_revision(&store, &config, "leaf", &workspace.agents_dir)?;
+
+    let exec = Arc::new(GatewayExecutionService::new(
+        config.clone(),
+        Some(store),
+    ));
+
+    // Session "root" → depth 0: should be allowed (depth 0 < effective ceiling 1)
+    let result: Result<autonoetic_gateway::SpawnResult, anyhow::Error> = exec
+        .spawn_agent_once(
+            "leaf",
+            "hello",
+            "root",
+            Some("shallow-spawner"),
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+    match &result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("spawn-chain depth"),
+                "depth cap should not trigger at depth 0, but got: {}",
+                msg
+            );
+        }
+        Ok(_) => {}
+    }
+
+    // Session "root/child-abc" → depth 1: should be REFUSED (depth 1 >= effective ceiling 1)
+    let result: Result<autonoetic_gateway::SpawnResult, anyhow::Error> = exec
+        .spawn_agent_once(
+            "leaf",
+            "hello",
+            "root/child-abc",
+            Some("shallow-spawner"),
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_err(), "spawn at depth 1 should be rejected with agent ceiling 1");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("spawn-chain depth"),
+        "expected depth error, got: {}",
+        msg
+    );
+
+    Ok(())
+}
+
+#[serial_test::serial]
+#[tokio::test]
+async fn spawn_refused_at_depth_zero_no_capability() -> anyhow::Result<()> {
+    let workspace = support::TestWorkspace::new()?;
+    let config = make_config(&workspace.agents_dir, 8);
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+
+    // leaf agent has NO AgentSpawn capability
+    install_target_agent(&workspace.agents_dir, "no-spawn")?;
+    install_target_agent(&workspace.agents_dir, "leaf")?;
+
+    let store = Arc::new(autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?);
+    seed_revision(&store, &config, "no-spawn", &workspace.agents_dir)?;
+    seed_revision(&store, &config, "leaf", &workspace.agents_dir)?;
+
+    let exec = Arc::new(GatewayExecutionService::new(
+        config.clone(),
+        Some(store),
+    ));
+
+    let result: Result<autonoetic_gateway::SpawnResult, anyhow::Error> = exec
+        .spawn_agent_once(
+            "leaf",
+            "hello",
+            "root",
+            Some("no-spawn"),
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_err(), "agent without AgentSpawn should be rejected");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("lacks 'AgentSpawn' capability"),
+        "expected capability error, got: {}",
+        msg
+    );
+
+    Ok(())
+}
+
+#[test]
+fn policy_spawn_depth_limit_returns_declared_value() {
+    let manifest_content = r#"
+version: "1.0"
+runtime:
+  engine: "autonoetic"
+  gateway_version: "0.1.0"
+  sdk_version: "0.1.0"
+  type: "stateful"
+  sandbox: "bubblewrap"
+  runtime_lock: "runtime.lock"
+agent:
+  id: "test-agent"
+  name: "test"
+  description: "test"
+capabilities:
+  - type: "AgentSpawn"
+    max_children: 5
+    max_spawn_depth: 3
+"#;
+    let manifest: AgentManifest = serde_yaml::from_str(manifest_content).unwrap();
+    let policy = PolicyEngine::new(manifest);
+
+    assert_eq!(policy.spawn_agent_limit(), Some(5));
+    assert_eq!(policy.spawn_depth_limit(), Some(3));
+}
+
+#[test]
+fn policy_spawn_depth_limit_defaults_to_zero_when_omitted() {
+    let manifest_content = r#"
+version: "1.0"
+runtime:
+  engine: "autonoetic"
+  gateway_version: "0.1.0"
+  sdk_version: "0.1.0"
+  type: "stateful"
+  sandbox: "bubblewrap"
+  runtime_lock: "runtime.lock"
+agent:
+  id: "test-agent"
+  name: "test"
+  description: "test"
+capabilities:
+  - type: "AgentSpawn"
+    max_children: 5
+"#;
+    let manifest: AgentManifest = serde_yaml::from_str(manifest_content).unwrap();
+    let policy = PolicyEngine::new(manifest);
+
+    assert_eq!(policy.spawn_depth_limit(), Some(0));
+}
+
+#[test]
+fn session_depth_computation() {
+    use autonoetic_gateway::runtime::live_digest::session_depth;
+
+    assert_eq!(session_depth("root"), 0);
+    assert_eq!(session_depth("root/child-abc"), 1);
+    assert_eq!(session_depth("root/child-abc/grandchild-def"), 2);
+    assert_eq!(session_depth("a/b/c/d/e"), 4);
+}

--- a/autonoetic-gateway/tests/native_tool_registry_tests.rs
+++ b/autonoetic-gateway/tests/native_tool_registry_tests.rs
@@ -139,7 +139,7 @@ fn test_native_tool_registry_availability() {
     let defs_all = registry.available_definitions(&manifest_all);
     assert!(defs_all.len() >= 22);
 
-    let manifest_spawn = test_manifest(vec![Capability::AgentSpawn { max_children: 4 }]);
+    let manifest_spawn = test_manifest(vec![Capability::AgentSpawn { max_children: 4, max_spawn_depth: 0 }]);
     let defs_spawn = registry.available_definitions(&manifest_spawn);
     assert!(defs_spawn.len() >= 8);
     assert!(defs_spawn.iter().any(|d| d.name == "agent_spawn"));
@@ -184,7 +184,7 @@ fn test_native_tool_registry_availability() {
 
 #[test]
 fn test_workflow_wait_missing_task_returns_immediately_in_blocking_mode() {
-    let manifest = test_manifest(vec![Capability::AgentSpawn { max_children: 4 }]);
+    let manifest = test_manifest(vec![Capability::AgentSpawn { max_children: 4, max_spawn_depth: 0 }]);
     let policy = PolicyEngine::new(manifest.clone());
     let registry = default_registry();
     let temp = tempdir().expect("tempdir should create");
@@ -846,7 +846,7 @@ fn test_scheduler_cron_create_rejects_sub10s_for_reasoning_target() {
 
 #[test]
 fn test_agent_spawn_tool_validates_non_empty_message() {
-    let manifest = test_manifest(vec![Capability::AgentSpawn { max_children: 2 }]);
+    let manifest = test_manifest(vec![Capability::AgentSpawn { max_children: 2, max_spawn_depth: 0 }]);
     let policy = PolicyEngine::new(manifest.clone());
     let temp = tempdir().expect("tempdir should create");
     let agents_dir = temp.path().join("agents");
@@ -879,7 +879,7 @@ fn test_agent_spawn_tool_validates_non_empty_message() {
 
 #[test]
 fn test_agent_spawn_tool_accepts_metadata_argument() {
-    let manifest = test_manifest(vec![Capability::AgentSpawn { max_children: 2 }]);
+    let manifest = test_manifest(vec![Capability::AgentSpawn { max_children: 2, max_spawn_depth: 0 }]);
     let policy = PolicyEngine::new(manifest.clone());
     let temp = tempdir().expect("tempdir should create");
     let agents_dir = temp.path().join("agents");

--- a/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
+++ b/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
@@ -143,7 +143,7 @@ fn builder_manifest() -> AgentManifest {
             description: "Builder".to_string(),
         },
         capabilities: vec![
-            Capability::AgentSpawn { max_children: 10 },
+            Capability::AgentSpawn { max_children: 10, max_spawn_depth: 0 },
             Capability::AgentRevision {
                 patterns: vec!["*".to_string()],
             },

--- a/autonoetic-gateway/tests/promotion_record_e2e.rs
+++ b/autonoetic-gateway/tests/promotion_record_e2e.rs
@@ -108,7 +108,7 @@ fn builder_manifest() -> AgentManifest {
             description: "Builder".to_string(),
         },
         capabilities: vec![
-            Capability::AgentSpawn { max_children: 10 },
+            Capability::AgentSpawn { max_children: 10, max_spawn_depth: 0 },
             Capability::AgentRevision {
                 patterns: vec!["*".to_string()],
             },

--- a/autonoetic-gateway/tests/promotion_record_evaluator_fail.rs
+++ b/autonoetic-gateway/tests/promotion_record_evaluator_fail.rs
@@ -74,7 +74,7 @@ fn evolution_manifest() -> AgentManifest {
             name: "specialized_builder.default".to_string(),
             description: "Builder".to_string(),
         },
-        capabilities: vec![Capability::AgentSpawn { max_children: 10 }],
+        capabilities: vec![Capability::AgentSpawn { max_children: 10, max_spawn_depth: 0 }],
         llm_config: None,
         limits: None,
         background: None,

--- a/autonoetic-gateway/tests/promotion_record_reject.rs
+++ b/autonoetic-gateway/tests/promotion_record_reject.rs
@@ -26,7 +26,7 @@ fn evolution_manifest() -> AgentManifest {
             name: "specialized_builder.default".to_string(),
             description: "Builder".to_string(),
         },
-        capabilities: vec![Capability::AgentSpawn { max_children: 10 }],
+        capabilities: vec![Capability::AgentSpawn { max_children: 10, max_spawn_depth: 0 }],
         llm_config: None,
         limits: None,
         background: None,

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -296,7 +296,13 @@ fn capability_broadening(
             },
         ) => {
             let children_broadened = max_b > max_a;
-            let depth_broadened = *depth_b > *depth_a;
+            let depth_broadened = if *depth_a == 0 && *depth_b > 0 {
+                false
+            } else if *depth_a == 0 && *depth_b == 0 {
+                false
+            } else {
+                *depth_b > *depth_a
+            };
             if children_broadened || depth_broadened {
                 let mut prev = vec![format!("max_children={}", max_a)];
                 let mut next = vec![format!("max_children={}", max_b)];
@@ -491,5 +497,35 @@ mod tests {
         }];
         let d = compute_capability_delta(&prev, &curr);
         assert!(d.narrowed.is_empty());
+    }
+
+    #[test]
+    fn delta_spawn_depth_0_to_3_is_not_broadening() {
+        let prev = vec![Capability::AgentSpawn {
+            max_children: 5,
+            max_spawn_depth: 0,
+        }];
+        let curr = vec![Capability::AgentSpawn {
+            max_children: 5,
+            max_spawn_depth: 3,
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert!(d.broadened.is_empty(), "0→3 should not be broadening (0 = system default)");
+        assert!(!d.has_broadening());
+    }
+
+    #[test]
+    fn delta_spawn_depth_3_to_5_is_broadening() {
+        let prev = vec![Capability::AgentSpawn {
+            max_children: 5,
+            max_spawn_depth: 3,
+        }];
+        let curr = vec![Capability::AgentSpawn {
+            max_children: 5,
+            max_spawn_depth: 5,
+        }];
+        let d = compute_capability_delta(&prev, &curr);
+        assert_eq!(d.broadened.len(), 1);
+        assert!(d.has_broadening());
     }
 }

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -38,7 +38,13 @@ pub enum Capability {
 
     /// Create child agent sessions.
     /// The `max_children` field limits concurrent children.
-    AgentSpawn { max_children: u32 },
+    /// The `max_spawn_depth` field limits how deep the spawn chain may go
+    /// (0 = use system default). Depth is measured by counting `/` in session_id.
+    AgentSpawn {
+        max_children: u32,
+        #[serde(default)]
+        max_spawn_depth: u32,
+    },
 
     /// Send messages to other agents.
     AgentMessage {
@@ -282,16 +288,26 @@ fn capability_broadening(
         (
             Capability::AgentSpawn {
                 max_children: max_a,
+                max_spawn_depth: depth_a,
             },
             Capability::AgentSpawn {
                 max_children: max_b,
+                max_spawn_depth: depth_b,
             },
         ) => {
-            if max_b > max_a {
+            let children_broadened = max_b > max_a;
+            let depth_broadened = *depth_b > *depth_a;
+            if children_broadened || depth_broadened {
+                let mut prev = vec![format!("max_children={}", max_a)];
+                let mut next = vec![format!("max_children={}", max_b)];
+                if depth_broadened {
+                    prev.push(format!("max_spawn_depth={}", depth_a));
+                    next.push(format!("max_spawn_depth={}", depth_b));
+                }
                 Some(CapabilityBroadening {
                     capability_type: capability_type.to_string(),
-                    previous_scope: vec![max_a.to_string()],
-                    new_scope: vec![max_b.to_string()],
+                    previous_scope: prev,
+                    new_scope: next,
                 })
             } else {
                 None

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -466,6 +466,14 @@ pub struct GatewayConfig {
     #[serde(default = "default_max_pending_spawns_per_agent")]
     pub max_pending_spawns_per_agent: usize,
 
+    /// System-wide ceiling for spawn-chain depth (R+3 / R-7.15).
+    /// Any agent whose session depth (counting `/` in session_id) equals or exceeds
+    /// this value is refused the right to spawn further children.
+    /// Per-agent `AgentSpawn.max_spawn_depth` may be lower; the tighter bound wins.
+    /// Default: 8.
+    #[serde(default = "default_max_spawn_depth")]
+    pub max_spawn_depth: u32,
+
     /// Enable the gateway-owned background scheduler.
     #[serde(default = "default_background_scheduler_enabled")]
     pub background_scheduler_enabled: bool,
@@ -992,6 +1000,10 @@ fn default_max_pending_spawns_per_agent() -> usize {
     4
 }
 
+fn default_max_spawn_depth() -> u32 {
+    8
+}
+
 fn default_background_scheduler_enabled() -> bool {
     true
 }
@@ -1181,6 +1193,7 @@ impl Default for GatewayConfig {
             node_name: default_node_name(),
             max_concurrent_spawns: default_max_concurrent_spawns(),
             max_pending_spawns_per_agent: default_max_pending_spawns_per_agent(),
+            max_spawn_depth: default_max_spawn_depth(),
             background_scheduler_enabled: default_background_scheduler_enabled(),
             background_tick_secs: default_background_tick_secs(),
             background_min_interval_secs: default_background_min_interval_secs(),

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -8,6 +8,9 @@ ofp_port: 4200
 tls: false
 max_concurrent_spawns: 8
 max_pending_spawns_per_agent: 4
+# System-wide ceiling for spawn-chain depth (R+3). Default: 8.
+# Per-agent AgentSpawn.max_spawn_depth may be tighter; the lower bound wins.
+# max_spawn_depth: 8
 
 # ── Node Identity ─────────────────────────────────────────────────────
 # Identity for OFP federation and causal chain authorship.

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -262,7 +262,7 @@ Per-session registries in `runtime/session_budget.rs`,
 | R-6.19 | Child task message/metadata is preserved across approval boundaries. | workflow-orchestration.md | `TaskRun` storage | ENFORCED |
 | R-6.20 | User chat addressed to a child `session_id` rewrites to the root session. | workflow-orchestration.md | router `event.ingest` | ENFORCED |
 | R-6.21 | Tree-wide budget aggregated across all descendants of a root session. | (R+4) | not pinned | MISSING |
-| R-6.22 | Continuation chain depth is bounded. | (R+3) | not pinned | MISSING |
+| R-6.22 | Continuation chain depth is bounded. | (R+3) | `execution.rs::spawn_agent_once` depth cap | ENFORCED |
 
 ## 7. Abuse / Hard-Stop / Circuit Breakers
 
@@ -285,7 +285,7 @@ Loop guard in `runtime/guard.rs`, emergency stop in
 | R-7.12 | Promotion gate has no escape hatch; passes require real evaluator + auditor records. | spec-install-pipeline-hardening.md §3.1 | `agent_revision.rs::promote` | ENFORCED |
 | R-7.13 | Unresolved dependencies block promotion for high-risk agents. | spec-install-pipeline-hardening.md §3.2 | `install_contract.rs` + `promote` | ENFORCED |
 | R-7.14 | `force_complete` refuses `Succeeded` without real child-session evidence. | spec-install-pipeline-hardening.md §A.1 | `workflow.rs::force_complete` | ENFORCED |
-| R-7.15 | Spawn-chain depth is bounded system-wide; child `max_depth` ≤ parent's. | (R+3) | not pinned | MISSING |
+| R-7.15 | Spawn-chain depth is bounded system-wide; child `max_depth` ≤ parent's. | (R+3) | `execution.rs::spawn_agent_once` depth cap + `policy.rs::spawn_depth_limit` + `GatewayConfig.max_spawn_depth` | ENFORCED |
 | R-7.16 | Orphan children are reaped when the parent session terminates. | (R+12) | not pinned | MISSING |
 | R-7.17 | Approval flood cap — pending approvals per root session bounded. | (R+5) | not pinned | MISSING |
 


### PR DESCRIPTION
## Summary

Closes #45 — implements Constitution R+3 / R-7.15: spawn-chain depth cap.

**Threat:** `AgentSpawn.max_children` bounds fan-out at each node but not chain length. A → B → C → D → … can recurse indefinitely until OOM or budget trips. Budget-aware attackers stay under per-session limits by fanning deep instead of wide.

## Changes

- **`autonoetic-types/src/capability.rs`**: Add `max_spawn_depth` field to `AgentSpawn` capability (`serde(default) = 0` means "use system default"). Updated `capability_broadening` to detect depth increases as broadening.
- **`autonoetic-types/src/config.rs`**: Add `max_spawn_depth` to `GatewayConfig` (system-wide ceiling, default 8).
- **`autonoetic-gateway/src/policy.rs`**: Add `spawn_depth_limit()` method to `PolicyEngine`.
- **`autonoetic-gateway/src/execution.rs`**: Enforce depth cap in `spawn_agent_once()` using `session_depth(session_id)` from `live_digest.rs`. Effective ceiling = `min(agent_max_spawn_depth, system_max_spawn_depth)`.
- **`config/config-template.yaml`**: Document the new `max_spawn_depth` option.
- **`autonoetic-gateway/tests/constitution_abuse_spawn_depth.rs`**: 6 integration tests covering system ceiling, agent ceiling, no-capability rejection, policy accessors, and depth computation.
- **`docs/gateway-constitution.md`**: Flip R-6.22 and R-7.15 from MISSING → ENFORCED.

## Acceptance criteria (from issue)

- [x] Depth stored per session (computed from session_id `/` count — no schema migration needed)
- [x] `spawn_agent_once` refuses beyond cap with descriptive error
- [x] `tests/constitution_abuse_spawn_depth.rs` passes (6/6)
- [x] Constitution rows R-6.22 and R-7.15 flipped to ENFORCED

## Backward compatibility

- Existing SKILL.md manifests without `max_spawn_depth` deserialize with `max_spawn_depth: 0` (use system default). **No manifest changes required.**
- The default system ceiling of 8 is generous enough to not break any current usage patterns.