### PR TITLE
feat(constitution): R++3 distinct evaluator/auditor identity at promotion

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -1918,6 +1918,20 @@ impl NativeTool for AgentRevisionPromoteTool {
                 artifact_id
             );
 
+            // R++3 — Distinct evaluator/auditor identity.
+            // The evaluator and auditor must be different agent identities,
+            // not merely distinct sessions of the same agent.
+            {
+                let eval_id = record.evaluator_id.as_deref().unwrap_or("<unknown>");
+                let audit_id = record.auditor_id.as_deref().unwrap_or("<unknown>");
+                anyhow::ensure!(
+                    eval_id != audit_id,
+                    "Promotion gate: evaluator and auditor are the same agent '{}' (R++3). \
+                     A single agent cannot self-approve. Use distinct evaluator and auditor agents.",
+                    eval_id
+                );
+            }
+
             let has_unresolved = rev
                 .metadata_json
                 .get("has_unresolved_dependencies")

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -1918,15 +1918,27 @@ impl NativeTool for AgentRevisionPromoteTool {
                 artifact_id
             );
 
-            // R++3 — Distinct evaluator/auditor identity.
+            // R-2.17 (formerly R++3) — Distinct evaluator/auditor identity.
             // The evaluator and auditor must be different agent identities,
             // not merely distinct sessions of the same agent.
             {
-                let eval_id = record.evaluator_id.as_deref().unwrap_or("<unknown>");
-                let audit_id = record.auditor_id.as_deref().unwrap_or("<unknown>");
+                let eval_id = record.evaluator_id.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Promotion gate: evaluator identity missing for artifact '{}' (R-2.17). \
+                         Re-run evaluator.default to record its identity.",
+                        artifact_id
+                    )
+                })?;
+                let audit_id = record.auditor_id.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Promotion gate: auditor identity missing for artifact '{}' (R-2.17). \
+                         Re-run auditor.default to record its identity.",
+                        artifact_id
+                    )
+                })?;
                 anyhow::ensure!(
                     eval_id != audit_id,
-                    "Promotion gate: evaluator and auditor are the same agent '{}' (R++3). \
+                    "Promotion gate: evaluator and auditor are the same agent '{}' (R-2.17). \
                      A single agent cannot self-approve. Use distinct evaluator and auditor agents.",
                     eval_id
                 );

--- a/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
@@ -1,0 +1,372 @@
+//! Constitution R++3 — Distinct evaluator/auditor identity at promotion.
+//!
+//! The evaluator and auditor backing a promotion must be distinct agent
+//! identities (not merely distinct sessions of the same agent). A single
+//! agent that self-approves by recording both evaluator and auditor passes
+//! must be rejected.
+
+mod support;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::artifact::ArtifactKind;
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn high_risk_skill_md(agent_id: &str) -> String {
+    format!(
+        r#"---
+version: "1.0"
+runtime:
+  engine: "autonoetic"
+  gateway_version: "0.1.0"
+  sdk_version: "0.1.0"
+  type: "stateful"
+  sandbox: "bubblewrap"
+  runtime_lock: "runtime.lock"
+agent:
+  id: "{agent_id}"
+  name: "{agent_id}"
+  description: "High-risk test agent"
+capabilities:
+  - type: CodeExecution
+    patterns: ["python3 "]
+execution_mode: script
+script_entry: main.py
+---
+# Test agent
+"#
+    )
+}
+
+fn manifest_for(agent_id: &str) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: agent_id.to_string(),
+            name: agent_id.to_string(),
+            description: "Test".to_string(),
+        },
+        capabilities: vec![Capability::AgentRevision {
+            patterns: vec!["*".to_string()],
+        }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        response_contract: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+    }
+}
+
+fn build_agent_bundle(base_dir: &Path, skill_md: &str) -> (String, PathBuf) {
+    let gateway_dir = base_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let content_store = ContentStore::new(&gateway_dir).unwrap();
+    let artifact_store =
+        autonoetic_gateway::artifact_store::ArtifactStore::new(&gateway_dir).unwrap();
+    let session_id = "test-session";
+
+    let runtime_lock = r#"gateway:
+  artifact: autonogetic-gateway
+  version: "0.1.0"
+  sha256: unmanaged
+  signature: null
+sdk:
+  version: "0.1.0"
+sandbox:
+  backend: bubblewrap
+dependencies: []
+artifacts: []
+layers: []
+"#;
+
+    let main_py = "#!/usr/bin/env python3\nimport json\nprint(json.dumps({'status': 'ok'}))\n";
+
+    for (path, content) in [
+        ("SKILL.md", skill_md.as_bytes()),
+        ("runtime.lock", runtime_lock.as_bytes()),
+        ("main.py", main_py.as_bytes()),
+    ] {
+        let handle = content_store.write(content).unwrap();
+        content_store
+            .register_name(session_id, path, &handle)
+            .unwrap();
+    }
+
+    let bundle = artifact_store
+        .build_with_kind(
+            &[
+                "SKILL.md".to_string(),
+                "runtime.lock".to_string(),
+                "main.py".to_string(),
+            ],
+            Some(&["main.py".to_string()]),
+            None,
+            ArtifactKind::AgentBundle,
+            session_id,
+        )
+        .unwrap();
+    (bundle.artifact_id, gateway_dir)
+}
+
+fn record_promotion(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    builder_dir: &Path,
+    gateway_dir: &Path,
+    config: &GatewayConfig,
+    artifact_id: &str,
+    role: &str,
+    pass: bool,
+    session_id: &str,
+) {
+    let args = serde_json::json!({
+        "artifact_id": artifact_id,
+        "role": role,
+        "pass": pass,
+        "findings": [],
+        "summary": format!("{role} check — pass={pass}"),
+    });
+    let result = registry
+        .execute(
+            "promotion_record",
+            manifest,
+            policy,
+            builder_dir,
+            Some(gateway_dir),
+            &serde_json::to_string(&args).unwrap(),
+            Some(session_id),
+            None,
+            Some(config),
+            None,
+            None,
+        )
+        .expect("promotion.record should succeed");
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(
+        parsed.get("ok").and_then(|v| v.as_bool()),
+        Some(true),
+        "promotion.record should return ok=true, got: {result}"
+    );
+}
+
+fn create_revision(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    builder_dir: &Path,
+    gateway_dir: &Path,
+    config: &GatewayConfig,
+    store: Arc<GatewayStore>,
+    agent_id: &str,
+    artifact_id: &str,
+) -> String {
+    let args = serde_json::json!({
+        "agent_id": agent_id,
+        "artifact_id": artifact_id,
+    });
+    let result = registry
+        .execute(
+            "agent_revision_create",
+            manifest,
+            policy,
+            builder_dir,
+            Some(gateway_dir),
+            &serde_json::to_string(&args).unwrap(),
+            Some("session-create"),
+            None,
+            Some(config),
+            Some(store),
+            None,
+        )
+        .expect("revision create should succeed");
+
+    let created: serde_json::Value = serde_json::from_str(&result).unwrap();
+    created
+        .get("revision_id")
+        .and_then(|v| v.as_str())
+        .expect("revision_id in response")
+        .to_string()
+}
+
+fn try_promote(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    builder_dir: &Path,
+    gateway_dir: &Path,
+    config: &GatewayConfig,
+    store: Arc<GatewayStore>,
+    agent_id: &str,
+    revision_id: &str,
+) -> Result<serde_json::Value, String> {
+    let args = serde_json::json!({
+        "agent_id": agent_id,
+        "revision_id": revision_id,
+        "reason": "integration test",
+    });
+    match registry.execute(
+        "agent_revision_promote",
+        manifest,
+        policy,
+        builder_dir,
+        Some(gateway_dir),
+        &serde_json::to_string(&args).unwrap(),
+        Some("session-promote"),
+        None,
+        Some(config),
+        Some(store),
+        None,
+    ) {
+        Ok(result) => Ok(serde_json::from_str(&result).unwrap()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[test]
+fn same_agent_identity_rejected_even_if_both_passed() {
+    let agent_id = "rpp3.test.agent";
+    let skill = high_risk_skill_md(agent_id);
+    let temp = tempdir().unwrap();
+    let agents_dir = temp.path().join("agents");
+    let builder_dir = agents_dir.join("specialized_builder.default");
+    std::fs::create_dir_all(&builder_dir).unwrap();
+
+    let (artifact_id, gateway_dir) = build_agent_bundle(temp.path(), &skill);
+    let config = GatewayConfig {
+        agents_dir,
+        ..Default::default()
+    };
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+
+    let builder = manifest_for("specialized_builder.default");
+    let builder_policy = PolicyEngine::new(builder.clone());
+
+    let revision_id = create_revision(
+        &registry,
+        &builder,
+        &builder_policy,
+        &builder_dir,
+        &gateway_dir,
+        &config,
+        store.clone(),
+        agent_id,
+        &artifact_id,
+    );
+
+    // Same agent identity (evaluator.default) records both evaluator and auditor passes.
+    let same_agent = manifest_for("evaluator.default");
+    let same_policy = PolicyEngine::new(same_agent.clone());
+
+    record_promotion(
+        &registry, &same_agent, &same_policy, &builder_dir,
+        &gateway_dir, &config, &artifact_id, "evaluator", true, "session-eval",
+    );
+    record_promotion(
+        &registry, &same_agent, &same_policy, &builder_dir,
+        &gateway_dir, &config, &artifact_id, "auditor", true, "session-audit",
+    );
+
+    let result = try_promote(
+        &registry, &builder, &builder_policy, &builder_dir,
+        &gateway_dir, &config, store, agent_id, &revision_id,
+    );
+
+    assert!(result.is_err(), "promote should fail when evaluator and auditor share identity");
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("R++3"),
+        "error should reference R++3: {err}"
+    );
+    assert!(
+        err.contains("same agent"),
+        "error should mention same agent: {err}"
+    );
+    assert!(
+        err.contains("evaluator.default"),
+        "error should name the overlapping agent: {err}"
+    );
+}
+
+#[test]
+fn distinct_identities_allowed() {
+    let agent_id = "rpp3.distinct.agent";
+    let skill = high_risk_skill_md(agent_id);
+    let temp = tempdir().unwrap();
+    let agents_dir = temp.path().join("agents");
+    let builder_dir = agents_dir.join("specialized_builder.default");
+    std::fs::create_dir_all(&builder_dir).unwrap();
+
+    let (artifact_id, gateway_dir) = build_agent_bundle(temp.path(), &skill);
+    let config = GatewayConfig {
+        agents_dir,
+        ..Default::default()
+    };
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+
+    let builder = manifest_for("specialized_builder.default");
+    let builder_policy = PolicyEngine::new(builder.clone());
+
+    let revision_id = create_revision(
+        &registry,
+        &builder,
+        &builder_policy,
+        &builder_dir,
+        &gateway_dir,
+        &config,
+        store.clone(),
+        agent_id,
+        &artifact_id,
+    );
+
+    let evaluator = manifest_for("evaluator.default");
+    let eval_policy = PolicyEngine::new(evaluator.clone());
+    record_promotion(
+        &registry, &evaluator, &eval_policy, &builder_dir,
+        &gateway_dir, &config, &artifact_id, "evaluator", true, "session-eval",
+    );
+
+    let auditor = manifest_for("auditor.default");
+    let audit_policy = PolicyEngine::new(auditor.clone());
+    record_promotion(
+        &registry, &auditor, &audit_policy, &builder_dir,
+        &gateway_dir, &config, &artifact_id, "auditor", true, "session-audit",
+    );
+
+    let result = try_promote(
+        &registry, &builder, &builder_policy, &builder_dir,
+        &gateway_dir, &config, store, agent_id, &revision_id,
+    );
+
+    assert!(result.is_ok(), "promote should succeed with distinct identities, got err: {:?}", result.unwrap_err());
+    let promoted = result.unwrap();
+    assert_eq!(promoted["ok"], true);
+}

--- a/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
@@ -91,7 +91,7 @@ fn build_agent_bundle(base_dir: &Path, skill_md: &str) -> (String, PathBuf) {
     let session_id = "test-session";
 
     let runtime_lock = r#"gateway:
-  artifact: autonogetic-gateway
+  artifact: autonoetic-gateway
   version: "0.1.0"
   sha256: unmanaged
   signature: null
@@ -302,8 +302,8 @@ fn same_agent_identity_rejected_even_if_both_passed() {
     assert!(result.is_err(), "promote should fail when evaluator and auditor share identity");
     let err = result.unwrap_err();
     assert!(
-        err.contains("R++3"),
-        "error should reference R++3: {err}"
+        err.contains("R-2.17"),
+        "error should reference R-2.17: {err}"
     );
     assert!(
         err.contains("same agent"),

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -620,7 +620,7 @@ ECONNREFUSED.
 
 ---
 
-### 2.9 `R++3` Distinct auditor / evaluator identity at promotion
+### 2.9 `R++3` Distinct auditor / evaluator identity at promotion — **ENFORCED** (now R-2.17)
 
 **Threat.** Today's gate (R-2.8) requires both evaluator and auditor
 records but does not require their `agent_id` to differ. A single

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -175,7 +175,7 @@ approve via `runtime/continuation.rs`.
 | R-2.14 | `user_ask` is refused if the workflow has active children or pending approvals. | architecture-interaction-mechanisms.md | runtime guard | PARTIAL |
 | R-2.15 | Spawn payload is preserved verbatim across approval resume. | approval-system.md | `continuation.rs:332` | ENFORCED |
 | R-2.16 | Promotion of revision N computes `cap_set(N) \ cap_set(N-1)`. A non-empty delta triggers a **separate, differently-shaped approval** (`ScheduledAction::RevisionPromote`) that names each added capability explicitly. The operator must acknowledge every added/broadened capability by name (`--acknowledge-capability`) — silent accretion across approvals is impossible. | gateway-constitution-roadmap.md | `autonoetic-gateway/src/runtime/tools/agent_revision.rs` (gate creation), `autonoetic-gateway/src/scheduler/approval.rs` (acknowledgement check) | ENFORCED |
-| R-2.17 | The auditor and evaluator backing a promotion must be **distinct agent identities** (not merely distinct sessions of the same agent). A single agent recording both evaluator and auditor passes is rejected. | gateway-constitution-roadmap.md | `autonoetic-gateway/src/runtime/tools/agent_revision.rs::enforce_promotion_gate` (identity comparison) | ENFORCED |
+| R-2.17 | The auditor and evaluator backing a promotion must be **distinct agent identities** (not merely distinct sessions of the same agent). A single agent recording both evaluator and auditor passes is rejected. | gateway-constitution-roadmap.md | `autonoetic-gateway/src/runtime/tools/agent_revision.rs` `AgentRevisionPromoteTool::execute` (identity comparison in promotion gate) | ENFORCED |
 
 ## 3. Sandbox Isolation
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -175,6 +175,7 @@ approve via `runtime/continuation.rs`.
 | R-2.14 | `user_ask` is refused if the workflow has active children or pending approvals. | architecture-interaction-mechanisms.md | runtime guard | PARTIAL |
 | R-2.15 | Spawn payload is preserved verbatim across approval resume. | approval-system.md | `continuation.rs:332` | ENFORCED |
 | R-2.16 | Promotion of revision N computes `cap_set(N) \ cap_set(N-1)`. A non-empty delta triggers a **separate, differently-shaped approval** (`ScheduledAction::RevisionPromote`) that names each added capability explicitly. The operator must acknowledge every added/broadened capability by name (`--acknowledge-capability`) — silent accretion across approvals is impossible. | gateway-constitution-roadmap.md | `autonoetic-gateway/src/runtime/tools/agent_revision.rs` (gate creation), `autonoetic-gateway/src/scheduler/approval.rs` (acknowledgement check) | ENFORCED |
+| R-2.17 | The auditor and evaluator backing a promotion must be **distinct agent identities** (not merely distinct sessions of the same agent). A single agent recording both evaluator and auditor passes is rejected. | gateway-constitution-roadmap.md | `autonoetic-gateway/src/runtime/tools/agent_revision.rs::enforce_promotion_gate` (identity comparison) | ENFORCED |
 
 ## 3. Sandbox Isolation
 
@@ -408,7 +409,6 @@ item will move into its numbered category once ENFORCED.
 
 | ID | Rule | Priority | Target category |
 |---|---|---|---|
-| R++3 | The auditor and evaluator backing a promotion must be **distinct agent identities** (not merely distinct sessions of the same agent). | P1 | §2 Approval |
 | R++4 | Operator approval hardening: (a) dwell time (minimum-visible seconds) on high-risk approvals before the confirm action enables; (b) typed confirmation string required for destructive approval classes (bundle promotion, credential register, first-ever host approval); (c) structural-similarity dedup to the operator, not just fingerprint dedup (prevents near-identical prompt floods from bypassing attention). | P1 | §2 Approval |
 | R++7 | Cross-gateway causal continuity: cross-gateway events carry a `peer_event_ref` pointing to the corresponding remote chain entry; gateways periodically exchange signed `chain_attestation` digests allowing end-to-end federated trace verification. | P1 | §10 Federation + §8 Audit |
 | R++8 | Sandbox-escape attempts are counted. Kernel-denied syscalls (seccomp), denied mount attempts, ptrace calls, and equivalents on docker/microvm drivers increment a per-session counter. Threshold crossings trigger R-7.18 degraded mode; further escalation triggers emergency stop. | P2 | §3 Sandbox + §7 Abuse |


### PR DESCRIPTION
## Summary

Constitution rule **R++3**: the evaluator and auditor backing a promotion must be **distinct agent identities** (not merely distinct sessions of the same agent).

### Changes

- **`agent_revision.rs`**: Added identity comparison in `enforce_promotion_gate` closure — compares `evaluator_id` and `auditor_id` from the promotion record. Rejects with `R++3` rule reference and the overlapping agent name.
- **Integration tests** (`constitution_promotion_distinct_identity.rs`):
  - `same_agent_identity_rejected`: `evaluator.default` records both evaluator and auditor passes → promote fails with R++3 reference
  - `distinct_identities_allowed`: `evaluator.default` + `auditor.default` → promote succeeds
- **Constitution doc**: R++3 moved from R++ table into §2 as **R-2.17** (ENFORCED)
- **Roadmap**: §2.9 marked ENFORCED (now R-2.17)

### Test plan
- `cargo test -p autonoetic-gateway --test constitution_promotion_distinct_identity` (2 tests, both pass)
- `cargo build -p autonoetic-gateway` (clean)