### PR TITLE
R+11: Bundle signature verification at revision create

### DIFF
--- a/autonoetic-gateway/src/runtime/crypto.rs
+++ b/autonoetic-gateway/src/runtime/crypto.rs
@@ -29,6 +29,10 @@ impl ManifestSigner {
         use base64::{engine::general_purpose::STANDARD, Engine as _};
         STANDARD.encode(signature.to_bytes())
     }
+
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.key.verifying_key().to_bytes()
+    }
 }
 
 pub struct ManifestVerifier;

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -360,7 +360,7 @@ fn parse_frontmatter_capabilities(
 }
 
 #[derive(Debug, Deserialize)]
-struct RevisionCreateArgs {
+ struct RevisionCreateArgs {
     agent_id: String,
     artifact_id: String,
     #[serde(default, alias = "base_ref")]
@@ -369,6 +369,8 @@ struct RevisionCreateArgs {
     summary: Option<String>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
+    #[serde(default)]
+    signature: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -402,6 +404,8 @@ struct RevisionCreateFromIntentArgs {
     summary: Option<String>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
+    #[serde(default)]
+    signature: Option<String>,
 }
 
 #[derive(Debug)]
@@ -413,6 +417,7 @@ struct RevisionCreateCommonArgs {
     metadata: Option<serde_json::Value>,
     source_kind: String,
     source_ref: Option<String>,
+    signature: Option<String>,
 }
 
 #[derive(Debug)]
@@ -838,6 +843,16 @@ impl NativeTool for AgentRevisionCreateTool {
         };
 
         let gateway_dir = gateway_dir.ok_or_else(|| anyhow::anyhow!("gateway_dir required"))?;
+
+        if let Some(config) = _config {
+            if !config.trust_unsigned_bundles && args.signature.is_none() {
+                return Err(anyhow::anyhow!(
+                    "R+11: Bundle signature required but not provided. \
+                     Set trust_unsigned_bundles: true in config for local development."
+                ));
+            }
+        }
+
         let artifact = crate::ArtifactStore::new(gateway_dir)?;
 
         let bundle = artifact
@@ -963,6 +978,7 @@ impl NativeTool for AgentRevisionCreateTool {
             metadata: args.metadata.clone(),
             source_kind: "artifact".to_string(),
             source_ref: Some(args.artifact_id.clone()),
+            signature: args.signature.clone(),
         };
         let persisted = create_revision_from_files(
             &common,
@@ -1085,6 +1101,16 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
             ));
         };
         let gateway_dir = gateway_dir.ok_or_else(|| anyhow::anyhow!("gateway_dir required"))?;
+
+        if let Some(config) = _config {
+            if !config.trust_unsigned_bundles && args.signature.is_none() {
+                return Err(anyhow::anyhow!(
+                    "R+11: Bundle signature required but not provided. \
+                     Set trust_unsigned_bundles: true in config for local development."
+                ));
+            }
+        }
+
         let resolved_artifact = resolve_revision_artifact_input(
             args.artifact_id.as_deref(),
             args.artifact_ref.as_deref(),
@@ -1313,6 +1339,7 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
             metadata: args.metadata.clone(),
             source_kind,
             source_ref,
+            signature: args.signature.clone(),
         };
         let persisted = create_revision_from_files(
             &common,

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -535,6 +535,7 @@ fn create_revision_from_files(
     health_report: Option<&crate::runtime::install_contract::BundleHealthReport>,
     script_entry: Option<&str>,
     artifact_content_digest: Option<&str>,
+    config: Option<&GatewayConfig>,
 ) -> anyhow::Result<PersistedRevisionResult> {
     let expected_layers = bundle.map(expected_locked_layers).unwrap_or_default();
     let normalized_lock = normalize_runtime_lock(parsed_lock);
@@ -569,6 +570,27 @@ fn create_revision_from_files(
     let content_digest = artifact_content_digest
         .map(|d| d.to_string())
         .unwrap_or_else(|| format!("sha256:{}", revision_digest_hex));
+
+    if let Some(sig) = &common.signature {
+        let pub_path = gateway_dir.join(crate::runtime::crypto::GatewayIdentityKey::PUBLIC_FILENAME);
+        if pub_path.exists() {
+            let pub_bytes = std::fs::read(&pub_path)?;
+            if pub_bytes.len() == 32 {
+                let mut pk = [0u8; 32];
+                pk.copy_from_slice(&pub_bytes);
+                let valid = crate::runtime::crypto::ManifestVerifier::verify(
+                    &pk,
+                    &revision_digest_hex,
+                    sig,
+                )?;
+                anyhow::ensure!(
+                    valid,
+                    "R+11: Bundle signature verification failed — signature does not match \
+                     the canonical content digest. Tampered or mis-signed bundle."
+                );
+            }
+        }
+    }
 
     if let Some(existing_rev) = gateway_store.get_agent_revision(&revision_id)? {
         let _ = materialize_revision_directory(
@@ -791,7 +813,8 @@ impl NativeTool for AgentRevisionCreateTool {
                     "agent_id": { "type": "string", "description": "Logical agent ID for this revision" },
                     "artifact_id": { "type": "string", "description": "Artifact ID containing the agent bundle (SKILL.md + files)" },
                     "base_revision_id": { "type": "string", "description": "Optional: base revision this is derived from" },
-                    "summary": { "type": "string", "description": "Optional: human-readable summary of changes" }
+                    "summary": { "type": "string", "description": "Optional: human-readable summary of changes" },
+                    "signature": { "type": "string", "description": "Ed25519 signature over the canonical content digest of the bundle, base64-encoded. Required unless trust_unsigned_bundles is enabled (R+11)." }
                 },
                 "required": ["agent_id", "artifact_id"],
                 "additionalProperties": false
@@ -844,13 +867,12 @@ impl NativeTool for AgentRevisionCreateTool {
 
         let gateway_dir = gateway_dir.ok_or_else(|| anyhow::anyhow!("gateway_dir required"))?;
 
-        if let Some(config) = _config {
-            if !config.trust_unsigned_bundles && args.signature.is_none() {
-                return Err(anyhow::anyhow!(
-                    "R+11: Bundle signature required but not provided. \
-                     Set trust_unsigned_bundles: true in config for local development."
-                ));
-            }
+        let trust_unsigned = _config.map_or(false, |c| c.trust_unsigned_bundles);
+        if !trust_unsigned && args.signature.is_none() {
+            return Err(anyhow::anyhow!(
+                "R+11: Bundle signature required but not provided. \
+                 Set trust_unsigned_bundles: true in config for local development."
+            ));
         }
 
         let artifact = crate::ArtifactStore::new(gateway_dir)?;
@@ -993,6 +1015,7 @@ impl NativeTool for AgentRevisionCreateTool {
             None,
             None,
             bundle_manifest.script_entry.as_deref(),
+            _config,
         )?;
         Ok(persisted.response.to_string())
     }
@@ -1039,7 +1062,8 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
                     "middleware": { "type": "object" },
                     "response_contract": { "type": "object" },
                     "base_revision_id": { "type": "string" },
-                    "summary": { "type": "string" }
+                    "summary": { "type": "string" },
+                    "signature": { "type": "string", "description": "Ed25519 signature over the canonical content digest of the bundle, base64-encoded. Required unless trust_unsigned_bundles is enabled (R+11)." }
                 },
                 "required": ["agent_id", "instructions", "description", "capabilities"],
                 "additionalProperties": false
@@ -1102,13 +1126,12 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
         };
         let gateway_dir = gateway_dir.ok_or_else(|| anyhow::anyhow!("gateway_dir required"))?;
 
-        if let Some(config) = _config {
-            if !config.trust_unsigned_bundles && args.signature.is_none() {
-                return Err(anyhow::anyhow!(
-                    "R+11: Bundle signature required but not provided. \
-                     Set trust_unsigned_bundles: true in config for local development."
-                ));
-            }
+        let trust_unsigned = _config.map_or(false, |c| c.trust_unsigned_bundles);
+        if !trust_unsigned && args.signature.is_none() {
+            return Err(anyhow::anyhow!(
+                "R+11: Bundle signature required but not provided. \
+                 Set trust_unsigned_bundles: true in config for local development."
+            ));
         }
 
         let resolved_artifact = resolve_revision_artifact_input(
@@ -1354,6 +1377,7 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
             health_report.as_ref(),
             resolved_script_entry.as_deref(),
             artifact_only_digest.as_deref(),
+            _config,
         )?;
 
         let mut response = persisted.response;

--- a/autonoetic-gateway/tests/constitution_install_signature.rs
+++ b/autonoetic-gateway/tests/constitution_install_signature.rs
@@ -1,0 +1,178 @@
+//! Constitution R+11 / R-9.13: Bundle signature verification at revision create.
+//!
+//! When `trust_unsigned_bundles` is false (the default in production), every
+//! `agent_revision_create` must carry a valid Ed25519 signature over the
+//! canonical content digest. Unsigned bundles are rejected.
+//!
+//! When `trust_unsigned_bundles` is true (dev mode), signatures are optional.
+
+mod support;
+
+use autonoetic_gateway::runtime::crypto::{ManifestSigner, ManifestVerifier};
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn test_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "revision.tester".to_string(),
+            name: "revision.tester".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![Capability::AgentRevision { patterns: vec!["*".to_string()] }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        response_contract: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+    }
+}
+
+fn setup_gateway(base: &std::path::Path) -> (std::path::PathBuf, Arc<GatewayStore>) {
+    let gw_dir = base.join(".gateway");
+    std::fs::create_dir_all(&gw_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gw_dir).unwrap());
+    (gw_dir, store)
+}
+
+fn config_strict() -> GatewayConfig {
+    let mut c = GatewayConfig::default();
+    c.trust_unsigned_bundles = false;
+    c
+}
+
+fn config_trust() -> GatewayConfig {
+    let mut c = GatewayConfig::default();
+    c.trust_unsigned_bundles = true;
+    c
+}
+
+#[test]
+fn r11_sign_and_verify_roundtrip() {
+    let secret = [42u8; 32];
+    let signer = ManifestSigner::new(&secret);
+    let content = "test bundle content digest hex";
+    let sig = signer.sign(content);
+
+    let public_bytes = signer.public_key_bytes();
+    assert!(
+        ManifestVerifier::verify(&public_bytes, content, &sig).unwrap(),
+        "signature should verify"
+    );
+    assert!(
+        !ManifestVerifier::verify(&public_bytes, "tampered content", &sig).unwrap(),
+        "tampered content should not verify"
+    );
+}
+
+#[test]
+fn r11_config_default_is_strict() {
+    let config = GatewayConfig::default();
+    assert!(
+        !config.trust_unsigned_bundles,
+        "default should require signatures"
+    );
+}
+
+#[test]
+fn r11_revision_create_rejects_unsigned_when_strict() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+    let manifest = test_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let config = config_strict();
+
+    let args = serde_json::json!({
+        "agent_id": "revision.tester",
+        "artifact_id": "nonexistent",
+    });
+
+    let result = registry.execute(
+        "agent_revision_create",
+        &manifest,
+        &policy,
+        temp.path(),
+        Some(&gw_dir),
+        &args.to_string(),
+        None,
+        None,
+        Some(&config),
+        Some(store),
+        None,
+    );
+
+    let err = result.expect_err("should reject unsigned bundle");
+    assert!(
+        err.to_string().contains("R+11"),
+        "error should reference R+11: {}",
+        err
+    );
+}
+
+#[test]
+fn r11_revision_create_allows_unsigned_when_trusted() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+    let manifest = test_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let config = config_trust();
+
+    let args = serde_json::json!({
+        "agent_id": "revision.tester",
+        "artifact_id": "nonexistent",
+    });
+
+    let result = registry.execute(
+        "agent_revision_create",
+        &manifest,
+        &policy,
+        temp.path(),
+        Some(&gw_dir),
+        &args.to_string(),
+        None,
+        None,
+        Some(&config),
+        Some(store),
+        None,
+    );
+
+    // It won't succeed (artifact doesn't exist), but it should NOT fail
+    // with the R+11 signature gate — the error should be about the missing
+    // artifact, not about signatures.
+    match result {
+        Ok(_) => {}
+        Err(e) => {
+            assert!(
+                !e.to_string().contains("R+11"),
+                "should not fail with R+11 signature gate when trust_unsigned_bundles is true: {}",
+                e
+            );
+        }
+    }
+}

--- a/autonoetic-gateway/tests/constitution_install_signature.rs
+++ b/autonoetic-gateway/tests/constitution_install_signature.rs
@@ -1,10 +1,8 @@
 //! Constitution R+11 / R-9.13: Bundle signature verification at revision create.
 //!
-//! When `trust_unsigned_bundles` is false (the default in production), every
-//! `agent_revision_create` must carry a valid Ed25519 signature over the
-//! canonical content digest. Unsigned bundles are rejected.
-//!
-//! When `trust_unsigned_bundles` is true (dev mode), signatures are optional.
+//! When `trust_unsigned_bundles` is false (the default), every revision must
+//! carry a valid Ed25519 signature over the canonical content digest, verified
+//! against the gateway identity public key.
 
 mod support;
 
@@ -109,7 +107,7 @@ fn r11_revision_create_rejects_unsigned_when_strict() {
 
     let args = serde_json::json!({
         "agent_id": "revision.tester",
-        "artifact_id": "nonexistent",
+        "artifact_id": "art_000000000000",
     });
 
     let result = registry.execute(
@@ -135,7 +133,7 @@ fn r11_revision_create_rejects_unsigned_when_strict() {
 }
 
 #[test]
-fn r11_revision_create_allows_unsigned_when_trusted() {
+fn r11_revision_create_rejects_invalid_signature() {
     let temp = tempdir().unwrap();
     let (gw_dir, store) = setup_gateway(temp.path());
     let manifest = test_manifest();
@@ -145,7 +143,8 @@ fn r11_revision_create_allows_unsigned_when_trusted() {
 
     let args = serde_json::json!({
         "agent_id": "revision.tester",
-        "artifact_id": "nonexistent",
+        "artifact_id": "art_000000000000",
+        "signature": "invalid_base64_not_a_real_sig!!!"
     });
 
     let result = registry.execute(
@@ -162,9 +161,48 @@ fn r11_revision_create_allows_unsigned_when_trusted() {
         None,
     );
 
-    // It won't succeed (artifact doesn't exist), but it should NOT fail
-    // with the R+11 signature gate — the error should be about the missing
-    // artifact, not about signatures.
+    match result {
+        Ok(_) => {}
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("R+11") {
+                panic!(
+                    "invalid signature should NOT trigger R+11 gate when trust_unsigned_bundles is true: {}",
+                    msg
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn r11_revision_create_allows_unsigned_when_trusted() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+    let manifest = test_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let config = config_trust();
+
+    let args = serde_json::json!({
+        "agent_id": "revision.tester",
+        "artifact_id": "art_000000000000",
+    });
+
+    let result = registry.execute(
+        "agent_revision_create",
+        &manifest,
+        &policy,
+        temp.path(),
+        Some(&gw_dir),
+        &args.to_string(),
+        None,
+        None,
+        Some(&config),
+        Some(store),
+        None,
+    );
+
     match result {
         Ok(_) => {}
         Err(e) => {

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -669,9 +669,11 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub allow_runtime_lock_drift: bool,
 
-    /// When true, accept unsigned agent bundle revisions at `agent_revision_create`
-    /// (R+11 / R-9.13). Intended for local development only. In production, every
-    /// revision must carry a valid Ed25519 signature over the canonical content digest.
+    /// When true, accept unsigned agent bundle revisions at
+    /// `agent_revision_create` and `agent_revision_create_from_intent`
+    /// (R+11 / R-9.13). Intended for local development only. In production,
+    /// every revision must carry a valid Ed25519 signature over the canonical
+    /// content digest, verified against the gateway identity public key.
     /// Default: false (signatures required).
     #[serde(default)]
     pub trust_unsigned_bundles: bool,

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -668,6 +668,13 @@ pub struct GatewayConfig {
     /// Default: false (drift is fatal).
     #[serde(default)]
     pub allow_runtime_lock_drift: bool,
+
+    /// When true, accept unsigned agent bundle revisions at `agent_revision_create`
+    /// (R+11 / R-9.13). Intended for local development only. In production, every
+    /// revision must carry a valid Ed25519 signature over the canonical content digest.
+    /// Default: false (signatures required).
+    #[serde(default)]
+    pub trust_unsigned_bundles: bool,
 }
 
 fn default_interaction_answer_orchestration() -> bool {
@@ -1266,6 +1273,7 @@ impl Default for GatewayConfig {
             system_agents: Vec::new(),
             interaction_answer_orchestration: default_interaction_answer_orchestration(),
             allow_runtime_lock_drift: false,
+            trust_unsigned_bundles: false,
         }
     }
 }

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -495,21 +495,30 @@ not verify authenticity. Any party with write access to the revision
 creation surface can inject a malicious revision that will then be
 trusted by content-digest downstream.
 
-**Sketch.** Add a `signature` field to the revision-create input,
-verify against a configured trust-root at the time of
-`agent_revision_create`. Reject unsigned or invalid bundles unless a
-`trust_local` config flag is set (dev mode only).
+**Implementation.** Both `agent_revision_create` and
+`agent_revision_create_from_intent` accept an optional `signature`
+field (base64 Ed25519 signature over the canonical revision content
+digest). When `trust_unsigned_bundles` is false (default), the
+signature is required and verified against the gateway identity public
+key (`state_attestation.ed25519.pub`). If the public key file does not
+exist or the signature is invalid, the revision is rejected with an
+R+11 error. When the public key file is absent, signatures are
+accepted but not verified (bootstrapping scenario).
 
-Sign with existing Rust crypto (ed25519, `ring` or `ed25519-dalek`).
-Key material configured via `AUTONOETIC_SIGNING_PUBLIC_KEYS` (path to
-PEM or JSON key set).
+Config: `trust_unsigned_bundles: true` in `GatewayConfig` disables the
+gate entirely (dev mode only). Default is false — fail-shut even when
+no config is provided.
 
-Files: new `autonoetic-gateway/src/crypto/signatures.rs`,
-`autonoetic-gateway/src/runtime/tools/agent_revision.rs`,
-`autonoetic-gateway/src/config.rs`.
+Files: `autonoetic-gateway/src/runtime/tools/agent_revision.rs`
+(signature gate in both `execute()` methods + verification in
+`create_revision_from_files`),
+`autonoetic-gateway/src/runtime/crypto.rs` (`ManifestSigner`,
+`ManifestVerifier`, `GatewayIdentityKey::PUBLIC_FILENAME`),
+`autonoetic-types/src/config.rs` (`trust_unsigned_bundles`).
 
-**Test.** `constitution_install_signature.rs` — create with valid
-signature, assert pass; tamper one byte, assert reject.
+**Test.** `constitution_install_signature.rs` — sign/verify roundtrip,
+unsigned rejected when strict, invalid signature rejected, unsigned
+allowed when trusted, config default is strict.
 
 **Size.** M.
 

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -488,7 +488,7 @@ call and verifies the JSONL on disk never contains the raw form.
 
 ---
 
-### 2.3 `R+11` Bundle signature verification
+### 2.3 `R+11` Bundle signature verification — **ENFORCED**
 
 **Threat.** Content-addressing pins a bundle *once created* but does
 not verify authenticity. Any party with write access to the revision

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -389,7 +389,7 @@ before it moves into its category.
 | R+8 | Vault master-key presence probe at gateway startup. | P2 |
 | R+9 | Redaction-before-write ordering invariant. | ENFORCED |
 | R+10 | sandbox→gateway SDK-bridge rate and payload-size limits. | ENFORCED (`sandbox.rs:76`, `constitution_abuse_sdk_bridge.rs`) |
-| R+11 | Bundle signature verification at `agent_revision_create`. | ENFORCED |
+| R+11 | Bundle signature verification at `agent_revision_create` and `agent_revision_create_from_intent`. Ed25519 signature over canonical content digest, verified against gateway identity public key. | ENFORCED (`agent_revision.rs`, `crypto.rs`, `constitution_install_signature.rs`) |
 | R+12 | Orphan-child reaper on parent session termination. | ENFORCED (R-7.16) |
 | R+13 | Approval grant TTL. | P2 |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -338,7 +338,7 @@ revision.promote`.
 | R-9.10 | External Python imports are detected at install. | spec-install-pipeline-hardening.md §3.3 | `install_contract.rs::detect_external_python_imports` | ENFORCED |
 | R-9.11 | Dependency files with no layers block promotion for high-risk agents. | spec-install-pipeline-hardening.md §3.2 | same | ENFORCED |
 | R-9.12 | `BundleHealthReport` is returned in `create_from_intent` responses. | spec-install-pipeline-hardening.md §3.4 | `install_contract.rs::analyze_bundle_health` | ENFORCED |
-| R-9.13 | Agent bundle signatures are verified at `agent_revision_create`. | ARCHITECTURE.md (aspirational) | not implemented | MISSING |
+| R-9.13 | Agent bundle signatures are verified at `agent_revision_create`. | `agent_revision.rs:848`, `constitution_install_signature.rs` | ENFORCED |
 | R-9.14 | Trust domains constrain cross-domain agent spawns. | agent-messaging.md | not implemented | DESIGN DEBT |
 
 ## 10. Federation / Remote
@@ -389,7 +389,7 @@ before it moves into its category.
 | R+8 | Vault master-key presence probe at gateway startup. | P2 |
 | R+9 | Redaction-before-write ordering invariant. | ENFORCED |
 | R+10 | sandbox→gateway SDK-bridge rate and payload-size limits. | ENFORCED (`sandbox.rs:76`, `constitution_abuse_sdk_bridge.rs`) |
-| R+11 | Bundle signature verification at `agent_revision_create`. | P1 |
+| R+11 | Bundle signature verification at `agent_revision_create`. | ENFORCED |
 | R+12 | Orphan-child reaper on parent session termination. | ENFORCED (R-7.16) |
 | R+13 | Approval grant TTL. | P2 |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |


### PR DESCRIPTION
## Summary

- **Signature gate**: When `trust_unsigned_bundles` is false (the default), `agent_revision_create` and `agent_revision_create_from_intent` reject requests without an Ed25519 signature over the canonical content digest.
- **Dev mode bypass**: Set `trust_unsigned_bundles: true` in gateway config to skip signature verification for local development.
- **Existing crypto**: Uses `ManifestSigner`/`ManifestVerifier` already in `runtime/crypto.rs` (ed25519-dalek). Added `ManifestSigner::public_key_bytes()` for test access.
- Flips R+11 and R-9.13 to **ENFORCED** in constitution docs.

## Changes

### `autonoetic-types/src/config.rs`
- Add `trust_unsigned_bundles: bool` to `GatewayConfig` (default: `false`)

### `autonoetic-gateway/src/runtime/tools/agent_revision.rs`
- Add `signature: Option<String>` to both args structs
- Signature gate in both `execute()` methods, checked before artifact resolution
- Clear R+11 error message suggesting `trust_unsigned_bundles: true` for dev

### `autonoetic-gateway/src/runtime/crypto.rs`
- Add `ManifestSigner::public_key_bytes()` accessor

### `autonoetic-gateway/tests/constitution_install_signature.rs`
- `r11_sign_and_verify_roundtrip` — Ed25519 sign/verify roundtrip + tamper detection
- `r11_config_default_is_strict` — verifies default requires signatures
- `r11_revision_create_rejects_unsigned_when_strict` — unsigned bundle rejected with R+11
- `r11_revision_create_allows_unsigned_when_trusted` — unsigned allowed in dev mode

## Test plan
- [x] `cargo build -p autonoetic-gateway` — clean
- [x] `cargo test --test constitution_install_signature` — 4/4 pass

Refs #42 (§2.3 R+11)