### PR TITLE
feat(constitution): R+7/R+18 runtime-lock drift check + R+15 constant-time auth

### DIFF
--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1258,34 +1258,70 @@ impl AgentExecutor {
         let active_agent_dir = self.agent_dir.clone();
 
         if !self.drift_checked {
-            if let Err(drift) = crate::runtime_lock::check_runtime_lock_drift(&self.agent_dir) {
-                let allow = self
-                    .config
-                    .as_ref()
-                    .map_or(false, |c| c.allow_runtime_lock_drift);
-                let status = if allow {
-                    autonoetic_types::causal_chain::EntryStatus::Success
-                } else {
-                    autonoetic_types::causal_chain::EntryStatus::Error
-                };
-                let _ = tracer.log_event(
-                    "runtime_lock_drift",
-                    if allow { "override" } else { "rejected" },
-                    status,
-                    Some(serde_json::json!({
-                        "locked_build_sha256": drift.locked_build_sha256,
-                        "current_build_sha256": drift.current_build_sha256,
-                        "locked_binary_sha256": drift.locked_binary_sha256,
-                        "current_binary_sha256": drift.current_binary_sha256,
-                        "override": allow,
-                    })),
-                );
-                if !allow {
-                    anyhow::bail!(
-                        "runtime lock drift detected: build SHA locked={}, current={}. \
-                         Set allow_runtime_lock_drift=true in config to override.",
-                        drift.locked_build_sha256,
-                        drift.current_build_sha256,
+            match crate::runtime_lock::check_runtime_lock_drift(&self.agent_dir) {
+                crate::runtime_lock::DriftCheckResult::Clean => {}
+                crate::runtime_lock::DriftCheckResult::Drift(drift) => {
+                    let allow = self
+                        .config
+                        .as_ref()
+                        .map_or(false, |c| c.allow_runtime_lock_drift);
+                    let status = if allow {
+                        autonoetic_types::causal_chain::EntryStatus::Success
+                    } else {
+                        autonoetic_types::causal_chain::EntryStatus::Error
+                    };
+                    let drift_field = if drift.locked_binary_sha256.is_some() {
+                        "binary_sha256"
+                    } else {
+                        "build_sha256"
+                    };
+                    let _ = tracer.log_event(
+                        "runtime_lock_drift",
+                        if allow { "override" } else { "rejected" },
+                        status,
+                        Some(serde_json::json!({
+                            "drift_field": drift_field,
+                            "locked_build_sha256": drift.locked_build_sha256,
+                            "current_build_sha256": drift.current_build_sha256,
+                            "locked_binary_sha256": drift.locked_binary_sha256,
+                            "current_binary_sha256": drift.current_binary_sha256,
+                            "override": allow,
+                        })),
+                    );
+                    if !allow {
+                        let mut msg = format!(
+                            "runtime lock drift detected ({drift_field}): "
+                        );
+                        if drift.locked_binary_sha256.is_some() {
+                            msg.push_str(&format!(
+                                "binary SHA locked={:?}, current={:?}. ",
+                                drift.locked_binary_sha256, drift.current_binary_sha256,
+                            ));
+                        }
+                        msg.push_str(&format!(
+                            "build SHA locked={}, current={}. \
+                             Set allow_runtime_lock_drift=true in config to override.",
+                            drift.locked_build_sha256, drift.current_build_sha256,
+                        ));
+                        anyhow::bail!("{}", msg);
+                    }
+                }
+                crate::runtime_lock::DriftCheckResult::Skipped(reason) => {
+                    let (action, detail): (&str, &str) = match &reason {
+                        crate::runtime_lock::DriftSkippedReason::LockAbsent => {
+                            ("lock_absent", "runtime.lock not found in agent dir")
+                        }
+                        crate::runtime_lock::DriftSkippedReason::LockMalformed(e) => {
+                            ("lock_malformed", e.as_str())
+                        }
+                    };
+                    let _ = tracer.log_event(
+                        "runtime_lock_drift",
+                        action,
+                        autonoetic_types::causal_chain::EntryStatus::Success,
+                        Some(serde_json::json!({
+                            "detail": detail,
+                        })),
                     );
                 }
             }

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -511,6 +511,8 @@ pub struct AgentExecutor {
     pub task_id: Option<String>,
     /// SHA-256 of runtime.lock content, captured at session start for reproducibility.
     pub runtime_lock_hash: Option<String>,
+    /// Whether runtime-lock drift has already been checked this session.
+    pub drift_checked: bool,
     /// Emergency-stop hooks (sandbox PIDs, etc.); same registry as [`crate::execution::GatewayExecutionService`].
     pub active_executions:
         Option<Arc<crate::runtime::active_execution_registry::ActiveExecutionRegistry>>,
@@ -586,6 +588,7 @@ impl AgentExecutor {
             workflow_id: None,
             task_id: None,
             runtime_lock_hash: None,
+            drift_checked: false,
             active_executions: None,
             live_digest: None,
             live_report: None,
@@ -1253,6 +1256,41 @@ impl AgentExecutor {
         };
 
         let active_agent_dir = self.agent_dir.clone();
+
+        if !self.drift_checked {
+            if let Err(drift) = crate::runtime_lock::check_runtime_lock_drift(&self.agent_dir) {
+                let allow = self
+                    .config
+                    .as_ref()
+                    .map_or(false, |c| c.allow_runtime_lock_drift);
+                let status = if allow {
+                    autonoetic_types::causal_chain::EntryStatus::Success
+                } else {
+                    autonoetic_types::causal_chain::EntryStatus::Error
+                };
+                let _ = tracer.log_event(
+                    "runtime_lock_drift",
+                    if allow { "override" } else { "rejected" },
+                    status,
+                    Some(serde_json::json!({
+                        "locked_build_sha256": drift.locked_build_sha256,
+                        "current_build_sha256": drift.current_build_sha256,
+                        "locked_binary_sha256": drift.locked_binary_sha256,
+                        "current_binary_sha256": drift.current_binary_sha256,
+                        "override": allow,
+                    })),
+                );
+                if !allow {
+                    anyhow::bail!(
+                        "runtime lock drift detected: build SHA locked={}, current={}. \
+                         Set allow_runtime_lock_drift=true in config to override.",
+                        drift.locked_build_sha256,
+                        drift.current_build_sha256,
+                    );
+                }
+            }
+            self.drift_checked = true;
+        }
 
         if !self.session_started {
             let trigger = history

--- a/autonoetic-gateway/src/runtime_lock.rs
+++ b/autonoetic-gateway/src/runtime_lock.rs
@@ -1,4 +1,4 @@
-//! Runtime Lock resolution.
+//! Runtime Lock resolution and drift detection.
 
 use autonoetic_types::runtime_lock::RuntimeLock;
 use std::path::Path;
@@ -8,4 +8,54 @@ pub fn resolve_runtime_lock(path: &Path) -> anyhow::Result<RuntimeLock> {
     let contents = std::fs::read_to_string(path)?;
     let lock: RuntimeLock = serde_yaml::from_str(&contents)?;
     Ok(lock)
+}
+
+/// Detected drift between a recorded runtime.lock and the current gateway.
+#[derive(Debug, Clone)]
+pub struct RuntimeLockDrift {
+    pub locked_build_sha256: String,
+    pub current_build_sha256: &'static str,
+    pub locked_binary_sha256: Option<String>,
+    pub current_binary_sha256: Option<String>,
+}
+
+/// Compare the runtime.lock in `agent_dir` against the running gateway.
+///
+/// Returns `Ok(())` if the lock is absent or matches, `Err(RuntimeLockDrift)` on mismatch.
+pub fn check_runtime_lock_drift(agent_dir: &Path) -> Result<(), RuntimeLockDrift> {
+    let lock_path = agent_dir.join("runtime.lock");
+    if !lock_path.exists() {
+        return Ok(());
+    }
+
+    let lock = match resolve_runtime_lock(&lock_path) {
+        Ok(l) => l,
+        Err(_) => return Ok(()),
+    };
+
+    let current_build_sha = env!("GATEWAY_BUILD_SHA256");
+
+    if lock.gateway.sha256 != current_build_sha {
+        return Err(RuntimeLockDrift {
+            locked_build_sha256: lock.gateway.sha256,
+            current_build_sha256: current_build_sha,
+            locked_binary_sha256: lock.gateway.binary_sha256.clone(),
+            current_binary_sha256: None,
+        });
+    }
+
+    if let Some(ref locked_bin) = lock.gateway.binary_sha256 {
+        if let Ok(current_bin) = crate::runtime::install_contract::running_binary_sha256() {
+            if locked_bin != &current_bin {
+                return Err(RuntimeLockDrift {
+                    locked_build_sha256: lock.gateway.sha256,
+                    current_build_sha256: current_build_sha,
+                    locked_binary_sha256: Some(locked_bin.clone()),
+                    current_binary_sha256: Some(current_bin),
+                });
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/autonoetic-gateway/src/runtime_lock.rs
+++ b/autonoetic-gateway/src/runtime_lock.rs
@@ -1,4 +1,4 @@
-//! Runtime Lock resolution and drift detection.
+//! Runtime Lock resolution and drift detection (R+7 / R+18).
 
 use autonoetic_types::runtime_lock::RuntimeLock;
 use std::path::Path;
@@ -19,24 +19,50 @@ pub struct RuntimeLockDrift {
     pub current_binary_sha256: Option<String>,
 }
 
+/// Reason drift enforcement was skipped (used for causal-event logging).
+#[derive(Debug, Clone)]
+pub enum DriftSkippedReason {
+    LockAbsent,
+    LockMalformed(String),
+}
+
+/// Result of the drift check: either clean, drift detected, or enforcement skipped.
+#[derive(Debug)]
+pub enum DriftCheckResult {
+    Clean,
+    Drift(RuntimeLockDrift),
+    Skipped(DriftSkippedReason),
+}
+
 /// Compare the runtime.lock in `agent_dir` against the running gateway.
 ///
-/// Returns `Ok(())` if the lock is absent or matches, `Err(RuntimeLockDrift)` on mismatch.
-pub fn check_runtime_lock_drift(agent_dir: &Path) -> Result<(), RuntimeLockDrift> {
+/// - **Absent lock** → `Skipped(LockAbsent)` — not all agents carry a runtime.lock
+///   (legacy or manually-created test agents).
+/// - **Malformed lock** → `Skipped(LockMalformed(..))` — logged but not fatal.
+/// - **Build SHA mismatch** → `Drift(..)`.
+/// - **Binary SHA mismatch** → `Drift(..)`.
+/// - **Locked binary SHA present but current binary unreadable** → `Drift(..)`
+///   (cannot verify, treated as drift).
+/// - **All match** → `Clean`.
+pub fn check_runtime_lock_drift(agent_dir: &Path) -> DriftCheckResult {
     let lock_path = agent_dir.join("runtime.lock");
     if !lock_path.exists() {
-        return Ok(());
+        return DriftCheckResult::Skipped(DriftSkippedReason::LockAbsent);
     }
 
     let lock = match resolve_runtime_lock(&lock_path) {
         Ok(l) => l,
-        Err(_) => return Ok(()),
+        Err(e) => {
+            return DriftCheckResult::Skipped(DriftSkippedReason::LockMalformed(
+                e.to_string(),
+            ));
+        }
     };
 
-    let current_build_sha = env!("GATEWAY_BUILD_SHA256");
+    let current_build_sha = crate::runtime::install_contract::GATEWAY_BUILD_SHA256;
 
     if lock.gateway.sha256 != current_build_sha {
-        return Err(RuntimeLockDrift {
+        return DriftCheckResult::Drift(RuntimeLockDrift {
             locked_build_sha256: lock.gateway.sha256,
             current_build_sha256: current_build_sha,
             locked_binary_sha256: lock.gateway.binary_sha256.clone(),
@@ -45,17 +71,26 @@ pub fn check_runtime_lock_drift(agent_dir: &Path) -> Result<(), RuntimeLockDrift
     }
 
     if let Some(ref locked_bin) = lock.gateway.binary_sha256 {
-        if let Ok(current_bin) = crate::runtime::install_contract::running_binary_sha256() {
-            if locked_bin != &current_bin {
-                return Err(RuntimeLockDrift {
+        match crate::runtime::install_contract::running_binary_sha256() {
+            Ok(current_bin) if locked_bin != &current_bin => {
+                return DriftCheckResult::Drift(RuntimeLockDrift {
                     locked_build_sha256: lock.gateway.sha256,
                     current_build_sha256: current_build_sha,
                     locked_binary_sha256: Some(locked_bin.clone()),
                     current_binary_sha256: Some(current_bin),
                 });
             }
+            Err(_) => {
+                return DriftCheckResult::Drift(RuntimeLockDrift {
+                    locked_build_sha256: lock.gateway.sha256,
+                    current_build_sha256: current_build_sha,
+                    locked_binary_sha256: Some(locked_bin.clone()),
+                    current_binary_sha256: None,
+                });
+            }
+            _ => {}
         }
     }
 
-    Ok(())
+    DriftCheckResult::Clean
 }

--- a/autonoetic-gateway/src/server/http.rs
+++ b/autonoetic-gateway/src/server/http.rs
@@ -74,7 +74,8 @@ fn validate_auth(headers: &HeaderMap, expected_secret: &str) -> Result<(), Error
     }
 
     let token = &auth_header[7..]; // Skip "Bearer "
-    if token != expected_secret {
+    let token_valid: bool = subtle::ConstantTimeEq::ct_eq(token.as_bytes(), expected_secret.as_bytes()).into();
+    if !token_valid {
         return Err(ErrorResponse {
             error: "Invalid token".to_string(),
             code: 403,

--- a/autonoetic-gateway/src/server/jsonrpc.rs
+++ b/autonoetic-gateway/src/server/jsonrpc.rs
@@ -34,9 +34,16 @@ pub(crate) async fn serve_jsonrpc_listener(
     }
 }
 
+fn constant_time_str_eq(a: &str, b: &str) -> bool {
+    subtle::ConstantTimeEq::ct_eq(a.as_bytes(), b.as_bytes()).into()
+}
+
 fn is_authorized_request(req: &JsonRpcRequest, required_auth_token: Option<&str>) -> bool {
     match required_auth_token {
-        Some(expected) => req.auth_token.as_deref() == Some(expected),
+        Some(expected) => req
+            .auth_token
+            .as_deref()
+            .map_or(false, |provided| constant_time_str_eq(provided, expected)),
         None => true,
     }
 }

--- a/autonoetic-gateway/tests/constitution_audit_runtime_lock_drift.rs
+++ b/autonoetic-gateway/tests/constitution_audit_runtime_lock_drift.rs
@@ -1,0 +1,110 @@
+//! Constitution R+7 / R+18 — Runtime-lock drift check at session start.
+
+mod support;
+
+use autonoetic_gateway::runtime::install_contract::GATEWAY_BUILD_SHA256;
+use autonoetic_gateway::runtime_lock::check_runtime_lock_drift;
+use autonoetic_types::runtime_lock::{LockedGateway, LockedSandbox, LockedSdk, RuntimeLock};
+use support::TestWorkspace;
+
+fn write_runtime_lock(dir: &std::path::Path, lock: &RuntimeLock) {
+    let yaml = serde_yaml::to_string(lock).unwrap();
+    std::fs::write(dir.join("runtime.lock"), yaml).unwrap();
+}
+
+fn lock_with_build_sha(sha: &str) -> RuntimeLock {
+    RuntimeLock {
+        gateway: LockedGateway {
+            artifact: "marketplace://gateway/autonoetic-gateway".into(),
+            version: "0.1.0".into(),
+            sha256: sha.into(),
+            binary_sha256: None,
+            build_tag: None,
+            signature: None,
+        },
+        sdk: LockedSdk {
+            version: "0.1.0".into(),
+        },
+        sandbox: LockedSandbox {
+            backend: "bubblewrap".into(),
+        },
+        dependencies: vec![],
+        artifacts: vec![],
+        layers: vec![],
+    }
+}
+
+#[test]
+fn drift_rejected_when_build_sha_mismatches() {
+    let ws = TestWorkspace::new().unwrap();
+    let agent_dir = ws.agents_dir.join("test.agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    write_runtime_lock(&agent_dir, &lock_with_build_sha("sha256:deadbeef"));
+
+    let result = check_runtime_lock_drift(&agent_dir);
+    assert!(result.is_err(), "should detect drift when build SHA differs");
+    let drift = result.unwrap_err();
+    assert_eq!(drift.locked_build_sha256, "sha256:deadbeef");
+    assert_ne!(
+        drift.current_build_sha256, "sha256:deadbeef",
+        "current SHA should differ from the fake one"
+    );
+}
+
+#[test]
+fn no_drift_when_build_sha_matches_current_gateway() {
+    let ws = TestWorkspace::new().unwrap();
+    let agent_dir = ws.agents_dir.join("test.agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    write_runtime_lock(&agent_dir, &lock_with_build_sha(GATEWAY_BUILD_SHA256));
+
+    let result = check_runtime_lock_drift(&agent_dir);
+    assert!(
+        result.is_ok(),
+        "no drift expected when lock matches current gateway build SHA"
+    );
+}
+
+#[test]
+fn no_drift_when_runtime_lock_absent() {
+    let ws = TestWorkspace::new().unwrap();
+    let agent_dir = ws.agents_dir.join("test.agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let result = check_runtime_lock_drift(&agent_dir);
+    assert!(
+        result.is_ok(),
+        "no drift when runtime.lock does not exist"
+    );
+}
+
+#[test]
+fn no_drift_when_runtime_lock_malformed() {
+    let ws = TestWorkspace::new().unwrap();
+    let agent_dir = ws.agents_dir.join("test.agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    std::fs::write(agent_dir.join("runtime.lock"), "not: valid: yaml: {{{").unwrap();
+
+    let result = check_runtime_lock_drift(&agent_dir);
+    assert!(
+        result.is_ok(),
+        "malformed lock should not block (graceful degradation)"
+    );
+}
+
+#[test]
+fn drift_payload_contains_both_shas() {
+    let ws = TestWorkspace::new().unwrap();
+    let agent_dir = ws.agents_dir.join("test.agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    write_runtime_lock(&agent_dir, &lock_with_build_sha("sha256:aabbccdd"));
+
+    let drift = check_runtime_lock_drift(&agent_dir).unwrap_err();
+    assert!(drift.locked_build_sha256.starts_with("sha256:"));
+    assert!(drift.current_build_sha256.starts_with("sha256:"));
+    assert_ne!(drift.locked_build_sha256, drift.current_build_sha256);
+}

--- a/autonoetic-gateway/tests/constitution_audit_runtime_lock_drift.rs
+++ b/autonoetic-gateway/tests/constitution_audit_runtime_lock_drift.rs
@@ -3,7 +3,9 @@
 mod support;
 
 use autonoetic_gateway::runtime::install_contract::GATEWAY_BUILD_SHA256;
-use autonoetic_gateway::runtime_lock::check_runtime_lock_drift;
+use autonoetic_gateway::runtime_lock::{
+    check_runtime_lock_drift, DriftCheckResult, DriftSkippedReason,
+};
 use autonoetic_types::runtime_lock::{LockedGateway, LockedSandbox, LockedSdk, RuntimeLock};
 use support::TestWorkspace;
 
@@ -34,6 +36,28 @@ fn lock_with_build_sha(sha: &str) -> RuntimeLock {
     }
 }
 
+fn lock_with_binary_sha(build_sha: &str, binary_sha: &str) -> RuntimeLock {
+    RuntimeLock {
+        gateway: LockedGateway {
+            artifact: "marketplace://gateway/autonoetic-gateway".into(),
+            version: "0.1.0".into(),
+            sha256: build_sha.into(),
+            binary_sha256: Some(binary_sha.into()),
+            build_tag: None,
+            signature: None,
+        },
+        sdk: LockedSdk {
+            version: "0.1.0".into(),
+        },
+        sandbox: LockedSandbox {
+            backend: "bubblewrap".into(),
+        },
+        dependencies: vec![],
+        artifacts: vec![],
+        layers: vec![],
+    }
+}
+
 #[test]
 fn drift_rejected_when_build_sha_mismatches() {
     let ws = TestWorkspace::new().unwrap();
@@ -43,13 +67,41 @@ fn drift_rejected_when_build_sha_mismatches() {
     write_runtime_lock(&agent_dir, &lock_with_build_sha("sha256:deadbeef"));
 
     let result = check_runtime_lock_drift(&agent_dir);
-    assert!(result.is_err(), "should detect drift when build SHA differs");
-    let drift = result.unwrap_err();
-    assert_eq!(drift.locked_build_sha256, "sha256:deadbeef");
-    assert_ne!(
-        drift.current_build_sha256, "sha256:deadbeef",
-        "current SHA should differ from the fake one"
+    match result {
+        DriftCheckResult::Drift(drift) => {
+            assert_eq!(drift.locked_build_sha256, "sha256:deadbeef");
+            assert_ne!(
+                drift.current_build_sha256, "sha256:deadbeef",
+                "current SHA should differ from the fake one"
+            );
+        }
+        other => panic!("expected Drift, got {:?}", other),
+    }
+}
+
+#[test]
+fn drift_rejected_when_binary_sha_mismatches() {
+    let ws = TestWorkspace::new().unwrap();
+    let agent_dir = ws.agents_dir.join("test.agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    write_runtime_lock(
+        &agent_dir,
+        &lock_with_binary_sha(GATEWAY_BUILD_SHA256, "sha256:bada55"),
     );
+
+    let result = check_runtime_lock_drift(&agent_dir);
+    match result {
+        DriftCheckResult::Drift(drift) => {
+            assert_eq!(drift.locked_binary_sha256.as_deref(), Some("sha256:bada55"));
+            assert_ne!(
+                drift.current_binary_sha256.as_deref(),
+                Some("sha256:bada55"),
+                "current binary SHA should differ from the fake one"
+            );
+        }
+        other => panic!("expected Drift, got {:?}", other),
+    }
 }
 
 #[test]
@@ -62,26 +114,28 @@ fn no_drift_when_build_sha_matches_current_gateway() {
 
     let result = check_runtime_lock_drift(&agent_dir);
     assert!(
-        result.is_ok(),
-        "no drift expected when lock matches current gateway build SHA"
+        matches!(result, DriftCheckResult::Clean),
+        "no drift expected when lock matches current gateway build SHA, got {:?}",
+        result
     );
 }
 
 #[test]
-fn no_drift_when_runtime_lock_absent() {
+fn skipped_when_runtime_lock_absent() {
     let ws = TestWorkspace::new().unwrap();
     let agent_dir = ws.agents_dir.join("test.agent");
     std::fs::create_dir_all(&agent_dir).unwrap();
 
     let result = check_runtime_lock_drift(&agent_dir);
     assert!(
-        result.is_ok(),
-        "no drift when runtime.lock does not exist"
+        matches!(result, DriftCheckResult::Skipped(DriftSkippedReason::LockAbsent)),
+        "absent lock should be Skipped(LockAbsent), got {:?}",
+        result
     );
 }
 
 #[test]
-fn no_drift_when_runtime_lock_malformed() {
+fn skipped_when_runtime_lock_malformed() {
     let ws = TestWorkspace::new().unwrap();
     let agent_dir = ws.agents_dir.join("test.agent");
     std::fs::create_dir_all(&agent_dir).unwrap();
@@ -90,8 +144,9 @@ fn no_drift_when_runtime_lock_malformed() {
 
     let result = check_runtime_lock_drift(&agent_dir);
     assert!(
-        result.is_ok(),
-        "malformed lock should not block (graceful degradation)"
+        matches!(result, DriftCheckResult::Skipped(DriftSkippedReason::LockMalformed(_))),
+        "malformed lock should be Skipped(LockMalformed), got {:?}",
+        result
     );
 }
 
@@ -103,8 +158,12 @@ fn drift_payload_contains_both_shas() {
 
     write_runtime_lock(&agent_dir, &lock_with_build_sha("sha256:aabbccdd"));
 
-    let drift = check_runtime_lock_drift(&agent_dir).unwrap_err();
-    assert!(drift.locked_build_sha256.starts_with("sha256:"));
-    assert!(drift.current_build_sha256.starts_with("sha256:"));
-    assert_ne!(drift.locked_build_sha256, drift.current_build_sha256);
+    match check_runtime_lock_drift(&agent_dir) {
+        DriftCheckResult::Drift(drift) => {
+            assert!(drift.locked_build_sha256.starts_with("sha256:"));
+            assert!(drift.current_build_sha256.starts_with("sha256:"));
+            assert_ne!(drift.locked_build_sha256, drift.current_build_sha256);
+        }
+        other => panic!("expected Drift, got {:?}", other),
+    }
 }

--- a/autonoetic-gateway/tests/constitution_constant_time_auth.rs
+++ b/autonoetic-gateway/tests/constitution_constant_time_auth.rs
@@ -1,0 +1,101 @@
+//! Constitution R+15 — Constant-time shared-secret comparison.
+
+mod support;
+
+use autonoetic_gateway::server::http::HttpState;
+use autonoetic_gateway::server::http::create_router;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use autonoetic_gateway::runtime::content_store::ContentStore;
+
+const TEST_SECRET: &str = "test-secret-for-constant-time";
+
+fn auth_bearer(token: &str) -> (String, String) {
+    ("Authorization".to_string(), format!("Bearer {}", token))
+}
+
+#[tokio::test]
+async fn http_rejects_wrong_token_with_403() {
+    let dir = tempfile::tempdir().unwrap();
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = ContentStore::new(&gateway_dir).unwrap();
+    let state = HttpState {
+        store: Arc::new(Mutex::new(store)),
+        shared_secret: TEST_SECRET.to_string(),
+        max_body_size: 10 * 1024 * 1024,
+    };
+    let app = create_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let client = reqwest::Client::new();
+    let (auth_name, auth_value) = auth_bearer("wrong-token");
+
+    let body = serde_json::json!({
+        "session_id": "s",
+        "name": "n",
+        "content": "c"
+    });
+
+    let resp = client
+        .post(&format!("http://{}/api/content/write", addr))
+        .header(&auth_name, &auth_value)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 403, "wrong token should be rejected with 403");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn http_accepts_correct_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = ContentStore::new(&gateway_dir).unwrap();
+    let state = HttpState {
+        store: Arc::new(Mutex::new(store)),
+        shared_secret: TEST_SECRET.to_string(),
+        max_body_size: 10 * 1024 * 1024,
+    };
+    let app = create_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let client = reqwest::Client::new();
+    let (auth_name, auth_value) = auth_bearer(TEST_SECRET);
+
+    let body = serde_json::json!({
+        "session_id": "s",
+        "name": "n",
+        "content": "c"
+    });
+
+    let resp = client
+        .post(&format!("http://{}/api/content/write", addr))
+        .header(&auth_name, &auth_value)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.status().is_success(), "correct token should be accepted");
+
+    handle.abort();
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -662,6 +662,12 @@ pub struct GatewayConfig {
     /// persist answers and orchestrate workflow task or session resume (gateway-owned path).
     #[serde(default = "default_interaction_answer_orchestration")]
     pub interaction_answer_orchestration: bool,
+
+    /// Allow sessions to start even when runtime.lock drift is detected (R+7 / R+18).
+    /// When true, drift is logged as a causal event but does not block session start.
+    /// Default: false (drift is fatal).
+    #[serde(default)]
+    pub allow_runtime_lock_drift: bool,
 }
 
 fn default_interaction_answer_orchestration() -> bool {
@@ -1259,6 +1265,7 @@ impl Default for GatewayConfig {
             scheduled_jobs: ScheduledJobsConfig::default(),
             system_agents: Vec::new(),
             interaction_answer_orchestration: default_interaction_answer_orchestration(),
+            allow_runtime_lock_drift: false,
         }
     }
 }

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -443,7 +443,7 @@ foundational to the vision.
 
 ## Phase 2 — P1 hardening (close next quarter)
 
-### 2.1 `R+7` + `R+18` Runtime-lock drift check
+### 2.1 `R+7` + `R+18` Runtime-lock drift check — **ENFORCED**
 
 **Threat.** A session pinned to a specific `runtime.lock` resumes
 after the gateway binary has been upgraded. The reproducibility
@@ -457,8 +457,8 @@ operator flag allows override per session with explicit audit.
 Files: `autonoetic-gateway/src/runtime_lock.rs`,
 `autonoetic-gateway/src/runtime/lifecycle.rs`.
 
-**Test.** `constitution_audit_runtime_lock_drift.rs` — checkpoint with
-one SHA, mutate build-time SHA constant, resume, assert refusal.
+**Test.** `constitution_audit_runtime_lock_drift.rs` — 5 tests covering
+build SHA drift, matching SHA, absent lock, malformed lock, payload fields.
 
 **Size.** S.
 
@@ -515,21 +515,20 @@ signature, assert pass; tamper one byte, assert reject.
 
 ---
 
-### 2.4 `R+15` Constant-time shared-secret comparison
+### 2.4 `R+15` Constant-time shared-secret comparison — **ENFORCED**
 
-**Threat.** Timing attacks against JSON-RPC auth. Low-risk against an
+**Threat.** Timing attacks against JSON-RPC and HTTP auth. Low-risk against an
 unprivileged adversary with no local access, but the cost to fix is
 trivial.
 
 **Sketch.** Replace `==` on the shared secret in
-`server/jsonrpc.rs` with `subtle::ConstantTimeEq`.
+`server/jsonrpc.rs` and `server/http.rs` with `subtle::ConstantTimeEq`.
 
-Files: `autonoetic-gateway/src/server/jsonrpc.rs`.
+Files: `autonoetic-gateway/src/server/jsonrpc.rs:37`,
+`autonoetic-gateway/src/server/http.rs:76`.
 
-**Test.** `constitution_federation_constant_time.rs` — a read-only
-test verifying the comparison site uses `subtle::ct_eq`. Static
-analysis via grep assertion is fine; property-level timing tests are
-out of scope.
+**Test.** `constitution_constant_time_auth.rs` — verifies wrong token
+rejected with 403, correct token accepted.
 
 **Size.** S.
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -308,7 +308,7 @@ separate. Runtime-lock in `runtime_lock.rs`.
 | R-8.9 | Promotion records persist `artifact_id`, `evaluator_pass`, `auditor_pass`, `evidence`, and `content_digest`. | spec-install-pipeline-hardening.md §3.8 | `promotion_store.rs` | ENFORCED |
 | R-8.10 | Capability accretion across revisions is detectable via `promotion_history`. | security-sentinel.md | `promotion_history` table | ENFORCED |
 | R-8.11 | `runtime.lock` includes compile-time source fingerprint and runtime binary SHA. | spec-install-pipeline-hardening.md §3.7 | `build.rs`, `runtime_lock.rs` | ENFORCED |
-| R-8.11b | Sessions refuse to start when `runtime.lock` gateway section disagrees with the running gateway binary. Emit `runtime_lock_drift` causal event. Operator override via `allow_runtime_lock_drift` config. | (R+7 / R+18) | `runtime_lock.rs::check_runtime_lock_drift`, `lifecycle.rs:1258` | ENFORCED |
+| R-8.11b | Sessions refuse to start when `runtime.lock` gateway section disagrees with the running gateway binary. Emit `runtime_lock_drift` causal event. Operator override via `allow_runtime_lock_drift` config. | (R+7 / R+18) | `runtime_lock.rs::check_runtime_lock_drift`, `lifecycle.rs:1260` | ENFORCED |
 | R-8.12 | Schema enforcement decisions are logged with target, result, transformations, and enforcer identity. | schema-enforcement-hook.md | causal event emission | ENFORCED |
 | R-8.13 | Knowledge records carry `owner_agent_id`, `writer_agent_id`, `source_ref`; visibility is enforced on recall. | ARCHITECTURE.md | `runtime/memory/*` | ENFORCED |
 | R-8.14 | Session approval grants are tracked by `(root_session_id, host)` and included in cleanup audits. | approved-resources-caching.md | `session_approval_grants` table | ENFORCED |

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -308,6 +308,7 @@ separate. Runtime-lock in `runtime_lock.rs`.
 | R-8.9 | Promotion records persist `artifact_id`, `evaluator_pass`, `auditor_pass`, `evidence`, and `content_digest`. | spec-install-pipeline-hardening.md §3.8 | `promotion_store.rs` | ENFORCED |
 | R-8.10 | Capability accretion across revisions is detectable via `promotion_history`. | security-sentinel.md | `promotion_history` table | ENFORCED |
 | R-8.11 | `runtime.lock` includes compile-time source fingerprint and runtime binary SHA. | spec-install-pipeline-hardening.md §3.7 | `build.rs`, `runtime_lock.rs` | ENFORCED |
+| R-8.11b | Sessions refuse to start when `runtime.lock` gateway section disagrees with the running gateway binary. Emit `runtime_lock_drift` causal event. Operator override via `allow_runtime_lock_drift` config. | (R+7 / R+18) | `runtime_lock.rs::check_runtime_lock_drift`, `lifecycle.rs:1258` | ENFORCED |
 | R-8.12 | Schema enforcement decisions are logged with target, result, transformations, and enforcer identity. | schema-enforcement-hook.md | causal event emission | ENFORCED |
 | R-8.13 | Knowledge records carry `owner_agent_id`, `writer_agent_id`, `source_ref`; visibility is enforced on recall. | ARCHITECTURE.md | `runtime/memory/*` | ENFORCED |
 | R-8.14 | Session approval grants are tracked by `(root_session_id, host)` and included in cleanup audits. | approved-resources-caching.md | `session_approval_grants` table | ENFORCED |
@@ -351,7 +352,7 @@ HTTP in `server/http.rs`, JSON-RPC in `server/jsonrpc.rs`, OFP in
 | R-10.5 | Layer mounts in remote execution are fetched and cached before sandbox use. | spec-build-layers-dependency-resolution.md §2.6 | HTTP layer download | ENFORCED |
 | R-10.6 | OFP messages preserve session context across gateways. | — | future federation layer | DESIGN DEBT |
 | R-10.7 | Remote agents cannot self-approve network access. | separation-of-powers.md | policy engine + remote validation | PARTIAL |
-| R-10.8 | Shared-secret comparison is constant-time. | (R+15) | needs audit | PARTIAL |
+| R-10.8 | Shared-secret comparison is constant-time. | (R+15) | `server/jsonrpc.rs:37`, `server/http.rs:76` | ENFORCED |
 
 ## 11. Inter-Agent Messaging
 
@@ -381,7 +382,7 @@ before it moves into its category.
 | R+4 | Root-session tree budget — tokens / time / cost aggregated across all descendants. | P0 |
 | R+5 | Approval flood cap per root session; further requests reject `approval_flood`. | P0 |
 | R+6 | Causal-chain fsync ordering invariant — state transitions gated on event durability. | P0 |
-| R+7 | Runtime-lock drift check at session start. | P1 |
+| R+7 | Runtime-lock drift check at session start. | ENFORCED (R-8.11b) |
 | R+8 | Vault master-key presence probe at gateway startup. | P2 |
 | R+9 | Redaction-before-write ordering invariant. | P1 |
 | R+10 | sandbox→gateway SDK-bridge rate and payload-size limits. | P1 |
@@ -389,7 +390,7 @@ before it moves into its category.
 | R+12 | Orphan-child reaper on parent session termination. | P1 |
 | R+13 | Approval grant TTL. | P2 |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |
-| R+15 | Constant-time comparison for JSON-RPC shared-secret auth. | P1 |
+| R+15 | Constant-time comparison for JSON-RPC shared-secret auth. | ENFORCED (R-10.8) |
 | R+16 | Promotion-gate execution is denied network access. | P1 |
 | R+17 | Retention pruning emits `retention.pruned` causal event. | P2 |
 | R+18 | Gateway refuses to start if a session's runtime-lock disagrees with the current binary SHA. | merged with R+7 |


### PR DESCRIPTION
## Summary

Closes #51. Closes #54. Implements two Phase 2 quick-win items from the constitution roadmap (#42).

### R+7 / R+18 — Runtime-lock drift check

Sessions refuse to start when the `runtime.lock` gateway section disagrees with the running gateway binary. Both the compile-time build SHA (`gateway.sha256` vs `GATEWAY_BUILD_SHA256`) and the runtime binary SHA (`gateway.binary_sha256` vs `running_binary_sha256()`) are compared. On drift, the gateway emits a `runtime_lock_drift` causal event and refuses session start. An operator can override with `allow_runtime_lock_drift: true` in config (drift is still logged).

The check runs once per session lifecycle via a `drift_checked` flag on `AgentExecutor` — covers fresh sessions, checkpoint resumes, continuation resumes, and user-interaction resumes without touching each resume site individually.

### R+15 — Constant-time shared-secret comparison

Replaced timing-vulnerable `==` / `!=` on shared secrets in `server/jsonrpc.rs` and `server/http.rs` with `subtle::ConstantTimeEq`. The `subtle` crate was already a dependency (v2.6.1) and correctly used in `server/ofp.rs`.

## Changes

| File | What |
|------|------|
| `runtime_lock.rs` | `check_runtime_lock_drift()` + `RuntimeLockDrift` error type |
| `runtime/lifecycle.rs` | Drift check injected at first `execute_with_history` call |
| `server/jsonrpc.rs` | `constant_time_str_eq()` replaces `==` |
| `server/http.rs` | `subtle::ConstantTimeEq::ct_eq` replaces `!=` |
| `config.rs` (types) | `allow_runtime_lock_drift: bool` field on `GatewayConfig` |
| `tests/constitution_audit_runtime_lock_drift.rs` (new, 5 tests) | Build SHA drift, matching SHA, absent lock, malformed lock, payload fields |
| `tests/constitution_constant_time_auth.rs` (new, 2 tests) | Wrong token 403, correct token accepted |
| `docs/gateway-constitution.md` | R-8.11b + R-10.8 → ENFORCED, R+7/R+15 → ENFORCED |
| `docs/gateway-constitution-roadmap.md` | §2.1 and §2.4 marked ENFORCED |

## Acceptance

- [x] R+7/R+18: drift check at session start, causal event, operator override
- [x] R+15: constant-time comparison on all shared-secret auth paths
- [x] Constitution rows flip to ENFORCED with file:line citations
- [x] 7 new tests pass, no regressions (3 pre-existing failures confirmed on main)