### PR TITLE
docs(issue#89): refresh approval docs for Phase 2/3 features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,10 +74,17 @@ agents/                  Agent bundles (SKILL.md manifests)
 4. Update `LoopGuardState` if the checkpoint format changes
 
 ### Approval system
-Three layers of approval dedup (checked in order):
+Four layers of approval dedup (checked in order):
 1. **Exec cache** (fingerprint-level, cross-session) — only when all patterns are concrete (url_literal/ip_address)
-2. **Session approval grants** (host-level, within root session) — `session_approval_grants` table, created on approval, cleaned up on session close/emergency stop
+2. **Session approval grants** (target-level, scope-aware, within root session) — `session_approval_grants` + `session_approval_grant_targets` tables; supports `ExactHost`, `HostSuffix`, `HostAndPort`, `UrlPrefix`; scoped `RootSession` or `Session`; optional expiry (`expires_at`)
 3. **Existing approved/pending approvals** (domain-level matching)
+4. **Approval flood cap** (`max_pending_approvals_per_root`, default 50) — rejects requests that would exceed the cap with `approval_flood`
+
+Additional approval features:
+- **Similarity scoring**: on creation, Jaccard similarity over command tokens (70%) + hosts (30%) against recent same-agent approvals. Stored as `similar_to_request_id` + `similarity_score`.
+- **Grant revocation**: `gateway grants revoke --root-session <id> --host X` without emergency stop; emits `grant_revocation` causal event.
+- **Continuation HMAC**: signed with `continuation_key` (or derived from `node_id`); verified on resume; action-equality check vs stored approval.
+- **Continuation cleanup**: on resume, reject/cancel/withdraw, gateway startup reaper, emergency stop, task cancellation.
 
 ### Promotion severity gating
 `promotion.record` mechanically rejects:
@@ -104,6 +111,11 @@ Notable test suites:
 - `approved_exec_cache_integration.rs` — cache fingerprint, normalization, full cycle
 - `emergency_stop_root_session_integration.rs` — circuit breaker, grant cleanup
 - `promotion_record_e2e.rs` / `promotion_gate_hardening_integration.rs` — severity gating
+- `continuation_hmac_integrity_integration.rs` — HMAC signing, verification, tamper detection
+- `continuation_cleanup_integration.rs` — delete on reject/cancel/withdraw, startup reaper, emergency stop
+- `approval_scope_targets_integration.rs` — session-scoped grants, pattern-based targets, expiry
+- `approval_grant_revocation_integration.rs` — revoke all/specific host, causal event
+- `constitution_abuse_approval_flood.rs` — flood cap enforcement, cap=0 bypass
 
 ## SDKs
 

--- a/docs/approval-system.md
+++ b/docs/approval-system.md
@@ -234,7 +234,7 @@ Grants can optionally expire:
 - `--until 2025-12-31T23:59:59Z` — expires at an absolute RFC3339 timestamp
 - Without either, the grant lasts until session end or emergency stop
 
-Expired grants are excluded from coverage checks and cleaned up by the startup janitor.
+Expired grants are excluded from coverage checks. They are not automatically deleted by gateway startup; persisted expired grants may remain until a separate cleanup path removes them.
 
 **Scope:**
 - `RootSession` grants are visible to all agents within the root session
@@ -245,7 +245,7 @@ Expired grants are excluded from coverage checks and cleaned up by the startup j
 
 **The approval check order is:**
 1. Approved exec cache (fingerprint-level, cross-session)
-2. Session approval grants (target-level, scope-aware, within root session)
+2. Session approval grants (target-level, root-session-scoped, within root session)
 3. Existing approved/pending approvals (domain-level)
 4. New approval request
 

--- a/docs/approval-system.md
+++ b/docs/approval-system.md
@@ -189,27 +189,110 @@ This works because:
 
 ### Session Approval Grants
 
-When the operator approves a `sandbox_exec` that accesses specific hosts, the gateway creates **session approval grants** — `(root_session_id, host)` pairs stored in SQLite. These grants prevent repeated operator prompts for the same hosts within the same root session.
+When the operator approves a `sandbox_exec` that accesses specific hosts, the gateway creates **session approval grants** stored in SQLite. These grants prevent repeated operator prompts for the same hosts within the same session.
 
-**How it works:**
+**Grant scope:**
 
-1. Operator approves `sandbox_exec` accessing `api.open-meteo.com` and `nominatim.openstreetmap.org`
-2. Gateway extracts the detected hosts from the approval action and inserts them as session grants
-3. When the same agent (or any other agent in the same root session) calls `sandbox_exec` with code that accesses a **subset** of the already-granted hosts, the gateway auto-approves without operator interaction
+| Scope | Meaning | Use case |
+|-------|---------|----------|
+| `RootSession` (default) | All agents within the root session benefit | Normal operation — the operator trusts the host for the whole workflow |
+| `Session` | Only the specific child session that requested approval | When the operator wants to limit access to a single agent |
+
+Scope is set at approval time via `--scope root` (default) or `--scope session`.
+
+**Grant targets:**
+
+Grants record **pattern-based targets**, not just exact hosts. Four target kinds are available:
+
+| Target kind | Syntax | Matches | Example |
+|-------------|--------|---------|---------|
+| `ExactHost` | `host:api.github.com` | Exact hostname (case-insensitive) | `api.github.com` |
+| `HostSuffix` | `suffix:*.github.com` | Any subdomain of the suffix | `api.github.com`, `v2.api.github.com` |
+| `HostAndPort` | `host:api.github.com:443` or `hostport:api.github.com:443` | Exact host + port | `api.github.com:443` |
+| `UrlPrefix` | `url:https://api.github.com/public/` | URLs starting with this prefix (scheme+host lowercased, path case-sensitive) | `https://api.github.com/public/users` |
+
+By default, grants record one `ExactHost` per detected host. Operators can narrow at approval time:
+
+```bash
+# Grant access to any GitHub subdomain for 1 hour
+autonoetic gateway approvals approve apr-xxx \
+  --scope root \
+  --target "suffix:*.github.com" \
+  --ttl 1h
+
+# Grant access to a specific URL prefix for this session only
+autonoetic gateway approvals approve apr-xxx \
+  --scope session \
+  --target "url:https://api.example.com/public/" \
+  --until "2025-12-31T23:59:59Z"
+```
+
+**Grant expiry:**
+
+Grants can optionally expire:
+- `--ttl 10m` — expires in 10 minutes (supports `s`, `m`, `h` suffixes)
+- `--until 2025-12-31T23:59:59Z` — expires at an absolute RFC3339 timestamp
+- Without either, the grant lasts until session end or emergency stop
+
+Expired grants are excluded from coverage checks and cleaned up by the startup janitor.
 
 **Scope:**
-- Grants are scoped to the **root session** — all agents within the root session benefit (e.g., `coder.default` and `evaluator.default` working on the same artifact)
+- `RootSession` grants are visible to all agents within the root session
+- `Session` grants are visible only to the specific child session
 - Grants require **concrete targets** (URL literals or IP addresses) — dynamic URLs that can't be statically resolved don't produce grants
 - Grants are cleaned up when the root session ends (completed, failed, or emergency-stopped)
 - Grants are **not** cleaned up for suspended sessions (which may resume and still need their grants)
 
-**Why root-session scoping?** Agents within a root session cooperate on the same workflow. If the operator trusts `api.open-meteo.com` for one agent in the session, it should be trusted for all. The `agent_id` is stored per grant row for audit/forensics purposes.
-
 **The approval check order is:**
 1. Approved exec cache (fingerprint-level, cross-session)
-2. Session approval grants (host-level, within root session)
+2. Session approval grants (target-level, scope-aware, within root session)
 3. Existing approved/pending approvals (domain-level)
 4. New approval request
+
+### Grant Revocation
+
+Operators can revoke grants without emergency-stop using the `gateway grants` commands:
+
+```bash
+# List active grants for a root session
+autonoetic gateway grants list --root-session <id>
+
+# Revoke all grants for a session
+autonoetic gateway grants revoke --root-session <id> --all --reason "rotating credentials"
+
+# Revoke a specific host only
+autonoetic gateway grants revoke --root-session <id> --host api.example.com --reason "suspicious activity"
+```
+
+Revocation emits a `grant_revocation` causal event for audit. Subsequent requests for the revoked host re-prompt the operator.
+
+### Approval Similarity
+
+On approval creation, the gateway computes a **similarity score** against recent approvals for the same agent. The score is based on Jaccard similarity over command tokens (70% weight) and detected hosts (30% weight). This is structural (not raw-text) comparison, so whitespace and comments don't defeat it.
+
+- `approvals list` annotates near-matches: `~apr-xxxx (92%)`
+- `approvals show <id>` displays the similar approval's outcome
+- The `similar_to_request_id` and `similarity_score` columns are stored for audit
+
+```bash
+# Show full details including similarity
+autonoetic gateway approvals show apr-xxx
+```
+
+### Approval Analytics
+
+The `approvals stats` command surfaces approval patterns:
+
+```bash
+# Overall stats
+autonoetic gateway approvals stats
+
+# Filtered by agent, session, or time window
+autonoetic gateway approvals stats --agent coder.default --since 1h
+autonoetic gateway approvals stats --session <root-session-id> --since 24h
+```
+
+Output includes total/approved/rejected/pending counts, approval and rejection rates, and top agents by approval volume. This helps operators spot unusual approval rates, agent spam, or compromise signals without manual SQLite queries.
 
 ### Hook-Based Reactive Dispatch
 
@@ -355,17 +438,26 @@ The `agent_revision_create` step auto-detects domains from URL literals in the a
 ## CLI Commands
 
 ```bash
-# List pending approvals
+# List pending approvals (annotated with similarity)
 autonoetic gateway approvals list --config /path/to/config.yaml
 
-# Approve a request
+# Show full details of a specific approval
+autonoetic gateway approvals show apr-xxx --config /path/to/config.yaml
+
+# Approve a request (with optional scope, targets, TTL)
 autonoetic gateway approvals approve apr-xxx --config /path/to/config.yaml
+autonoetic gateway approvals approve apr-xxx --scope root --target "suffix:*.github.com" --ttl 1h
 
 # Reject a request
 autonoetic gateway approvals reject apr-xxx --config /path/to/config.yaml
 
-# Show approval details
-autonoetic gateway approvals show apr-xxx --config /path/to/config.yaml
+# Show approval statistics
+autonoetic gateway approvals stats --agent coder.default --since 1h
+
+# Manage session grants
+autonoetic gateway grants list --root-session <id>
+autonoetic gateway grants revoke --root-session <id> --all --reason "rotating credentials"
+autonoetic gateway grants revoke --root-session <id> --host api.example.com
 ```
 
 ## Implementation Files
@@ -373,7 +465,9 @@ autonoetic gateway approvals show apr-xxx --config /path/to/config.yaml
 | File | Role |
 |---|---|
 | `autonoetic-gateway/src/scheduler/approval.rs` | Approval lifecycle, resume logic, signal delivery, pending approval queries, session grant insertion on approval |
-| `autonoetic-gateway/src/scheduler/gateway_store/approvals.rs` | Approval persistence (SQLite), session grant CRUD (`insert_session_grant`, `get_session_grants`, `session_grants_cover_targets`, `delete_session_grants`) |
+| `autonoetic-gateway/src/scheduler/gateway_store/approvals.rs` | Approval persistence (SQLite), session grant CRUD (`insert_session_grant`, `get_session_grants`, `get_session_grants_structured`, `grants_cover_targets`, `revoke_session_grants`, `prune_expired_grants`, `get_approval_stats`) |
+| `autonoetic-gateway/src/scheduler/approval_similarity.rs` | Jaccard-based similarity over command tokens + detected hosts |
+| `autonoetic-gateway/src/runtime/continuation.rs` | Turn continuation HMAC signing/verification, `reap_orphaned_continuations` startup janitor |
 | `autonoetic-gateway/src/runtime/tools/sandbox.rs` | Approval checks in `SandboxExecTool`; session grant check; sandbox deduplication logic |
 | `autonoetic-gateway/src/runtime/tools/agent.rs` | Approval checks in `AgentRevisionPromoteTool`; promote deduplication logic |
 | `autonoetic-gateway/src/runtime/tools/promotion.rs` | Mechanical severity gating for `promotion_record` — rejects `pass=true` with error/critical findings or warnings without evidence |
@@ -381,7 +475,7 @@ autonoetic gateway approvals show apr-xxx --config /path/to/config.yaml
 | `autonoetic-gateway/src/runtime/approved_exec_cache.rs` | Domain normalization (`normalize_targets`), fingerprinting, host normalization (lowercase + trailing dot stripping) |
 | `autonoetic-gateway/src/runtime/lifecycle.rs` | Session close — grant cleanup for non-suspended sessions |
 | `autonoetic-gateway/src/execution.rs` | Emergency stop — grant cleanup during circuit breaker |
-| `autonoetic-gateway/src/scheduler/gateway_store/migrate.rs` | Database migration v4: `session_approval_grants` table |
+| `autonoetic-gateway/src/scheduler/gateway_store/migrate.rs` | Database migrations v4: `session_approval_grants` table; v16: scope + session_id; v17: `session_approval_grant_targets` table; v18: `expires_at`; v19: `similar_to_request_id` + `similarity_score` |
 | `autonoetic-gateway/src/scheduler/hooks.rs` | Hook system — configurable reactive dispatch (`publish_report`, `deliver_signal`). Future: hook-based approval auto-resolution |
 | `autonoetic-gateway/src/scheduler/gateway_store/migrate.rs` | Database migration v7: `published_session_reports`, `published_session_reports_fts`, `hook_deliveries` tables |
 | `autonoetic-types/src/background.rs` | `ApprovalRequest`, `ScheduledAction` (with `detected_hosts`), `ApprovalStatus` types |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -26,6 +26,8 @@ Fields marked **required** must be present or the gateway will fail to start.
 | `node_name` | string | `"gateway"` | Human-readable node name for OFP federation. Overridable by `AUTONOETIC_NODE_NAME` env var. |
 | `max_concurrent_spawns` | usize | `8` | Maximum agent runtime executions allowed concurrently across all sessions. |
 | `max_pending_spawns_per_agent` | usize | `4` | Maximum pending executions admitted per target agent (includes the currently running execution). |
+| `max_pending_approvals_per_root` | usize | `50` | Maximum concurrent pending approvals per root session. When a new request would push the count above this cap, the request is rejected with `approval_flood`. Set to `0` to disable (not recommended). Controls the R+5 / R-7.17 approval flood cap. |
+| `continuation_key` | string | `null` | HMAC-SHA256 key for signing turn continuation files. When unset, the gateway derives a deterministic key from `node_id` (development convenience only). Production deployments should set this to a high-entropy secret. Rotate by changing the value — existing continuations will fail integrity verification and be rejected. |
 | `approval_timeout_secs` | u64 | `600` | Maximum seconds a workflow task can remain in `AwaitingApproval` before auto-failing. `0` disables (not recommended for production). |
 | `workflow_task_heartbeat_secs` | u64 \| null | `null` | Optional heartbeat interval for `Running` workflow tasks (sync + async) to refresh `updated_at` and avoid false stuck resolution during long tails. If `null`, derives from `background_tick_secs` (clamped `1..=5`). Effective range when set: `1..=30`. |
 | `max_session_turns` | u32 | `12` | Maximum turns per agent session (circuit breaker for runaway loops). When exceeded, the session suspends with `MaxTurnsReached`. |
@@ -508,6 +510,8 @@ node_name: "gateway"
 max_concurrent_spawns: 8
 max_pending_spawns_per_agent: 4
 approval_timeout_secs: 600
+max_pending_approvals_per_root: 50
+# continuation_key: "set-me-in-production-from-a-secret-source"
 workflow_task_heartbeat_secs: 2
 evidence_mode: full
 max_session_turns: 12

--- a/docs/remote-access-approval.md
+++ b/docs/remote-access-approval.md
@@ -81,7 +81,7 @@ Static analysis inspects the **actual code** to detect remote access patterns de
 │    └─ Remote patterns found → proceed to approval checks    │
 │ 3. Approval resolution checks (in order):                   │
 │    a. Exec cache hit (identical code fingerprint) → EXECUTE │
-│    b. Session grant covers targets → EXECUTE                │
+│    b. Session grant covers targets (scope-aware) → EXECUTE  │
 │    c. Existing approved/pending approval → REUSE            │
 │    d. None of the above → BLOCK + require approval          │
 └─────────────────────────────────────────────────────────────┘
@@ -89,9 +89,24 @@ Static analysis inspects the **actual code** to detect remote access patterns de
 
 ### Session Approval Grants
 
-When an operator approves `sandbox_exec` for specific hosts, those hosts are recorded as session-level grants. Subsequent `sandbox_exec` calls in the same root session that access a subset of the granted hosts are auto-approved. This prevents the common scenario where the evaluator, coder, and tester all trigger separate approval prompts for the same `api.open-meteo.com`.
+When an operator approves `sandbox_exec` for specific hosts, those hosts are recorded as **session approval grants** — pattern-based targets stored in SQLite. Subsequent `sandbox_exec` calls whose detected hosts are covered by a grant are auto-approved.
 
-Grants are cleaned up when the session ends. See [Approval System](approval-system.md) for full details.
+**Grant targets** support four kinds (set at approval time via `--target`):
+
+| Target kind | Syntax | Example match |
+|-------------|--------|---------------|
+| `ExactHost` | `host:api.github.com` | `api.github.com` |
+| `HostSuffix` | `suffix:*.github.com` | `api.github.com`, `v2.api.github.com` |
+| `HostAndPort` | `hostport:api.github.com:443` | `api.github.com:443` |
+| `UrlPrefix` | `url:https://api.github.com/public/` | `https://api.github.com/public/users` |
+
+**Grant scope:** `RootSession` (default — all agents in the workflow benefit) or `Session` (only the requesting child session). Set via `--scope root` or `--scope session`.
+
+**Grant expiry:** `--ttl 10m` or `--until 2025-12-31T23:59:59Z`. Without either, the grant lasts until session end or emergency stop.
+
+**Grant revocation:** `autonoetic gateway grants revoke --root-session <id> --host api.example.com --reason "..."` — revokes without emergency stop, emits a causal event.
+
+Grants are cleaned up on session end, emergency stop, or expiry. See [Approval System](approval-system.md) for full details including similarity scoring and analytics.
 
 ### Promotion Severity Gating
 
@@ -142,7 +157,7 @@ The tool returns a structured response instead of executing:
       "command": "python3 weather_client.py",
       "remote_access_detected": true,
       "detected_patterns": [...],
-      "normalized_targets": ["api.open-meteo.com"],
+      "normalized_targets": ["host:api.open-meteo.com"],
       "hosts": ["api.open-meteo.com"]
     }
   }

--- a/docs/remote-access-approval.md
+++ b/docs/remote-access-approval.md
@@ -81,7 +81,7 @@ Static analysis inspects the **actual code** to detect remote access patterns de
 │    └─ Remote patterns found → proceed to approval checks    │
 │ 3. Approval resolution checks (in order):                   │
 │    a. Exec cache hit (identical code fingerprint) → EXECUTE │
-│    b. Session grant covers targets (scope-aware) → EXECUTE  │
+│    b. Root-session grant covers targets → EXECUTE           │
 │    c. Existing approved/pending approval → REUSE            │
 │    d. None of the above → BLOCK + require approval          │
 └─────────────────────────────────────────────────────────────┘
@@ -157,7 +157,7 @@ The tool returns a structured response instead of executing:
       "command": "python3 weather_client.py",
       "remote_access_detected": true,
       "detected_patterns": [...],
-      "normalized_targets": ["host:api.open-meteo.com"],
+      "normalized_targets": ["api.open-meteo.com"],
       "hosts": ["api.open-meteo.com"]
     }
   }

--- a/docs/separation-of-powers.md
+++ b/docs/separation-of-powers.md
@@ -296,3 +296,41 @@ The agent is a reasoning loop with a capabilities vocabulary but no execution au
 **The autonoetic properties emerge from agent composition of gateway primitives**, not from the gateway hardcoding orchestration patterns. A planner agent composes `agent_spawn` + `task.board` into delegation. A background agent composes `scheduler.interval` + `agent.state` into reevaluation. A coder agent composes `skill.store` + `approval.queue` into evolution.
 
 The gateway "ensures" autonoetic behavior by making it **possible and auditable**, not by making it **prescriptive**.
+
+---
+
+## Integrity Guarantees
+
+### HMAC-Signed Continuations
+
+When an agent's turn is suspended at an approval boundary, the gateway writes a **signed continuation file** to disk. The file contains an HMAC-SHA256 signature over the serialized turn state, computed with a per-gateway key derived from `continuation_key` (or `node_id` as fallback).
+
+On resume:
+1. The signature is verified before deserialization
+2. If the signature is invalid (tampered file), the gateway:
+   - Rejects the continuation
+   - Emits a causal event
+   - Cancels the bound approval
+3. The `pending_action` on the continuation is compared to the stored approval action (action-equality check) to detect TOCTOU swaps
+
+### Threat Model
+
+| In scope | Out of scope |
+|----------|-------------|
+| **Malicious agent**: LLM attempting to bypass approval gates, tamper with continuation files, or escalate privileges | **Local filesystem attacker with vault key**: an attacker who has compromised the host and obtained the `continuation_key` or vault master key can forge continuations or decrypt secrets |
+| **Agent retry attacks**: re-submitting near-identical approval requests (detected by similarity scoring) | **Kernel-level compromise**: root-level access to the host |
+| **Continuation tampering**: modifying `.gateway/continuations/<task_id>.json` on disk (detected by HMAC) | **Supply-chain attacks on LLM providers** |
+| **Approval fatigue**: operator approving without review (mitigated by similarity annotations, stats, and diff surface) | |
+
+The security boundary is **gateway vs agent**, not **gateway vs host**. The gateway trusts the local filesystem and its own key material; it does not trust any data produced or influenced by the agent.
+
+### Continuation Cleanup
+
+Continuation files are cleaned up in these scenarios:
+- **Successful resume** after approval (normal path)
+- **Reject, cancel, or withdraw** — the file is deleted immediately
+- **Gateway startup** — a reaper scans for orphaned files whose bound approval is terminal or missing
+- **Emergency stop** — all continuation files for the root session are deleted
+- **Workflow task cancellation** — the file is deleted
+
+This prevents stale continuation files from accumulating on disk after crashes or interrupted sessions.


### PR DESCRIPTION
## Summary

- **`approval-system.md`**: Rewrote Session Approval Grants section with grant scope (RootSession/Session), pattern-based targets (ExactHost/HostSuffix/HostAndPort/UrlPrefix), grant expiry (--ttl/--until), grant revocation CLI, approval similarity scoring (Jaccard), approval analytics CLI, updated migration table to v19, updated implementation files table
- **`separation-of-powers.md`**: Added Integrity Guarantees section — HMAC-signed continuations, action-equality on resume, explicit threat model table, continuation cleanup paths
- **`remote-access-approval.md`**: Updated Session Approval Grants with target-kind examples/syntax, scope-aware grant check in flow diagram, grant revocation cross-reference, updated `normalized_targets` format
- **`config-reference.md`**: Added `max_pending_approvals_per_root` and `continuation_key` fields to top-level table and full example
- **`AGENTS.md`**: Updated approval dedup from 3 to 4 layers (added flood cap), added similarity/revocation/HMAC/cleanup notes, added Phase 2/3 test suites to notable test suites list

Closes #89