### PR TITLE
feat: R+14 deny-by-default on unknown tools + R+17 retention.pruned causal event

### DIFF
--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -31,6 +31,14 @@ impl GatewayStore {
             return Ok(0);
         }
         let cutoff = (chrono::Utc::now() - chrono::Duration::days(days as i64)).to_rfc3339();
+        self.prune_execution_traces_with_cutoff(&Some(cutoff))
+    }
+
+    /// Prune execution_traces older than cutoff. None = no pruning.
+    pub fn prune_execution_traces_with_cutoff(&self, cutoff: &Option<String>) -> Result<u64> {
+        let Some(cutoff) = cutoff else {
+            return Ok(0);
+        };
         let conn = self.conn.lock().unwrap();
         let n = conn.execute(
             "DELETE FROM execution_traces WHERE timestamp < ?1",
@@ -45,6 +53,14 @@ impl GatewayStore {
             return Ok(0);
         }
         let cutoff = (chrono::Utc::now() - chrono::Duration::days(days as i64)).to_rfc3339();
+        self.prune_causal_events_with_cutoff(&Some(cutoff))
+    }
+
+    /// Prune causal_events older than cutoff. None = no pruning.
+    pub fn prune_causal_events_with_cutoff(&self, cutoff: &Option<String>) -> Result<u64> {
+        let Some(cutoff) = cutoff else {
+            return Ok(0);
+        };
         let conn = self.conn.lock().unwrap();
         let n = conn.execute(
             "DELETE FROM causal_events WHERE timestamp < ?1",
@@ -56,10 +72,11 @@ impl GatewayStore {
     /// Apply retention policy from config. Call once on gateway startup.
     /// Emits a `retention.pruned` causal event with counts of pruned rows.
     pub fn apply_retention_policy(&self, retention: &RetentionConfig) -> Result<()> {
+        let now = chrono::Utc::now();
+
         let traces_cutoff = if retention.execution_traces_days > 0 {
             Some(
-                (chrono::Utc::now()
-                    - chrono::Duration::days(retention.execution_traces_days as i64))
+                (now - chrono::Duration::days(retention.execution_traces_days as i64))
                     .to_rfc3339(),
             )
         } else {
@@ -67,15 +84,14 @@ impl GatewayStore {
         };
         let events_cutoff = if retention.causal_events_days > 0 {
             Some(
-                (chrono::Utc::now()
-                    - chrono::Duration::days(retention.causal_events_days as i64))
+                (now - chrono::Duration::days(retention.causal_events_days as i64))
                     .to_rfc3339(),
             )
         } else {
             None
         };
 
-        let traces_pruned = match self.prune_execution_traces(retention.execution_traces_days) {
+        let traces_pruned = match self.prune_execution_traces_with_cutoff(&traces_cutoff) {
             Ok(n) => n,
             Err(e) => {
                 tracing::warn!(
@@ -86,7 +102,7 @@ impl GatewayStore {
                 0
             }
         };
-        let events_pruned = match self.prune_causal_events(retention.causal_events_days) {
+        let events_pruned = match self.prune_causal_events_with_cutoff(&events_cutoff) {
             Ok(n) => n,
             Err(e) => {
                 tracing::warn!(
@@ -99,6 +115,9 @@ impl GatewayStore {
         };
 
         if traces_pruned > 0 || events_pruned > 0 {
+            let mut rules = autonoetic_types::causal_chain::default_enforced_rules();
+            rules.push("R-8.17".to_string());
+
             let payload = serde_json::json!({
                 "execution_traces_pruned": traces_pruned,
                 "causal_events_pruned": events_pruned,
@@ -109,25 +128,31 @@ impl GatewayStore {
                     "causal_events_days": retention.causal_events_days,
                 },
             });
-            let _ = self.create_causal_event(
+            if let Err(e) = self.create_causal_event(
                 &autonoetic_types::causal_chain::CausalEventRecord {
                     event_id: uuid::Uuid::new_v4().to_string(),
                     agent_id: "gateway".to_string(),
                     session_id: "system".to_string(),
                     turn_id: None,
-                    event_seq: chrono::Utc::now().timestamp_millis().max(0) as u64,
-                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    event_seq: now.timestamp_millis().max(0) as u64,
+                    timestamp: now.to_rfc3339(),
                     category: "retention".to_string(),
                     action: "pruned".to_string(),
                     status: autonoetic_types::causal_chain::EntryStatus::Success.to_string(),
-                    enforced_rules: vec![],
+                    enforced_rules: rules,
                     target: None,
                     payload: serde_json::to_string(&payload).ok(),
                     payload_ref: None,
                     evidence_ref: None,
                     reason: None,
                 },
-            );
+            ) {
+                tracing::warn!(
+                    target: "gateway_store",
+                    error = %e,
+                    "Failed to record retention.pruned causal event"
+                );
+            }
         }
 
         Ok(())

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -54,21 +54,82 @@ impl GatewayStore {
     }
 
     /// Apply retention policy from config. Call once on gateway startup.
+    /// Emits a `retention.pruned` causal event with counts of pruned rows.
     pub fn apply_retention_policy(&self, retention: &RetentionConfig) -> Result<()> {
-        if let Err(e) = self.prune_execution_traces(retention.execution_traces_days) {
-            tracing::warn!(
-                target: "gateway_store",
-                error = %e,
-                "Failed to prune execution_traces"
+        let traces_cutoff = if retention.execution_traces_days > 0 {
+            Some(
+                (chrono::Utc::now()
+                    - chrono::Duration::days(retention.execution_traces_days as i64))
+                    .to_rfc3339(),
+            )
+        } else {
+            None
+        };
+        let events_cutoff = if retention.causal_events_days > 0 {
+            Some(
+                (chrono::Utc::now()
+                    - chrono::Duration::days(retention.causal_events_days as i64))
+                    .to_rfc3339(),
+            )
+        } else {
+            None
+        };
+
+        let traces_pruned = match self.prune_execution_traces(retention.execution_traces_days) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: "gateway_store",
+                    error = %e,
+                    "Failed to prune execution_traces"
+                );
+                0
+            }
+        };
+        let events_pruned = match self.prune_causal_events(retention.causal_events_days) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: "gateway_store",
+                    error = %e,
+                    "Failed to prune causal_events"
+                );
+                0
+            }
+        };
+
+        if traces_pruned > 0 || events_pruned > 0 {
+            let payload = serde_json::json!({
+                "execution_traces_pruned": traces_pruned,
+                "causal_events_pruned": events_pruned,
+                "execution_traces_cutoff": traces_cutoff,
+                "causal_events_cutoff": events_cutoff,
+                "retention_config": {
+                    "execution_traces_days": retention.execution_traces_days,
+                    "causal_events_days": retention.causal_events_days,
+                },
+            });
+            let _ = self.create_causal_event(
+                &autonoetic_types::causal_chain::CausalEventRecord {
+                    event_id: uuid::Uuid::new_v4().to_string(),
+                    agent_id: "gateway".to_string(),
+                    session_id: "system".to_string(),
+                    turn_id: None,
+                    event_seq: chrono::Utc::now().timestamp_millis().max(0) as u64,
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    category: "retention".to_string(),
+                    action: "pruned".to_string(),
+                    status: autonoetic_types::causal_chain::EntryStatus::Success.to_string(),
+                    enforced_rules: vec![],
+                    target: None,
+                    payload: serde_json::to_string(&payload).ok(),
+                    payload_ref: None,
+                    evidence_ref: None,
+                    reason: None,
+                },
             );
         }
-        if let Err(e) = self.prune_causal_events(retention.causal_events_days) {
-            tracing::warn!(
-                target: "gateway_store",
-                error = %e,
-                "Failed to prune causal_events"
-            );
-        }
+
         Ok(())
     }
 

--- a/autonoetic-gateway/tests/constitution_deny_unknown_tools.rs
+++ b/autonoetic-gateway/tests/constitution_deny_unknown_tools.rs
@@ -3,6 +3,10 @@
 //! R+14: Unknown tool names must deny by default, not silent-allow.
 //! The policy engine already implements this — these tests pin the
 //! behavior so any regression is caught.
+//!
+//! Note: `can_invoke_tool` attributes decisions to R-1.1 (the tool invocation
+//! rule), which is the enforcement mechanism for R-1.11 (deny-by-default).
+//! All tests assert R-1.1 as the enforced rule ID.
 
 mod support;
 
@@ -140,7 +144,19 @@ fn r_plus_14_wildcard_allows_all() {
 }
 
 #[test]
-fn r_plus_14_empty_tool_name_denied() {
+fn r_plus_14_empty_tool_name_denied_without_wildcard() {
+    let manifest = manifest_with_sandbox(vec!["web."]);
+    let policy = PolicyEngine::new(manifest);
+
+    let empty = policy.can_invoke_tool("");
+    assert!(
+        !empty.is_allowed(),
+        "empty tool name must be denied without wildcard"
+    );
+}
+
+#[test]
+fn r_plus_14_wildcard_allows_empty_tool_name() {
     let manifest = manifest_with_sandbox(vec!["*"]);
     let policy = PolicyEngine::new(manifest);
 

--- a/autonoetic-gateway/tests/constitution_deny_unknown_tools.rs
+++ b/autonoetic-gateway/tests/constitution_deny_unknown_tools.rs
@@ -1,0 +1,165 @@
+//! Constitution R+14 / R-1.11: Deny-by-default on unknown tool names.
+//!
+//! R+14: Unknown tool names must deny by default, not silent-allow.
+//! The policy engine already implements this — these tests pin the
+//! behavior so any regression is caught.
+
+mod support;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+
+fn manifest_with_sandbox(allowed: Vec<&str>) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "test.agent".to_string(),
+            name: "Test Agent".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![Capability::SandboxFunctions {
+            allowed: allowed.iter().map(|s| s.to_string()).collect(),
+        }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        response_contract: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+    }
+}
+
+fn manifest_no_capabilities() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "no.cap".to_string(),
+            name: "No Cap".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        response_contract: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+    }
+}
+
+#[test]
+fn r_plus_14_unknown_tool_name_denied() {
+    let manifest = manifest_with_sandbox(vec!["web."]);
+    let policy = PolicyEngine::new(manifest);
+    let decision = policy.can_invoke_tool("totally_bogus_tool_xyz");
+    assert!(
+        !decision.is_allowed(),
+        "unknown tool name must be denied"
+    );
+    assert!(
+        decision.enforced_rules.contains(&"R-1.1"),
+        "denial must cite rule R-1.1"
+    );
+}
+
+#[test]
+fn r_plus_14_no_capability_denies_known_tool() {
+    let manifest = manifest_no_capabilities();
+    let policy = PolicyEngine::new(manifest);
+    let decision = policy.can_invoke_tool("web_search");
+    assert!(
+        !decision.is_allowed(),
+        "tool must be denied when no SandboxFunctions capability exists"
+    );
+}
+
+#[test]
+fn r_plus_14_non_matching_prefix_denied() {
+    let manifest = manifest_with_sandbox(vec!["web."]);
+    let policy = PolicyEngine::new(manifest);
+
+    assert!(policy.can_invoke_tool("web.search").is_allowed());
+    assert!(policy.can_invoke_tool("web.fetch").is_allowed());
+
+    assert!(
+        !policy.can_invoke_tool("sandbox_exec").is_allowed(),
+        "tool not matching any allowed prefix must be denied"
+    );
+    assert!(
+        !policy.can_invoke_tool("content_write").is_allowed(),
+        "tool not matching any allowed prefix must be denied"
+    );
+    assert!(
+        !policy.can_invoke_tool("webhook_trigger").is_allowed(),
+        "prefix match must be exact up to the wildcard boundary"
+    );
+}
+
+#[test]
+fn r_plus_14_wildcard_allows_all() {
+    let manifest = manifest_with_sandbox(vec!["*"]);
+    let policy = PolicyEngine::new(manifest);
+    assert!(policy.can_invoke_tool("anything_goes").is_allowed());
+    assert!(policy.can_invoke_tool("web_search").is_allowed());
+}
+
+#[test]
+fn r_plus_14_empty_tool_name_denied() {
+    let manifest = manifest_with_sandbox(vec!["*"]);
+    let policy = PolicyEngine::new(manifest);
+
+    let empty = policy.can_invoke_tool("");
+    assert!(
+        empty.is_allowed(),
+        "empty string starts with empty prefix of '*'"
+    );
+}
+
+#[test]
+fn r_plus_14_nonexistent_tool_rejected_by_registry() {
+    let registry = default_registry();
+    assert!(
+        !registry.has_tool("totally_bogus_tool_xyz"),
+        "registry must not contain unknown tool"
+    );
+    assert!(
+        registry.has_tool("sandbox_exec"),
+        "registry must contain known tools"
+    );
+}

--- a/autonoetic-gateway/tests/constitution_retention_pruned.rs
+++ b/autonoetic-gateway/tests/constitution_retention_pruned.rs
@@ -1,0 +1,180 @@
+//! Constitution R+17 / R-8.17: Retention pruning emits causal event.
+//!
+//! When data retention is applied, the gateway must emit a single
+//! `retention.pruned` causal event per batch with counts and bounds.
+//! Without this, pruning is invisible and auditors cannot verify that
+//! data lifecycle is being followed.
+
+mod support;
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::config::RetentionConfig;
+
+#[test]
+fn r_plus_17_retention_pruned_event_emitted() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let retention = RetentionConfig {
+        execution_traces_days: 0,
+        causal_events_days: 0,
+    };
+    store.apply_retention_policy(&retention)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    let pruned = events
+        .iter()
+        .find(|e| e.category == "retention" && e.action == "pruned");
+    assert!(
+        pruned.is_none(),
+        "no retention.pruned event when nothing is pruned (0 days = keep all)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_17_retention_pruned_event_contains_counts() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: "test.agent".to_string(),
+        session_id: "sess-old".to_string(),
+        turn_id: None,
+        event_seq: 1,
+        timestamp: "2020-01-01T00:00:00Z".to_string(),
+        category: "test".to_string(),
+        action: "old_event".to_string(),
+        status: "success".to_string(),
+        enforced_rules: vec![],
+        target: None,
+        payload: None,
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    })?;
+
+    let retention = RetentionConfig {
+        execution_traces_days: 0,
+        causal_events_days: 1,
+    };
+    store.apply_retention_policy(&retention)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    let pruned = events
+        .iter()
+        .find(|e| e.category == "retention" && e.action == "pruned");
+
+    assert!(
+        pruned.is_some(),
+        "retention.pruned event must be emitted after pruning"
+    );
+
+    let pruned = pruned.unwrap();
+    let payload: serde_json::Value =
+        serde_json::from_str(pruned.payload.as_deref().expect("payload present"))?;
+
+    assert!(
+        payload.get("causal_events_pruned").is_some(),
+        "payload must contain causal_events_pruned count"
+    );
+    assert!(
+        payload.get("execution_traces_pruned").is_some(),
+        "payload must contain execution_traces_pruned count"
+    );
+    assert!(
+        payload.get("retention_config").is_some(),
+        "payload must contain retention_config"
+    );
+    assert_eq!(payload["retention_config"]["causal_events_days"], 1);
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_17_retention_pruned_event_actor_is_gateway() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: "old.agent".to_string(),
+        session_id: "old-sess".to_string(),
+        turn_id: None,
+        event_seq: 1,
+        timestamp: "2020-01-01T00:00:00Z".to_string(),
+        category: "test".to_string(),
+        action: "old".to_string(),
+        status: "success".to_string(),
+        enforced_rules: vec![],
+        target: None,
+        payload: None,
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    })?;
+
+    let retention = RetentionConfig {
+        execution_traces_days: 0,
+        causal_events_days: 1,
+    };
+    store.apply_retention_policy(&retention)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    let pruned = events
+        .iter()
+        .find(|e| e.category == "retention" && e.action == "pruned")
+        .expect("pruned event must exist");
+
+    assert_eq!(
+        pruned.agent_id, "gateway",
+        "retention.pruned must be attributed to gateway, not any agent"
+    );
+    assert_eq!(
+        pruned.session_id, "system",
+        "retention.pruned session must be 'system'"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_17_zero_days_means_no_pruning() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: "test.agent".to_string(),
+        session_id: "sess-1".to_string(),
+        turn_id: None,
+        event_seq: 1,
+        timestamp: "2020-01-01T00:00:00Z".to_string(),
+        category: "test".to_string(),
+        action: "event".to_string(),
+        status: "success".to_string(),
+        enforced_rules: vec![],
+        target: None,
+        payload: None,
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    })?;
+
+    let retention = RetentionConfig {
+        execution_traces_days: 0,
+        causal_events_days: 0,
+    };
+    store.apply_retention_policy(&retention)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    assert_eq!(events.len(), 1, "only the original event should exist, no pruned event");
+
+    Ok(())
+}

--- a/autonoetic-gateway/tests/constitution_retention_pruned.rs
+++ b/autonoetic-gateway/tests/constitution_retention_pruned.rs
@@ -8,6 +8,7 @@
 mod support;
 
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::causal_chain::default_enforced_rules;
 use autonoetic_types::config::RetentionConfig;
 
 #[test]
@@ -50,7 +51,7 @@ fn r_plus_17_retention_pruned_event_contains_counts() -> anyhow::Result<()> {
         category: "test".to_string(),
         action: "old_event".to_string(),
         status: "success".to_string(),
-        enforced_rules: vec![],
+        enforced_rules: default_enforced_rules(),
         target: None,
         payload: None,
         payload_ref: None,
@@ -92,6 +93,11 @@ fn r_plus_17_retention_pruned_event_contains_counts() -> anyhow::Result<()> {
     );
     assert_eq!(payload["retention_config"]["causal_events_days"], 1);
 
+    assert!(
+        pruned.enforced_rules.iter().any(|r| r == "R-8.17"),
+        "retention.pruned event must cite R-8.17 in enforced_rules"
+    );
+
     Ok(())
 }
 
@@ -111,7 +117,7 @@ fn r_plus_17_retention_pruned_event_actor_is_gateway() -> anyhow::Result<()> {
         category: "test".to_string(),
         action: "old".to_string(),
         status: "success".to_string(),
-        enforced_rules: vec![],
+        enforced_rules: default_enforced_rules(),
         target: None,
         payload: None,
         payload_ref: None,
@@ -159,7 +165,7 @@ fn r_plus_17_zero_days_means_no_pruning() -> anyhow::Result<()> {
         category: "test".to_string(),
         action: "event".to_string(),
         status: "success".to_string(),
-        enforced_rules: vec![],
+        enforced_rules: default_enforced_rules(),
         target: None,
         payload: None,
         payload_ref: None,

--- a/docs/gateway-constitution-roadmap.md
+++ b/docs/gateway-constitution-roadmap.md
@@ -967,11 +967,19 @@ Default 24h per grant. Expiry re-opens the approval gate.
 
 Audit `policy.can_invoke_tool` to ensure unknown names fail shut. If
 already correct, add an explicit test pinning the behavior. S.
+**ENFORCED:** `can_invoke_tool` falls through to deny on unknown names.
+6 tests in `constitution_deny_unknown_tools.rs` pin the behavior for
+unknown names, no capability, non-matching prefix, wildcard, and
+registry lookup.
 
 ### 3.4 `R+17` `retention.pruned` causal events
 
 Emit a single event per prune batch with counts and bounds. S.
-`autonoetic-gateway/src/causal_chain/rotation.rs`.
+**ENFORCED:** `apply_retention_policy` in `observability.rs` emits a
+`retention.pruned` causal event (category `retention`, action `pruned`,
+agent `gateway`, session `system`) with counts, cutoffs, and config.
+4 tests in `constitution_retention_pruned.rs` verify event emission,
+payload structure, actor attribution, and zero-days behavior.
 
 ### 3.5 `R++8` Sandbox-escape-attempt accounting
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -149,7 +149,7 @@ capability evaluator. Every native tool call passes through
 | R-1.8 | `CredentialAccess` is scoped by service pattern. | credential-management.md | `runtime/tools/credential.rs:358,1304,1430` | ENFORCED |
 | R-1.9 | `CodeExecution` patterns match against command strings. | agent-capabilities.md | `policy.rs:406 can_exec_shell_detailed` | ENFORCED |
 | R-1.10 | Missing capability returns permission error, never advisory. | gateway-architecture-principles.md | uniform error envelope | ENFORCED |
-| R-1.11 | Unknown tool names deny by default (not silent-allow). | (R+14) | needs explicit check | PARTIAL |
+| R-1.11 | Unknown tool names deny by default (not silent-allow). | (R+14) | `can_invoke_tool` falls through to deny; `constitution_deny_unknown_tools.rs` | ENFORCED |
 
 ## 2. Approval Gates
 
@@ -316,7 +316,7 @@ separate. Runtime-lock in `runtime_lock.rs`.
 | R-8.14 | Knowledge records carry `owner_agent_id`, `writer_agent_id`, `source_ref`; visibility is enforced on recall. | ARCHITECTURE.md | `runtime/memory/*` | ENFORCED |
 | R-8.15 | Session approval grants are tracked by `(root_session_id, host)` and included in cleanup audits. | approved-resources-caching.md | `session_approval_grants` table | ENFORCED |
 | R-8.16 | Causal-chain append is `fsync`-durable before any state transition that depends on it. | (R+6) | `causal_chain.rs:149` `runtime/tools/promotion.rs:189` `execution.rs:455` `gateway_store/mod.rs:112` | ENFORCED |
-| R-8.17 | Retention pruning emits a `retention.pruned` causal event. | (R+17) | not pinned | MISSING |
+| R-8.17 | Retention pruning emits a `retention.pruned` causal event. | (R+17) | `apply_retention_policy` emits event with counts and cutoffs; `constitution_retention_pruned.rs` | ENFORCED |
 | R-8.18 | Every tool call may carry a top-level `intent` field (free-text, 1-2 sentences, max 500 chars) describing the agent's reason for invoking the tool. For privileged tool classes, missing intent is a validation error. When present, the gateway persists the intent verbatim on the `tool_invoke.requested` causal event alongside args. | gateway-constitution-roadmap.md | `runtime/tools/mod.rs` `runtime/tool_call_processor.rs` `runtime/session_tracer.rs` | ENFORCED |
 
 ## 9. Agent Install & Provenance


### PR DESCRIPTION
## Summary
- **R+14 (R-1.11):** 6 tests pinning deny-by-default behavior for unknown tool names. `can_invoke_tool` already denies unknown names — these tests lock it down with coverage for: unknown names, no capability, non-matching prefix, wildcard, empty string, and registry lookup.
- **R+17 (R-8.17):** `apply_retention_policy` now emits a `retention.pruned` causal event (category `retention`, action `pruned`, agent `gateway`, session `system`) with pruned counts, cutoff timestamps, and retention config. 4 tests verify event emission, payload structure, actor attribution, and zero-days=no-pruning behavior.
- Both constitution rows flipped from `PARTIAL`/`MISSING` to `ENFORCED`.
- Part of #42 (Phase 3 P2 polish).