### PR TITLE
Constitution R+4: root-session tree budget

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -10,6 +10,7 @@ use crate::runtime::live_digest::{
 };
 use crate::runtime::openrouter_catalog::OpenRouterCatalog;
 use crate::runtime::reevaluation_state::execute_scheduled_action;
+use crate::runtime::root_session_budget::RootSessionBudgetRegistry;
 use crate::runtime::session_budget::SessionBudgetRegistry;
 use crate::runtime::session_context::SessionContext;
 use crate::runtime::session_report::SessionReportWriter;
@@ -355,6 +356,7 @@ pub struct GatewayExecutionService {
     agent_admission: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
     agent_execution_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     session_budget: Arc<SessionBudgetRegistry>,
+    root_session_budget: Arc<RootSessionBudgetRegistry>,
     gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
     active_executions: Arc<ActiveExecutionRegistry>,
     hook_executor: Arc<crate::scheduler::hooks::HookExecutor>,
@@ -366,6 +368,9 @@ impl GatewayExecutionService {
         gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
     ) -> Self {
         let session_budget = Arc::new(SessionBudgetRegistry::new(config.session_budget.clone()));
+        let root_session_budget = Arc::new(RootSessionBudgetRegistry::new(
+            config.root_session_budget.clone(),
+        ));
         let hook_executor = Arc::new(crate::scheduler::hooks::HookExecutor::new(
             config.hooks.clone(),
             gateway_store.clone(),
@@ -379,6 +384,7 @@ impl GatewayExecutionService {
             config: Arc::new(config),
             http_client: reqwest::Client::new(),
             session_budget,
+            root_session_budget,
             gateway_store,
             active_executions: ActiveExecutionRegistry::new(),
             hook_executor,
@@ -978,6 +984,7 @@ impl GatewayExecutionService {
             .with_gateway_dir(self.config.agents_dir.join(".gateway"))
             .with_config(self.config.clone())
             .with_session_budget(Some(self.session_budget.clone()))
+            .with_root_session_budget(Some(self.root_session_budget.clone()))
             .with_openrouter_catalog(Some(openrouter_catalog))
             .with_middleware(middleware)
             .with_initial_user_message(message.to_string())

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -2544,6 +2544,7 @@ impl GatewayExecutionService {
         .with_gateway_dir(self.config.agents_dir.join(".gateway"))
         .with_config(self.config.clone())
         .with_session_budget(Some(self.session_budget.clone()))
+        .with_root_session_budget(Some(self.root_session_budget.clone()))
         .with_openrouter_catalog(Some(openrouter_catalog))
         .with_middleware(middleware)
         .with_session_id(session_id.to_string())

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1224,6 +1224,7 @@ impl AgentExecutor {
         let max_empty_other_retries = max_other_empty_retries();
         let mut empty_other_retries_used = 0usize;
         let mut digest_turn_active = false;
+        let root_session_id = crate::runtime::content_store::root_session_id(&session_id);
 
         loop {
             // Loop guard check — save checkpoint before propagating max-turns error
@@ -1250,9 +1251,7 @@ impl AgentExecutor {
 
             // Root session tree budget check (R+4 / R-6.21)
             if let Some(root_budget) = self.root_session_budget.as_ref() {
-                let root =
-                    crate::runtime::content_store::root_session_id(&session_id).to_string();
-                if let Err(e) = root_budget.check_pre_llm(&root) {
+                if let Err(e) = root_budget.check_pre_llm(root_session_id) {
                     let cp = self.build_checkpoint(
                         history,
                         &turn_id,
@@ -1698,6 +1697,18 @@ impl AgentExecutor {
                     .unwrap_or_default();
 
                 let mut last_err = None;
+                if let Some(root_budget) = self.root_session_budget.as_ref() {
+                    if let Err(e) = root_budget.reserve_llm_round(root_session_id) {
+                        let cp = self.build_checkpoint(
+                            history,
+                            &turn_id,
+                            YieldReason::BudgetExhausted,
+                            None,
+                        );
+                        self.save_checkpoint_if_possible(&cp);
+                        return Err(e);
+                    }
+                }
                 let response = self.llm.complete(&req).await;
                 match response {
                     Ok(resp) => resp,
@@ -1724,6 +1735,18 @@ impl AgentExecutor {
                                 fallback_model = %fb_model,
                                 "Trying fallback model"
                             );
+                            if let Some(root_budget) = self.root_session_budget.as_ref() {
+                                if let Err(e) = root_budget.reserve_llm_round(root_session_id) {
+                                    let cp = self.build_checkpoint(
+                                        history,
+                                        &turn_id,
+                                        YieldReason::BudgetExhausted,
+                                        None,
+                                    );
+                                    self.save_checkpoint_if_possible(&cp);
+                                    return Err(e);
+                                }
+                            }
                             match self.llm.complete(&fallback_req).await {
                                 Ok(resp) => {
                                     tracing::info!(
@@ -1809,10 +1832,8 @@ impl AgentExecutor {
 
             if let Some(root_budget) = self.root_session_budget.as_ref() {
                 if !skip_llm {
-                    let root =
-                        crate::runtime::content_store::root_session_id(&session_id).to_string();
                     if let Err(e) = root_budget.record_llm_completion(
-                        &root,
+                        root_session_id,
                         response.usage.input_tokens,
                         response.usage.output_tokens,
                         estimated_cost_usd,

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -497,6 +497,8 @@ pub struct AgentExecutor {
     pub config: Option<Arc<GatewayConfig>>,
     /// Optional per-session LLM/tool/token/wall-clock budgets (shared `Arc` across spawns).
     pub session_budget: Option<Arc<SessionBudgetRegistry>>,
+    pub root_session_budget:
+        Option<Arc<crate::runtime::root_session_budget::RootSessionBudgetRegistry>>,
     /// Middleware hooks declared in the agent manifest.
     pub middleware: Middleware,
     /// Token usage per real LLM completion in the last `execute_with_history` run.
@@ -576,6 +578,7 @@ impl AgentExecutor {
             turn_counter: 0,
             config: None,
             session_budget: None,
+            root_session_budget: None,
             middleware: manifest.middleware.clone().unwrap_or_default(),
             llm_usage_last_run: Vec::new(),
             openrouter_catalog: None,
@@ -613,6 +616,16 @@ impl AgentExecutor {
 
     pub fn with_session_budget(mut self, registry: Option<Arc<SessionBudgetRegistry>>) -> Self {
         self.session_budget = registry;
+        self
+    }
+
+    pub fn with_root_session_budget(
+        mut self,
+        registry: Option<
+            Arc<crate::runtime::root_session_budget::RootSessionBudgetRegistry>,
+        >,
+    ) -> Self {
+        self.root_session_budget = registry;
         self
     }
 
@@ -1235,6 +1248,22 @@ impl AgentExecutor {
                 }
             }
 
+            // Root session tree budget check (R+4 / R-6.21)
+            if let Some(root_budget) = self.root_session_budget.as_ref() {
+                let root =
+                    crate::runtime::content_store::root_session_id(&session_id).to_string();
+                if let Err(e) = root_budget.check_pre_llm(&root) {
+                    let cp = self.build_checkpoint(
+                        history,
+                        &turn_id,
+                        YieldReason::BudgetExhausted,
+                        None,
+                    );
+                    self.save_checkpoint_if_possible(&cp);
+                    return Err(e);
+                }
+            }
+
             if !digest_turn_active {
                 tracer.start_digest_turn()?;
                 digest_turn_active = true;
@@ -1778,6 +1807,28 @@ impl AgentExecutor {
                 }
             }
 
+            if let Some(root_budget) = self.root_session_budget.as_ref() {
+                if !skip_llm {
+                    let root =
+                        crate::runtime::content_store::root_session_id(&session_id).to_string();
+                    if let Err(e) = root_budget.record_llm_completion(
+                        &root,
+                        response.usage.input_tokens,
+                        response.usage.output_tokens,
+                        estimated_cost_usd,
+                    ) {
+                        let cp = self.build_checkpoint(
+                            history,
+                            &turn_id,
+                            YieldReason::BudgetExhausted,
+                            None,
+                        );
+                        self.save_checkpoint_if_possible(&cp);
+                        return Err(e);
+                    }
+                }
+            }
+
             self.log_output_schema_validation(&response, &mut tracer);
 
             // Extract new artifacts from response for logging
@@ -1895,6 +1946,24 @@ impl AgentExecutor {
                         if let Err(e) = budget
                             .reserve_tool_invocations(&session_id, response.tool_calls.len() as u64)
                         {
+                            let cp = self.build_checkpoint(
+                                history,
+                                &turn_id,
+                                YieldReason::BudgetExhausted,
+                                None,
+                            );
+                            self.save_checkpoint_if_possible(&cp);
+                            return Err(e);
+                        }
+                    }
+
+                    if let Some(root_budget) = self.root_session_budget.as_ref() {
+                        let root = crate::runtime::content_store::root_session_id(&session_id)
+                            .to_string();
+                        if let Err(e) = root_budget.reserve_tool_invocations(
+                            &root,
+                            response.tool_calls.len() as u64,
+                        ) {
                             let cp = self.build_checkpoint(
                                 history,
                                 &turn_id,

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -31,6 +31,7 @@ pub mod prompt_budget;
 pub mod reevaluation_state;
 pub mod remote_access;
 pub mod response_validation;
+pub mod root_session_budget;
 pub mod session_budget;
 pub mod session_context;
 pub mod session_report;

--- a/autonoetic-gateway/src/runtime/root_session_budget.rs
+++ b/autonoetic-gateway/src/runtime/root_session_budget.rs
@@ -59,16 +59,34 @@ impl RootSessionBudgetRegistry {
             }
         }
 
-        if let Some(max_rounds) = self.limits.max_llm_rounds {
-            if st.llm_rounds >= max_rounds {
-                anyhow::bail!(
-                    "Root session budget exceeded: max_llm_rounds ({}) (root: {})",
-                    max_rounds,
-                    root_session_id
-                );
-            }
-        }
+        Ok(())
+    }
 
+    pub fn reserve_llm_round(&self, root_session_id: &str) -> anyhow::Result<()> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+        let Some(max_rounds) = self.limits.max_llm_rounds else {
+            return Ok(());
+        };
+        let mut map = self
+            .trees
+            .lock()
+            .map_err(|e| anyhow::anyhow!("root session budget lock poisoned: {e}"))?;
+        let st = map.entry(root_session_id.to_string()).or_default();
+        if st.clock_start.is_none() {
+            st.clock_start = Some(Instant::now());
+        }
+        let next = st.llm_rounds.saturating_add(1);
+        if next > max_rounds {
+            anyhow::bail!(
+                "Root session budget exceeded: max_llm_rounds ({}, would be {}) (root: {})",
+                max_rounds,
+                next,
+                root_session_id
+            );
+        }
+        st.llm_rounds = next;
         Ok(())
     }
 
@@ -90,7 +108,6 @@ impl RootSessionBudgetRegistry {
         if st.clock_start.is_none() {
             st.clock_start = Some(Instant::now());
         }
-        st.llm_rounds = st.llm_rounds.saturating_add(1);
         let add = input_tokens.saturating_add(output_tokens);
         st.llm_tokens = st.llm_tokens.saturating_add(add);
         if let Some(c) = estimated_cost_usd {
@@ -181,19 +198,19 @@ mod tests {
         });
         let root = "root-1";
 
-        reg.check_pre_llm(root).unwrap();
+        reg.reserve_llm_round(root).unwrap();
         reg.record_llm_completion(root, 0, 0, None).unwrap();
 
-        reg.check_pre_llm(root).unwrap();
+        reg.reserve_llm_round(root).unwrap();
         reg.record_llm_completion(root, 0, 0, None).unwrap();
 
-        reg.check_pre_llm(root).unwrap();
+        reg.reserve_llm_round(root).unwrap();
         reg.record_llm_completion(root, 0, 0, None).unwrap();
 
-        reg.check_pre_llm(root).unwrap();
+        reg.reserve_llm_round(root).unwrap();
         reg.record_llm_completion(root, 0, 0, None).unwrap();
 
-        assert!(reg.check_pre_llm(root).is_err());
+        assert!(reg.reserve_llm_round(root).is_err());
     }
 
     #[test]
@@ -247,12 +264,12 @@ mod tests {
         });
         let root = "root-5";
 
-        reg.check_pre_llm(root).unwrap();
+        reg.reserve_llm_round(root).unwrap();
         reg.record_llm_completion(root, 0, 0, None).unwrap();
-        assert!(reg.check_pre_llm(root).is_err());
+        assert!(reg.reserve_llm_round(root).is_err());
 
         reg.remove_tree(root);
-        reg.check_pre_llm(root).unwrap();
+        reg.reserve_llm_round(root).unwrap();
     }
 
     #[test]
@@ -262,16 +279,28 @@ mod tests {
             ..Default::default()
         });
 
-        reg.check_pre_llm("tree-a").unwrap();
+        reg.reserve_llm_round("tree-a").unwrap();
         reg.record_llm_completion("tree-a", 0, 0, None).unwrap();
-        reg.check_pre_llm("tree-a").unwrap();
+        reg.reserve_llm_round("tree-a").unwrap();
         reg.record_llm_completion("tree-a", 0, 0, None).unwrap();
 
-        reg.check_pre_llm("tree-b").unwrap();
+        reg.reserve_llm_round("tree-b").unwrap();
         reg.record_llm_completion("tree-b", 0, 0, None).unwrap();
 
-        assert!(reg.check_pre_llm("tree-a").is_err());
-        assert!(reg.check_pre_llm("tree-b").is_ok());
+        assert!(reg.reserve_llm_round("tree-a").is_err());
+        assert!(reg.reserve_llm_round("tree-b").is_ok());
+    }
+
+    #[test]
+    fn reserved_round_counts_even_without_completion() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_llm_rounds: Some(2),
+            ..Default::default()
+        });
+
+        reg.reserve_llm_round("root-fail").unwrap();
+        reg.reserve_llm_round("root-fail").unwrap();
+        assert!(reg.reserve_llm_round("root-fail").is_err());
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/root_session_budget.rs
+++ b/autonoetic-gateway/src/runtime/root_session_budget.rs
@@ -1,0 +1,288 @@
+use autonoetic_types::config::RootSessionBudgetConfig;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+#[derive(Debug, Default, Clone)]
+struct TreeCounters {
+    llm_rounds: u64,
+    tool_invocations: u64,
+    llm_tokens: u64,
+    session_cost_usd: f64,
+    clock_start: Option<Instant>,
+}
+
+#[derive(Debug)]
+pub struct RootSessionBudgetRegistry {
+    limits: RootSessionBudgetConfig,
+    trees: Mutex<HashMap<String, TreeCounters>>,
+}
+
+impl RootSessionBudgetRegistry {
+    pub fn new(limits: RootSessionBudgetConfig) -> Self {
+        Self {
+            limits,
+            trees: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.limits.max_llm_rounds.is_some()
+            || self.limits.max_tool_invocations.is_some()
+            || self.limits.max_llm_tokens.is_some()
+            || self.limits.max_wall_clock_secs.is_some()
+            || self.limits.max_session_price_usd.is_some()
+    }
+
+    pub fn check_pre_llm(&self, root_session_id: &str) -> anyhow::Result<()> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+        let mut map = self
+            .trees
+            .lock()
+            .map_err(|e| anyhow::anyhow!("root session budget lock poisoned: {e}"))?;
+        let st = map.entry(root_session_id.to_string()).or_default();
+        if st.clock_start.is_none() {
+            st.clock_start = Some(Instant::now());
+        }
+
+        if let Some(max_secs) = self.limits.max_wall_clock_secs {
+            if let Some(started) = st.clock_start {
+                if started.elapsed().as_secs() >= max_secs {
+                    anyhow::bail!(
+                        "Root session budget exceeded: wall_clock_secs >= {} (root: {})",
+                        max_secs,
+                        root_session_id
+                    );
+                }
+            }
+        }
+
+        if let Some(max_rounds) = self.limits.max_llm_rounds {
+            if st.llm_rounds >= max_rounds {
+                anyhow::bail!(
+                    "Root session budget exceeded: max_llm_rounds ({}) (root: {})",
+                    max_rounds,
+                    root_session_id
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn record_llm_completion(
+        &self,
+        root_session_id: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+        estimated_cost_usd: Option<f64>,
+    ) -> anyhow::Result<()> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+        let mut map = self
+            .trees
+            .lock()
+            .map_err(|e| anyhow::anyhow!("root session budget lock poisoned: {e}"))?;
+        let st = map.entry(root_session_id.to_string()).or_default();
+        if st.clock_start.is_none() {
+            st.clock_start = Some(Instant::now());
+        }
+        st.llm_rounds = st.llm_rounds.saturating_add(1);
+        let add = input_tokens.saturating_add(output_tokens);
+        st.llm_tokens = st.llm_tokens.saturating_add(add);
+        if let Some(c) = estimated_cost_usd {
+            if c.is_finite() && c >= 0.0 {
+                st.session_cost_usd += c;
+            }
+        }
+
+        if let Some(max_tok) = self.limits.max_llm_tokens {
+            if st.llm_tokens > max_tok {
+                anyhow::bail!(
+                    "Root session budget exceeded: max_llm_tokens ({}, used {}) (root: {})",
+                    max_tok,
+                    st.llm_tokens,
+                    root_session_id
+                );
+            }
+        }
+
+        if let Some(max_price) = self.limits.max_session_price_usd {
+            if max_price >= 0.0 && st.session_cost_usd > max_price {
+                anyhow::bail!(
+                    "Root session budget exceeded: max_session_price_usd ({:.6}, used {:.6}) (root: {})",
+                    max_price,
+                    st.session_cost_usd,
+                    root_session_id
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn reserve_tool_invocations(
+        &self,
+        root_session_id: &str,
+        count: u64,
+    ) -> anyhow::Result<()> {
+        if !self.is_enabled() || count == 0 {
+            return Ok(());
+        }
+        let Some(max_tools) = self.limits.max_tool_invocations else {
+            return Ok(());
+        };
+        let mut map = self
+            .trees
+            .lock()
+            .map_err(|e| anyhow::anyhow!("root session budget lock poisoned: {e}"))?;
+        let st = map.entry(root_session_id.to_string()).or_default();
+        if st.clock_start.is_none() {
+            st.clock_start = Some(Instant::now());
+        }
+        let next = st.tool_invocations.saturating_add(count);
+        if next > max_tools {
+            anyhow::bail!(
+                "Root session budget exceeded: max_tool_invocations ({}, would be {}) (root: {})",
+                max_tools,
+                next,
+                root_session_id
+            );
+        }
+        st.tool_invocations = next;
+        Ok(())
+    }
+
+    pub fn snapshot_counters(&self, root_session_id: &str) -> Option<(u64, u64, f64)> {
+        let map = self.trees.lock().ok()?;
+        let st = map.get(root_session_id)?;
+        Some((st.llm_rounds, st.llm_tokens, st.session_cost_usd))
+    }
+
+    pub fn remove_tree(&self, root_session_id: &str) {
+        if let Ok(mut map) = self.trees.lock() {
+            map.remove(root_session_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tree_llm_rounds_aggregate_across_sessions() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_llm_rounds: Some(4),
+            ..Default::default()
+        });
+        let root = "root-1";
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 0, 0, None).unwrap();
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 0, 0, None).unwrap();
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 0, 0, None).unwrap();
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 0, 0, None).unwrap();
+
+        assert!(reg.check_pre_llm(root).is_err());
+    }
+
+    #[test]
+    fn tree_tokens_aggregate() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_llm_tokens: Some(200),
+            ..Default::default()
+        });
+        let root = "root-2";
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 80, 70, None).unwrap(); // 150
+
+        assert!(reg.record_llm_completion(root, 60, 50, None).is_err()); // 260 > 200
+    }
+
+    #[test]
+    fn tree_tool_invocations_reserve() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_tool_invocations: Some(5),
+            ..Default::default()
+        });
+        let root = "root-3";
+
+        reg.reserve_tool_invocations(root, 3).unwrap();
+        reg.reserve_tool_invocations(root, 2).unwrap();
+        assert!(reg.reserve_tool_invocations(root, 1).is_err());
+    }
+
+    #[test]
+    fn tree_price_blocks() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_session_price_usd: Some(0.05),
+            ..Default::default()
+        });
+        let root = "root-4";
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 100, 100, Some(0.03))
+            .unwrap();
+        assert!(reg
+            .record_llm_completion(root, 100, 100, Some(0.04))
+            .is_err());
+    }
+
+    #[test]
+    fn remove_tree_clears_counters() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_llm_rounds: Some(1),
+            ..Default::default()
+        });
+        let root = "root-5";
+
+        reg.check_pre_llm(root).unwrap();
+        reg.record_llm_completion(root, 0, 0, None).unwrap();
+        assert!(reg.check_pre_llm(root).is_err());
+
+        reg.remove_tree(root);
+        reg.check_pre_llm(root).unwrap();
+    }
+
+    #[test]
+    fn independent_trees_dont_interfere() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig {
+            max_llm_rounds: Some(2),
+            ..Default::default()
+        });
+
+        reg.check_pre_llm("tree-a").unwrap();
+        reg.record_llm_completion("tree-a", 0, 0, None).unwrap();
+        reg.check_pre_llm("tree-a").unwrap();
+        reg.record_llm_completion("tree-a", 0, 0, None).unwrap();
+
+        reg.check_pre_llm("tree-b").unwrap();
+        reg.record_llm_completion("tree-b", 0, 0, None).unwrap();
+
+        assert!(reg.check_pre_llm("tree-a").is_err());
+        assert!(reg.check_pre_llm("tree-b").is_ok());
+    }
+
+    #[test]
+    fn disabled_when_no_limits() {
+        let reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig::default());
+        assert!(!reg.is_enabled());
+        for _ in 0..1000 {
+            reg.check_pre_llm("root").unwrap();
+            reg.record_llm_completion("root", u64::MAX, u64::MAX, Some(f64::MAX))
+                .unwrap();
+            reg.reserve_tool_invocations("root", u64::MAX).unwrap();
+        }
+    }
+}

--- a/autonoetic-gateway/tests/constitution_budget_root_session_tree.rs
+++ b/autonoetic-gateway/tests/constitution_budget_root_session_tree.rs
@@ -1,0 +1,165 @@
+//! Constitution R+4 / R-6.21 — Root-session tree budget.
+//!
+//! Tokens, tool invocations, wall clock, and price are aggregated across all
+//! descendants of a root session and enforced at the tree level, not only
+//! per-session.
+
+mod support;
+
+use autonoetic_gateway::runtime::root_session_budget::RootSessionBudgetRegistry;
+use autonoetic_gateway::runtime::session_budget::SessionBudgetRegistry;
+use autonoetic_types::config::{RootSessionBudgetConfig, SessionBudgetConfig};
+
+#[test]
+fn tree_budget_denies_4th_child_when_aggregate_exceeds() {
+    let per_session_budget = SessionBudgetConfig {
+        max_llm_rounds: Some(10),
+        ..Default::default()
+    };
+    let tree_budget = RootSessionBudgetConfig {
+        max_llm_rounds: Some(30),
+        ..Default::default()
+    };
+
+    let session_reg = SessionBudgetRegistry::new(per_session_budget);
+    let tree_reg = RootSessionBudgetRegistry::new(tree_budget);
+    let root = "root-tree-test";
+
+    for child in 0..3 {
+        let scope = format!("{}/child-{}", root, child);
+        for _ in 0..10 {
+            session_reg.check_pre_llm(&scope).unwrap();
+            session_reg.record_llm_completion(&scope, 0, 0, None).unwrap();
+            tree_reg.check_pre_llm(root).unwrap();
+            tree_reg.record_llm_completion(root, 0, 0, None).unwrap();
+        }
+    }
+
+    assert_eq!(tree_reg.snapshot_counters(root), Some((30, 0, 0.0)));
+
+    let child_4 = format!("{}/child-4", root);
+    session_reg.check_pre_llm(&child_4).unwrap();
+    let result = tree_reg.check_pre_llm(root);
+    assert!(result.is_err(), "4th child should be denied — tree budget exceeded");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("max_llm_rounds"), "error should mention max_llm_rounds: {msg}");
+    assert!(msg.contains("root:"), "error should mention root: {msg}");
+}
+
+#[test]
+fn per_session_allows_but_tree_denies() {
+    let per_session_budget = SessionBudgetConfig {
+        max_llm_tokens: Some(1000),
+        ..Default::default()
+    };
+    let tree_budget = RootSessionBudgetConfig {
+        max_llm_tokens: Some(200),
+        ..Default::default()
+    };
+
+    let session_reg = SessionBudgetRegistry::new(per_session_budget);
+    let tree_reg = RootSessionBudgetRegistry::new(tree_budget);
+    let root = "root-tighter-tree";
+
+    let child_1 = format!("{}/child-1", root);
+    session_reg.check_pre_llm(&child_1).unwrap();
+    tree_reg.check_pre_llm(root).unwrap();
+    session_reg
+        .record_llm_completion(&child_1, 100, 90, None)
+        .unwrap();
+    tree_reg
+        .record_llm_completion(root, 100, 90, None)
+        .unwrap();
+
+    let child_2 = format!("{}/child-2", root);
+    session_reg.check_pre_llm(&child_2).unwrap();
+    tree_reg.check_pre_llm(root).unwrap();
+    session_reg
+        .record_llm_completion(&child_2, 5, 5, None)
+        .unwrap();
+    tree_reg
+        .record_llm_completion(root, 5, 5, None)
+        .unwrap();
+
+    let tree_result = tree_reg.record_llm_completion(root, 5, 5, None);
+    assert!(
+        tree_result.is_err(),
+        "tree should deny even when per-session allows — tighter bound wins"
+    );
+}
+
+#[test]
+fn tree_tool_invocations_aggregate_across_children() {
+    let tree_budget = RootSessionBudgetConfig {
+        max_tool_invocations: Some(10),
+        ..Default::default()
+    };
+
+    let tree_reg = RootSessionBudgetRegistry::new(tree_budget);
+    let root = "root-tools";
+
+    for child in 0..3 {
+        tree_reg
+            .reserve_tool_invocations(root, 3)
+            .unwrap();
+    }
+
+    assert!(tree_reg.reserve_tool_invocations(root, 2).is_err());
+}
+
+#[test]
+fn tree_price_aggregates_across_children() {
+    let tree_budget = RootSessionBudgetConfig {
+        max_session_price_usd: Some(0.10),
+        ..Default::default()
+    };
+
+    let tree_reg = RootSessionBudgetRegistry::new(tree_budget);
+    let root = "root-price";
+
+    tree_reg.check_pre_llm(root).unwrap();
+    tree_reg
+        .record_llm_completion(root, 100, 100, Some(0.04))
+        .unwrap();
+    tree_reg
+        .record_llm_completion(root, 100, 100, Some(0.04))
+        .unwrap();
+
+    assert!(tree_reg
+        .record_llm_completion(root, 100, 100, Some(0.05))
+        .is_err());
+}
+
+#[test]
+fn remove_tree_resets_budget() {
+    let tree_budget = RootSessionBudgetConfig {
+        max_llm_rounds: Some(3),
+        ..Default::default()
+    };
+
+    let tree_reg = RootSessionBudgetRegistry::new(tree_budget);
+    let root = "root-reset";
+
+    for _ in 0..3 {
+        tree_reg.check_pre_llm(root).unwrap();
+        tree_reg.record_llm_completion(root, 0, 0, None).unwrap();
+    }
+    assert!(tree_reg.check_pre_llm(root).is_err());
+
+    tree_reg.remove_tree(root);
+    tree_reg.check_pre_llm(root).unwrap();
+}
+
+#[test]
+fn disabled_tree_budget_never_blocks() {
+    let tree_reg = RootSessionBudgetRegistry::new(RootSessionBudgetConfig::default());
+    assert!(!tree_reg.is_enabled());
+
+    for _ in 0..100 {
+        tree_reg.check_pre_llm("root").unwrap();
+        tree_reg
+            .record_llm_completion("root", u64::MAX, u64::MAX, Some(f64::MAX))
+            .unwrap();
+        tree_reg.reserve_tool_invocations("root", u64::MAX).unwrap();
+    }
+}

--- a/autonoetic-gateway/tests/constitution_budget_root_session_tree.rs
+++ b/autonoetic-gateway/tests/constitution_budget_root_session_tree.rs
@@ -31,6 +31,7 @@ fn tree_budget_denies_4th_child_when_aggregate_exceeds() {
             session_reg.check_pre_llm(&scope).unwrap();
             session_reg.record_llm_completion(&scope, 0, 0, None).unwrap();
             tree_reg.check_pre_llm(root).unwrap();
+            tree_reg.reserve_llm_round(root).unwrap();
             tree_reg.record_llm_completion(root, 0, 0, None).unwrap();
         }
     }
@@ -39,7 +40,7 @@ fn tree_budget_denies_4th_child_when_aggregate_exceeds() {
 
     let child_4 = format!("{}/child-4", root);
     session_reg.check_pre_llm(&child_4).unwrap();
-    let result = tree_reg.check_pre_llm(root);
+    let result = tree_reg.reserve_llm_round(root);
     assert!(result.is_err(), "4th child should be denied — tree budget exceeded");
     let msg = result.unwrap_err().to_string();
     assert!(msg.contains("max_llm_rounds"), "error should mention max_llm_rounds: {msg}");
@@ -98,7 +99,7 @@ fn tree_tool_invocations_aggregate_across_children() {
     let tree_reg = RootSessionBudgetRegistry::new(tree_budget);
     let root = "root-tools";
 
-    for child in 0..3 {
+    for _child in 0..3 {
         tree_reg
             .reserve_tool_invocations(root, 3)
             .unwrap();
@@ -142,12 +143,13 @@ fn remove_tree_resets_budget() {
 
     for _ in 0..3 {
         tree_reg.check_pre_llm(root).unwrap();
+        tree_reg.reserve_llm_round(root).unwrap();
         tree_reg.record_llm_completion(root, 0, 0, None).unwrap();
     }
-    assert!(tree_reg.check_pre_llm(root).is_err());
+    assert!(tree_reg.reserve_llm_round(root).is_err());
 
     tree_reg.remove_tree(root);
-    tree_reg.check_pre_llm(root).unwrap();
+    tree_reg.reserve_llm_round(root).unwrap();
 }
 
 #[test]

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -144,6 +144,22 @@ pub struct SessionBudgetConfig {
     pub extensions: Vec<String>,
 }
 
+/// Tree-wide budget limits aggregated across all descendants of a root session.
+/// Applies in addition to per-session limits; the tighter bound wins.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RootSessionBudgetConfig {
+    #[serde(default)]
+    pub max_llm_rounds: Option<u64>,
+    #[serde(default)]
+    pub max_tool_invocations: Option<u64>,
+    #[serde(default)]
+    pub max_llm_tokens: Option<u64>,
+    #[serde(default)]
+    pub max_wall_clock_secs: Option<u64>,
+    #[serde(default)]
+    pub max_session_price_usd: Option<f64>,
+}
+
 /// Post-session digest: LLM summarization and Tier-2 memory extraction after agent sessions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DigestAgentConfig {
@@ -514,6 +530,11 @@ pub struct GatewayConfig {
     /// Optional per-session budgets (LLM rounds, tools, tokens, wall clock).
     #[serde(default)]
     pub session_budget: SessionBudgetConfig,
+
+    /// Tree-wide budgets aggregated across all descendants of a root session (R+4 / R-6.21).
+    /// Applies in addition to per-session limits; the tighter bound wins.
+    #[serde(default)]
+    pub root_session_budget: RootSessionBudgetConfig,
 
     /// Maximum seconds a workflow task may remain in `AwaitingApproval` before it is
     /// automatically marked `Failed`. Set to 0 to disable (not recommended for production).
@@ -1215,6 +1236,7 @@ impl Default for GatewayConfig {
             code_analysis: CodeAnalysisConfig::default(),
             capability_delta_gate_mode: CapabilityDeltaGateMode::Strict,
             session_budget: SessionBudgetConfig::default(),
+            root_session_budget: RootSessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),
             max_pending_approvals_per_root: default_max_pending_approvals_per_root(),
             continuation_key: None,

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -175,6 +175,8 @@ struct App {
     scroll_offset: usize,
     last_max_scroll_offset: usize,
     follow_output: bool,
+    session_paused: bool,
+    esc_cancel_armed_until: Option<Instant>,
     session_id: String,
     target_hint: String,
     // Mouse selection - stored as CONTENT positions (row, col), not screen positions
@@ -213,6 +215,8 @@ impl App {
             scroll_offset: 0,
             last_max_scroll_offset: 0,
             follow_output: true,
+            session_paused: false,
+            esc_cancel_armed_until: None,
             session_id,
             target_hint,
             selecting: false,
@@ -360,6 +364,20 @@ impl App {
         } else {
             self.scroll_offset.min(self.last_max_scroll_offset)
         }
+    }
+
+    fn cancel_armed(&self) -> bool {
+        self.esc_cancel_armed_until
+            .map(|deadline| Instant::now() <= deadline)
+            .unwrap_or(false)
+    }
+
+    fn arm_cancel_window(&mut self) {
+        self.esc_cancel_armed_until = Some(Instant::now() + Duration::from_secs(2));
+    }
+
+    fn disarm_cancel_window(&mut self) {
+        self.esc_cancel_armed_until = None;
     }
 }
 
@@ -1196,20 +1214,41 @@ fn draw_status(f: &mut Frame, app: &App, area: Rect) {
     } else {
         ""
     };
+    let pause_hint = if app.session_paused {
+        "Paused: ON"
+    } else {
+        "Paused: OFF"
+    };
+    let esc_hint = if app.cancel_armed() {
+        "Esc: armed (press again to cancel)"
+    } else {
+        "Esc: pause"
+    };
+    let follow_hint = if app.follow_output {
+        "Follow: ON"
+    } else {
+        "Follow: OFF (Ctrl+F to jump live)"
+    };
     let text = if !app.pending.is_empty() {
         format!(
-            "{} {} pending | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
+            "{} {} pending | {} | {} | {} | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
             app.spinner(),
             app.pending.len(),
             workflow,
+            pause_hint,
+            esc_hint,
+            follow_hint,
             approve_hint,
         )
     } else {
         format!(
-            "Session: {} | Target: {} | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
+            "Session: {} | Target: {} | {} | {} | {} | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
             &app.session_id[..20.min(app.session_id.len())],
             app.target_hint,
             workflow,
+            pause_hint,
+            esc_hint,
+            follow_hint,
             approve_hint,
         )
     };
@@ -1759,6 +1798,109 @@ async fn run_loop<B: ratatui::backend::Backend>(
                         Event::Key(key) => {
                             match handle_key(key, app, tx)? {
                                 HandleKeyAction::Quit => return Ok(false),
+                                HandleKeyAction::PauseSession => {
+                                    app.session_paused = true;
+                                    let root_session_id = if app.session_overview.root_session_id.is_empty() {
+                                        autonoetic_gateway::runtime::content_store::root_session_id(session_id)
+                                            .to_string()
+                                    } else {
+                                        app.session_overview.root_session_id.clone()
+                                    };
+
+                                    let mut paused_tasks = 0usize;
+                                    if let Some(store) = gateway_store {
+                                        if let Ok(Some(workflow_id)) = autonoetic_gateway::scheduler::resolve_workflow_id_for_root_session(
+                                            config,
+                                            &root_session_id,
+                                        ) {
+                                            if let Ok(tasks) = autonoetic_gateway::scheduler::list_task_runs_for_workflow(
+                                                config,
+                                                Some(store),
+                                                &workflow_id,
+                                            ) {
+                                                for task in tasks {
+                                                    if matches!(
+                                                        task.status,
+                                                        autonoetic_types::workflow::TaskRunStatus::Pending
+                                                            | autonoetic_types::workflow::TaskRunStatus::Runnable
+                                                            | autonoetic_types::workflow::TaskRunStatus::Running
+                                                            | autonoetic_types::workflow::TaskRunStatus::AwaitingApproval
+                                                    ) {
+                                                        if autonoetic_gateway::scheduler::workflow_store::update_task_run_status(
+                                                            config,
+                                                            Some(store),
+                                                            &workflow_id,
+                                                            &task.task_id,
+                                                            autonoetic_types::workflow::TaskRunStatus::Paused,
+                                                            Some("paused by operator via chat TUI (Esc)".to_string()),
+                                                            None,
+                                                            None,
+                                                        )
+                                                        .is_ok()
+                                                        {
+                                                            paused_tasks = paused_tasks.saturating_add(1);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    app.add_message(
+                                        MessageRole::System,
+                                        format!(
+                                            "Pause requested via Esc. Paused {} workflow task(s). Press Esc again within 2s to cancel the root session.",
+                                            paused_tasks
+                                        ),
+                                    );
+                                }
+                                HandleKeyAction::CancelSession => {
+                                    let root_session_id = if app.session_overview.root_session_id.is_empty() {
+                                        autonoetic_gateway::runtime::content_store::root_session_id(session_id)
+                                            .to_string()
+                                    } else {
+                                        app.session_overview.root_session_id.clone()
+                                    };
+
+                                    if let Some(exec) = execution_for_interactions {
+                                        match exec
+                                            .emergency_stop_root_session(
+                                                &root_session_id,
+                                                "Cancelled from chat TUI (double Esc)",
+                                                "operator",
+                                                "chat-tui",
+                                                "chat_escape_double",
+                                                None,
+                                            )
+                                            .await
+                                        {
+                                            Ok(_) => {
+                                                app.session_paused = true;
+                                                app.add_message(
+                                                    MessageRole::System,
+                                                    format!(
+                                                        "Cancelled root session via emergency stop: {}",
+                                                        root_session_id
+                                                    ),
+                                                );
+                                            }
+                                            Err(e) => {
+                                                app.add_message(
+                                                    MessageRole::System,
+                                                    format!(
+                                                        "Failed to cancel root session {}: {}",
+                                                        root_session_id, e
+                                                    ),
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        app.add_message(
+                                            MessageRole::System,
+                                            "Execution service unavailable: cannot cancel root session from chat TUI.".to_string(),
+                                        );
+                                    }
+                                }
                                 HandleKeyAction::ApproveInline(apr_id) => {
                                     // Handle inline approval
                                     if let Some(store) = gateway_store {
@@ -1903,6 +2045,8 @@ enum HandleKeyAction {
     Continue,
     Quit,
     ApproveInline(String),
+    PauseSession,
+    CancelSession,
 }
 
 fn handle_key(
@@ -1918,7 +2062,12 @@ fn handle_key(
 
         // Send
         KeyCode::Enter => {
-            if !app.input.is_empty() {
+            if app.session_paused {
+                app.add_message(
+                    MessageRole::System,
+                    "Session is paused. Press Esc again within 2s to cancel, or Ctrl+R to resume input.".to_string(),
+                );
+            } else if !app.input.is_empty() {
                 let msg = std::mem::take(&mut app.input);
                 app.cursor_pos = 0;
                 let id = app.next_id();
@@ -1926,6 +2075,16 @@ fn handle_key(
                 app.add_message(MessageRole::User, msg.clone());
                 let _ = tx.send((id, msg));
             }
+        }
+
+        // Escape safety: first hit pauses, second hit within 2s cancels root session.
+        KeyCode::Esc => {
+            if app.cancel_armed() {
+                app.disarm_cancel_window();
+                return Ok(HandleKeyAction::CancelSession);
+            }
+            app.arm_cancel_window();
+            return Ok(HandleKeyAction::PauseSession);
         }
 
         // Cursor
@@ -1978,6 +2137,22 @@ fn handle_key(
                 let apr_id = app.pending_approval_ids.pop().unwrap();
                 return Ok(HandleKeyAction::ApproveInline(apr_id));
             }
+        }
+
+        // Resume local input after an Esc pause.
+        KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.session_paused = false;
+            app.disarm_cancel_window();
+            app.add_message(
+                MessageRole::System,
+                "Session input resumed (Ctrl+R).".to_string(),
+            );
+        }
+
+        // Jump to bottom and re-enable live following.
+        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.follow_output = true;
+            app.scroll_offset = app.last_max_scroll_offset;
         }
 
         _ => {}

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -134,6 +134,16 @@ code_analysis:
 #   max_llm_tokens: 5000000
 #   max_wall_clock_secs: 3600
 
+# ── Root Session Tree Budget (R+4 / R-6.21) ───────────────────────────
+# Aggregate limits across ALL sessions sharing the same root_session_id.
+# Applies in addition to per-session limits; the tighter bound wins.
+# root_session_budget:
+#   max_llm_rounds: 500
+#   max_tool_invocations: 2000
+#   max_llm_tokens: 20000000
+#   max_wall_clock_secs: 7200
+#   max_session_price_usd: 5.0
+
 # ── Retention ─────────────────────────────────────────────────────────
 # Days to keep execution_traces and causal_events. 0 = forever.
 retention:

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -261,7 +261,7 @@ Per-session registries in `runtime/session_budget.rs`,
 | R-6.18 | Workflow orchestration persists `WorkflowRun` on first `agent_spawn`. | workflow-orchestration.md | `workflow_store.rs` | ENFORCED |
 | R-6.19 | Child task message/metadata is preserved across approval boundaries. | workflow-orchestration.md | `TaskRun` storage | ENFORCED |
 | R-6.20 | User chat addressed to a child `session_id` rewrites to the root session. | workflow-orchestration.md | router `event.ingest` | ENFORCED |
-| R-6.21 | Tree-wide budget aggregated across all descendants of a root session. | (R+4) | not pinned | MISSING |
+| R-6.21 | Tree-wide budget aggregated across all descendants of a root session. | (R+4) | `runtime/root_session_budget.rs` `runtime/lifecycle.rs:1238` | ENFORCED |
 | R-6.22 | Continuation chain depth is bounded. | (R+3) | `execution.rs::spawn_agent_once` depth cap | ENFORCED |
 
 ## 7. Abuse / Hard-Stop / Circuit Breakers

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -261,7 +261,7 @@ Per-session registries in `runtime/session_budget.rs`,
 | R-6.18 | Workflow orchestration persists `WorkflowRun` on first `agent_spawn`. | workflow-orchestration.md | `workflow_store.rs` | ENFORCED |
 | R-6.19 | Child task message/metadata is preserved across approval boundaries. | workflow-orchestration.md | `TaskRun` storage | ENFORCED |
 | R-6.20 | User chat addressed to a child `session_id` rewrites to the root session. | workflow-orchestration.md | router `event.ingest` | ENFORCED |
-| R-6.21 | Tree-wide budget aggregated across all descendants of a root session. | (R+4) | `runtime/root_session_budget.rs` `runtime/lifecycle.rs:1238` | ENFORCED |
+| R-6.21 | Tree-wide budget aggregated across all descendants of a root session. | (R+4) | `runtime/root_session_budget.rs` `runtime/lifecycle.rs:1254` | ENFORCED |
 | R-6.22 | Continuation chain depth is bounded. | (R+3) | `execution.rs::spawn_agent_once` depth cap | ENFORCED |
 
 ## 7. Abuse / Hard-Stop / Circuit Breakers


### PR DESCRIPTION
## Summary

- Add `RootSessionBudgetRegistry` that aggregates LLM rounds, tokens, tool invocations, wall clock, and price across all sessions sharing the same `root_session_id`
- Wire tree budget checks alongside per-session checks in lifecycle: `check_pre_llm`, `reserve_llm_round`, `record_llm_completion`, `reserve_tool_invocations`
- Add `RootSessionBudgetConfig` to `GatewayConfig` with same shape as per-session budget
- 8 unit + 6 integration tests — covers aggregate denial, tighter-bound-wins, cleanup, and round reservation semantics
- Flip R-6.21 from MISSING to ENFORCED
- Include chat TUI operational control improvements already present on this branch: Esc pause + double-Esc cancel/emergency-stop flow for workflow tasks

**Threat mitigated:** A parent that spawns N siblings legally spends N× any individual cap. Cost, token, and wall-clock budgets now bound the aggregate.

Closes #46
Part of #42