### PR TITLE
feat(constitution): R+1 structured scopes for all capabilities

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -240,15 +240,18 @@ fn normalize_capability_from_llm(v: serde_json::Value) -> anyhow::Result<Capabil
 
 fn capability_from_shorthand(s: &str) -> anyhow::Result<Capability> {
     match s.trim() {
-        "SandboxFunctions" => Ok(Capability::SandboxFunctions {
-            allowed: vec!["*".to_string()],
-        }),
-        "ReadAccess" => Ok(Capability::ReadAccess {
-            scopes: vec!["*".to_string()],
-        }),
-        "WriteAccess" => Ok(Capability::WriteAccess {
-            scopes: vec!["*".to_string()],
-        }),
+        "SandboxFunctions" => Err(anyhow::anyhow!(
+            "capability 'SandboxFunctions' cannot be a bare string — explicit tool scoping required. \
+             Use {{ \"type\": \"SandboxFunctions\", \"allowed\": [\"content.\", \"knowledge.\"] }} instead."
+        )),
+        "ReadAccess" => Err(anyhow::anyhow!(
+            "capability 'ReadAccess' cannot be a bare string — explicit scope required. \
+             Use {{ \"type\": \"ReadAccess\", \"scopes\": [\"self.*\"] }} instead."
+        )),
+        "WriteAccess" => Err(anyhow::anyhow!(
+            "capability 'WriteAccess' cannot be a bare string — explicit scope required. \
+             Use {{ \"type\": \"WriteAccess\", \"scopes\": [\"self.*\"] }} instead."
+        )),
         "NetworkAccess" => Err(anyhow::anyhow!(
             "capability 'NetworkAccess' cannot be a bare string — explicit host scoping required. \
              Use {{ \"type\": \"NetworkAccess\", \"hosts\": [\"api.example.com\"] }} instead."
@@ -257,31 +260,55 @@ fn capability_from_shorthand(s: &str) -> anyhow::Result<Capability> {
             "capability 'CodeExecution' cannot be a bare string — explicit command patterns required. \
              Use {{ \"type\": \"CodeExecution\", \"patterns\": [\"python*\"] }} instead."
         )),
-        "AgentMessage" => Ok(Capability::AgentMessage {
-            patterns: vec!["*".to_string()],
-        }),
-        "AgentRevision" => Ok(Capability::AgentRevision {
-            patterns: vec!["*".to_string()],
-        }),
-        "Evaluation" => Ok(Capability::Evaluation {
-            patterns: vec!["*".to_string()],
-        }),
-        "ApprovalQueue" => Ok(Capability::ApprovalQueue {
-            patterns: vec!["*".to_string()],
-        }),
-        "SchedulerSignal" => Ok(Capability::SchedulerSignal {
-            patterns: vec!["*".to_string()],
-        }),
+        "AgentMessage" => Err(anyhow::anyhow!(
+            "capability 'AgentMessage' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"AgentMessage\", \"patterns\": [\"*\"] }} instead."
+        )),
+        "AgentRevision" => Err(anyhow::anyhow!(
+            "capability 'AgentRevision' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"AgentRevision\", \"patterns\": [\"*\"] }} instead."
+        )),
+        "Evaluation" => Err(anyhow::anyhow!(
+            "capability 'Evaluation' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"Evaluation\", \"patterns\": [\"*\"] }} instead."
+        )),
+        "ApprovalQueue" => Err(anyhow::anyhow!(
+            "capability 'ApprovalQueue' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"ApprovalQueue\", \"patterns\": [\"*\"] }} instead."
+        )),
+        "SchedulerSignal" => Err(anyhow::anyhow!(
+            "capability 'SchedulerSignal' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"SchedulerSignal\", \"patterns\": [\"*\"] }} instead."
+        )),
+        "SchedulerAccess" => Err(anyhow::anyhow!(
+            "capability 'SchedulerAccess' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"SchedulerAccess\", \"patterns\": [\"scheduler.cron.*\"] }} instead."
+        )),
         "CredentialAccess" => Err(anyhow::anyhow!(
             "capability 'CredentialAccess' cannot be a bare string — explicit service scoping required. \
              Use {{ \"type\": \"CredentialAccess\", \"services\": [\"github\"] }} instead."
         )),
-        "EmergencyStop" => Ok(Capability::EmergencyStop),
+        "UserProfileAccess" => Err(anyhow::anyhow!(
+            "capability 'UserProfileAccess' cannot be a bare string — explicit scope required. \
+             Use {{ \"type\": \"UserProfileAccess\", \"scopes\": [\"basic\"] }} instead."
+        )),
+        "SkillInstall" => Err(anyhow::anyhow!(
+            "capability 'SkillInstall' cannot be a bare string — explicit source scoping required. \
+             Use {{ \"type\": \"SkillInstall\", \"allowed_sources\": [\"agentskills.io\"] }} instead."
+        )),
+        "ConstitutionalProposal" => Err(anyhow::anyhow!(
+            "capability 'ConstitutionalProposal' cannot be a bare string — explicit patterns required. \
+             Use {{ \"type\": \"ConstitutionalProposal\", \"patterns\": [\"*\"] }} instead."
+        )),
+        "EmergencyStop" => Err(anyhow::anyhow!(
+            "capability 'EmergencyStop' cannot be a bare string — use a tagged object instead. \
+             Use {{ \"type\": \"EmergencyStop\" }} instead."
+        )),
         "AgentSpawn" | "BackgroundReevaluation" => Err(anyhow::anyhow!(
             "capability '{s}' cannot be a bare string; use a JSON object with required fields (see Capability schema)"
         )),
         other => Err(anyhow::anyhow!(
-            "unknown capability shorthand '{other}'; use {{ \"type\": \"ReadAccess\", \"scopes\": [\"*\"] }} or another tagged Capability object"
+            "unknown capability '{other}'; use a tagged Capability object, e.g. {{ \"type\": \"ReadAccess\", \"scopes\": [\"*\"] }}"
         )),
     }
 }
@@ -988,7 +1015,7 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
                     "llm_config": { "type": "object" },
                     "capabilities": {
                         "type": "array",
-                        "description": "Each item is a tagged Capability object, e.g. {\"type\":\"NetworkAccess\",\"hosts\":[\"*\"]} (not scopes); {\"type\":\"ReadAccess\",\"scopes\":[\"*\"]}; or a string shorthand for simple caps: \"ReadAccess\", \"NetworkAccess\", \"CodeExecution\". AgentSpawn and BackgroundReevaluation must be full objects."
+                        "description": "Each item must be a tagged Capability object — bare strings are rejected. Examples: {\"type\":\"NetworkAccess\",\"hosts\":[\"*\"]}, {\"type\":\"ReadAccess\",\"scopes\":[\"self.*\"]}, {\"type\":\"SandboxFunctions\",\"allowed\":[\"content.\",\"knowledge.\"]}, {\"type\":\"EmergencyStop\"}."
                     },
                     "io": {
                         "type": "object",
@@ -2581,13 +2608,94 @@ mod capability_lenient_deser_tests {
     }
 
     #[test]
-    fn string_shorthand_read_access_allowed() {
+    fn string_shorthand_read_access_refused() {
         let j = r#"{"capabilities":["ReadAccess"]}"#;
-        let c: CapsOnly = serde_json::from_str(j).unwrap();
-        assert!(matches!(
-            c.capabilities.as_slice(),
-            [Capability::ReadAccess { scopes }] if scopes == &["*".to_string()]
-        ));
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(
+            msg.contains("capabilities[0]"),
+            "error should reference index, got: {msg}"
+        );
+        assert!(
+            msg.contains("ReadAccess"),
+            "error should name capability, got: {msg}"
+        );
+        assert!(
+            msg.contains("scopes"),
+            "error should mention required field, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn string_shorthand_sandbox_functions_refused() {
+        let j = r#"{"capabilities":["SandboxFunctions"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("SandboxFunctions"), "got: {msg}");
+        assert!(msg.contains("allowed"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_write_access_refused() {
+        let j = r#"{"capabilities":["WriteAccess"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("WriteAccess"), "got: {msg}");
+        assert!(msg.contains("scopes"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_agent_message_refused() {
+        let j = r#"{"capabilities":["AgentMessage"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("AgentMessage"), "got: {msg}");
+        assert!(msg.contains("patterns"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_emergency_stop_refused() {
+        let j = r#"{"capabilities":["EmergencyStop"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("EmergencyStop"), "got: {msg}");
+        assert!(msg.contains("tagged object"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_skill_install_refused() {
+        let j = r#"{"capabilities":["SkillInstall"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("SkillInstall"), "got: {msg}");
+        assert!(msg.contains("allowed_sources"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_scheduler_access_refused() {
+        let j = r#"{"capabilities":["SchedulerAccess"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("SchedulerAccess"), "got: {msg}");
+        assert!(msg.contains("patterns"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_constitutional_proposal_refused() {
+        let j = r#"{"capabilities":["ConstitutionalProposal"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("ConstitutionalProposal"), "got: {msg}");
+        assert!(msg.contains("patterns"), "got: {msg}");
+    }
+
+    #[test]
+    fn string_shorthand_user_profile_access_refused() {
+        let j = r#"{"capabilities":["UserProfileAccess"]}"#;
+        let e = serde_json::from_str::<CapsOnly>(j).unwrap_err();
+        let msg = e.to_string();
+        assert!(msg.contains("UserProfileAccess"), "got: {msg}");
+        assert!(msg.contains("scopes"), "got: {msg}");
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -188,7 +188,7 @@ fn collect_revision_files(root: &Path) -> anyhow::Result<BTreeMap<String, Vec<u8
 
 /// LLMs often emit invalid shapes (bare strings, `scopes` instead of `hosts` on NetworkAccess).
 /// Try strict [`Capability`] first, then apply a small set of normalizations, then error.
-fn normalize_capability_from_llm(v: serde_json::Value) -> anyhow::Result<Capability> {
+pub fn normalize_capability_from_llm(v: serde_json::Value) -> anyhow::Result<Capability> {
     if let Ok(c) = serde_json::from_value::<Capability>(v.clone()) {
         return Ok(c);
     }

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -861,9 +861,9 @@ pub mod web;
 pub mod workflow;
 
 pub use crate::runtime::tools::agent_revision::{
-    AgentRevisionCreateFromIntentTool, AgentRevisionCreateTool, AgentRevisionDiffTool,
-    AgentRevisionInspectTool, AgentRevisionListTool, AgentRevisionPromoteTool,
-    AgentRevisionRollbackTool,
+    normalize_capability_from_llm, AgentRevisionCreateFromIntentTool, AgentRevisionCreateTool,
+    AgentRevisionDiffTool, AgentRevisionInspectTool, AgentRevisionListTool,
+    AgentRevisionPromoteTool, AgentRevisionRollbackTool,
 };
 pub use crate::runtime::tools::evaluation::{
     validate_suite_spec, EvalCompareTool, EvalReportTool, EvalRunTool, EvalSuiteCaseSpec,

--- a/autonoetic-gateway/tests/constitution_capability_scope_required.rs
+++ b/autonoetic-gateway/tests/constitution_capability_scope_required.rs
@@ -1,0 +1,119 @@
+//! Constitution R+1 — Structured capability scopes mandatory for all capabilities.
+//!
+//! Bare-string capability declarations (e.g. `"ReadAccess"`) are rejected for
+//! every capability type. Agents must supply tagged objects with explicit scope
+//! fields (e.g. `{"type":"ReadAccess","scopes":["self.*"]}`).
+
+mod support;
+
+use autonoetic_types::capability::Capability;
+
+fn bare_string_caps_json(caps: &[&str]) -> String {
+    let items: Vec<String> = caps.iter().map(|c| format!("\"{}\"", c)).collect();
+    format!(r#"{{"capabilities":[{}]}}"#, items.join(","))
+}
+
+fn tagged_caps_json(caps: &[serde_json::Value]) -> String {
+    format!(
+        r#"{{"capabilities":[{}]}}"#,
+        caps.iter()
+            .map(|c| serde_json::to_string(c).unwrap())
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CapsOnly {
+    capabilities: Vec<Capability>,
+}
+
+const ALL_CAPABILITY_NAMES: &[&str] = &[
+    "SandboxFunctions",
+    "ReadAccess",
+    "WriteAccess",
+    "NetworkAccess",
+    "CodeExecution",
+    "AgentMessage",
+    "AgentRevision",
+    "Evaluation",
+    "ApprovalQueue",
+    "SchedulerSignal",
+    "SchedulerAccess",
+    "CredentialAccess",
+    "UserProfileAccess",
+    "SkillInstall",
+    "ConstitutionalProposal",
+    "EmergencyStop",
+    "AgentSpawn",
+    "BackgroundReevaluation",
+];
+
+#[test]
+fn all_bare_string_capabilities_rejected() {
+    for name in ALL_CAPABILITY_NAMES {
+        let j = bare_string_caps_json(&[name]);
+        let result = serde_json::from_str::<CapsOnly>(&j);
+        assert!(
+            result.is_err(),
+            "R+1: bare-string '{}' should be rejected, but was accepted",
+            name
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains(name),
+            "R+1: error for '{}' should name the capability, got: {}",
+            name,
+            msg
+        );
+    }
+}
+
+#[test]
+fn tagged_objects_with_explicit_scopes_accepted() {
+    let cases: Vec<serde_json::Value> = vec![
+        serde_json::json!({"type":"SandboxFunctions","allowed":["content."]}),
+        serde_json::json!({"type":"ReadAccess","scopes":["self.*"]}),
+        serde_json::json!({"type":"WriteAccess","scopes":["self.*"]}),
+        serde_json::json!({"type":"NetworkAccess","hosts":["api.example.com"]}),
+        serde_json::json!({"type":"CodeExecution","patterns":["python3 "]}),
+        serde_json::json!({"type":"AgentMessage","patterns":["*"]}),
+        serde_json::json!({"type":"AgentRevision","patterns":["*"]}),
+        serde_json::json!({"type":"Evaluation","patterns":["*"]}),
+        serde_json::json!({"type":"ApprovalQueue","patterns":["*"]}),
+        serde_json::json!({"type":"SchedulerSignal","patterns":["*"]}),
+        serde_json::json!({"type":"SchedulerAccess","patterns":["scheduler.cron.*"]}),
+        serde_json::json!({"type":"CredentialAccess","services":["github"]}),
+        serde_json::json!({"type":"UserProfileAccess","scopes":["basic"]}),
+        serde_json::json!({"type":"SkillInstall","allowed_sources":["agentskills.io"]}),
+        serde_json::json!({"type":"ConstitutionalProposal","patterns":["*"]}),
+        serde_json::json!({"type":"EmergencyStop"}),
+        serde_json::json!({"type":"AgentSpawn","max_children":5}),
+        serde_json::json!({"type":"BackgroundReevaluation","min_interval_secs":60,"allow_reasoning":true}),
+    ];
+
+    let j = tagged_caps_json(&cases);
+    let result: CapsOnly = serde_json::from_str(&j).unwrap();
+    assert_eq!(
+        result.capabilities.len(),
+        cases.len(),
+        "all {} tagged capabilities should parse",
+        cases.len()
+    );
+}
+
+#[test]
+fn mixed_bare_and_tagged_rejected_at_first_bare() {
+    let j = format!(
+        r#"{{"capabilities":[{}, "ReadAccess"]}}"#,
+        serde_json::to_string(&serde_json::json!({"type":"NetworkAccess","hosts":["*"]})).unwrap()
+    );
+    let result = serde_json::from_str::<CapsOnly>(&j);
+    assert!(result.is_err(), "mixed bare+tagged should be rejected");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("ReadAccess"),
+        "error should name the offending capability, got: {}",
+        msg
+    );
+}

--- a/autonoetic-gateway/tests/constitution_capability_scope_required.rs
+++ b/autonoetic-gateway/tests/constitution_capability_scope_required.rs
@@ -1,32 +1,13 @@
 //! Constitution R+1 — Structured capability scopes mandatory for all capabilities.
 //!
 //! Bare-string capability declarations (e.g. `"ReadAccess"`) are rejected for
-//! every capability type. Agents must supply tagged objects with explicit scope
-//! fields (e.g. `{"type":"ReadAccess","scopes":["self.*"]}`).
+//! every capability type when routed through the lenient LLM normalization path
+//! (`normalize_capability_from_llm`), which is the same code path used by
+//! `agent_revision.create_from_intent` and frontmatter capability parsing.
 
 mod support;
 
-use autonoetic_types::capability::Capability;
-
-fn bare_string_caps_json(caps: &[&str]) -> String {
-    let items: Vec<String> = caps.iter().map(|c| format!("\"{}\"", c)).collect();
-    format!(r#"{{"capabilities":[{}]}}"#, items.join(","))
-}
-
-fn tagged_caps_json(caps: &[serde_json::Value]) -> String {
-    format!(
-        r#"{{"capabilities":[{}]}}"#,
-        caps.iter()
-            .map(|c| serde_json::to_string(c).unwrap())
-            .collect::<Vec<_>>()
-            .join(",")
-    )
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct CapsOnly {
-    capabilities: Vec<Capability>,
-}
+use autonoetic_gateway::runtime::tools::agent_revision::normalize_capability_from_llm;
 
 const ALL_CAPABILITY_NAMES: &[&str] = &[
     "SandboxFunctions",
@@ -50,13 +31,12 @@ const ALL_CAPABILITY_NAMES: &[&str] = &[
 ];
 
 #[test]
-fn all_bare_string_capabilities_rejected() {
+fn lenient_path_rejects_all_bare_strings() {
     for name in ALL_CAPABILITY_NAMES {
-        let j = bare_string_caps_json(&[name]);
-        let result = serde_json::from_str::<CapsOnly>(&j);
+        let result = normalize_capability_from_llm(serde_json::Value::String(name.to_string()));
         assert!(
             result.is_err(),
-            "R+1: bare-string '{}' should be rejected, but was accepted",
+            "R+1: bare-string '{}' should be rejected by lenient path, but was accepted",
             name
         );
         let msg = result.unwrap_err().to_string();
@@ -70,50 +50,50 @@ fn all_bare_string_capabilities_rejected() {
 }
 
 #[test]
-fn tagged_objects_with_explicit_scopes_accepted() {
-    let cases: Vec<serde_json::Value> = vec![
-        serde_json::json!({"type":"SandboxFunctions","allowed":["content."]}),
-        serde_json::json!({"type":"ReadAccess","scopes":["self.*"]}),
-        serde_json::json!({"type":"WriteAccess","scopes":["self.*"]}),
-        serde_json::json!({"type":"NetworkAccess","hosts":["api.example.com"]}),
-        serde_json::json!({"type":"CodeExecution","patterns":["python3 "]}),
-        serde_json::json!({"type":"AgentMessage","patterns":["*"]}),
-        serde_json::json!({"type":"AgentRevision","patterns":["*"]}),
-        serde_json::json!({"type":"Evaluation","patterns":["*"]}),
-        serde_json::json!({"type":"ApprovalQueue","patterns":["*"]}),
-        serde_json::json!({"type":"SchedulerSignal","patterns":["*"]}),
-        serde_json::json!({"type":"SchedulerAccess","patterns":["scheduler.cron.*"]}),
-        serde_json::json!({"type":"CredentialAccess","services":["github"]}),
-        serde_json::json!({"type":"UserProfileAccess","scopes":["basic"]}),
-        serde_json::json!({"type":"SkillInstall","allowed_sources":["agentskills.io"]}),
-        serde_json::json!({"type":"ConstitutionalProposal","patterns":["*"]}),
-        serde_json::json!({"type":"EmergencyStop"}),
-        serde_json::json!({"type":"AgentSpawn","max_children":5}),
-        serde_json::json!({"type":"BackgroundReevaluation","min_interval_secs":60,"allow_reasoning":true}),
+fn lenient_path_accepts_all_tagged_objects() {
+    let cases: Vec<(serde_json::Value, &str)> = vec![
+        (serde_json::json!({"type":"SandboxFunctions","allowed":["content."]}), "SandboxFunctions"),
+        (serde_json::json!({"type":"ReadAccess","scopes":["self.*"]}), "ReadAccess"),
+        (serde_json::json!({"type":"WriteAccess","scopes":["self.*"]}), "WriteAccess"),
+        (serde_json::json!({"type":"NetworkAccess","hosts":["api.example.com"]}), "NetworkAccess"),
+        (serde_json::json!({"type":"CodeExecution","patterns":["python3 "]}), "CodeExecution"),
+        (serde_json::json!({"type":"AgentMessage","patterns":["*"]}), "AgentMessage"),
+        (serde_json::json!({"type":"AgentRevision","patterns":["*"]}), "AgentRevision"),
+        (serde_json::json!({"type":"Evaluation","patterns":["*"]}), "Evaluation"),
+        (serde_json::json!({"type":"ApprovalQueue","patterns":["*"]}), "ApprovalQueue"),
+        (serde_json::json!({"type":"SchedulerSignal","patterns":["*"]}), "SchedulerSignal"),
+        (serde_json::json!({"type":"SchedulerAccess","patterns":["scheduler.cron.*"]}), "SchedulerAccess"),
+        (serde_json::json!({"type":"CredentialAccess","services":["github"]}), "CredentialAccess"),
+        (serde_json::json!({"type":"UserProfileAccess","scopes":["basic"]}), "UserProfileAccess"),
+        (serde_json::json!({"type":"SkillInstall","allowed_sources":["agentskills.io"]}), "SkillInstall"),
+        (serde_json::json!({"type":"ConstitutionalProposal","patterns":["*"]}), "ConstitutionalProposal"),
+        (serde_json::json!({"type":"EmergencyStop"}), "EmergencyStop"),
+        (serde_json::json!({"type":"AgentSpawn","max_children":5}), "AgentSpawn"),
+        (serde_json::json!({"type":"BackgroundReevaluation","min_interval_secs":60,"allow_reasoning":true}), "BackgroundReevaluation"),
     ];
 
-    let j = tagged_caps_json(&cases);
-    let result: CapsOnly = serde_json::from_str(&j).unwrap();
-    assert_eq!(
-        result.capabilities.len(),
-        cases.len(),
-        "all {} tagged capabilities should parse",
-        cases.len()
-    );
+    for (value, name) in &cases {
+        let result = normalize_capability_from_llm(value.clone());
+        assert!(
+            result.is_ok(),
+            "R+1: tagged object for '{}' should be accepted, got error: {}",
+            name,
+            result.unwrap_err()
+        );
+    }
+    assert_eq!(cases.len(), ALL_CAPABILITY_NAMES.len());
 }
 
 #[test]
-fn mixed_bare_and_tagged_rejected_at_first_bare() {
-    let j = format!(
-        r#"{{"capabilities":[{}, "ReadAccess"]}}"#,
-        serde_json::to_string(&serde_json::json!({"type":"NetworkAccess","hosts":["*"]})).unwrap()
-    );
-    let result = serde_json::from_str::<CapsOnly>(&j);
-    assert!(result.is_err(), "mixed bare+tagged should be rejected");
-    let msg = result.unwrap_err().to_string();
+fn lenient_path_rejects_mixed_bare_after_tagged() {
+    let _tagged = normalize_capability_from_llm(serde_json::json!({"type":"NetworkAccess","hosts":["*"]}))
+        .expect("tagged NetworkAccess should parse");
+    let bare = normalize_capability_from_llm(serde_json::Value::String("ReadAccess".to_string()));
+    assert!(bare.is_err(), "bare ReadAccess after tagged NetworkAccess should still be rejected");
+    let msg = bare.unwrap_err().to_string();
     assert!(
-        msg.contains("ReadAccess"),
-        "error should name the offending capability, got: {}",
+        msg.contains("ReadAccess") && msg.contains("scopes"),
+        "error should name capability and required field, got: {}",
         msg
     );
 }

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -575,7 +575,7 @@ cancelled, active parent not reaped, no store noop, multiple orphans.
 
 ---
 
-### 2.7 `R+1` Structured scopes for all capabilities
+### 2.7 `R+1` Structured scopes for all capabilities — **ENFORCED**
 
 **Threat.** Bare-string shorthand for low-risk capabilities is a soft
 path for underdeclaration. Auditing a manifest requires reading Rust

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -376,7 +376,7 @@ before it moves into its category.
 
 | ID | Rule | Priority |
 |---|---|---|
-| R+1 | Structured capability scopes mandatory for all capabilities (not only the three high-risk ones). | P1 |
+| R+1 | Structured capability scopes mandatory for all capabilities (not only the three high-risk ones). | ENFORCED |
 | R+2 | Child → parent tool results validate against `io.returns` on egress. | P0 |
 | R+3 | Spawn-chain depth cap — child `max_children` and `max_depth` ≤ parent's; global ceiling applies. | P0 |
 | R+4 | Root-session tree budget — tokens / time / cost aggregated across all descendants. | P0 |


### PR DESCRIPTION
## Summary

- **R+1 ENFORCED**: Bare-string capability shorthand (`"ReadAccess"`, `"SandboxFunctions"`, etc.) is now rejected for all 18 capability types, not just the 6 previously high-risk ones. Agents must supply tagged objects with explicit scope fields.
- Tool schema description for `create_from_intent` updated — no longer mentions string shorthand.
- Constitution docs flipped: `R+1` → ENFORCED in both `gateway-constitution.md` and `gateway-constitution-roadmap.md`.

## Changes

| File | Change |
|------|--------|
| `agent_revision.rs` (`capability_from_shorthand`) | All 18 match arms now return `Err(...)`. Previously-accepted shorthands (SandboxFunctions, ReadAccess, WriteAccess, AgentMessage, AgentRevision, Evaluation, ApprovalQueue, SchedulerSignal, EmergencyStop) now reject with actionable messages naming the required field. Missing variants (UserProfileAccess, SchedulerAccess, SkillInstall, ConstitutionalProposal) added as explicit rejections. |
| `agent_revision.rs` (tool schema) | Removed shorthand mention from `create_from_intent` capabilities description. |
| `constitution_capability_scope_required.rs` | New integration test: iterates all 18 bare strings → all rejected; all 18 tagged objects → all accepted; mixed bare+tagged → rejected at first bare entry. |
| `gateway-constitution.md` | R+1 row: P1 → ENFORCED |
| `gateway-constitution-roadmap.md` | §2.7 header: added **ENFORCED** |

## Test coverage

- **22 unit tests** in `capability_lenient_deser_tests` — 12 shorthand rejection tests (6 existing + 6 new) + 10 existing acceptance/wildcard tests.
- **3 integration tests** in `constitution_capability_scope_required.rs` — exhaustive sweep of all 18 capability names.

## Definition of Done (from #42)

- [x] Code change enforces the invariant mechanically
- [x] `constitution_*` test file
- [x] Constitution doc row flipped to ENFORCED
- [x] No on-disk manifest changes needed — all agents already use structured form

Closes #57.