### PR TITLE
Constitution R+2: egress schema validation

### DIFF
--- a/autonoetic-gateway/tests/constitution_schema_egress.rs
+++ b/autonoetic-gateway/tests/constitution_schema_egress.rs
@@ -1,0 +1,201 @@
+//! Constitution R+2 / R-5.13 — Egress schema validation on tool results.
+//!
+//! Child → parent tool results validate against `io.returns` on egress,
+//! symmetric to ingress `io.accepts`.  Fail-open for missing schema,
+//! fail-closed for declared-but-violated schema.
+
+mod support;
+
+use autonoetic_gateway::execution::SpawnResult;
+use autonoetic_gateway::runtime::response_validation::{
+    parse_response_contract, validate_spawn_response,
+};
+use autonoetic_types::agent::ResponseContract;
+
+fn minimal_result(reply: &str) -> SpawnResult {
+    SpawnResult {
+        agent_id: "child-agent".to_string(),
+        session_id: "sess-1".to_string(),
+        assistant_reply: Some(reply.to_string()),
+        should_signal_background: false,
+        artifacts: vec![],
+        files: vec![],
+        shared_knowledge: vec![],
+        llm_usage: vec![],
+        suspended_for_approval: None,
+        suspended_for_user_input: false,
+    }
+}
+
+fn contract_with_output_schema(schema: serde_json::Value) -> ResponseContract {
+    ResponseContract {
+        output_schema: Some(schema),
+        ..ResponseContract::default()
+    }
+}
+
+#[test]
+fn egress_rejects_missing_required_field() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["status", "count"],
+        "properties": {
+            "status": { "type": "string" },
+            "count": { "type": "integer" }
+        }
+    });
+    let contract = contract_with_output_schema(schema);
+    let result = minimal_result(r#"{"status": "ok"}"#);
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(!violations.is_empty(), "should violate missing 'count'");
+    assert!(
+        violations.iter().any(|v| v.message.contains("count")),
+        "{:?}",
+        violations
+    );
+}
+
+#[test]
+fn egress_rejects_wrong_type() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["count"],
+        "properties": {
+            "count": { "type": "integer" }
+        }
+    });
+    let contract = contract_with_output_schema(schema);
+    let result = minimal_result(r#"{"count": "not-a-number"}"#);
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(!violations.is_empty(), "should violate type");
+    assert!(
+        violations.iter().any(|v| v.message.contains("expected type")),
+        "{:?}",
+        violations
+    );
+}
+
+#[test]
+fn egress_rejects_invalid_json_when_schema_constrained() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": { "type": "string" }
+        }
+    });
+    let contract = contract_with_output_schema(schema);
+    let result = minimal_result("this is not json");
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(!violations.is_empty(), "should violate invalid JSON");
+    assert!(
+        violations.iter().any(|v| v.message.contains("not valid JSON")),
+        "{:?}",
+        violations
+    );
+}
+
+#[test]
+fn egress_passes_valid_response() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": { "type": "string" },
+            "data": { "type": "object" }
+        }
+    });
+    let contract = contract_with_output_schema(schema);
+    let result = minimal_result(r#"{"status": "ok", "data": {"x": 1}}"#);
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(violations.is_empty(), "valid response should pass: {:?}", violations);
+}
+
+#[test]
+fn egress_no_schema_means_no_violations() {
+    let contract = ResponseContract::default();
+    let result = minimal_result("anything at all");
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(
+        violations.is_empty(),
+        "no output_schema should pass everything: {:?}",
+        violations
+    );
+}
+
+#[test]
+fn egress_parse_contract_from_metadata() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["result"],
+        "properties": {
+            "result": { "type": "string" }
+        }
+    });
+    let metadata = serde_json::json!({
+        "response_contract": {
+            "output_schema": schema
+        }
+    });
+
+    let contract = parse_response_contract(Some(&metadata))
+        .expect("parse")
+        .expect("should produce contract");
+
+    let result = minimal_result(r#"{"result": "ok"}"#);
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(violations.is_empty(), "{:?}", violations);
+
+    let bad_result = minimal_result(r#"{"wrong": true}"#);
+    let violations = validate_spawn_response(&bad_result, &contract, None);
+    assert!(!violations.is_empty(), "should violate missing 'result'");
+}
+
+#[test]
+fn egress_rejects_no_reply_when_schema_constrained() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": { "type": "string" }
+        }
+    });
+    let contract = contract_with_output_schema(schema);
+
+    let mut result = minimal_result("");
+    result.assistant_reply = None;
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(!violations.is_empty(), "no reply should violate constrained schema");
+    assert!(
+        violations.iter().any(|v| v.message.contains("no reply produced")),
+        "{:?}",
+        violations
+    );
+}
+
+#[test]
+fn egress_enum_violation() {
+    let schema = serde_json::json!({
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": { "type": "string", "enum": ["ok", "error"] }
+        }
+    });
+    let contract = contract_with_output_schema(schema);
+    let result = minimal_result(r#"{"status": "unknown"}"#);
+
+    let violations = validate_spawn_response(&result, &contract, None);
+    assert!(!violations.is_empty(), "enum violation should be caught");
+    assert!(
+        violations.iter().any(|v| v.message.contains("not in enum")),
+        "{:?}",
+        violations
+    );
+}

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -175,6 +175,8 @@ struct App {
     scroll_offset: usize,
     last_max_scroll_offset: usize,
     follow_output: bool,
+    session_paused: bool,
+    esc_cancel_armed_until: Option<Instant>,
     session_id: String,
     target_hint: String,
     // Mouse selection - stored as CONTENT positions (row, col), not screen positions
@@ -213,6 +215,8 @@ impl App {
             scroll_offset: 0,
             last_max_scroll_offset: 0,
             follow_output: true,
+            session_paused: false,
+            esc_cancel_armed_until: None,
             session_id,
             target_hint,
             selecting: false,
@@ -360,6 +364,20 @@ impl App {
         } else {
             self.scroll_offset.min(self.last_max_scroll_offset)
         }
+    }
+
+    fn cancel_armed(&self) -> bool {
+        self.esc_cancel_armed_until
+            .map(|deadline| Instant::now() <= deadline)
+            .unwrap_or(false)
+    }
+
+    fn arm_cancel_window(&mut self) {
+        self.esc_cancel_armed_until = Some(Instant::now() + Duration::from_secs(2));
+    }
+
+    fn disarm_cancel_window(&mut self) {
+        self.esc_cancel_armed_until = None;
     }
 }
 
@@ -1196,20 +1214,41 @@ fn draw_status(f: &mut Frame, app: &App, area: Rect) {
     } else {
         ""
     };
+    let pause_hint = if app.session_paused {
+        "Paused: ON"
+    } else {
+        "Paused: OFF"
+    };
+    let esc_hint = if app.cancel_armed() {
+        "Esc: armed (press again to cancel)"
+    } else {
+        "Esc: pause"
+    };
+    let follow_hint = if app.follow_output {
+        "Follow: ON"
+    } else {
+        "Follow: OFF (Ctrl+F to jump live)"
+    };
     let text = if !app.pending.is_empty() {
         format!(
-            "{} {} pending | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
+            "{} {} pending | {} | {} | {} | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
             app.spinner(),
             app.pending.len(),
             workflow,
+            pause_hint,
+            esc_hint,
+            follow_hint,
             approve_hint,
         )
     } else {
         format!(
-            "Session: {} | Target: {} | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
+            "Session: {} | Target: {} | {} | {} | {} | {} | Enter: send | Scroll: Shift+↑↓ | Quit: Ctrl+C{}",
             &app.session_id[..20.min(app.session_id.len())],
             app.target_hint,
             workflow,
+            pause_hint,
+            esc_hint,
+            follow_hint,
             approve_hint,
         )
     };
@@ -1759,6 +1798,109 @@ async fn run_loop<B: ratatui::backend::Backend>(
                         Event::Key(key) => {
                             match handle_key(key, app, tx)? {
                                 HandleKeyAction::Quit => return Ok(false),
+                                HandleKeyAction::PauseSession => {
+                                    app.session_paused = true;
+                                    let root_session_id = if app.session_overview.root_session_id.is_empty() {
+                                        autonoetic_gateway::runtime::content_store::root_session_id(session_id)
+                                            .to_string()
+                                    } else {
+                                        app.session_overview.root_session_id.clone()
+                                    };
+
+                                    let mut paused_tasks = 0usize;
+                                    if let Some(store) = gateway_store {
+                                        if let Ok(Some(workflow_id)) = autonoetic_gateway::scheduler::resolve_workflow_id_for_root_session(
+                                            config,
+                                            &root_session_id,
+                                        ) {
+                                            if let Ok(tasks) = autonoetic_gateway::scheduler::list_task_runs_for_workflow(
+                                                config,
+                                                Some(store),
+                                                &workflow_id,
+                                            ) {
+                                                for task in tasks {
+                                                    if matches!(
+                                                        task.status,
+                                                        autonoetic_types::workflow::TaskRunStatus::Pending
+                                                            | autonoetic_types::workflow::TaskRunStatus::Runnable
+                                                            | autonoetic_types::workflow::TaskRunStatus::Running
+                                                            | autonoetic_types::workflow::TaskRunStatus::AwaitingApproval
+                                                    ) {
+                                                        if autonoetic_gateway::scheduler::workflow_store::update_task_run_status(
+                                                            config,
+                                                            Some(store),
+                                                            &workflow_id,
+                                                            &task.task_id,
+                                                            autonoetic_types::workflow::TaskRunStatus::Paused,
+                                                            Some("paused by operator via chat TUI (Esc)".to_string()),
+                                                            None,
+                                                            None,
+                                                        )
+                                                        .is_ok()
+                                                        {
+                                                            paused_tasks = paused_tasks.saturating_add(1);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    app.add_message(
+                                        MessageRole::System,
+                                        format!(
+                                            "Pause requested via Esc. Paused {} workflow task(s). Press Esc again within 2s to cancel the root session.",
+                                            paused_tasks
+                                        ),
+                                    );
+                                }
+                                HandleKeyAction::CancelSession => {
+                                    let root_session_id = if app.session_overview.root_session_id.is_empty() {
+                                        autonoetic_gateway::runtime::content_store::root_session_id(session_id)
+                                            .to_string()
+                                    } else {
+                                        app.session_overview.root_session_id.clone()
+                                    };
+
+                                    if let Some(exec) = execution_for_interactions {
+                                        match exec
+                                            .emergency_stop_root_session(
+                                                &root_session_id,
+                                                "Cancelled from chat TUI (double Esc)",
+                                                "operator",
+                                                "chat-tui",
+                                                "chat_escape_double",
+                                                None,
+                                            )
+                                            .await
+                                        {
+                                            Ok(_) => {
+                                                app.session_paused = true;
+                                                app.add_message(
+                                                    MessageRole::System,
+                                                    format!(
+                                                        "Cancelled root session via emergency stop: {}",
+                                                        root_session_id
+                                                    ),
+                                                );
+                                            }
+                                            Err(e) => {
+                                                app.add_message(
+                                                    MessageRole::System,
+                                                    format!(
+                                                        "Failed to cancel root session {}: {}",
+                                                        root_session_id, e
+                                                    ),
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        app.add_message(
+                                            MessageRole::System,
+                                            "Execution service unavailable: cannot cancel root session from chat TUI.".to_string(),
+                                        );
+                                    }
+                                }
                                 HandleKeyAction::ApproveInline(apr_id) => {
                                     // Handle inline approval
                                     if let Some(store) = gateway_store {
@@ -1903,6 +2045,8 @@ enum HandleKeyAction {
     Continue,
     Quit,
     ApproveInline(String),
+    PauseSession,
+    CancelSession,
 }
 
 fn handle_key(
@@ -1918,7 +2062,12 @@ fn handle_key(
 
         // Send
         KeyCode::Enter => {
-            if !app.input.is_empty() {
+            if app.session_paused {
+                app.add_message(
+                    MessageRole::System,
+                    "Session is paused. Press Esc again within 2s to cancel, or Ctrl+R to resume input.".to_string(),
+                );
+            } else if !app.input.is_empty() {
                 let msg = std::mem::take(&mut app.input);
                 app.cursor_pos = 0;
                 let id = app.next_id();
@@ -1926,6 +2075,16 @@ fn handle_key(
                 app.add_message(MessageRole::User, msg.clone());
                 let _ = tx.send((id, msg));
             }
+        }
+
+        // Escape safety: first hit pauses, second hit within 2s cancels root session.
+        KeyCode::Esc => {
+            if app.cancel_armed() {
+                app.disarm_cancel_window();
+                return Ok(HandleKeyAction::CancelSession);
+            }
+            app.arm_cancel_window();
+            return Ok(HandleKeyAction::PauseSession);
         }
 
         // Cursor
@@ -1978,6 +2137,22 @@ fn handle_key(
                 let apr_id = app.pending_approval_ids.pop().unwrap();
                 return Ok(HandleKeyAction::ApproveInline(apr_id));
             }
+        }
+
+        // Resume local input after an Esc pause.
+        KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.session_paused = false;
+            app.disarm_cancel_window();
+            app.add_message(
+                MessageRole::System,
+                "Session input resumed (Ctrl+R).".to_string(),
+            );
+        }
+
+        // Jump to bottom and re-enable live following.
+        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.follow_output = true;
+            app.scroll_offset = app.last_max_scroll_offset;
         }
 
         _ => {}

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -804,7 +804,7 @@ fn format_workflow_event_card(
         )),
         "task.updated" => Some((
             format!("🔄 [{}] Task updated: {}{} ({})", ts_short, task, agent_suffix, status),
-            MessageRole::Signal,
+            MessageRole::SignalLow,
         )),
         other => {
             Some((
@@ -815,6 +815,34 @@ fn format_workflow_event_card(
     };
 
     result
+}
+
+fn push_workflow_event_message(app: &mut App, role: MessageRole, card: String) {
+    match role {
+        MessageRole::SignalLow => {
+            // Keep one rolling low-signal line instead of growing the transcript.
+            if let Some(last_idx) = app
+                .messages
+                .iter()
+                .rposition(|m| matches!(m.role, MessageRole::SignalLow))
+            {
+                app.messages[last_idx].content = card;
+            } else {
+                app.add_message(role, card);
+            }
+        }
+        _ => {
+            // Drop stale low-signal noise when meaningful events arrive.
+            if let Some(last_idx) = app
+                .messages
+                .iter()
+                .rposition(|m| matches!(m.role, MessageRole::SignalLow))
+            {
+                app.messages.remove(last_idx);
+            }
+            app.add_message(role, card);
+        }
+    }
 }
 
 // ============================================================================
@@ -2576,8 +2604,11 @@ async fn check_signals(
                                     let start_idx = events.len().saturating_sub(recap_count);
                                     for event in &events[start_idx..] {
                                         if let Some((card, role)) = format_workflow_event_card(event) {
+                                            if matches!(role, MessageRole::SignalLow) {
+                                                continue;
+                                            }
                                             app.session_overview.latest_signal = Some(card.clone());
-                                            app.add_message(role, card);
+                                            push_workflow_event_message(app, role, card);
                                             processed_any = true;
                                         }
                                     }
@@ -2595,17 +2626,7 @@ async fn check_signals(
                         for event in events {
                             if app.seen_workflow_event_ids.insert(event.event_id.clone()) {
                                 if let Some((card, role)) = format_workflow_event_card(&event) {
-                                    match role {
-                                        MessageRole::SignalLow => {
-                                            app.add_message(role, card.clone());
-                                        }
-                                        _ => {
-                                            if let Some(last_idx) = app.messages.iter().rposition(|m| matches!(m.role, MessageRole::SignalLow)) {
-                                                app.messages.remove(last_idx);
-                                            }
-                                            app.add_message(role, card.clone());
-                                        }
-                                    }
+                                    push_workflow_event_message(app, role, card.clone());
                                     app.session_overview.latest_signal = Some(card.clone());
 
                                     // Track pending approval IDs for inline approval (Ctrl+A)

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -232,7 +232,7 @@ Enforcement hook for ingress, response validation gate for egress.
 | R-5.10 | `artifact_inspect` accepts explicit `art_*` IDs only; implicit `impl_task-*` handles are rejected. | content-store.md | `runtime/tools/artifact.rs` | ENFORCED |
 | R-5.11 | Native tool errors use a uniform `{error_type, message, repair_hint}` envelope. | ARCHITECTURE.md | per-tool response construction | PARTIAL |
 | R-5.12 | `error_type: fatal` triggers session abort; recoverable types do not. | ARCHITECTURE.md | lifecycle error processing | ENFORCED |
-| R-5.13 | Child → parent tool results validate against `io.produces` on egress. | (R+2) | not pinned | MISSING |
+| R-5.13 | Child → parent tool results validate against `io.returns` on egress. | (R+2) | `runtime/response_validation.rs:68` `execution.rs:1903` | ENFORCED |
 
 ## 6. Session, Workflow & Budget
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -374,7 +374,7 @@ before it moves into its category.
 | ID | Rule | Priority |
 |---|---|---|
 | R+1 | Structured capability scopes mandatory for all capabilities (not only the three high-risk ones). | P1 |
-| R+2 | Child → parent tool results validate against `io.produces` on egress. | P0 |
+| R+2 | Child → parent tool results validate against `io.returns` on egress. | P0 |
 | R+3 | Spawn-chain depth cap — child `max_children` and `max_depth` ≤ parent's; global ceiling applies. | P0 |
 | R+4 | Root-session tree budget — tokens / time / cost aggregated across all descendants. | P0 |
 | R+5 | Approval flood cap per root session; further requests reject `approval_flood`. | P0 |


### PR DESCRIPTION
## Summary

The egress validation path already exists through the response contract system. `io.returns` from the child manifest is merged into the response contract via `build_effective_response_contract_metadata()` and validated by `validate_spawn_response()` — even when `response_validation.enabled` is false (the `enforcing_manifest_returns` gate at `execution.rs:1903`).

This commit adds the acceptance test suite, flips R-5.13, and includes chat TUI operator-control improvements (Esc pause + double-Esc cancel/emergency-stop flow for workflow tasks) already present on this branch.

- 8 integration tests covering: missing required fields, type violations, invalid JSON, enum violations, no-reply-when-constrained, valid pass-through, no-schema pass-through, metadata-based contract parsing
- Flip R-5.13 from MISSING to ENFORCED
- Update R+2 pending-rule row to reference `io.returns` (consistent with R-5.13 enforcement pin)

Closes #47
Part of #42