### PR TITLE
Implement approval flood cap (R+5 / R-7.17)

### DIFF
--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -9,6 +9,24 @@ use super::GatewayStore;
 impl GatewayStore {
     pub fn create_approval(&self, request: &ApprovalRequest) -> Result<()> {
         let conn = self.conn.lock().unwrap();
+
+        if let Some(ref root_session_id) = request.root_session_id {
+            let pending_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM approvals WHERE root_session_id = ?1 AND status = 'pending'",
+                params![root_session_id],
+                |row| row.get(0),
+            )?;
+            let cap = self.approval_flood_cap.load(std::sync::atomic::Ordering::Relaxed);
+            if cap > 0 && (pending_count as usize) >= cap {
+                anyhow::bail!(
+                    "approval_flood: root session '{}' already has {} pending approvals (cap {})",
+                    root_session_id,
+                    pending_count,
+                    cap
+                );
+            }
+        }
+
         let action_payload = serde_json::to_string(&request.action)?;
         conn.execute(
             "INSERT INTO approvals (
@@ -33,6 +51,20 @@ impl GatewayStore {
             ],
         )?;
         Ok(())
+    }
+
+    pub fn set_approval_flood_cap(&self, cap: usize) {
+        self.approval_flood_cap.store(cap, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn count_pending_for_root(&self, root_session_id: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM approvals WHERE root_session_id = ?1 AND status = 'pending'",
+            params![root_session_id],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
     }
 
     fn get_approval_with_conn(

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -11,19 +11,21 @@ impl GatewayStore {
         let conn = self.conn.lock().unwrap();
 
         if let Some(ref root_session_id) = request.root_session_id {
-            let pending_count: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM approvals WHERE root_session_id = ?1 AND status = 'pending'",
-                params![root_session_id],
-                |row| row.get(0),
-            )?;
             let cap = self.approval_flood_cap.load(std::sync::atomic::Ordering::Relaxed);
-            if cap > 0 && (pending_count as usize) >= cap {
-                anyhow::bail!(
-                    "approval_flood: root session '{}' already has {} pending approvals (cap {})",
-                    root_session_id,
-                    pending_count,
-                    cap
-                );
+            if cap > 0 {
+                let pending_count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM approvals WHERE root_session_id = ?1 AND status = 'pending'",
+                    params![root_session_id],
+                    |row| row.get(0),
+                )?;
+                if (pending_count as usize) >= cap {
+                    anyhow::bail!(
+                        "approval_flood: root session '{}' already has {} pending approvals (cap {})",
+                        root_session_id,
+                        pending_count,
+                        cap
+                    );
+                }
             }
         }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -94,6 +94,7 @@ pub fn default_gateway_host_id() -> String {
 
 pub struct GatewayStore {
     conn: std::sync::Mutex<Connection>,
+    approval_flood_cap: std::sync::atomic::AtomicUsize,
 }
 
 impl GatewayStore {
@@ -112,6 +113,7 @@ impl GatewayStore {
 
         let store = Self {
             conn: std::sync::Mutex::new(conn),
+            approval_flood_cap: std::sync::atomic::AtomicUsize::new(0),
         };
         {
             let mut conn = store.conn.lock().unwrap();

--- a/autonoetic-gateway/src/server/mod.rs
+++ b/autonoetic-gateway/src/server/mod.rs
@@ -51,6 +51,7 @@ impl GatewayServer {
         let gateway_store = Arc::new(crate::scheduler::gateway_store::GatewayStore::open(
             &gateway_dir,
         )?);
+        gateway_store.set_approval_flood_cap(self.config.max_pending_approvals_per_root);
 
         // Apply data retention policy on startup
         if let Err(e) = gateway_store.apply_retention_policy(&self.config.retention) {

--- a/autonoetic-gateway/tests/constitution_abuse_approval_flood.rs
+++ b/autonoetic-gateway/tests/constitution_abuse_approval_flood.rs
@@ -6,11 +6,8 @@
 
 mod support;
 
-use std::sync::Arc;
-
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
-use autonoetic_types::config::GatewayConfig;
 
 fn make_request(ix: usize, root_session_id: &str) -> ApprovalRequest {
     ApprovalRequest {

--- a/autonoetic-gateway/tests/constitution_abuse_approval_flood.rs
+++ b/autonoetic-gateway/tests/constitution_abuse_approval_flood.rs
@@ -1,0 +1,131 @@
+//! Constitution test: R+5 / R-7.17 — Approval flood cap.
+//!
+//! Verifies that pending approvals per root_session_id are bounded.
+//! The N+1th request is rejected with `approval_flood`, and the first
+//! N remain pending.
+
+mod support;
+
+use std::sync::Arc;
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
+use autonoetic_types::config::GatewayConfig;
+
+fn make_request(ix: usize, root_session_id: &str) -> ApprovalRequest {
+    ApprovalRequest {
+        request_id: format!("req-{}", ix),
+        agent_id: "test-agent".to_string(),
+        session_id: format!("sess-{}", ix),
+        root_session_id: Some(root_session_id.to_string()),
+        workflow_id: None,
+        task_id: None,
+        action: ScheduledAction::SandboxExec {
+            command: format!("echo {}", ix),
+            detected_hosts: Some(vec![format!("host-{}.example.com", ix)]),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+        },
+        created_at: chrono::Utc::now().to_rfc3339(),
+        reason: Some(format!("test approval {}", ix)),
+        evidence_ref: None,
+        status: None,
+        decided_at: None,
+        decided_by: None,
+        decision_reason: None,
+        approval_level: ApprovalLevel::Operator,
+    }
+}
+
+#[serial_test::serial]
+#[test]
+fn flood_cap_rejects_at_limit_and_keeps_existing() -> anyhow::Result<()> {
+    let workspace = support::TestWorkspace::new()?;
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+
+    let store = GatewayStore::open(&gateway_dir)?;
+    let cap: usize = 5;
+    store.set_approval_flood_cap(cap);
+
+    let root = "root-session-flood";
+
+    // Insert exactly `cap` approvals — all should succeed.
+    for i in 0..cap {
+        let req = make_request(i, root);
+        store.create_approval(&req)?;
+    }
+
+    // The cap+1th should be rejected.
+    let over = make_request(cap, root);
+    let result = store.create_approval(&over);
+    assert!(result.is_err(), "approval beyond cap should be rejected");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("approval_flood"),
+        "expected approval_flood error, got: {}",
+        err_msg
+    );
+    assert!(
+        err_msg.contains(&format!("cap {}", cap)),
+        "error should mention the cap, got: {}",
+        err_msg
+    );
+
+    // The original cap approvals should still be pending.
+    let pending = store.count_pending_for_root(root)?;
+    assert_eq!(pending, cap, "all {} original approvals should remain pending", cap);
+
+    // A different root session should not be affected.
+    let other_root = "other-root-session";
+    let other_req = make_request(999, other_root);
+    store.create_approval(&other_req)?;
+    assert_eq!(store.count_pending_for_root(other_root)?, 1);
+
+    Ok(())
+}
+
+#[serial_test::serial]
+#[test]
+fn flood_cap_zero_means_disabled() -> anyhow::Result<()> {
+    let workspace = support::TestWorkspace::new()?;
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+
+    let store = GatewayStore::open(&gateway_dir)?;
+    store.set_approval_flood_cap(0);
+
+    let root = "root-no-cap";
+
+    // Insert 60 approvals — all should succeed when cap = 0.
+    for i in 0..60 {
+        let req = make_request(i, root);
+        store.create_approval(&req)?;
+    }
+
+    let pending = store.count_pending_for_root(root)?;
+    assert_eq!(pending, 60);
+
+    Ok(())
+}
+
+#[serial_test::serial]
+#[test]
+fn flood_cap_skipped_when_no_root_session_id() -> anyhow::Result<()> {
+    let workspace = support::TestWorkspace::new()?;
+    let gateway_dir = workspace.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+
+    let store = GatewayStore::open(&gateway_dir)?;
+    store.set_approval_flood_cap(1);
+
+    // Requests without root_session_id should bypass the cap.
+    for i in 0..5 {
+        let mut req = make_request(i, "unused");
+        req.root_session_id = None;
+        store.create_approval(&req)?;
+    }
+
+    Ok(())
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -521,6 +521,13 @@ pub struct GatewayConfig {
     #[serde(default = "default_approval_timeout_secs")]
     pub approval_timeout_secs: u64,
 
+    /// Maximum number of concurrent pending approvals per root_session_id (R+5 / R-7.17).
+    /// When a new approval request would push the count above this cap, the insert is
+    /// rejected with `approval_flood`. Set to 0 to disable (not recommended).
+    /// Default: 50.
+    #[serde(default = "default_max_pending_approvals_per_root")]
+    pub max_pending_approvals_per_root: usize,
+
     /// HMAC-SHA256 key for signing turn continuation files.
     /// This value should be a secret, high-entropy key provided from a secret
     /// source (environment secret or vault); do not derive it from `node_id`
@@ -1024,6 +1031,10 @@ fn default_approval_timeout_secs() -> u64 {
     600
 }
 
+fn default_max_pending_approvals_per_root() -> usize {
+    50
+}
+
 fn default_workflow_task_heartbeat_secs_val() -> Option<u64> {
     None
 }
@@ -1205,6 +1216,7 @@ impl Default for GatewayConfig {
             capability_delta_gate_mode: CapabilityDeltaGateMode::Strict,
             session_budget: SessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),
+            max_pending_approvals_per_root: default_max_pending_approvals_per_root(),
             continuation_key: None,
             workflow_task_heartbeat_secs: default_workflow_task_heartbeat_secs_val(),
             stuck_task_timeout_secs: default_stuck_task_timeout_secs_val(),

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -51,6 +51,9 @@ response_validation:
 # ── Approval Timeout ──────────────────────────────────────────────────
 # Max seconds a task can stay in AwaitingApproval before auto-fail. 0 = no timeout.
 approval_timeout_secs: 600
+# Maximum concurrent pending approvals per root session (R+5). Default: 50.
+# Excess requests are rejected immediately with approval_flood.
+# max_pending_approvals_per_root: 50
 # Optional: heartbeat interval for Running workflow tasks (seconds).
 # Keeps task updated_at fresh during long-running child execution/finalization.
 # If omitted, derives from background_tick_secs (clamped 1..=5). Valid range: 1..=30.

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -287,7 +287,7 @@ Loop guard in `runtime/guard.rs`, emergency stop in
 | R-7.14 | `force_complete` refuses `Succeeded` without real child-session evidence. | spec-install-pipeline-hardening.md §A.1 | `workflow.rs::force_complete` | ENFORCED |
 | R-7.15 | Spawn-chain depth is bounded system-wide; child `max_depth` ≤ parent's. | (R+3) | `execution.rs::spawn_agent_once` depth cap + `policy.rs::spawn_depth_limit` + `GatewayConfig.max_spawn_depth` | ENFORCED |
 | R-7.16 | Orphan children are reaped when the parent session terminates. | (R+12) | not pinned | MISSING |
-| R-7.17 | Approval flood cap — pending approvals per root session bounded. | (R+5) | not pinned | MISSING |
+| R-7.17 | Approval flood cap — pending approvals per root session bounded. | (R+5) | `gateway_store/approvals.rs::create_approval` + `GatewayConfig.max_pending_approvals_per_root` | ENFORCED |
 
 ## 8. Audit & Traceability
 


### PR DESCRIPTION
## Summary

Closes #44 — implements Constitution R+5 / R-7.17: approval flood cap.

**Threat:** A rogue or buggy agent emits an unbounded stream of distinct approval requests (fresh fingerprint each, defeating dedup). The operator's approval queue is DoSed; every session sharing that operator is wedged.

## Changes

- **`autonoetic-types/src/config.rs`**: Add `max_pending_approvals_per_root` (default 50, 0 = disabled).
- **`gateway_store/approvals.rs`**: Check pending count inside `create_approval()` — same SQLite mutex as the insert, so no race condition. Reject with `approval_flood` when count >= cap. Skip when `root_session_id` is None.
- **`gateway_store/mod.rs`**: Add `AtomicUsize` field for the cap, `set_approval_flood_cap()` method.
- **`server/mod.rs`**: Wire cap from config at gateway startup.
- **`config/config-template.yaml`**: Document the new option.
- **`tests/constitution_abuse_approval_flood.rs`**: 3 tests — cap enforcement, cap=0 disabled, no-root bypass.
- **`docs/gateway-constitution.md`**: Flip R-7.17 from MISSING → ENFORCED.

## Acceptance criteria (from issue)

- [x] Cap enforced at insert time (inside SQLite mutex, race-free)
- [x] Error message clearly identifies `approval_flood` with count and cap
- [x] `tests/constitution_abuse_approval_flood.rs` passes (3/3)
- [x] Constitution row R-7.17 flipped to ENFORCED