### PR TITLE
feat(constitution): R+16 promotion-gate denied network access

### DIFF
--- a/agents/specialists/auditor.default/SKILL.md
+++ b/agents/specialists/auditor.default/SKILL.md
@@ -26,6 +26,8 @@ metadata:
         scopes: ["self.*", "skills/*"]
       - type: "WriteAccess"
         scopes: ["self.*", "skills/*"]
+      - type: "Evaluation"
+        patterns: ["*"]
     validation: "soft"
 ---
 # Auditor

--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -234,6 +234,10 @@ artifact_exec({
 
 `artifact_exec` analyzes the artifact's source files for remote access (not the shell command string), and binds approval reuse to the artifact identity. This means re-running the same artifact with different arguments will reuse prior approvals instead of re-requesting them.
 
+### Promotion Evaluation Has No Network
+
+Artifacts that go through promotion evaluation are tested in a sandbox with no network access (gateway constitution rule R+16). All tests must mock external services — a test that makes a real HTTP call will fail with `ECONNREFUSED`. Use `constitution.read` to inspect the full rule.
+
 ### When to Use Dependencies
 You don't have `NetworkAccess`, so you cannot install packages directly. If your code needs external packages:
 

--- a/agents/specialists/evaluator.default/SKILL.md
+++ b/agents/specialists/evaluator.default/SKILL.md
@@ -33,6 +33,8 @@ metadata:
         scopes: ["self.*", "skills/*"]
       - type: "ReadAccess"
         scopes: ["self.*", "skills/*"]
+      - type: "Evaluation"
+        patterns: ["*"]
     validation: "soft"
     response_contract:
       max_reply_length_chars: 8000

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -3795,7 +3795,14 @@ async fn execute_script_in_sandbox(
     );
 
     let driver = crate::sandbox::SandboxDriverKind::parse(sandbox_type)?;
-    let overrides = crate::sandbox::BwrapIsolationOverrides::from_capabilities(capabilities);
+    let mut overrides = crate::sandbox::BwrapIsolationOverrides::from_capabilities(capabilities);
+    let has_evaluation_cap = capabilities.iter().any(|c| {
+        matches!(c, autonoetic_types::capability::Capability::Evaluation { .. })
+    });
+    if has_evaluation_cap {
+        overrides.force_network_off = true;
+        overrides.share_net = false;
+    }
     let entrypoint_relative = match script_path.strip_prefix(agent_dir) {
         Ok(relative) => format!(
             "{}/{}",

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3120,6 +3120,7 @@ fn input_tokens_as_context_pct(input_tokens: u64, context_window: Option<u32>) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use autonoetic_types::agent::SessionState;
     use crate::llm::{
         CompletionRequest, CompletionResponse, LlmDriver, StopReason, TokenUsage, ToolCall,
         ToolDefinition,
@@ -3182,6 +3183,7 @@ mod tests {
             &manifest,
             Some("root/agent-factory.default-12345678"),
             false,
+            SessionState::Normal,
         );
 
         assert!(filter.allows("content_write"));
@@ -3199,6 +3201,7 @@ mod tests {
             &manifest,
             Some("root/specialized_builder.default-12345678"),
             false,
+            SessionState::Normal,
         );
 
         assert!(filter.allows("content_read"));

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -667,6 +667,7 @@ impl NativeTool for ArtifactExecTool {
                 &stdout_str,
                 &stderr_str,
                 has_network_cap,
+                false,
             );
         }
 
@@ -872,6 +873,7 @@ fn execute_with_ticket(
             &stdout,
             &stderr,
             has_network_cap,
+            false,
         );
     }
 

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -1788,6 +1788,14 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
             overrides.share_net = true;
         }
 
+        let has_evaluation_cap = manifest.capabilities.iter().any(|c| {
+            matches!(c, autonoetic_types::capability::Capability::Evaluation { .. })
+        });
+        if has_evaluation_cap {
+            overrides.force_network_off = true;
+            overrides.share_net = false;
+        }
+
         let layer_python_path_str = layer_python_paths.join(":");
         let mut extra_env: Vec<(String, String)> = if !layer_python_path_str.is_empty() {
             vec![("PYTHONPATH".to_string(), layer_python_path_str)]

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -348,6 +348,7 @@ pub fn apply_network_isolation_failure_to_result(
     stdout: &str,
     stderr: &str,
     has_network_cap: bool,
+    evaluation_blocked: bool,
 ) -> Option<Vec<String>> {
     let combined_output = format!("{stdout}\n{stderr}");
     let network_errors = detect_network_errors_in_output(&combined_output);
@@ -355,17 +356,23 @@ pub fn apply_network_isolation_failure_to_result(
         return None;
     }
 
+    let reason = if evaluation_blocked {
+        "Promotion evaluation sessions have no network access (gateway constitution rule R+16). \
+         Use constitution.read to inspect the rule. Mock all external services in tests so they \
+         run offline."
+    } else if has_network_cap {
+        "This agent declares NetworkAccess but this run did not enable the network \
+         namespace (e.g. missing operator approval or misconfiguration)."
+    } else {
+        "This agent does not declare NetworkAccess: outbound calls are blocked. \
+         Add scoped NetworkAccess, or use packager.default layers so tests run offline."
+    };
+
     let summary = format!(
         "Sandbox ran without outbound network and output indicates a network failure \
          ({}). {}",
         network_errors.join(", "),
-        if has_network_cap {
-            "This agent declares NetworkAccess but this run did not enable the network \
-             namespace (e.g. missing operator approval or misconfiguration)."
-        } else {
-            "This agent does not declare NetworkAccess: outbound calls are blocked. \
-             Add scoped NetworkAccess, or use packager.default layers so tests run offline."
-        }
+        reason
     );
     if let Some(obj) = body.as_object_mut() {
         obj.insert("ok".to_string(), serde_json::json!(false));
@@ -1916,6 +1923,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                 &stdout,
                 &stderr,
                 has_network_cap,
+                has_evaluation_cap,
             ) {
                 tracing::warn!(
                     target: "sandbox_exec",
@@ -2158,6 +2166,7 @@ mod network_error_detection_tests {
             "requests.exceptions.ConnectionError: boom",
             "",
             false,
+            false,
         );
         assert!(
             detected.is_some(),
@@ -2177,11 +2186,43 @@ mod network_error_detection_tests {
             "stderr": ""
         });
         let detected =
-            apply_network_isolation_failure_to_result(&mut body, "normal output", "", false);
+            apply_network_isolation_failure_to_result(&mut body, "normal output", "", false, false);
         assert!(detected.is_none(), "should not detect network patterns");
         assert_eq!(body["ok"], json!(true));
         assert!(body.get("error_type").is_none());
         assert!(body.get("network_blocked").is_none());
+    }
+
+    #[test]
+    fn evaluation_blocked_message_mentions_r16_and_constitution() {
+        let mut body = json!({
+            "ok": true,
+            "exit_code": 0,
+            "stdout": "done",
+            "stderr": ""
+        });
+        let detected = apply_network_isolation_failure_to_result(
+            &mut body,
+            "requests.exceptions.ConnectionError: boom",
+            "",
+            true,
+            true,
+        );
+        assert!(detected.is_some());
+        assert_eq!(body["ok"], json!(false));
+        let msg = body["network_warning"].as_str().unwrap();
+        assert!(
+            msg.contains("R+16"),
+            "evaluation-blocked message should reference R+16: {msg}"
+        );
+        assert!(
+            msg.contains("constitution"),
+            "evaluation-blocked message should mention constitution: {msg}"
+        );
+        assert!(
+            msg.contains("Mock all external services"),
+            "evaluation-blocked message should advise mocking: {msg}"
+        );
     }
 }
 

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -32,18 +32,20 @@ static SANDBOX_CONFIG: OnceLock<SandboxConfig> = OnceLock::new();
 /// Derived from the executing agent's capabilities.
 #[derive(Debug, Clone, Default)]
 pub struct BwrapIsolationOverrides {
-    /// Share host network namespace (adds --share-net to bwrap).
     pub share_net: bool,
+    pub force_network_off: bool,
 }
 
 impl BwrapIsolationOverrides {
-    /// Derive overrides from agent capabilities.
-    /// Returns `share_net: true` if any `NetworkAccess` capability is present.
     pub fn from_capabilities(caps: &[Capability]) -> Self {
         let share_net = caps
             .iter()
             .any(|cap| matches!(cap, Capability::NetworkAccess { hosts } if !hosts.is_empty()));
-        Self { share_net }
+        Self { share_net, force_network_off: false }
+    }
+
+    pub fn promotion_gate_overrides() -> Self {
+        Self { share_net: false, force_network_off: true }
     }
 }
 
@@ -917,9 +919,14 @@ pub fn append_bwrap_isolation_flags(
 ) {
     argv.push("--unshare-all".to_string());
 
-    let share_net = overrides
-        .map(|o| o.share_net)
-        .unwrap_or_else(bwrap_share_net_enabled);
+    let force_off = overrides.map(|o| o.force_network_off).unwrap_or(false);
+    let share_net = if force_off {
+        false
+    } else {
+        overrides
+            .map(|o| o.share_net)
+            .unwrap_or_else(bwrap_share_net_enabled)
+    };
 
     if share_net {
         argv.push("--share-net".to_string());

--- a/autonoetic-gateway/tests/constitution_promotion_no_network.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_no_network.rs
@@ -30,11 +30,22 @@ fn evaluation_capability_forces_network_off() {
     let mut overrides = BwrapIsolationOverrides::from_capabilities(&caps);
     assert!(overrides.share_net, "NetworkAccess sets share_net=true");
 
+    // Simulate approval_validated_for_command granting network
+    overrides.share_net = true;
+
+    // Now apply R+16 (mirrors the logic in sandbox_exec / execute_script_in_sandbox)
     overrides.force_network_off = true;
     overrides.share_net = false;
 
     assert!(overrides.force_network_off);
     assert!(!overrides.share_net, "R+16 overrides NetworkAccess for evaluation agents");
+
+    let mut argv = vec!["--unshare-all".to_string()];
+    autonoetic_gateway::sandbox::append_bwrap_isolation_flags(&mut argv, Some(&overrides));
+    assert!(
+        !argv.contains(&"--share-net".to_string()),
+        "R+16 must suppress --share-net even after approval grants network"
+    );
 }
 
 #[test]

--- a/autonoetic-gateway/tests/constitution_promotion_no_network.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_no_network.rs
@@ -1,0 +1,80 @@
+//! Constitution R+16 — Promotion-gate execution denied network access.
+//!
+//! Evaluator and auditor sessions (agents with Evaluation capability)
+//! must have network namespace unshared regardless of declared
+//! NetworkAccess. This ensures promotion verdicts are reproducible
+//! from recorded evidence alone.
+
+mod support;
+
+use autonoetic_gateway::sandbox::BwrapIsolationOverrides;
+use autonoetic_types::capability::Capability;
+
+#[test]
+fn promotion_gate_overrides_force_network_off() {
+    let overrides = BwrapIsolationOverrides::promotion_gate_overrides();
+    assert!(!overrides.share_net, "share_net must be false");
+    assert!(overrides.force_network_off, "force_network_off must be true");
+}
+
+#[test]
+fn evaluation_capability_forces_network_off() {
+    let caps = vec![
+        Capability::Evaluation {
+            patterns: vec!["*".to_string()],
+        },
+        Capability::NetworkAccess {
+            hosts: vec!["*".to_string()],
+        },
+    ];
+    let mut overrides = BwrapIsolationOverrides::from_capabilities(&caps);
+    assert!(overrides.share_net, "NetworkAccess sets share_net=true");
+
+    overrides.force_network_off = true;
+    overrides.share_net = false;
+
+    assert!(overrides.force_network_off);
+    assert!(!overrides.share_net, "R+16 overrides NetworkAccess for evaluation agents");
+}
+
+#[test]
+fn non_evaluation_agents_keep_network() {
+    let caps = vec![Capability::NetworkAccess {
+        hosts: vec!["api.example.com".to_string()],
+    }];
+    let overrides = BwrapIsolationOverrides::from_capabilities(&caps);
+    assert!(overrides.share_net, "NetworkAccess without Evaluation keeps share_net");
+    assert!(!overrides.force_network_off);
+}
+
+#[test]
+fn force_network_off_wins_over_share_net_in_flags() {
+    let overrides = BwrapIsolationOverrides {
+        share_net: true,
+        force_network_off: true,
+    };
+    let mut argv = vec!["--unshare-all".to_string()];
+
+    autonoetic_gateway::sandbox::append_bwrap_isolation_flags(&mut argv, Some(&overrides));
+
+    assert!(
+        !argv.contains(&"--share-net".to_string()),
+        "force_network_off must suppress --share-net even when share_net=true"
+    );
+}
+
+#[test]
+fn normal_overrides_add_share_net() {
+    let overrides = BwrapIsolationOverrides {
+        share_net: true,
+        force_network_off: false,
+    };
+    let mut argv = vec!["--unshare-all".to_string()];
+
+    autonoetic_gateway::sandbox::append_bwrap_isolation_flags(&mut argv, Some(&overrides));
+
+    assert!(
+        argv.contains(&"--share-net".to_string()),
+        "share_net=true without force_network_off should add --share-net"
+    );
+}

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -597,7 +597,7 @@ is what makes this S vs. L.
 
 ---
 
-### 2.8 `R+16` Promotion-gate execution denied network
+### 2.8 `R+16` Promotion-gate execution denied network — **ENFORCED**
 
 **Threat.** An auditor or evaluator that hits the network during a
 verdict is not reproducible from recorded evidence. A malicious

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -391,7 +391,7 @@ before it moves into its category.
 | R+13 | Approval grant TTL. | P2 |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |
 | R+15 | Constant-time comparison for JSON-RPC shared-secret auth. | ENFORCED (R-10.8) |
-| R+16 | Promotion-gate execution is denied network access. **ENFORCED** — `autonoetic-gateway/src/sandbox.rs` (`BwrapIsolationOverrides::force_network_off`), `autonoetic-gateway/src/runtime/tools/sandbox.rs` (Evaluation-cap override), `autonoetic-gateway/src/execution.rs` (`execute_script_in_sandbox` override). | P1 |
+| R+16 | Promotion-gate execution is denied network access. `autonoetic-gateway/src/sandbox.rs` (`BwrapIsolationOverrides::force_network_off`), `autonoetic-gateway/src/runtime/tools/sandbox.rs` (Evaluation-cap override), `autonoetic-gateway/src/execution.rs` (`execute_script_in_sandbox` override), `agents/specialists/evaluator.default/SKILL.md` + `agents/specialists/auditor.default/SKILL.md` (`Evaluation` capability). | ENFORCED |
 | R+17 | Retention pruning emits `retention.pruned` causal event. | P2 |
 | R+18 | Gateway refuses to start if a session's runtime-lock disagrees with the current binary SHA. | merged with R+7 |
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -391,7 +391,7 @@ before it moves into its category.
 | R+13 | Approval grant TTL. | P2 |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |
 | R+15 | Constant-time comparison for JSON-RPC shared-secret auth. | ENFORCED (R-10.8) |
-| R+16 | Promotion-gate execution is denied network access. | P1 |
+| R+16 | Promotion-gate execution is denied network access. **ENFORCED** — `autonoetic-gateway/src/sandbox.rs` (`BwrapIsolationOverrides::force_network_off`), `autonoetic-gateway/src/runtime/tools/sandbox.rs` (Evaluation-cap override), `autonoetic-gateway/src/execution.rs` (`execute_script_in_sandbox` override). | P1 |
 | R+17 | Retention pruning emits `retention.pruned` causal event. | P2 |
 | R+18 | Gateway refuses to start if a session's runtime-lock disagrees with the current binary SHA. | merged with R+7 |
 


### PR DESCRIPTION
## Summary

- **R+16 ENFORCED**: Agents with `Evaluation` capability now have their sandbox network namespace unshared (`--unshare-net`) regardless of declared `NetworkAccess`. Promotion verdicts are reproducible from recorded evidence alone.

## Changes

| File | Change |
|------|--------|
| `sandbox.rs` (`BwrapIsolationOverrides`) | New `force_network_off: bool` field + `promotion_gate_overrides()` constructor. `append_bwrap_isolation_flags` honors it over `share_net`. |
| `runtime/tools/sandbox.rs` (`sandbox_exec`) | When manifest has `Evaluation` capability, sets `force_network_off = true` and `share_net = false`. |
| `execution.rs` (`execute_script_in_sandbox`) | Same override for script-mode evaluator sessions. |
| `constitution_promotion_no_network.rs` | 5 tests: gate overrides, flag suppression, normal agents unaffected. |
| `gateway-constitution.md` | R+16 row: P1 → ENFORCED with file citations. |
| `gateway-constitution-roadmap.md` | §2.8 header: **ENFORCED**. |

## Test coverage

- 5 integration tests covering the enforcement mechanics
- All existing sandbox tests pass

Closes #58.