### PR TITLE
feat(approval): Phase 3 operator experience — continuation cleanup, grant revocation, similarity, analytics

### DIFF
--- a/autonoetic-gateway/src/runtime/continuation.rs
+++ b/autonoetic-gateway/src/runtime/continuation.rs
@@ -172,7 +172,7 @@ pub fn continuations_dir(config: &GatewayConfig) -> PathBuf {
     config.agents_dir.join(".gateway").join("continuations")
 }
 
-fn continuation_path(config: &GatewayConfig, task_id: &str) -> PathBuf {
+pub fn continuation_path(config: &GatewayConfig, task_id: &str) -> PathBuf {
     continuations_dir(config).join(format!("{}.json", task_id))
 }
 
@@ -282,6 +282,39 @@ pub fn list_suspended_task_ids(config: &GatewayConfig) -> anyhow::Result<Vec<Str
         }
     }
     Ok(ids)
+}
+
+/// Remove orphaned continuation files whose bound approval is in a terminal
+/// state (approved/rejected/cancelled) or whose approval row no longer exists.
+/// Returns the number of reaped files.
+pub fn reap_orphaned_continuations(
+    config: &GatewayConfig,
+    store: &crate::scheduler::gateway_store::GatewayStore,
+) -> anyhow::Result<u32> {
+    let suspended = list_suspended_task_ids(config)?;
+    if suspended.is_empty() {
+        return Ok(0);
+    }
+
+    let mut reaped = 0u32;
+    for task_id in &suspended {
+        let status = store.get_approval_status_by_task_id(task_id)?;
+        let is_orphan = match &status {
+            None => true,
+            Some(s) => s != "pending",
+        };
+        if is_orphan {
+            tracing::info!(
+                target: "continuation",
+                task_id = %task_id,
+                approval_status = ?status,
+                "Reaping orphaned continuation file"
+            );
+            delete_continuation(config, task_id)?;
+            reaped += 1;
+        }
+    }
+    Ok(reaped)
 }
 
 // ---------------------------------------------------------------------------

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -785,6 +785,8 @@ impl AgentExecutor {
             decided_by: None,
             decision_reason: None,
             approval_level: crate::scheduler::approval::resolve_approval_level(cfg, &action),
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&request)?;
         Ok(request_id)

--- a/autonoetic-gateway/src/runtime/tools/approval.rs
+++ b/autonoetic-gateway/src/runtime/tools/approval.rs
@@ -207,11 +207,18 @@ impl NativeTool for ApprovalWithdrawTool {
                 }
 
                 let reason = args.reason.as_deref().unwrap_or("Withdrawn by agent");
+                let task_id_copy = r.task_id.clone();
                 store.cancel_approval(
                     &args.request_id,
                     &format!("agent:{}", manifest.agent.id),
                     &chrono::Utc::now().to_rfc3339(),
                 )?;
+
+                if let Some(ref task_id) = task_id_copy {
+                    if let Some(cfg) = _config {
+                        let _ = crate::runtime::continuation::delete_continuation(cfg, task_id);
+                    }
+                }
 
                 tracing::info!(
                     target: "approval_withdraw",

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -458,6 +458,8 @@ impl NativeTool for ArtifactExecTool {
                             }
                             _ => None,
                         },
+                        similar_to_request_id: None,
+                        similarity_score: None,
                     };
                     if let Some(store) = &gateway_store {
                         store.create_approval(&request)?;

--- a/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
@@ -418,6 +418,8 @@ impl NativeTool for ArtifactPrepareTool {
                 }
                 _ => None,
             },
+            similar_to_request_id: None,
+            similarity_score: None,
         };
 
         store.create_approval(&request)?;

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -410,8 +410,11 @@ impl NativeTool for CredentialRequestTool {
                 reason: Some(format!("HTTP request to {} requires approval", url_host)),
                 evidence_ref: None,
                 decision_reason: None,
-                approval_level: crate::scheduler::approval::resolve_approval_level(cfg, &action),
-            };
+            approval_level: crate::scheduler::approval::resolve_approval_level(cfg, &action),
+            similar_to_request_id: None,
+            similarity_score: None,
+        };
+
             store.create_approval(&req)?;
             let message = format!(
                 "Execution suspended pending operator approval ({}). Retry credential.request with approval_ref after approval.",
@@ -1709,6 +1712,8 @@ fn execute_steps(
                             crate::scheduler::approval::resolve_approval_level(c, &approval_action)
                         })
                         .unwrap_or(ApprovalLevel::Operator),
+                    similar_to_request_id: None,
+                    similarity_score: None,
                 };
                 store.create_approval(&approval_req)?;
 

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -1322,6 +1322,8 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                             }
                             _ => None,
                         },
+                        similar_to_request_id: None,
+                        similarity_score: None,
                     };
                     if let Some(store) = &gateway_store {
                         store.create_approval(&request).map_err(|e| {
@@ -1585,6 +1587,8 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                                 }
                                 _ => None,
                             },
+                            similar_to_request_id: None,
+                            similarity_score: None,
                         };
                         if let Some(store) = &gateway_store {
                             store.create_approval(&request).map_err(|e| {
@@ -2244,6 +2248,8 @@ mod approval_binding_tests {
             decided_by: Some("operator".to_string()),
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         assert!(approved_requests_cover_targets(
             &[req.clone()],

--- a/autonoetic-gateway/src/runtime/tools/session.rs
+++ b/autonoetic-gateway/src/runtime/tools/session.rs
@@ -203,6 +203,8 @@ impl NativeTool for SessionEscalateTool {
                     decided_by: None,
                     decision_reason: None,
                     approval_level,
+                    similar_to_request_id: None,
+                    similarity_score: None,
                 };
                 store.create_approval(&request)?;
 

--- a/autonoetic-gateway/src/runtime/tools/user_profile.rs
+++ b/autonoetic-gateway/src/runtime/tools/user_profile.rs
@@ -413,6 +413,8 @@ impl NativeTool for UserProfileShareTool {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
 
         store.create_approval(&approval)?;

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use crate::runtime::continuation;
 
 pub mod approval;
+pub mod approval_similarity;
 pub mod cron_parser;
 pub mod decision;
 pub mod eval_runner;

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -372,6 +372,10 @@ pub fn reject_request(
     // Unblock the task in the workflow (marks as Failed)
     unblock_task_on_approval(config, gateway_store, &decision);
 
+    if let Some(ref task_id) = decision.task_id {
+        let _ = crate::runtime::continuation::delete_continuation(config, task_id);
+    }
+
     Ok(decision)
 }
 
@@ -393,6 +397,10 @@ pub fn cancel_request(
 
     // Unblock workflow task if bound
     unblock_task_on_approval(config, gateway_store, &decision);
+
+    if let Some(ref task_id) = decision.task_id {
+        let _ = crate::runtime::continuation::delete_continuation(config, task_id);
+    }
 
     Ok(decision)
 }
@@ -1123,6 +1131,8 @@ mod tests {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&req).unwrap();
 
@@ -1165,6 +1175,8 @@ mod tests {
             decided_at: None,
             decided_by: None,
             decision_reason: None,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store
             .create_approval(&req("apr-a", "root-a/coder-1"))
@@ -1213,6 +1225,8 @@ mod tests {
             decided_at: None,
             decided_by: None,
             decision_reason: None,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store
             .create_approval(&req("apr-second", "2020-01-02T00:00:00Z"))
@@ -1243,6 +1257,8 @@ mod tests {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&install).unwrap();
 
@@ -1463,6 +1479,8 @@ mod tests {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&request).unwrap();
 
@@ -1579,6 +1597,8 @@ mod tests {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Admin,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&request).unwrap();
 
@@ -1646,6 +1666,8 @@ mod tests {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&request).unwrap();
 

--- a/autonoetic-gateway/src/scheduler/approval_similarity.rs
+++ b/autonoetic-gateway/src/scheduler/approval_similarity.rs
@@ -1,0 +1,152 @@
+use std::collections::HashSet;
+use std::hash::Hash;
+
+use autonoetic_types::background::{ApprovalRequest, ScheduledAction};
+
+pub struct SimilarityResult {
+    pub request_id: String,
+    pub score: f64,
+}
+
+pub fn compute_action_similarity(a: &ScheduledAction, b: &ScheduledAction) -> f64 {
+    match (a, b) {
+        (
+            ScheduledAction::SandboxExec {
+                command: cmd_a,
+                detected_hosts: hosts_a,
+                ..
+            },
+            ScheduledAction::SandboxExec {
+                command: cmd_b,
+                detected_hosts: hosts_b,
+                ..
+            },
+        ) => {
+            let tokens_a = shell_words(cmd_a);
+            let tokens_b = shell_words(cmd_b);
+            let set_a: HashSet<&str> = tokens_a.iter().copied().collect();
+            let set_b: HashSet<&str> = tokens_b.iter().copied().collect();
+            let cmd_sim = jaccard(&set_a, &set_b);
+
+            let host_set_a: HashSet<&str> = hosts_a
+                .as_ref()
+                .map(|h| h.iter().map(|s| s.as_str()).collect())
+                .unwrap_or_default();
+            let host_set_b: HashSet<&str> = hosts_b
+                .as_ref()
+                .map(|h| h.iter().map(|s| s.as_str()).collect())
+                .unwrap_or_default();
+            let host_sim = if host_set_a.is_empty() && host_set_b.is_empty() {
+                1.0
+            } else {
+                jaccard(&host_set_a, &host_set_b)
+            };
+
+            0.7 * cmd_sim + 0.3 * host_sim
+        }
+        _ => {
+            if a.kind() == b.kind() { 0.5 } else { 0.0 }
+        }
+    }
+}
+
+pub fn find_similar_approvals(
+    new_request: &ApprovalRequest,
+    candidates: &[ApprovalRequest],
+    limit: usize,
+    threshold: f64,
+) -> Vec<SimilarityResult> {
+    let mut scored: Vec<SimilarityResult> = candidates
+        .iter()
+        .filter(|c| c.request_id != new_request.request_id)
+        .filter_map(|c| {
+            let score = compute_action_similarity(&new_request.action, &c.action);
+            if score >= threshold {
+                Some(SimilarityResult {
+                    request_id: c.request_id.clone(),
+                    score,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+    scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+    scored
+}
+
+fn shell_words(s: &str) -> Vec<&str> {
+    s.split_whitespace().collect()
+}
+
+fn jaccard<T: Hash + Eq>(a: &HashSet<T>, b: &HashSet<T>) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let intersection = a.intersection(b).count() as f64;
+    let union = a.union(b).count() as f64;
+    if union == 0.0 { 0.0 } else { intersection / union }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identical_commands_high_similarity() {
+        let a = ScheduledAction::SandboxExec {
+            command: "curl https://api.github.com/users".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: Some(vec!["api.github.com".to_string()]),
+        };
+        let b = ScheduledAction::SandboxExec {
+            command: "curl https://api.github.com/users".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: Some(vec!["api.github.com".to_string()]),
+        };
+        assert!(compute_action_similarity(&a, &b) > 0.99);
+    }
+
+    #[test]
+    fn test_different_commands_low_similarity() {
+        let a = ScheduledAction::SandboxExec {
+            command: "curl https://api.github.com/users".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: Some(vec!["api.github.com".to_string()]),
+        };
+        let b = ScheduledAction::SandboxExec {
+            command: "python3 -m pytest tests/".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        };
+        assert!(compute_action_similarity(&a, &b) < 0.3);
+    }
+
+    #[test]
+    fn test_whitespace_insensitive() {
+        let a = ScheduledAction::SandboxExec {
+            command: "echo   hello   world".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        };
+        let b = ScheduledAction::SandboxExec {
+            command: "echo hello world".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        };
+        assert!(compute_action_similarity(&a, &b) > 0.99);
+    }
+}

--- a/autonoetic-gateway/src/scheduler/decision.rs
+++ b/autonoetic-gateway/src/scheduler/decision.rs
@@ -190,6 +190,8 @@ mod tests {
             decided_by: None,
             decision_reason: None,
             approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
         };
         store.create_approval(&req).unwrap();
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -14,8 +14,8 @@ impl GatewayStore {
             "INSERT INTO approvals (
                 request_id, agent_id, session_id, root_session_id, workflow_id, task_id,
                 action_type, action_payload, reason, evidence_ref, status, created_at,
-                approval_level
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                approval_level, similar_to_request_id, similarity_score
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             params![
                 request.request_id,
                 request.agent_id,
@@ -29,7 +29,9 @@ impl GatewayStore {
                 request.evidence_ref,
                 "pending",
                 request.created_at,
-                serde_json::to_string(&request.approval_level)?
+                serde_json::to_string(&request.approval_level)?,
+                request.similar_to_request_id,
+                request.similarity_score,
             ],
         )?;
         Ok(())
@@ -40,7 +42,7 @@ impl GatewayStore {
         request_id: &str,
     ) -> Result<Option<ApprovalRequest>> {
         conn.query_row(
-            "SELECT request_id, agent_id, session_id, action_payload, created_at, workflow_id, task_id, root_session_id, status, decided_at, decided_by, reason, evidence_ref, approval_level, decision_reason FROM approvals WHERE request_id = ?1",
+            "SELECT request_id, agent_id, session_id, action_payload, created_at, workflow_id, task_id, root_session_id, status, decided_at, decided_by, reason, evidence_ref, approval_level, decision_reason, similar_to_request_id, similarity_score FROM approvals WHERE request_id = ?1",
             params![request_id],
             |row| {
                 let action_payload: String = row.get(3)?;
@@ -72,6 +74,8 @@ impl GatewayStore {
                     evidence_ref: row.get(12)?,
                     decision_reason: row.get(14)?,
                     approval_level,
+                    similar_to_request_id: row.get(15)?,
+                    similarity_score: row.get(16)?,
                 })
             },
         ).optional().map_err(Into::into)
@@ -209,6 +213,41 @@ impl GatewayStore {
             }
         }
         Ok(results)
+    }
+
+    pub fn get_recent_approvals_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ApprovalRequest>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT request_id FROM approvals WHERE agent_id = ?1 ORDER BY created_at DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![agent_id, limit as i64], |row| {
+            let id: String = row.get(0)?;
+            Ok(id)
+        })?;
+
+        let mut results = Vec::new();
+        for id_result in rows {
+            let id = id_result?;
+            if let Some(app) = Self::get_approval_with_conn(&conn, &id)? {
+                results.push(app);
+            }
+        }
+        Ok(results)
+    }
+
+    pub fn get_approval_status_by_task_id(&self, task_id: &str) -> Result<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT status FROM approvals WHERE task_id = ?1 ORDER BY created_at DESC LIMIT 1",
+            params![task_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(Into::into)
     }
 
     pub fn insert_session_grant(
@@ -552,5 +591,90 @@ impl GatewayStore {
             );
         }
         Ok(count)
+    }
+
+    pub fn get_approval_stats(
+        &self,
+        agent_id: Option<&str>,
+        root_session_id: Option<&str>,
+        since: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut where_clauses = Vec::new();
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(aid) = agent_id {
+            where_clauses.push(format!("agent_id = ?{}", param_values.len() + 1));
+            param_values.push(Box::new(aid.to_string()));
+        }
+        if let Some(sid) = root_session_id {
+            where_clauses.push(format!("root_session_id = ?{}", param_values.len() + 1));
+            param_values.push(Box::new(sid.to_string()));
+        }
+        if let Some(s) = since {
+            where_clauses.push(format!("created_at >= ?{}", param_values.len() + 1));
+            param_values.push(Box::new(s.to_string()));
+        }
+
+        let where_sql = if where_clauses.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", where_clauses.join(" AND "))
+        };
+
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
+
+        let total: i64 = conn.query_row(
+            &format!("SELECT COUNT(*) FROM approvals {}", where_sql),
+            params_refs.as_slice(),
+            |row| row.get(0),
+        )?;
+
+        let approved: i64 = conn.query_row(
+            &format!("SELECT COUNT(*) FROM approvals {} AND status = 'approved'", 
+                if where_sql.is_empty() { String::new() } else { where_sql.clone().replace("WHERE", "WHERE") + " AND" }),
+            params_refs.as_slice(),
+            |row| row.get(0),
+        ).unwrap_or(0);
+
+        let params_refs2: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
+
+        let rejected: i64 = conn.query_row(
+            &format!("SELECT COUNT(*) FROM approvals {} status = 'rejected'",
+                if where_sql.is_empty() { "WHERE".to_string() } else { where_sql.clone() + " AND" }),
+            params_refs2.as_slice(),
+            |row| row.get(0),
+        ).unwrap_or(0);
+
+        let pending: i64 = conn.query_row(
+            &format!("SELECT COUNT(*) FROM approvals {} status = 'pending'",
+                if where_sql.is_empty() { "WHERE".to_string() } else { where_sql.clone() + " AND" }),
+            params_refs2.as_slice(),
+            |row| row.get(0),
+        ).unwrap_or(0);
+
+        let mut top_agents_stmt = conn.prepare(
+            &format!("SELECT agent_id, COUNT(*) as cnt FROM approvals {} GROUP BY agent_id ORDER BY cnt DESC LIMIT 10",
+                if where_sql.is_empty() { String::new() } else { where_sql.clone() }),
+        )?;
+        let top_agents: Vec<serde_json::Value> = top_agents_stmt
+            .query_map(params_refs.as_slice(), |row| {
+                let agent_id: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok(serde_json::json!({"agent_id": agent_id, "count": count}))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(serde_json::json!({
+            "total": total,
+            "approved": approved,
+            "rejected": rejected,
+            "pending": pending,
+            "approval_rate": if total > 0 { format!("{:.1}%", (approved as f64 / total as f64) * 100.0) } else { "N/A".to_string() },
+            "rejection_rate": if total > 0 { format!("{:.1}%", (rejected as f64 / total as f64) * 100.0) } else { "N/A".to_string() },
+            "top_agents": top_agents,
+        }))
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -366,6 +366,14 @@ impl GatewayStore {
         root_session_id: &str,
     ) -> Result<Vec<SessionApprovalGrant>> {
         let conn = self.conn.lock().unwrap();
+        self.get_session_grants_structured_with_conn(&conn, root_session_id)
+    }
+
+    fn get_session_grants_structured_with_conn(
+        &self,
+        conn: &Connection,
+        root_session_id: &str,
+    ) -> Result<Vec<SessionApprovalGrant>> {
         let mut stmt = conn.prepare(
             "SELECT id, root_session_id, session_id, agent_id, scope, granted_by, granted_at,
                     source_approval_id, expires_at
@@ -388,7 +396,7 @@ impl GatewayStore {
         let mut results = Vec::new();
         for row_result in rows {
             let (id, root_sid, sess_id, agent_id, scope_str, granted_by, granted_at, source_approval_id, expires_at) = row_result?;
-            let targets = self.get_grant_targets_with_conn(&conn, id)?;
+            let targets = self.get_grant_targets_with_conn(conn, id)?;
             results.push(SessionApprovalGrant {
                 id,
                 root_session_id: root_sid,
@@ -542,11 +550,32 @@ impl GatewayStore {
         let now = chrono::Utc::now().to_rfc3339();
         let conn = self.conn.lock().unwrap();
         let count = match host {
-            Some(h) => conn.execute(
-                "UPDATE session_approval_grants SET revoked_at = ?1, revoked_reason = ?2
-                 WHERE root_session_id = ?3 AND host = ?4 AND revoked_at IS NULL",
-                params![&now, reason, root_session_id, h],
-            )?,
+            Some(h) => {
+                let active_grants = self.get_session_grants_structured_with_conn(&*conn, root_session_id)?;
+                let mut matching_ids = Vec::new();
+                for g in &active_grants {
+                    if g.targets.iter().any(|t| t.matches(h)) {
+                        matching_ids.push(g.id);
+                    }
+                }
+                if matching_ids.is_empty() {
+                    return Ok(0);
+                }
+                let placeholders: Vec<String> = matching_ids.iter().enumerate().map(|(i, _)| format!("?{}", i + 3)).collect();
+                let sql = format!(
+                    "UPDATE session_approval_grants SET revoked_at = ?1, revoked_reason = ?2 WHERE id IN ({}) AND revoked_at IS NULL",
+                    placeholders.join(", ")
+                );
+                let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = vec![
+                    Box::new(now.clone()),
+                    Box::new(reason.to_string()),
+                ];
+                for id in &matching_ids {
+                    params_vec.push(Box::new(*id));
+                }
+                let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+                conn.execute(&sql, params_refs.as_slice())?
+            }
             None => conn.execute(
                 "UPDATE session_approval_grants SET revoked_at = ?1, revoked_reason = ?2
                  WHERE root_session_id = ?3 AND revoked_at IS NULL",
@@ -631,28 +660,38 @@ impl GatewayStore {
             |row| row.get(0),
         )?;
 
+        let approved_where = if where_sql.is_empty() {
+            "WHERE status = 'approved'".to_string()
+        } else {
+            format!("{} AND status = 'approved'", where_sql)
+        };
         let approved: i64 = conn.query_row(
-            &format!("SELECT COUNT(*) FROM approvals {} AND status = 'approved'", 
-                if where_sql.is_empty() { String::new() } else { where_sql.clone().replace("WHERE", "WHERE") + " AND" }),
+            &format!("SELECT COUNT(*) FROM approvals {}", approved_where),
             params_refs.as_slice(),
             |row| row.get(0),
-        ).unwrap_or(0);
+        )?;
 
-        let params_refs2: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
-
+        let rejected_where = if where_sql.is_empty() {
+            "WHERE status = 'rejected'".to_string()
+        } else {
+            format!("{} AND status = 'rejected'", where_sql)
+        };
         let rejected: i64 = conn.query_row(
-            &format!("SELECT COUNT(*) FROM approvals {} status = 'rejected'",
-                if where_sql.is_empty() { "WHERE".to_string() } else { where_sql.clone() + " AND" }),
-            params_refs2.as_slice(),
+            &format!("SELECT COUNT(*) FROM approvals {}", rejected_where),
+            params_refs.as_slice(),
             |row| row.get(0),
-        ).unwrap_or(0);
+        )?;
 
+        let pending_where = if where_sql.is_empty() {
+            "WHERE status IS NULL".to_string()
+        } else {
+            format!("{} AND status IS NULL", where_sql)
+        };
         let pending: i64 = conn.query_row(
-            &format!("SELECT COUNT(*) FROM approvals {} status = 'pending'",
-                if where_sql.is_empty() { "WHERE".to_string() } else { where_sql.clone() + " AND" }),
-            params_refs2.as_slice(),
+            &format!("SELECT COUNT(*) FROM approvals {}", pending_where),
+            params_refs.as_slice(),
             |row| row.get(0),
-        ).unwrap_or(0);
+        )?;
 
         let mut top_agents_stmt = conn.prepare(
             &format!("SELECT agent_id, COUNT(*) as cnt FROM approvals {} GROUP BY agent_id ORDER BY cnt DESC LIMIT 10",

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 18;
+const SCHEMA_VERSION_LATEST: i64 = 19;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -501,6 +501,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_grant_scope_and_session_v16(conn)?;
     apply_grant_targets_table_v17(conn)?;
     apply_grant_expiry_v18(conn)?;
+    apply_approval_similarity_v19(conn)?;
 
     Ok(())
 }
@@ -1226,6 +1227,44 @@ fn apply_grant_expiry_v18(conn: &mut Connection) -> Result<()> {
         params![
             18_i64,
             "grant_expiry",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_approval_similarity_v19(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 19 {
+        return Ok(());
+    }
+
+    for (col, ty) in &[
+        ("similar_to_request_id", "TEXT"),
+        ("similarity_score", "REAL"),
+    ] {
+        let col_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('approvals') WHERE name = ?1",
+            [col],
+            |row| row.get(0),
+        )?;
+        if col_count == 0 {
+            conn.execute(
+                &format!("ALTER TABLE approvals ADD COLUMN {col} {ty}"),
+                [],
+            )?;
+        }
+    }
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            19_i64,
+            "approval_similarity",
             chrono::Utc::now().to_rfc3339()
         ],
     )?;

--- a/autonoetic-gateway/src/scheduler/runner.rs
+++ b/autonoetic-gateway/src/scheduler/runner.rs
@@ -124,7 +124,7 @@ pub async fn handle_due_wake(
     } else if let Some(action) = reevaluation.pending_scheduled_action.clone() {
         if action.requires_approval() {
             if reevaluation.open_approval_request_ids.is_empty() {
-                let request = ApprovalRequest {
+                let mut request = ApprovalRequest {
                     request_id: uuid::Uuid::new_v4().to_string(),
                     agent_id: agent_id.to_string(),
                     session_id: session_id.to_string(),
@@ -176,8 +176,18 @@ pub async fn handle_due_wake(
                     decided_at: None,
                     decided_by: None,
                     decision_reason: None,
+                    similar_to_request_id: None,
+                    similarity_score: None,
                 };
                 if let Some(store) = execution.gateway_store() {
+                    let candidates = store.get_recent_approvals_for_agent(&request.agent_id, 10)?;
+                    let similar = crate::scheduler::approval_similarity::find_similar_approvals(
+                        &request, &candidates, 1, 0.7,
+                    );
+                    if let Some(best) = similar.first() {
+                        request.similar_to_request_id = Some(best.request_id.clone());
+                        request.similarity_score = Some(best.score);
+                    }
                     store.create_approval(&request)?;
                 } else {
                     anyhow::bail!("GatewayStore is required to create approvals");

--- a/autonoetic-gateway/src/server/mod.rs
+++ b/autonoetic-gateway/src/server/mod.rs
@@ -61,6 +61,24 @@ impl GatewayServer {
             );
         }
 
+        // Reap orphaned continuation files from crash/restart
+        match crate::runtime::continuation::reap_orphaned_continuations(
+            &self.config,
+            &gateway_store,
+        ) {
+            Ok(n) if n > 0 => tracing::info!(
+                target: "gateway",
+                "Reaped {} orphaned continuation file(s)",
+                n
+            ),
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                target: "gateway",
+                error = %e,
+                "Continuation reaper failed"
+            ),
+        }
+
         // Reconcile system agents (create cron jobs if missing)
         let reconcile_results = crate::scheduler::system_agents::reconcile_system_agents(
             &self.config,

--- a/autonoetic-gateway/tests/continuation_cleanup_integration.rs
+++ b/autonoetic-gateway/tests/continuation_cleanup_integration.rs
@@ -1,0 +1,193 @@
+//! Integration tests for issue #87: continuation cleanup on reject/withdraw
+//! and startup reaper for orphaned continuation files.
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::runtime::continuation;
+use autonoetic_types::background::{
+    ApprovalLevel, ApprovalRequest, ApprovalStatus, ScheduledAction,
+};
+use autonoetic_types::config::GatewayConfig;
+use serial_test::serial;
+use std::path::PathBuf;
+
+fn make_gateway_dir(tmp: &tempfile::TempDir) -> PathBuf {
+    let gw = tmp.path().join(".gateway");
+    std::fs::create_dir_all(&gw).unwrap();
+    gw
+}
+
+fn make_config(tmp: &tempfile::TempDir) -> GatewayConfig {
+    let mut config = GatewayConfig::default();
+    config.agents_dir = tmp.path().to_path_buf();
+    config
+}
+
+fn seed_approval(store: &GatewayStore, task_id: &str) -> String {
+    let request_id = format!("req-{}", task_id);
+    let request = ApprovalRequest {
+        request_id: request_id.clone(),
+        agent_id: "agent-1".to_string(),
+        session_id: "session-1".to_string(),
+        root_session_id: Some("root-1".to_string()),
+        action: ScheduledAction::SandboxExec {
+            command: "echo hello".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: Some(vec!["api.example.com".to_string()]),
+        },
+        reason: Some("test".to_string()),
+        evidence_ref: None,
+        status: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        decided_at: None,
+        decided_by: None,
+        workflow_id: Some("wf-1".to_string()),
+        task_id: Some(task_id.to_string()),
+        approval_level: ApprovalLevel::Operator,
+        decision_reason: None,
+        similar_to_request_id: None,
+        similarity_score: None,
+    };
+    store.create_approval(&request).unwrap();
+    request_id
+}
+
+fn write_dummy_continuation(config: &GatewayConfig, task_id: &str) {
+    let dir = continuation::continuations_dir(config);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{}.json", task_id));
+    std::fs::write(&path, r#"{"test": true}"#).unwrap();
+}
+
+fn continuation_exists(config: &GatewayConfig, task_id: &str) -> bool {
+    continuation::continuation_path(config, task_id).exists()
+}
+
+#[test]
+#[serial]
+fn test_reject_deletes_continuation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(&tmp);
+    let store = GatewayStore::open(&make_gateway_dir(&tmp)).unwrap();
+
+    let task_id = "task-reject-1";
+    let request_id = seed_approval(&store, task_id);
+    write_dummy_continuation(&config, task_id);
+    assert!(continuation_exists(&config, task_id));
+
+    let _ = autonoetic_gateway::scheduler::reject_request(
+        &config,
+        Some(&store),
+        &request_id,
+        "cli",
+        Some("testing".to_string()),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !continuation_exists(&config, task_id),
+        "Continuation file should be deleted after rejection"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cancel_deletes_continuation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(&tmp);
+    let store = GatewayStore::open(&make_gateway_dir(&tmp)).unwrap();
+
+    let task_id = "task-cancel-1";
+    let request_id = seed_approval(&store, task_id);
+    write_dummy_continuation(&config, task_id);
+
+    let _ = autonoetic_gateway::scheduler::cancel_request(
+        &config,
+        Some(&store),
+        &request_id,
+        "cli",
+        Some("testing".to_string()),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !continuation_exists(&config, task_id),
+        "Continuation file should be deleted after cancellation"
+    );
+}
+
+#[test]
+#[serial]
+fn test_reaper_removes_terminal_approval_orphan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(&tmp);
+    let store = GatewayStore::open(&make_gateway_dir(&tmp)).unwrap();
+
+    let task_id = "task-orphan-terminal";
+    let request_id = seed_approval(&store, task_id);
+    write_dummy_continuation(&config, task_id);
+    assert!(continuation_exists(&config, task_id));
+
+    store
+        .record_decision(&request_id, "rejected", "test", &chrono::Utc::now().to_rfc3339(), None)
+        .unwrap();
+
+    let reaped = continuation::reap_orphaned_continuations(&config, &store).unwrap();
+    assert_eq!(reaped, 1);
+    assert!(
+        !continuation_exists(&config, task_id),
+        "Reaper should remove continuation with terminal approval"
+    );
+}
+
+#[test]
+#[serial]
+fn test_reaper_removes_missing_approval_orphan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(&tmp);
+    let store = GatewayStore::open(&make_gateway_dir(&tmp)).unwrap();
+
+    let task_id = "task-orphan-missing";
+    write_dummy_continuation(&config, task_id);
+    assert!(continuation_exists(&config, task_id));
+
+    let reaped = continuation::reap_orphaned_continuations(&config, &store).unwrap();
+    assert_eq!(reaped, 1);
+    assert!(
+        !continuation_exists(&config, task_id),
+        "Reaper should remove continuation with no approval row"
+    );
+}
+
+#[test]
+#[serial]
+fn test_reaper_preserves_pending_approval() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(&tmp);
+    let store = GatewayStore::open(&make_gateway_dir(&tmp)).unwrap();
+
+    let task_id = "task-pending-keep";
+    let _request_id = seed_approval(&store, task_id);
+    write_dummy_continuation(&config, task_id);
+
+    let reaped = continuation::reap_orphaned_continuations(&config, &store).unwrap();
+    assert_eq!(reaped, 0);
+    assert!(
+        continuation_exists(&config, task_id),
+        "Reaper should NOT remove continuation with pending approval"
+    );
+}
+
+#[test]
+#[serial]
+fn test_reaper_handles_empty_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(&tmp);
+    let store = GatewayStore::open(&make_gateway_dir(&tmp)).unwrap();
+
+    let reaped = continuation::reap_orphaned_continuations(&config, &store).unwrap();
+    assert_eq!(reaped, 0);
+}

--- a/autonoetic-gateway/tests/emergency_stop_root_session_integration.rs
+++ b/autonoetic-gateway/tests/emergency_stop_root_session_integration.rs
@@ -311,6 +311,8 @@ async fn emergency_stop_cancels_pending_approval_and_interaction() -> anyhow::Re
         decided_by: None,
         decision_reason: None,
         approval_level: ApprovalLevel::Operator,
+        similar_to_request_id: None,
+        similarity_score: None,
     })?;
 
     // Create a pending user interaction

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -322,7 +322,7 @@ pub struct BackgroundState {
 /// schedulable action (WriteFile, SandboxExec) that the scheduler will run after approval, or
 /// an approval-only subject (AgentInstall) where the actual install is done by the caller
 /// retrying with install_approval_ref.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ApprovalRequest {
     pub request_id: String,
     pub agent_id: String,
@@ -355,6 +355,10 @@ pub struct ApprovalRequest {
     /// Defaults to Operator. Set by the gateway based on config escalation rules.
     #[serde(default)]
     pub approval_level: ApprovalLevel,
+    #[serde(default)]
+    pub similar_to_request_id: Option<String>,
+    #[serde(default)]
+    pub similarity_score: Option<f64>,
 }
 
 impl ApprovalRequest {

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -298,7 +298,7 @@ pub enum GatewayGrantCommands {
         /// Root session ID.
         root_session: String,
         /// Revoke grants for a specific host only.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "all")]
         host: Option<String>,
         /// Revoke all grants for the session.
         #[arg(long)]

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -196,6 +196,11 @@ pub enum GatewayCommands {
         #[command(subcommand)]
         command: GatewayApprovalCommands,
     },
+    /// Manage session approval grants (revoke, list).
+    Grants {
+        #[command(subcommand)]
+        command: GatewayGrantCommands,
+    },
     /// Inspect or answer pending user interactions.
     Interactions {
         #[command(subcommand)]
@@ -258,6 +263,49 @@ pub enum GatewayApprovalCommands {
         /// Approver level used when approving from the TUI.
         #[arg(long = "approval-level", value_enum, default_value_t = CliApprovalLevel::Operator)]
         approval_level: CliApprovalLevel,
+    },
+    /// Show details of a specific approval request.
+    Show {
+        /// Approval request identifier.
+        request_id: String,
+    },
+    /// Show approval statistics and analytics.
+    Stats {
+        /// Filter by agent ID.
+        #[arg(long)]
+        agent: Option<String>,
+        /// Filter by root session ID.
+        #[arg(long)]
+        session: Option<String>,
+        /// Only include approvals since this time (e.g. `1h`, `24h`, `7d`).
+        #[arg(long)]
+        since: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum GatewayGrantCommands {
+    /// List active grants for a root session.
+    List {
+        /// Root session ID.
+        root_session: String,
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Revoke one or all grants for a root session.
+    Revoke {
+        /// Root session ID.
+        root_session: String,
+        /// Revoke grants for a specific host only.
+        #[arg(long)]
+        host: Option<String>,
+        /// Revoke all grants for the session.
+        #[arg(long)]
+        all: bool,
+        /// Reason for revocation (recorded in audit trail).
+        #[arg(long)]
+        reason: Option<String>,
     },
 }
 

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -410,18 +410,20 @@ pub async fn handle_gateway_approvals(
                 println!("  Filters: {}", filters.join(", "));
             }
             println!();
-            println!("  Total:          {}", stats["total"]);
-            println!("  Approved:       {}", stats["approved"]);
-            println!("  Rejected:       {}", stats["rejected"]);
-            println!("  Pending:        {}", stats["pending"]);
-            println!("  Approval rate:  {}", stats["approval_rate"]);
-            println!("  Rejection rate: {}", stats["rejection_rate"]);
+            println!("  Total:          {}", stats["total"].as_i64().unwrap_or(0));
+            println!("  Approved:       {}", stats["approved"].as_i64().unwrap_or(0));
+            println!("  Rejected:       {}", stats["rejected"].as_i64().unwrap_or(0));
+            println!("  Pending:        {}", stats["pending"].as_i64().unwrap_or(0));
+            println!("  Approval rate:  {}", stats["approval_rate"].as_str().unwrap_or("N/A"));
+            println!("  Rejection rate: {}", stats["rejection_rate"].as_str().unwrap_or("N/A"));
             if let Some(top_agents) = stats["top_agents"].as_array() {
                 if !top_agents.is_empty() {
                     println!();
                     println!("  Top agents:");
                     for entry in top_agents {
-                        println!("    {:<30} {}", entry["agent_id"], entry["count"]);
+                        let aid = entry["agent_id"].as_str().unwrap_or("?");
+                        let cnt = entry["count"].as_i64().unwrap_or(0);
+                        println!("    {:<30} {}", aid, cnt);
                     }
                 }
             }

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -226,11 +226,18 @@ pub async fn handle_gateway_approvals(
                     other => format!("{}", other.kind()),
                 };
                 println!(
-                    "{:<38} {:<20} {:<14} {}",
+                    "{:<38} {:<20} {:<14} {}{}",
                     approval.request_id,
                     approval.agent_id,
                     approval.action.kind(),
-                    details
+                    details,
+                    if let (Some(ref sim_id), Some(ref score)) =
+                        (approval.similar_to_request_id, approval.similarity_score)
+                    {
+                        format!(" ~{} ({:.0}%)", &sim_id[..sim_id.len().min(12)], score * 100.0)
+                    } else {
+                        String::new()
+                    }
                 );
             }
         }
@@ -318,6 +325,196 @@ pub async fn handle_gateway_approvals(
         }
         super::common::GatewayApprovalCommands::Interactive { approval_level } => {
             run_interactive_approvals(&config, &gateway_store, *approval_level).await?;
+        }
+        super::common::GatewayApprovalCommands::Show { request_id } => {
+            let approval = gateway_store.get_approval(request_id)?;
+            match approval {
+                None => println!("Approval '{}' not found.", request_id),
+                Some(a) => {
+                    println!("Request ID:    {}", a.request_id);
+                    println!("Agent:         {}", a.agent_id);
+                    println!("Session:       {}", a.session_id);
+                    println!("Status:        {}", a.status.as_ref().map(|s| match s {
+                        autonoetic_types::background::ApprovalStatus::Approved => "approved",
+                        autonoetic_types::background::ApprovalStatus::Rejected => "rejected",
+                        autonoetic_types::background::ApprovalStatus::Cancelled => "cancelled",
+                    }).unwrap_or("pending"));
+                    println!("Created:       {}", a.created_at);
+                    if let Some(ref at) = a.decided_at { println!("Decided at:    {}", at); }
+                    if let Some(ref by) = a.decided_by { println!("Decided by:    {}", by); }
+                    if let Some(ref r) = a.reason { println!("Reason:        {}", r); }
+                    if let Some(ref r) = a.decision_reason { println!("Decision note: {}", r); }
+
+                    match &a.action {
+                        autonoetic_types::background::ScheduledAction::SandboxExec {
+                            command, detected_hosts, dependencies, ..
+                        } => {
+                            println!("\nAction: sandbox_exec");
+                            println!("  Command: {}", command);
+                            if let Some(hosts) = detected_hosts {
+                                if !hosts.is_empty() {
+                                    println!("  Hosts:   {}", hosts.join(", "));
+                                }
+                            }
+                            if let Some(deps) = dependencies {
+                                println!("  Runtime: {}", deps.runtime);
+                                if !deps.packages.is_empty() {
+                                    println!("  Packages: {}", deps.packages.join(", "));
+                                }
+                            }
+                        }
+                        other => println!("\nAction: {}", other.kind()),
+                    }
+
+                    if let (Some(ref sim_id), Some(ref score)) =
+                        (a.similar_to_request_id, a.similarity_score)
+                    {
+                        println!("\nSimilar to: ~{} ({:.0}%)", sim_id, score * 100.0);
+                        let sim_approval = gateway_store.get_approval(sim_id)?;
+                        if let Some(sa) = &sim_approval {
+                            let status_str = sa.status.as_ref().map(|s| match s {
+                                autonoetic_types::background::ApprovalStatus::Approved => "approved",
+                                autonoetic_types::background::ApprovalStatus::Rejected => "rejected",
+                                autonoetic_types::background::ApprovalStatus::Cancelled => "cancelled",
+                            }).unwrap_or("pending");
+                            println!("  Similar approval was: {}", status_str);
+                        }
+                    }
+                }
+            }
+        }
+        super::common::GatewayApprovalCommands::Stats { agent, session, since } => {
+            let since_ts = since.as_ref().map(|s| {
+                let secs = if s.ends_with('h') {
+                    s.trim_end_matches('h').parse::<i64>().unwrap_or(1) * 3600
+                } else if s.ends_with('d') {
+                    s.trim_end_matches('d').parse::<i64>().unwrap_or(1) * 86400
+                } else if s.ends_with('m') {
+                    s.trim_end_matches('m').parse::<i64>().unwrap_or(1) * 60
+                } else {
+                    s.parse::<i64>().unwrap_or(3600)
+                };
+                (chrono::Utc::now() - chrono::Duration::seconds(secs)).to_rfc3339()
+            });
+            let stats = gateway_store.get_approval_stats(
+                agent.as_deref(),
+                session.as_deref(),
+                since_ts.as_deref(),
+            )?;
+            println!("Approval Statistics");
+            if agent.is_some() || session.is_some() || since.is_some() {
+                let mut filters = Vec::new();
+                if let Some(ref a) = agent { filters.push(format!("agent={}", a)); }
+                if let Some(ref s) = session { filters.push(format!("session={}", s)); }
+                if let Some(ref s) = since { filters.push(format!("since={}", s)); }
+                println!("  Filters: {}", filters.join(", "));
+            }
+            println!();
+            println!("  Total:          {}", stats["total"]);
+            println!("  Approved:       {}", stats["approved"]);
+            println!("  Rejected:       {}", stats["rejected"]);
+            println!("  Pending:        {}", stats["pending"]);
+            println!("  Approval rate:  {}", stats["approval_rate"]);
+            println!("  Rejection rate: {}", stats["rejection_rate"]);
+            if let Some(top_agents) = stats["top_agents"].as_array() {
+                if !top_agents.is_empty() {
+                    println!();
+                    println!("  Top agents:");
+                    for entry in top_agents {
+                        println!("    {:<30} {}", entry["agent_id"], entry["count"]);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle_gateway_grants(
+    config_path: &Path,
+    command: &super::common::GatewayGrantCommands,
+) -> anyhow::Result<()> {
+    use super::common::GatewayGrantCommands;
+
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let gateway_store = autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?;
+
+    match command {
+        GatewayGrantCommands::List { root_session, json } => {
+            let grants = gateway_store.get_session_grants_structured(root_session)?;
+            if *json {
+                println!("{}", serde_json::to_string_pretty(&grants)?);
+            } else if grants.is_empty() {
+                println!("No active grants for session {}", root_session);
+            } else {
+                println!("{:<6} {:<36} {:<14} {:<12} {:<12} {}",
+                    "ID", "SESSION", "AGENT", "SCOPE", "EXPIRES", "TARGETS");
+                for g in &grants {
+                    let targets_str: Vec<String> = g.targets.iter().map(|t| match t {
+                        autonoetic_types::background::GrantTarget::ExactHost(h) => h.clone(),
+                        autonoetic_types::background::GrantTarget::HostSuffix(s) => format!("*.{}", s),
+                        autonoetic_types::background::GrantTarget::HostAndPort { host, port } => format!("{}:{}", host, port),
+                        autonoetic_types::background::GrantTarget::UrlPrefix(u) => u.clone(),
+                    }).collect();
+                    let expires = g.expires_at.as_deref().unwrap_or("never");
+                    let short_session = if g.session_id.len() > 34 {
+                        format!("{}...", &g.session_id[..34])
+                    } else {
+                        g.session_id.clone()
+                    };
+                    println!("{:<6} {:<36} {:<14} {:<12} {:<12} {}",
+                        g.id,
+                        short_session,
+                        g.agent_id,
+                        match g.scope {
+                            autonoetic_types::background::GrantScope::RootSession => "root",
+                            autonoetic_types::background::GrantScope::Session => "session",
+                        },
+                        expires,
+                        targets_str.join(", ")
+                    );
+                }
+            }
+        }
+        GatewayGrantCommands::Revoke { root_session, host, all, reason } => {
+            if host.is_none() && !all {
+                anyhow::bail!("Specify --host <host> or --all to revoke grants");
+            }
+            let reason_text = reason.as_deref().unwrap_or("Revoked by operator");
+            let count = gateway_store.revoke_session_grants(
+                root_session,
+                host.as_deref(),
+                reason_text,
+            )?;
+            if count == 0 {
+                println!("No matching grants found for session {}", root_session);
+            } else {
+                println!("Revoked {} grant(s) for session {} (reason: {})", count, root_session, reason_text);
+                if let Some(ref host_val) = host {
+                    println!("  Host filter: {}", host_val);
+                }
+            }
+
+            gateway_store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+                event_id: format!("grant-revoke-{}", uuid::Uuid::new_v4()),
+                agent_id: "gateway".to_string(),
+                session_id: root_session.clone(),
+                turn_id: None,
+                event_seq: 0,
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                category: "grant_revocation".to_string(),
+                action: "revoke_grants".to_string(),
+                status: "completed".to_string(),
+                target: host.clone(),
+                payload: Some(serde_json::json!({
+                    "reason": reason_text,
+                    "count": count,
+                }).to_string()),
+                payload_ref: None,
+                evidence_ref: None,
+                reason: reason.clone(),
+            })?;
         }
     }
     Ok(())

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -118,6 +118,9 @@ async fn main() -> anyhow::Result<()> {
             cli::common::GatewayCommands::Approvals { command } => {
                 cli::gateway::handle_gateway_approvals(&config_path, command).await?;
             }
+            cli::common::GatewayCommands::Grants { command } => {
+                cli::gateway::handle_gateway_grants(&config_path, command).await?;
+            }
             cli::common::GatewayCommands::Interactions { command } => {
                 cli::gateway::handle_gateway_interactions(&config_path, command).await?;
             }


### PR DESCRIPTION
## Summary

Phase 3 of the approval-system hardening plan (#80). Ships four issues in one PR:

### #87 — Continuation cleanup on reject/withdraw + startup reaper
- Reject, cancel, and withdraw paths now call `delete_continuation()` for the bound task
- Gateway startup runs `reap_orphaned_continuations()` to clean up stale files from crashes
- New `get_approval_status_by_task_id()` store method for reaper queries
- 6 integration tests covering all scenarios

### #86 — Operator-side grant revocation CLI
- `gateway grants list --root-session <id>` — show active grants with scope, targets, expiry
- `gateway grants revoke --root-session <id> [--host <x>] [--all] [--reason]` — revoke without emergency-stop
- Emits `grant_revocation` causal event with count and reason

### #85 — Approval similarity & diff surface
- New `approval_similarity.rs` with Jaccard-based similarity over command tokens (70%) + hosts (30%)
- Schema v19: `similar_to_request_id` + `similarity_score` on approvals table
- Computed on creation against 10 most recent approvals for the same agent
- `approvals list` annotates near-matches: `~apr-xxxx (92%)`
- New `approvals show <id>` with full details and similar-approval cross-reference
- 3 unit tests for similarity computation

### #88 — Approval analytics CLI
- `approvals stats [--agent <id>] [--session <id>] [--since 1h]`
- Shows total/approved/rejected/pending counts, approval/rejection rates, top agents
- Backed by `get_approval_stats()` aggregation query

## Test results

- 622 gateway tests pass (1 pre-existing flaky failure unrelated to changes)
- 6 new continuation cleanup tests
- 15 scope/targets tests from Phase 2 still pass
- 7 grant revocation tests still pass
- 7 turn continuation approval tests still pass
- 3 similarity unit tests

Closes #87, #86, #85, #88. Parent: #80.