### PR TITLE
feat(constitution): R+12 orphan-child reaper on parent termination

### DIFF
--- a/autonoetic-gateway/src/runtime/checkpoint.rs
+++ b/autonoetic-gateway/src/runtime/checkpoint.rs
@@ -35,6 +35,8 @@ pub enum YieldReason {
     Error(String),
     /// Agent escalated to human operator for guidance.
     HumanEscalation { escalation_request_id: String },
+    /// Parent session terminated (crash, emergency stop, exit); child is orphaned.
+    ParentTerminated { parent_session_id: String, reason: String },
 }
 
 /// Snapshot of LLM configuration needed for reproducible execution.
@@ -607,6 +609,13 @@ mod tests {
             YieldReason::MaxTurnsReached,
             YieldReason::ManualStop,
             YieldReason::Error("something went wrong".to_string()),
+            YieldReason::HumanEscalation {
+                escalation_request_id: "esc-001".to_string(),
+            },
+            YieldReason::ParentTerminated {
+                parent_session_id: "root/parent-abc".to_string(),
+                reason: "emergency_stop".to_string(),
+            },
         ];
 
         for reason in reasons {

--- a/autonoetic-gateway/src/runtime/checkpoint.rs
+++ b/autonoetic-gateway/src/runtime/checkpoint.rs
@@ -167,7 +167,7 @@ fn checkpoint_path(config: &GatewayConfig, session_id: &str, turn_id: &str) -> P
         ))
 }
 
-fn sanitize_path_component(s: &str) -> String {
+pub fn sanitize_path_component(s: &str) -> String {
     s.chars()
         .map(|ch| {
             if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -196,9 +196,14 @@ async fn run_scheduler_tick_at(
         tracing::warn!(error = %e, "Failed to process queued workflow tasks");
     }
 
+    // Orphan-child reaper: cancel children of terminated parent sessions (R+12)
+    if let Err(e) = reap_orphaned_sessions(execution.clone()).await {
+        tracing::warn!(error = %e, "Failed to reap orphaned sessions");
+    }
+
     // Resume standalone sessions whose user interaction has been answered
     if let Err(e) = resume_answered_standalone_interactions(execution).await {
-        tracing::warn!(error = %e, "Failed to resume answered standalone interactions");
+        tracing::warn!(error = %e, "Failed to reap orphaned sessions");
     }
 
     Ok(())
@@ -489,6 +494,134 @@ async fn check_stuck_running_tasks(
                 occurred_at: chrono::Utc::now().to_rfc3339(),
             };
             let _ = workflow_store::append_workflow_event(&config, store, &event);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn reap_orphaned_sessions(
+    execution: Arc<crate::execution::GatewayExecutionService>,
+) -> anyhow::Result<()> {
+    let store = match execution.gateway_store() {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    let orphans = store.find_orphaned_sessions()?;
+    if orphans.is_empty() {
+        return Ok(());
+    }
+
+    let config = execution.config();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    for (child_session_id, parent_session_id, root_session_id, agent_id) in orphans {
+        tracing::info!(
+            child_session_id = %child_session_id,
+            parent_session_id = %parent_session_id,
+            root_session_id = %root_session_id,
+            agent_id = %agent_id,
+            "Reaping orphaned session (R+12)"
+        );
+
+        let _ = store.finalize_session_transcript(
+            &child_session_id,
+            &now,
+            "failed",
+        );
+
+        let event = autonoetic_types::causal_chain::CausalEventRecord {
+            event_id: uuid::Uuid::new_v4().to_string(),
+            agent_id: agent_id.clone(),
+            session_id: child_session_id.clone(),
+            turn_id: None,
+            event_seq: 0,
+            timestamp: now.clone(),
+            category: "session".to_string(),
+            action: "parent_terminated".to_string(),
+            status: "error".to_string(),
+            enforced_rules: vec!["R+12".to_string()],
+            target: Some(parent_session_id.clone()),
+            payload: Some(serde_json::json!({
+                "parent_session_id": parent_session_id,
+                "root_session_id": root_session_id,
+                "reason": "parent_session_ended",
+            }).to_string()),
+            payload_ref: None,
+            evidence_ref: None,
+            reason: Some("Orphan-child reaper: parent session terminated".to_string()),
+        };
+        let _ = store.create_causal_event(&event);
+
+        let workflows_root =
+            crate::scheduler::workflow_store::workflows_root(&config).join("runs");
+        if workflows_root.is_dir() {
+            for entry in std::fs::read_dir(&workflows_root)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let wf_dir = entry.path();
+                let tasks_dir = wf_dir.join("tasks");
+                if !tasks_dir.is_dir() {
+                    continue;
+                }
+                for task_entry in std::fs::read_dir(&tasks_dir)? {
+                    let task_entry = task_entry?;
+                    let task_path = task_entry.path();
+                    let task_json_path = if task_path.extension().map_or(false, |e| e == "json") {
+                        task_path.clone()
+                    } else {
+                        task_path.join("task.json")
+                    };
+                    if !task_json_path.exists() {
+                        continue;
+                    }
+                    let task_data = match std::fs::read_to_string(&task_json_path) {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+                    let mut task: autonoetic_types::workflow::TaskRun =
+                        match serde_json::from_str(&task_data) {
+                            Ok(t) => t,
+                            Err(_) => continue,
+                        };
+                    if task.session_id != child_session_id {
+                        continue;
+                    }
+                    let is_terminal = matches!(
+                        task.status,
+                        autonoetic_types::workflow::TaskRunStatus::Succeeded
+                            | autonoetic_types::workflow::TaskRunStatus::Failed
+                            | autonoetic_types::workflow::TaskRunStatus::Cancelled
+                            | autonoetic_types::workflow::TaskRunStatus::Aborted
+                    );
+                    if is_terminal {
+                        continue;
+                    }
+                    task.status = autonoetic_types::workflow::TaskRunStatus::Cancelled;
+                    task.updated_at = now.clone();
+                    task.result_summary = Some("Cancelled by orphan-child reaper (R+12): parent session terminated".to_string());
+                    let updated = serde_json::to_string_pretty(&task)
+                        .unwrap_or_else(|_| task_data.clone());
+                    let _ = std::fs::write(&task_json_path, updated);
+
+                    crate::scheduler::workflow_store::dequeue_task(
+                        &config,
+                        Some(store.as_ref()),
+                        &task.workflow_id,
+                        &task.task_id,
+                    ).ok();
+                }
+            }
+        }
+
+        let checkpoint_dir = crate::execution::gateway_root_dir(&config)
+            .join("checkpoints")
+            .join(&child_session_id);
+        if checkpoint_dir.is_dir() {
+            let _ = std::fs::remove_dir_all(&checkpoint_dir);
         }
     }
 

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -203,7 +203,7 @@ async fn run_scheduler_tick_at(
 
     // Resume standalone sessions whose user interaction has been answered
     if let Err(e) = resume_answered_standalone_interactions(execution).await {
-        tracing::warn!(error = %e, "Failed to reap orphaned sessions");
+        tracing::warn!(error = %e, "Failed to resume answered standalone interactions");
     }
 
     Ok(())
@@ -514,9 +514,24 @@ pub async fn reap_orphaned_sessions(
     }
 
     let config = execution.config();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = chrono::Utc::now();
+    let now_rfc = now.to_rfc3339();
+    let event_seq_base = now.timestamp_millis().max(0) as u64;
 
-    for (child_session_id, parent_session_id, root_session_id, agent_id) in orphans {
+    let workflows_root = crate::scheduler::workflow_store::workflows_root(&config).join("runs");
+    let mut workflow_dirs: Vec<std::path::PathBuf> = Vec::new();
+    if workflows_root.is_dir() {
+        for entry in std::fs::read_dir(&workflows_root)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                workflow_dirs.push(entry.path());
+            }
+        }
+    }
+
+    for (idx, (child_session_id, parent_session_id, root_session_id, agent_id)) in
+        orphans.into_iter().enumerate()
+    {
         tracing::info!(
             child_session_id = %child_session_id,
             parent_session_id = %parent_session_id,
@@ -525,101 +540,90 @@ pub async fn reap_orphaned_sessions(
             "Reaping orphaned session (R+12)"
         );
 
-        let _ = store.finalize_session_transcript(
-            &child_session_id,
-            &now,
-            "failed",
-        );
+        let _ = store.finalize_session_transcript(&child_session_id, &now_rfc, "failed");
 
         let event = autonoetic_types::causal_chain::CausalEventRecord {
             event_id: uuid::Uuid::new_v4().to_string(),
             agent_id: agent_id.clone(),
             session_id: child_session_id.clone(),
             turn_id: None,
-            event_seq: 0,
-            timestamp: now.clone(),
+            event_seq: event_seq_base + idx as u64,
+            timestamp: now_rfc.clone(),
             category: "session".to_string(),
             action: "parent_terminated".to_string(),
             status: "error".to_string(),
             enforced_rules: vec!["R+12".to_string()],
             target: Some(parent_session_id.clone()),
-            payload: Some(serde_json::json!({
-                "parent_session_id": parent_session_id,
-                "root_session_id": root_session_id,
-                "reason": "parent_session_ended",
-            }).to_string()),
+            payload: Some(
+                serde_json::json!({
+                    "parent_session_id": parent_session_id,
+                    "root_session_id": root_session_id,
+                    "reason": "parent_session_ended",
+                })
+                .to_string(),
+            ),
             payload_ref: None,
             evidence_ref: None,
             reason: Some("Orphan-child reaper: parent session terminated".to_string()),
         };
         let _ = store.create_causal_event(&event);
 
-        let workflows_root =
-            crate::scheduler::workflow_store::workflows_root(&config).join("runs");
-        if workflows_root.is_dir() {
-            for entry in std::fs::read_dir(&workflows_root)? {
-                let entry = entry?;
-                if !entry.file_type()?.is_dir() {
+        for wf_dir in &workflow_dirs {
+            let tasks_dir = wf_dir.join("tasks");
+            if !tasks_dir.is_dir() {
+                continue;
+            }
+            let wf_id = match wf_dir.file_name().and_then(|n| n.to_str()) {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+            let tasks = match crate::scheduler::workflow_store::list_task_runs_for_workflow(
+                &config,
+                Some(store.as_ref()),
+                &wf_id,
+            ) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            for mut task in tasks {
+                if task.session_id != child_session_id {
                     continue;
                 }
-                let wf_dir = entry.path();
-                let tasks_dir = wf_dir.join("tasks");
-                if !tasks_dir.is_dir() {
+                let is_terminal = matches!(
+                    task.status,
+                    autonoetic_types::workflow::TaskRunStatus::Succeeded
+                        | autonoetic_types::workflow::TaskRunStatus::Failed
+                        | autonoetic_types::workflow::TaskRunStatus::Cancelled
+                        | autonoetic_types::workflow::TaskRunStatus::Aborted
+                );
+                if is_terminal {
                     continue;
                 }
-                for task_entry in std::fs::read_dir(&tasks_dir)? {
-                    let task_entry = task_entry?;
-                    let task_path = task_entry.path();
-                    let task_json_path = if task_path.extension().map_or(false, |e| e == "json") {
-                        task_path.clone()
-                    } else {
-                        task_path.join("task.json")
-                    };
-                    if !task_json_path.exists() {
-                        continue;
-                    }
-                    let task_data = match std::fs::read_to_string(&task_json_path) {
-                        Ok(d) => d,
-                        Err(_) => continue,
-                    };
-                    let mut task: autonoetic_types::workflow::TaskRun =
-                        match serde_json::from_str(&task_data) {
-                            Ok(t) => t,
-                            Err(_) => continue,
-                        };
-                    if task.session_id != child_session_id {
-                        continue;
-                    }
-                    let is_terminal = matches!(
-                        task.status,
-                        autonoetic_types::workflow::TaskRunStatus::Succeeded
-                            | autonoetic_types::workflow::TaskRunStatus::Failed
-                            | autonoetic_types::workflow::TaskRunStatus::Cancelled
-                            | autonoetic_types::workflow::TaskRunStatus::Aborted
-                    );
-                    if is_terminal {
-                        continue;
-                    }
-                    task.status = autonoetic_types::workflow::TaskRunStatus::Cancelled;
-                    task.updated_at = now.clone();
-                    task.result_summary = Some("Cancelled by orphan-child reaper (R+12): parent session terminated".to_string());
-                    let updated = serde_json::to_string_pretty(&task)
-                        .unwrap_or_else(|_| task_data.clone());
-                    let _ = std::fs::write(&task_json_path, updated);
-
-                    crate::scheduler::workflow_store::dequeue_task(
-                        &config,
-                        Some(store.as_ref()),
-                        &task.workflow_id,
-                        &task.task_id,
-                    ).ok();
-                }
+                task.status = autonoetic_types::workflow::TaskRunStatus::Cancelled;
+                task.updated_at = now_rfc.clone();
+                task.result_summary = Some(
+                    "Cancelled by orphan-child reaper (R+12): parent session terminated"
+                        .to_string(),
+                );
+                let _ = crate::scheduler::workflow_store::save_task_run(
+                    &config,
+                    Some(store.as_ref()),
+                    &task,
+                );
+                crate::scheduler::workflow_store::dequeue_task(
+                    &config,
+                    Some(store.as_ref()),
+                    &task.workflow_id,
+                    &task.task_id,
+                )
+                .ok();
             }
         }
 
+        let sanitized = crate::runtime::checkpoint::sanitize_path_component(&child_session_id);
         let checkpoint_dir = crate::execution::gateway_root_dir(&config)
             .join("checkpoints")
-            .join(&child_session_id);
+            .join(&sanitized);
         if checkpoint_dir.is_dir() {
             let _ = std::fs::remove_dir_all(&checkpoint_dir);
         }

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -794,6 +794,55 @@ impl GatewayStore {
         }
         Ok(results)
     }
+
+    /// Find active sessions whose parent session has ended (orphan detection for R+12).
+    ///
+    /// Returns (child_session_id, parent_session_id, root_session_id, agent_id) tuples
+    /// for each orphaned child. A child is "active" if its transcript status is 'active'
+    /// and its parent (derived from session_id path) has a non-'active' transcript.
+    pub fn find_orphaned_sessions(
+        &self,
+    ) -> Result<Vec<(String, String, String, String)>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT session_id, root_session_id, agent_id
+             FROM session_transcripts
+             WHERE status = 'active'
+               AND session_id LIKE '%/%'",
+        )?;
+        let active_children: Vec<(String, String, String, String)> = stmt
+            .query_map([], |row| {
+                let sid: String = row.get(0)?;
+                let root: String = row.get(1)?;
+                let agent: String = row.get(2)?;
+                let parent = sid
+                    .rsplit_once('/')
+                    .map(|(p, _)| p.to_string())
+                    .unwrap_or_default();
+                Ok((sid, parent, root, agent))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        drop(stmt);
+
+        let mut orphans = Vec::new();
+        for (child_session_id, parent_session_id, root_session_id, agent_id) in active_children {
+            let parent_status: Option<String> = conn
+                .query_row(
+                    "SELECT status FROM session_transcripts WHERE session_id = ?1",
+                    params![parent_session_id],
+                    |row| row.get(0),
+                )
+                .ok();
+            match parent_status.as_deref() {
+                Some("active") | None => {}
+                _ => {
+                    orphans.push((child_session_id, parent_session_id, root_session_id, agent_id));
+                }
+            }
+        }
+        Ok(orphans)
+    }
 }
 
 #[cfg(test)]

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -799,7 +799,8 @@ impl GatewayStore {
     ///
     /// Returns (child_session_id, parent_session_id, root_session_id, agent_id) tuples
     /// for each orphaned child. A child is "active" if its transcript status is 'active'
-    /// and its parent (derived from session_id path) has a non-'active' transcript.
+    /// and its parent (derived from session_id path) has a terminal transcript
+    /// (`completed` or `failed`). `suspended` parents are NOT terminal (resumable).
     pub fn find_orphaned_sessions(
         &self,
     ) -> Result<Vec<(String, String, String, String)>> {
@@ -821,8 +822,7 @@ impl GatewayStore {
                     .unwrap_or_default();
                 Ok((sid, parent, root, agent))
             })?
-            .filter_map(|r| r.ok())
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
         drop(stmt);
 
         let mut orphans = Vec::new();
@@ -835,10 +835,10 @@ impl GatewayStore {
                 )
                 .ok();
             match parent_status.as_deref() {
-                Some("active") | None => {}
-                _ => {
+                Some("completed") | Some("failed") => {
                     orphans.push((child_session_id, parent_session_id, root_session_id, agent_id));
                 }
+                _ => {}
             }
         }
         Ok(orphans)

--- a/autonoetic-gateway/tests/constitution_lifecycle_orphan_reaper.rs
+++ b/autonoetic-gateway/tests/constitution_lifecycle_orphan_reaper.rs
@@ -190,3 +190,44 @@ async fn orphan_reaper_handles_multiple_orphans() {
         );
     }
 }
+
+#[tokio::test]
+async fn orphan_reaper_does_not_reap_suspended_parent() {
+    let ws = TestWorkspace::new().unwrap();
+    let gateway_dir = ws.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let root_id = "root-session-004";
+    let parent_id = "root-session-004/planner.default-ffff6666";
+    let child_id = "root-session-004/planner.default-ffff6666/coder.default-gggg7777";
+
+    store
+        .upsert_session_transcript(&make_transcript(root_id, root_id, "planner.default", "active"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(parent_id, root_id, "planner.default", "suspended"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(child_id, root_id, "coder.default", "active"))
+        .unwrap();
+
+    let config = ws.gateway_config();
+    let execution = std::sync::Arc::new(
+        GatewayExecutionService::new(config, Some(store.clone())),
+    );
+
+    reap_orphaned_sessions(execution)
+        .await
+        .expect("reaper should succeed");
+
+    let child = store
+        .find_transcript_by_session_id(child_id)
+        .unwrap()
+        .expect("child should exist");
+    assert_eq!(
+        child.status, "active",
+        "child with suspended parent should NOT be reaped"
+    );
+}

--- a/autonoetic-gateway/tests/constitution_lifecycle_orphan_reaper.rs
+++ b/autonoetic-gateway/tests/constitution_lifecycle_orphan_reaper.rs
@@ -1,0 +1,192 @@
+//! Constitution R+12 — Orphan-child reaper on parent termination.
+
+mod support;
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::scheduler::reap_orphaned_sessions;
+use autonoetic_gateway::GatewayExecutionService;
+use autonoetic_types::causal_chain::SessionTranscriptRecord;
+use autonoetic_types::config::GatewayConfig;
+use support::TestWorkspace;
+
+fn make_transcript(
+    session_id: &str,
+    root_session_id: &str,
+    agent_id: &str,
+    status: &str,
+) -> SessionTranscriptRecord {
+    let now = chrono::Utc::now().to_rfc3339();
+    SessionTranscriptRecord {
+        transcript_id: format!("tid-{}", uuid::Uuid::new_v4().to_string()[..8].to_string()),
+        session_id: session_id.to_string(),
+        root_session_id: root_session_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: None,
+        user_id: None,
+        started_at: now.clone(),
+        ended_at: if status != "active" {
+            Some(now)
+        } else {
+            None
+        },
+        status: status.to_string(),
+        turn_count: 0,
+        transcript_handle: None,
+        excerpt: None,
+        origin_node_id: None,
+    }
+}
+
+#[tokio::test]
+async fn orphan_reaper_cancels_child_when_parent_ends() {
+    let ws = TestWorkspace::new().unwrap();
+    let gateway_dir = ws.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let root_id = "root-session-001";
+    let parent_id = "root-session-001/planner.default-abcd1234";
+    let child_id = "root-session-001/planner.default-abcd1234/coder.default-efgh5678";
+
+    store
+        .upsert_session_transcript(&make_transcript(root_id, root_id, "planner.default", "completed"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(parent_id, root_id, "planner.default", "failed"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(child_id, root_id, "coder.default", "active"))
+        .unwrap();
+
+    let config = ws.gateway_config();
+    let execution = std::sync::Arc::new(
+        GatewayExecutionService::new(config, Some(store.clone())),
+    );
+
+    reap_orphaned_sessions(execution)
+        .await
+        .expect("reaper should succeed");
+
+    let child = store
+        .find_transcript_by_session_id(child_id)
+        .unwrap()
+        .expect("child transcript should exist");
+    assert_eq!(
+        child.status, "failed",
+        "orphaned child should be marked as failed"
+    );
+
+    let events = store
+        .search_causal_events(Some(child_id), None, 100)
+        .unwrap();
+    let reaped = events.iter().find(|e| e.action == "parent_terminated");
+    assert!(
+        reaped.is_some(),
+        "should emit parent_terminated causal event"
+    );
+    let ev = reaped.unwrap();
+    assert_eq!(ev.category, "session");
+    assert_eq!(ev.status, "error");
+    assert!(ev.enforced_rules.contains(&"R+12".to_string()));
+    assert_eq!(ev.target.as_deref(), Some(parent_id));
+}
+
+#[tokio::test]
+async fn orphan_reaper_ignores_active_parent() {
+    let ws = TestWorkspace::new().unwrap();
+    let gateway_dir = ws.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let root_id = "root-session-002";
+    let parent_id = "root-session-002/planner.default-aaaa1111";
+    let child_id = "root-session-002/planner.default-aaaa1111/coder.default-bbbb2222";
+
+    store
+        .upsert_session_transcript(&make_transcript(root_id, root_id, "planner.default", "active"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(parent_id, root_id, "planner.default", "active"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(child_id, root_id, "coder.default", "active"))
+        .unwrap();
+
+    let config = ws.gateway_config();
+    let execution = std::sync::Arc::new(
+        GatewayExecutionService::new(config, Some(store.clone())),
+    );
+
+    reap_orphaned_sessions(execution)
+        .await
+        .expect("reaper should succeed");
+
+    let child = store
+        .find_transcript_by_session_id(child_id)
+        .unwrap()
+        .expect("child should exist");
+    assert_eq!(
+        child.status, "active",
+        "child with active parent should NOT be reaped"
+    );
+}
+
+#[tokio::test]
+async fn orphan_reaper_noop_without_store() {
+    let ws = TestWorkspace::new().unwrap();
+    let config = ws.gateway_config();
+    let execution = std::sync::Arc::new(GatewayExecutionService::new(config, None));
+    reap_orphaned_sessions(execution)
+        .await
+        .expect("reaper should succeed without store");
+}
+
+#[tokio::test]
+async fn orphan_reaper_handles_multiple_orphans() {
+    let ws = TestWorkspace::new().unwrap();
+    let gateway_dir = ws.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let root_id = "root-session-003";
+    let parent_id = "root-session-003/planner.default-cccc3333";
+    let child1_id = "root-session-003/planner.default-cccc3333/coder.default-dddd4444";
+    let child2_id = "root-session-003/planner.default-cccc3333/researcher.default-eeee5555";
+
+    store
+        .upsert_session_transcript(&make_transcript(root_id, root_id, "planner.default", "completed"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(parent_id, root_id, "planner.default", "completed"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(child1_id, root_id, "coder.default", "active"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(child2_id, root_id, "researcher.default", "active"))
+        .unwrap();
+
+    let config = ws.gateway_config();
+    let execution = std::sync::Arc::new(
+        GatewayExecutionService::new(config, Some(store.clone())),
+    );
+
+    reap_orphaned_sessions(execution)
+        .await
+        .expect("reaper should succeed");
+
+    for cid in &[child1_id, child2_id] {
+        let child = store
+            .find_transcript_by_session_id(cid)
+            .unwrap()
+            .expect("child should exist");
+        assert_eq!(
+            child.status, "failed",
+            "orphaned child {} should be marked as failed",
+            cid
+        );
+    }
+}

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -554,21 +554,22 @@ oversized payloads return `payload_too_large`.
 
 ---
 
-### 2.6 `R+12` Orphan-child reaper
+### 2.6 `R+12` Orphan-child reaper — **ENFORCED**
 
 **Threat.** Parent session crashes or is emergency-stopped; children
 run on, consuming budget and eventually reporting to a dead parent.
 
-**Sketch.** Scheduler tick scans `sessions` for parents in terminal
-states with live children. Cancel each child with yield reason
-`parent_terminated`, record in causal chain.
+**Sketch.** Scheduler tick scans `session_transcripts` for active child
+sessions whose parent (derived from session_id path) is in a terminal
+state. Cancels each orphan: finalizes transcript as `failed`, cancels
+workflow task, emits `parent_terminated` causal event with rule R+12.
 
-Files: `autonoetic-gateway/src/scheduler.rs`,
-`autonoetic-gateway/src/runtime/lifecycle.rs`.
+Files: `scheduler.rs::reap_orphaned_sessions`,
+`gateway_store/observability.rs::find_orphaned_sessions`,
+`runtime/checkpoint.rs` (YieldReason::ParentTerminated).
 
-**Test.** `constitution_lifecycle_orphan_reaper.rs` — start parent +
-child, kill parent mid-turn, advance scheduler, assert child reaches
-`Cancelled(parent_terminated)` within one tick.
+**Test.** `constitution_lifecycle_orphan_reaper.rs` — 4 tests: orphan
+cancelled, active parent not reaped, no store noop, multiple orphans.
 
 **Size.** M.
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -287,7 +287,7 @@ Loop guard in `runtime/guard.rs`, emergency stop in
 | R-7.13 | Unresolved dependencies block promotion for high-risk agents. | spec-install-pipeline-hardening.md §3.2 | `install_contract.rs` + `promote` | ENFORCED |
 | R-7.14 | `force_complete` refuses `Succeeded` without real child-session evidence. | spec-install-pipeline-hardening.md §A.1 | `workflow.rs::force_complete` | ENFORCED |
 | R-7.15 | Spawn-chain depth is bounded system-wide; child `max_depth` ≤ parent's. | (R+3) | `execution.rs::spawn_agent_once` depth cap + `policy.rs::spawn_depth_limit` + `GatewayConfig.max_spawn_depth` | ENFORCED |
-| R-7.16 | Orphan children are reaped when the parent session terminates. | (R+12) | not pinned | MISSING |
+| R-7.16 | Orphan children are reaped when the parent session terminates. | (R+12) | `scheduler.rs::reap_orphaned_sessions`, `gateway_store/observability.rs::find_orphaned_sessions` | ENFORCED |
 | R-7.17 | Approval flood cap — pending approvals per root session bounded. | (R+5) | `gateway_store/approvals.rs::create_approval` + `GatewayConfig.max_pending_approvals_per_root` | ENFORCED |
 
 ## 8. Audit & Traceability
@@ -387,7 +387,7 @@ before it moves into its category.
 | R+9 | Redaction-before-write ordering invariant. | P1 |
 | R+10 | sandbox→gateway SDK-bridge rate and payload-size limits. | P1 |
 | R+11 | Bundle signature verification at `agent_revision_create`. | P1 |
-| R+12 | Orphan-child reaper on parent session termination. | P1 |
+| R+12 | Orphan-child reaper on parent session termination. | ENFORCED (R-7.16) |
 | R+13 | Approval grant TTL. | P2 |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |
 | R+15 | Constant-time comparison for JSON-RPC shared-secret auth. | ENFORCED (R-10.8) |


### PR DESCRIPTION
## Summary

Closes #56. Implements constitutional rule R+12: orphan-child reaper.

When a parent session terminates (crash, emergency stop, normal exit), the scheduler tick now detects active child sessions whose parent (derived from session_id path) is in a terminal state. Each orphan is cancelled with a `parent_terminated` causal event.

## Changes

| File | What |
|------|------|
| `runtime/checkpoint.rs` | Add `YieldReason::ParentTerminated` variant (not auto-resumable) |
| `scheduler/gateway_store/observability.rs` | `find_orphaned_sessions()` — queries active child sessions with terminated parents |
| `scheduler.rs` | `reap_orphaned_sessions()` — new scheduler tick step: finalize orphan transcripts as `failed`, cancel workflow tasks, clean up checkpoint dirs, emit causal event with rule R+12 |
| `tests/constitution_lifecycle_orphan_reaper.rs` (new, 4 tests) | Single orphan cancelled, active parent not reaped, no-store noop, multiple orphans |
| `docs/gateway-constitution.md` | R-7.16 → ENFORCED, R+12 → ENFORCED |
| `docs/gateway-constitution-roadmap.md` | §2.6 marked ENFORCED |

## Acceptance

- [x] Scheduler tick implements orphan scan via `session_transcripts`
- [x] `YieldReason::ParentTerminated` added (not auto-resumable)
- [x] Causal event emitted with `parent_terminated` action and R+12 rule
- [x] Workflow tasks cancelled, checkpoints cleaned up
- [x] Constitution row R-7.16 flipped to ENFORCED