### PR TITLE
feat: TUI evolutions — policy decision hook, digest linking, artifact_ref, revision signing

### DIFF
--- a/autonoetic-gateway/src/agent/repository.rs
+++ b/autonoetic-gateway/src/agent/repository.rs
@@ -714,6 +714,8 @@ Test instructions.
             status: autonoetic_types::agent_revision::AgentRevisionStatus::Ready,
             metadata_json: serde_json::Value::Null,
             short_id: "abcd1234".to_string(),
+            signature: None,
+            signer_id: None,
         };
         store
             .insert_agent_revision(&rev)

--- a/autonoetic-gateway/src/bootstrap.rs
+++ b/autonoetic-gateway/src/bootstrap.rs
@@ -195,6 +195,8 @@ fn bootstrap_agent_inner(
             "summary": "Bootstrapped from reference agent bundle",
         }),
         short_id: String::new(),
+        signature: None,
+        signer_id: None,
     };
 
     store.insert_agent_revision_transactional(&rev)?;

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -389,6 +389,10 @@ impl GatewayExecutionService {
         hook_exec.set_spawn_tx(spawn_tx);
         let hook_executor = Arc::new(hook_exec);
 
+        if let Some(ref store) = gateway_store {
+            store.set_policy_hook_executor(&hook_executor);
+        }
+
         let svc = Self {
             execution_semaphore: Arc::new(Semaphore::new(config.max_concurrent_spawns.max(1))),
             agent_admission: Arc::new(Mutex::new(HashMap::new())),

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -717,6 +717,17 @@ impl GatewayExecutionService {
             );
         }
 
+        let active_jobs_before_cancel: Vec<_> = store
+            .list_scheduled_jobs_for_root(root_session_id)?
+            .into_iter()
+            .filter(|j| {
+                matches!(
+                    j.status,
+                    autonoetic_types::scheduled_job::ScheduledJobStatus::Active
+                )
+            })
+            .collect();
+
         match store.cancel_scheduled_jobs_for_root(root_session_id) {
             Ok(count) => {
                 details["scheduled_jobs_cancelled"] = serde_json::json!(count);
@@ -726,6 +737,27 @@ impl GatewayExecutionService {
                     jobs_cancelled = count,
                     "Cancelled scheduled jobs during emergency stop"
                 );
+                for j in active_jobs_before_cancel {
+                    if let Err(e) =
+                        crate::scheduler::workflow_store::append_scheduled_job_cancelled_workflow_event(
+                            self.config.as_ref(),
+                            store.as_ref(),
+                            &j.root_session_id,
+                            &j.job_id,
+                            &j.owner_agent_id,
+                            &j.target_agent_id,
+                            &j.cron_expr,
+                            &format!("emergency_stop:{stop_id}"),
+                        )
+                    {
+                        tracing::warn!(
+                            target: "emergency_stop",
+                            error = %e,
+                            job_id = %j.job_id,
+                            "Failed to append scheduled_job.cancelled workflow event"
+                        );
+                    }
+                }
             }
             Err(e) => {
                 tracing::warn!(

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3020,7 +3020,7 @@ fn resolve_context_window_tokens(manifest: &AgentManifest) -> Option<u32> {
 ///
 /// Manifest-declared tiers always take precedence over runtime inference — if an
 /// agent explicitly restricts itself, the restriction is honoured.
-fn determine_tool_tier_filter(
+pub fn determine_tool_tier_filter(
     manifest: &AgentManifest,
     session_id: Option<&str>,
     has_pending_approvals: bool,

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1195,7 +1195,13 @@ impl AgentExecutor {
         if let Some(gw) = self.gateway_dir.as_ref() {
             if self.live_digest.is_none() {
                 let agent_id = &self.manifest.agent.id;
-                match crate::runtime::live_digest::LiveDigestWriter::open(gw, &session_id, agent_id)
+                match crate::runtime::live_digest::LiveDigestWriter::open(
+                    gw,
+                    &session_id,
+                    agent_id,
+                    self.task_id.as_deref(),
+                    self.workflow_id.as_deref(),
+                )
                 {
                     Ok(w) => {
                         self.live_digest = Some(Arc::new(std::sync::Mutex::new(w)));
@@ -3014,7 +3020,7 @@ fn resolve_context_window_tokens(manifest: &AgentManifest) -> Option<u32> {
 ///
 /// Manifest-declared tiers always take precedence over runtime inference — if an
 /// agent explicitly restricts itself, the restriction is honoured.
-pub fn determine_tool_tier_filter(
+fn determine_tool_tier_filter(
     manifest: &AgentManifest,
     session_id: Option<&str>,
     has_pending_approvals: bool,

--- a/autonoetic-gateway/src/runtime/live_digest.rs
+++ b/autonoetic-gateway/src/runtime/live_digest.rs
@@ -32,6 +32,12 @@ pub struct LiveDigestWriter {
     path: PathBuf,
     /// Agent that owns this writer instance.
     agent_id: String,
+    /// Full session id (e.g. `root/child.default-abc`) for digest cross-links.
+    digest_session_id: String,
+    /// Workflow task id when this run is tied to `workflow.spawn` / `workflow.wait`.
+    workflow_task_id: Option<String>,
+    /// Parent workflow id when known.
+    workflow_id: Option<String>,
     /// Nesting depth (0 = root, 1 = child …).
     depth: usize,
     digest_turn_seq: u32,
@@ -108,7 +114,17 @@ fn format_time_hhmmss(timestamp: &str) -> String {
 }
 
 impl LiveDigestWriter {
-    pub fn open(gateway_dir: &Path, session_id: &str, agent_id: &str) -> anyhow::Result<Self> {
+    /// Open a digest writer for `session_id` / `agent_id`.
+    ///
+    /// When this run is part of a workflow, pass `workflow_task_id` / `workflow_id` so the digest
+    /// can show stable cross-links beside each agent section header.
+    pub fn open(
+        gateway_dir: &Path,
+        session_id: &str,
+        agent_id: &str,
+        workflow_task_id: Option<&str>,
+        workflow_id: Option<&str>,
+    ) -> anyhow::Result<Self> {
         let base = base_session_id(session_id);
         let depth = session_depth(session_id);
         let dir = gateway_dir.join("sessions").join(base);
@@ -133,6 +149,9 @@ impl LiveDigestWriter {
         Ok(Self {
             path,
             agent_id: agent_id.to_string(),
+            digest_session_id: session_id.to_string(),
+            workflow_task_id: workflow_task_id.map(str::to_string),
+            workflow_id: workflow_id.map(str::to_string),
             depth,
             digest_turn_seq,
             tools_in_open_turn: 0,
@@ -254,6 +273,26 @@ impl LiveDigestWriter {
             use std::fmt::Write;
             let _ = writeln!(turn, "\n---");
             let _ = writeln!(turn, "### {}", agent_with_emoji);
+            let show_context = self.workflow_task_id.is_some()
+                || self
+                    .workflow_id
+                    .as_ref()
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false)
+                || self.depth > 0;
+            if show_context {
+                let mut parts: Vec<String> = Vec::new();
+                if let Some(tid) = self.workflow_task_id.as_deref() {
+                    parts.push(format!("task `{}`", cell(tid)));
+                }
+                if let Some(wid) = self.workflow_id.as_deref() {
+                    if !wid.is_empty() {
+                        parts.push(format!("workflow `{}`", cell(wid)));
+                    }
+                }
+                parts.push(format!("session `{}`", cell(&self.digest_session_id)));
+                let _ = writeln!(turn, "*Context:* {}", parts.join(" · "));
+            }
             let _ = writeln!(turn);
         }
 
@@ -896,7 +935,7 @@ mod tests {
     fn digest_creates_file_and_turns() {
         let tmp = tempdir().unwrap();
         let gw = tmp.path().join(".gateway");
-        let mut w = LiveDigestWriter::open(&gw, "s1", "agent.a").unwrap();
+        let mut w = LiveDigestWriter::open(&gw, "s1", "agent.a", None, None).unwrap();
         w.start_session("agent.a", "hello task").unwrap();
         w.start_turn().unwrap();
         w.record_action("Called `echo`").unwrap();
@@ -915,11 +954,11 @@ mod tests {
         let tmp = tempdir().unwrap();
         let gw = tmp.path().join(".gateway");
         {
-            let mut w = LiveDigestWriter::open(&gw, "s2", "agent.a").unwrap();
+            let mut w = LiveDigestWriter::open(&gw, "s2", "agent.a", None, None).unwrap();
             w.start_turn().unwrap();
             w.end_turn().unwrap();
         }
-        let mut w2 = LiveDigestWriter::open(&gw, "s2", "agent.a").unwrap();
+        let mut w2 = LiveDigestWriter::open(&gw, "s2", "agent.a", None, None).unwrap();
         w2.start_turn().unwrap();
         w2.end_turn().unwrap();
         let body = std::fs::read_to_string(w2.path()).unwrap();
@@ -933,13 +972,19 @@ mod tests {
         let tmp = tempdir().unwrap();
         let gw = tmp.path().join(".gateway");
 
-        let mut planner = LiveDigestWriter::open(&gw, "root", "planner.default").unwrap();
+        let mut planner = LiveDigestWriter::open(&gw, "root", "planner.default", None, None).unwrap();
         planner.start_turn().unwrap();
         planner.end_turn().unwrap();
 
         {
-            let mut child =
-                LiveDigestWriter::open(&gw, "root/coder.default-1", "coder.default").unwrap();
+            let mut child = LiveDigestWriter::open(
+                &gw,
+                "root/coder.default-1",
+                "coder.default",
+                Some("task-smoke-1"),
+                Some("wf-smoke"),
+            )
+            .unwrap();
             child.start_turn().unwrap();
             child.end_turn().unwrap();
             child.start_turn().unwrap();
@@ -954,6 +999,10 @@ mod tests {
         assert!(body.contains("**Turn 2**"));
         assert!(body.contains("**Turn 3**"));
         assert!(body.contains("**Turn 4**"));
+        assert!(
+            body.contains("*Context:* task `task-smoke-1` · workflow `wf-smoke` · session `root/coder.default-1`"),
+            "child section should link task, workflow, and session: {body}"
+        );
     }
 
     #[test]
@@ -978,7 +1027,7 @@ mod tests {
     fn digest_redacts_secret_like_annotation() {
         let tmp = tempdir().unwrap();
         let gw = tmp.path().join(".gateway");
-        let mut w = LiveDigestWriter::open(&gw, "s3", "agent.a").unwrap();
+        let mut w = LiveDigestWriter::open(&gw, "s3", "agent.a", None, None).unwrap();
         w.start_turn().unwrap();
         w.record_annotation("observation", "Authorization: Bearer top-secret-value")
             .unwrap();

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -680,9 +680,10 @@ fn create_revision_from_files(
     });
 
     if let Some(obj) = response_obj.as_object_mut() {
-        if let Some(sig) = &rev.signature {
-            obj.insert("signed_by".to_string(), serde_json::json!(rev.signer_id));
-            let _ = sig;
+        if rev.signature.is_some() {
+            if let Some(ref signer_id) = rev.signer_id {
+                obj.insert("signed_by".to_string(), serde_json::json!(signer_id));
+            }
         }
     }
 

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -369,8 +369,6 @@ fn parse_frontmatter_capabilities(
     summary: Option<String>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
-    #[serde(default)]
-    signature: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -404,8 +402,6 @@ struct RevisionCreateFromIntentArgs {
     summary: Option<String>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
-    #[serde(default)]
-    signature: Option<String>,
 }
 
 #[derive(Debug)]
@@ -417,7 +413,6 @@ struct RevisionCreateCommonArgs {
     metadata: Option<serde_json::Value>,
     source_kind: String,
     source_ref: Option<String>,
-    signature: Option<String>,
 }
 
 #[derive(Debug)]
@@ -534,7 +529,6 @@ fn create_revision_from_files(
     skill_content: &[u8],
     health_report: Option<&crate::runtime::install_contract::BundleHealthReport>,
     script_entry: Option<&str>,
-    artifact_content_digest: Option<&str>,
     config: Option<&GatewayConfig>,
 ) -> anyhow::Result<PersistedRevisionResult> {
     let expected_layers = bundle.map(expected_locked_layers).unwrap_or_default();
@@ -567,30 +561,32 @@ fn create_revision_from_files(
     let runtime_lock_hash = format!("sha256:{}", sha256_hex(&canonical_lock_bytes));
     let revision_digest_hex = compute_revision_content_digest_hex(file_map);
     let revision_id = format!("rev_sha256:{}", revision_digest_hex);
-    let content_digest = artifact_content_digest
-        .map(|d| d.to_string())
-        .unwrap_or_else(|| format!("sha256:{}", revision_digest_hex));
+    let content_digest = format!("sha256:{}", revision_digest_hex);
 
-    if let Some(sig) = &common.signature {
-        let pub_path = gateway_dir.join(crate::runtime::crypto::GatewayIdentityKey::PUBLIC_FILENAME);
-        if pub_path.exists() {
-            let pub_bytes = std::fs::read(&pub_path)?;
-            if pub_bytes.len() == 32 {
-                let mut pk = [0u8; 32];
-                pk.copy_from_slice(&pub_bytes);
-                let valid = crate::runtime::crypto::ManifestVerifier::verify(
-                    &pk,
-                    &revision_digest_hex,
-                    sig,
-                )?;
-                anyhow::ensure!(
-                    valid,
-                    "R+11: Bundle signature verification failed — signature does not match \
-                     the canonical content digest. Tampered or mis-signed bundle."
+    let (signature, signer_id) = match crate::runtime::crypto::GatewayIdentityKey::load_or_generate(gateway_dir) {
+        Ok(key) => {
+            let sig = key.sign(revision_digest_hex.as_bytes());
+            let fp = format!("gateway:{}", key.fingerprint());
+            (Some(sig), Some(fp))
+        }
+        Err(e) => {
+            let trust_unsigned = config.map_or(false, |c| c.trust_unsigned_bundles);
+            if trust_unsigned {
+                tracing::warn!(
+                    target: "revision",
+                    error = %e,
+                    "R+11: Gateway identity key unavailable, proceeding unsigned (trust_unsigned_bundles)"
                 );
+                (None, None)
+            } else {
+                return Err(anyhow::anyhow!(
+                    "R+11: Failed to load gateway identity key for auto-signing: {}. \
+                     Set trust_unsigned_bundles: true in config for local development.",
+                    e
+                ));
             }
         }
-    }
+    };
 
     if let Some(existing_rev) = gateway_store.get_agent_revision(&revision_id)? {
         let _ = materialize_revision_directory(
@@ -657,12 +653,12 @@ fn create_revision_from_files(
             "detected_external_imports": health_report.map(|h| h.detected_external_imports.clone()).unwrap_or_default(),
         }),
         short_id: String::new(),
+        signature,
+        signer_id,
     };
 
     let short_id = gateway_store.insert_agent_revision_transactional(&rev)?;
 
-    // If promotion evidence was recorded before revision creation, bind or rotate that evidence
-    // to this canonical revision digest now. Skip for artifact-free reasoning agents.
     if let Some(artifact_id) = &common.artifact_id {
         let promo_store = crate::runtime::promotion_store::PromotionStore::new(gateway_dir)?;
         let _ =
@@ -682,6 +678,13 @@ fn create_revision_from_files(
         "artifact_id": common.artifact_id,
         "next_step": "Use agent.revision.promote to activate this revision"
     });
+
+    if let Some(obj) = response_obj.as_object_mut() {
+        if let Some(sig) = &rev.signature {
+            obj.insert("signed_by".to_string(), serde_json::json!(rev.signer_id));
+            let _ = sig;
+        }
+    }
 
     if let Some(hr) = health_report {
         if let Some(obj) = response_obj.as_object_mut() {
@@ -813,8 +816,7 @@ impl NativeTool for AgentRevisionCreateTool {
                     "agent_id": { "type": "string", "description": "Logical agent ID for this revision" },
                     "artifact_id": { "type": "string", "description": "Artifact ID containing the agent bundle (SKILL.md + files)" },
                     "base_revision_id": { "type": "string", "description": "Optional: base revision this is derived from" },
-                    "summary": { "type": "string", "description": "Optional: human-readable summary of changes" },
-                    "signature": { "type": "string", "description": "Ed25519 signature over the canonical content digest of the bundle, base64-encoded. Required unless trust_unsigned_bundles is enabled (R+11)." }
+                    "summary": { "type": "string", "description": "Optional: human-readable summary of changes" }
                 },
                 "required": ["agent_id", "artifact_id"],
                 "additionalProperties": false
@@ -866,14 +868,6 @@ impl NativeTool for AgentRevisionCreateTool {
         };
 
         let gateway_dir = gateway_dir.ok_or_else(|| anyhow::anyhow!("gateway_dir required"))?;
-
-        let trust_unsigned = _config.map_or(false, |c| c.trust_unsigned_bundles);
-        if !trust_unsigned && args.signature.is_none() {
-            return Err(anyhow::anyhow!(
-                "R+11: Bundle signature required but not provided. \
-                 Set trust_unsigned_bundles: true in config for local development."
-            ));
-        }
 
         let artifact = crate::ArtifactStore::new(gateway_dir)?;
 
@@ -1000,7 +994,6 @@ impl NativeTool for AgentRevisionCreateTool {
             metadata: args.metadata.clone(),
             source_kind: "artifact".to_string(),
             source_ref: Some(args.artifact_id.clone()),
-            signature: args.signature.clone(),
         };
         let persisted = create_revision_from_files(
             &common,
@@ -1012,7 +1005,6 @@ impl NativeTool for AgentRevisionCreateTool {
             &lock_rel_path,
             parsed_lock,
             &skill_content,
-            None,
             None,
             bundle_manifest.script_entry.as_deref(),
             _config,
@@ -1062,8 +1054,7 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
                     "middleware": { "type": "object" },
                     "response_contract": { "type": "object" },
                     "base_revision_id": { "type": "string" },
-                    "summary": { "type": "string" },
-                    "signature": { "type": "string", "description": "Ed25519 signature over the canonical content digest of the bundle, base64-encoded. Required unless trust_unsigned_bundles is enabled (R+11)." }
+                    "summary": { "type": "string" }
                 },
                 "required": ["agent_id", "instructions", "description", "capabilities"],
                 "additionalProperties": false
@@ -1125,14 +1116,6 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
             ));
         };
         let gateway_dir = gateway_dir.ok_or_else(|| anyhow::anyhow!("gateway_dir required"))?;
-
-        let trust_unsigned = _config.map_or(false, |c| c.trust_unsigned_bundles);
-        if !trust_unsigned && args.signature.is_none() {
-            return Err(anyhow::anyhow!(
-                "R+11: Bundle signature required but not provided. \
-                 Set trust_unsigned_bundles: true in config for local development."
-            ));
-        }
 
         let resolved_artifact = resolve_revision_artifact_input(
             args.artifact_id.as_deref(),
@@ -1334,13 +1317,6 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
         )?;
         let skill_content = canonical_skill.as_bytes().to_vec();
 
-        let artifact_only_digest = if !file_map.is_empty() {
-            let digest_hex = compute_revision_content_digest_hex(&file_map);
-            Some(format!("sha256:{}", digest_hex))
-        } else {
-            None
-        };
-
         file_map.insert("SKILL.md".to_string(), skill_content.clone());
 
         let lock_rel_path = target_manifest.runtime.runtime_lock.clone();
@@ -1362,7 +1338,6 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
             metadata: args.metadata.clone(),
             source_kind,
             source_ref,
-            signature: args.signature.clone(),
         };
         let persisted = create_revision_from_files(
             &common,
@@ -1376,7 +1351,6 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
             &skill_content,
             health_report.as_ref(),
             resolved_script_entry.as_deref(),
-            artifact_only_digest.as_deref(),
             _config,
         )?;
 

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -771,6 +771,9 @@ pub(crate) struct SandboxExecArgs {
     pub approval_ref: Option<String>,
     #[serde(default)]
     pub artifact_id: Option<String>,
+    /// Resolved server-side to the canonical `art_*` bundle id (same lookup as `artifact_exec`).
+    #[serde(default)]
+    pub artifact_ref: Option<String>,
     #[serde(default)]
     pub capture_paths: Option<Vec<CapturePath>>,
     #[serde(default)]
@@ -1077,6 +1080,16 @@ mod tests {
         )
         .unwrap();
         assert_eq!(args.intent.as_deref(), Some("Run unit tests"));
+    }
+
+    #[test]
+    fn test_sandbox_exec_args_optional_artifact_ref() {
+        let args: SandboxExecArgs = serde_json::from_str(
+            r#"{"command": "python3 /tmp/main.py", "artifact_ref": "ar.demo"}"#,
+        )
+        .unwrap();
+        assert_eq!(args.artifact_ref.as_deref(), Some("ar.demo"));
+        assert!(args.artifact_id.is_none());
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -1486,7 +1486,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                     };
                     let sid = session_id.unwrap_or("");
                     let root_session_id = crate::runtime::content_store::root_session_id(sid);
-                    let request = autonoetic_types::background::ApprovalRequest {
+                    let mut request = autonoetic_types::background::ApprovalRequest {
                         request_id: request_id.clone(),
                         agent_id: manifest.agent.id.clone(),
                         session_id: sid.to_string(),
@@ -1519,9 +1519,11 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                         },
                         similar_to_request_id: None,
                         similarity_score: None,
+                        min_dwell_ms: None,
+                        confirm_phrase: None,
                     };
                     if let Some(store) = &gateway_store {
-                        store.create_approval(&request).map_err(|e| {
+                        store.create_approval(&mut request).map_err(|e| {
                             anyhow::anyhow!(
                                 "Failed to persist sandbox approval request '{}': {}",
                                 request_id,
@@ -1776,7 +1778,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                                 .collect::<std::collections::BTreeSet<_>>()
                                 .into_iter()
                                 .collect();
-                            let request = autonoetic_types::background::ApprovalRequest {
+                            let mut request = autonoetic_types::background::ApprovalRequest {
                             request_id: request_id.clone(),
                             agent_id: manifest.agent.id.clone(),
                             session_id: sid.to_string(),
@@ -1810,9 +1812,11 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                             },
                             similar_to_request_id: None,
                             similarity_score: None,
+                            min_dwell_ms: None,
+                            confirm_phrase: None,
                         };
                             if let Some(store) = &gateway_store {
-                                store.create_approval(&request).map_err(|e| {
+                                store.create_approval(&mut request).map_err(|e| {
                                     anyhow::anyhow!(
                                         "Failed to persist layer mount approval request '{}': {}",
                                         request_id,
@@ -2517,6 +2521,8 @@ mod approval_binding_tests {
             approval_level: ApprovalLevel::Operator,
             similar_to_request_id: None,
             similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
         };
         assert!(approved_requests_cover_targets(
             &[req.clone()],

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -751,7 +751,11 @@ impl NativeTool for SandboxExecTool {
                     },
                     "artifact_id": {
                         "type": "string",
-                        "description": "Optional artifact ID. When provided, only artifact files are mounted into the sandbox (closed boundary). When omitted, all session content is mounted."
+                        "description": "Optional canonical artifact bundle id (art_*). When set, only that bundle's files are mounted (closed boundary). For stable handles like ar.* from content/artifact_build, use artifact_ref instead — do not pass ar.* here."
+                    },
+                    "artifact_ref": {
+                        "type": "string",
+                        "description": "Optional artifact ref (e.g. ar.*). Resolved server-side to the canonical art_* id and mounted like artifact_id. If both artifact_id and artifact_ref are set, they must refer to the same bundle."
                     },
                     "capture_paths": {
                         "type": "array",
@@ -805,6 +809,77 @@ impl NativeTool for SandboxExecTool {
             "sandbox command must not be empty"
         );
 
+        let artifact_ref_trimmed = args
+            .artifact_ref
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+
+        if let Some(aid) = args.artifact_id.as_deref() {
+            let aid = aid.trim();
+            if aid.starts_with("ar.") {
+                return Err(tagged::Tagged::validation(anyhow::anyhow!(
+                    "sandbox_exec: '{}' looks like an artifact ref (ar.*). \
+                     Use the \"artifact_ref\" field, not \"artifact_id\". \
+                     \"artifact_id\" must be the canonical on-disk bundle id (art_*...).",
+                    aid
+                ))
+                .into());
+            }
+        }
+
+        let resolved_from_ref: Option<String> = if let Some(ref aref) = artifact_ref_trimmed {
+            let Some(store) = gateway_store.as_ref() else {
+                return Err(tagged::Tagged::validation(anyhow::anyhow!(
+                    "sandbox_exec: artifact_ref requires GatewayStore to be configured"
+                ))
+                .into());
+            };
+            let Some(sid) = session_id else {
+                return Err(tagged::Tagged::validation(anyhow::anyhow!(
+                    "sandbox_exec: artifact_ref requires an active session (session_id)"
+                ))
+                .into());
+            };
+            let resolved = match store.resolve_artifact_ref_any_scope(aref, sid) {
+                Ok(o) => o,
+                Err(e) => return Err(tagged::Tagged::validation(e).into()),
+            };
+            let Some(artifact_id) = resolved.map(|r| r.artifact_id) else {
+                return Err(tagged::Tagged::validation(anyhow::anyhow!(
+                    "artifact_ref '{}' not found, expired, or revoked",
+                    aref
+                ))
+                .into());
+            };
+            Some(artifact_id)
+        } else {
+            None
+        };
+
+        let explicit_mount_artifact_id: Option<String> =
+            match (&args.artifact_id, &resolved_from_ref) {
+                (Some(id), Some(rid)) => {
+                    let id = id.trim();
+                    if id == rid.as_str() {
+                        Some(id.to_string())
+                    } else {
+                        return Err(tagged::Tagged::validation(anyhow::anyhow!(
+                            "sandbox_exec: artifact_id '{}' does not match artifact_ref '{}' (resolved to '{}')",
+                            id,
+                            artifact_ref_trimmed.as_deref().unwrap_or_default(),
+                            rid
+                        ))
+                        .into());
+                    }
+                }
+                (Some(id), None) => Some(id.trim().to_string()),
+                (None, Some(rid)) => Some(rid.clone()),
+                (None, None) => None,
+            };
+        let explicit_mount_artifact_id = explicit_mount_artifact_id.filter(|s| !s.is_empty());
+
         let mut approval_validated_for_command = false;
         let mut layer_mount_approved = false;
         let mut approved_layer_mount_layers: Option<Vec<LayerMountScopeInfo>> = None;
@@ -855,7 +930,7 @@ impl NativeTool for SandboxExecTool {
                                 &manifest.agent.id,
                                 &normalized_targets,
                                 &code_to_analyze,
-                                args.artifact_id.as_deref(),
+                                explicit_mount_artifact_id.as_deref(),
                             );
                             if let Some(gw_dir) = gateway_dir {
                                 if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
@@ -934,7 +1009,7 @@ impl NativeTool for SandboxExecTool {
             }
         }
 
-        if let Some(artifact_id) = args.artifact_id.as_deref() {
+        if let Some(artifact_id) = explicit_mount_artifact_id.as_deref() {
             if artifact_id.starts_with("impl_") {
                 return Ok(crate::runtime::tools::implicit_artifact_id_error(
                     self.name(),
@@ -975,7 +1050,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
         let mut artifact_analysis_override: Option<
             crate::runtime::remote_access::RemoteAccessAnalysis,
         > = None;
-        let code_to_analyze = if let Some(ref aid) = args.artifact_id {
+        let code_to_analyze = if let Some(ref aid) = explicit_mount_artifact_id {
             if let Some(gw_dir) = gateway_dir {
                 match extract_and_cache_artifact_analysis(gw_dir, aid) {
                     Some((code, analysis)) => {
@@ -1200,7 +1275,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                             &manifest.agent.id,
                             &targets,
                             &code_to_analyze,
-                            args.artifact_id.as_deref(),
+                            explicit_mount_artifact_id.as_deref(),
                         );
                         if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                             if let Some(entry) = cache.find(&fingerprint) {
@@ -1245,7 +1320,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                                             &manifest.agent.id,
                                             &targets,
                                             &code_to_analyze,
-                                            args.artifact_id.as_deref(),
+                                            explicit_mount_artifact_id.as_deref(),
                                         );
                                         if let Some(gw_dir) = gateway_dir {
                                             if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
@@ -1411,7 +1486,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                     };
                     let sid = session_id.unwrap_or("");
                     let root_session_id = crate::runtime::content_store::root_session_id(sid);
-                    let mut request = autonoetic_types::background::ApprovalRequest {
+                    let request = autonoetic_types::background::ApprovalRequest {
                         request_id: request_id.clone(),
                         agent_id: manifest.agent.id.clone(),
                         session_id: sid.to_string(),
@@ -1444,11 +1519,9 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                         },
                         similar_to_request_id: None,
                         similarity_score: None,
-                        min_dwell_ms: None,
-                        confirm_phrase: None,
                     };
                     if let Some(store) = &gateway_store {
-                        store.create_approval(&mut request).map_err(|e| {
+                        store.create_approval(&request).map_err(|e| {
                             anyhow::anyhow!(
                                 "Failed to persist sandbox approval request '{}': {}",
                                 request_id,
@@ -1614,8 +1687,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                 };
 
                 // Resolve the effective artifact_id early for the scope check.
-                let effective_artifact_id_for_scope = args
-                    .artifact_id
+                let effective_artifact_id_for_scope = explicit_mount_artifact_id
                     .as_ref()
                     .or_else(|| run_context.as_ref().and_then(|c| c.artifact_id.as_ref()));
 
@@ -1704,7 +1776,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                                 .collect::<std::collections::BTreeSet<_>>()
                                 .into_iter()
                                 .collect();
-                            let mut request = autonoetic_types::background::ApprovalRequest {
+                            let request = autonoetic_types::background::ApprovalRequest {
                             request_id: request_id.clone(),
                             agent_id: manifest.agent.id.clone(),
                             session_id: sid.to_string(),
@@ -1738,11 +1810,9 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                             },
                             similar_to_request_id: None,
                             similarity_score: None,
-                            min_dwell_ms: None,
-                            confirm_phrase: None,
                         };
                             if let Some(store) = &gateway_store {
-                                store.create_approval(&mut request).map_err(|e| {
+                                store.create_approval(&request).map_err(|e| {
                                     anyhow::anyhow!(
                                         "Failed to persist layer mount approval request '{}': {}",
                                         request_id,
@@ -1814,10 +1884,9 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Agent directory is not valid UTF-8"))?;
 
-        // Resolve effective artifact_id: explicit arg takes priority, then fall back to
-        // the artifact_id from the tool run context (set by parent agent.spawn).
-        let effective_artifact_id = args
-            .artifact_id
+        // Resolve effective artifact_id: explicit arg (or artifact_ref) takes priority, then fall
+        // back to the artifact_id from the tool run context (set by parent agent.spawn).
+        let effective_artifact_id = explicit_mount_artifact_id
             .as_ref()
             .or_else(|| run_context.as_ref().and_then(|c| c.artifact_id.as_ref()));
 
@@ -2174,7 +2243,7 @@ Use content.read(cnt_...) to inspect content by handle, or use the path returned
                 &manifest.agent.id,
                 &normalized_targets,
                 &code_to_analyze,
-                args.artifact_id.as_deref(),
+                explicit_mount_artifact_id.as_deref(),
             );
             if let Some(gw_dir) = gateway_dir {
                 if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
@@ -2448,8 +2517,6 @@ mod approval_binding_tests {
             approval_level: ApprovalLevel::Operator,
             similar_to_request_id: None,
             similarity_score: None,
-            min_dwell_ms: None,
-            confirm_phrase: None,
         };
         assert!(approved_requests_cover_targets(
             &[req.clone()],

--- a/autonoetic-gateway/src/runtime/tools/scheduler.rs
+++ b/autonoetic-gateway/src/runtime/tools/scheduler.rs
@@ -637,7 +637,7 @@ impl NativeTool for SchedulerCronCancelTool {
         arguments_json: &str,
         _session_id: Option<&str>,
         _turn_id: Option<&str>,
-        _config: Option<&autonoetic_types::config::GatewayConfig>,
+        config: Option<&autonoetic_types::config::GatewayConfig>,
         gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
@@ -676,6 +676,29 @@ impl NativeTool for SchedulerCronCancelTool {
                     .to_error_response());
                 }
                 let cancelled = store.cancel_scheduled_job(&args.job_id)?;
+                if cancelled {
+                    if let Some(cfg) = config {
+                        if let Err(e) =
+                            crate::scheduler::workflow_store::append_scheduled_job_cancelled_workflow_event(
+                                cfg,
+                                store.as_ref(),
+                                &j.root_session_id,
+                                &j.job_id,
+                                &j.owner_agent_id,
+                                &j.target_agent_id,
+                                &j.cron_expr,
+                                "scheduler.cron.cancel",
+                            )
+                        {
+                            tracing::warn!(
+                                target: "scheduler",
+                                error = %e,
+                                job_id = %args.job_id,
+                                "Failed to append scheduled_job.cancelled workflow event"
+                            );
+                        }
+                    }
+                }
                 Ok(serde_json::to_string(&serde_json::json!({
                     "ok": cancelled,
                     "job_id": args.job_id,

--- a/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
@@ -38,8 +38,9 @@ impl GatewayStore {
                 "INSERT INTO agent_revisions (
                     revision_id, agent_id, base_revision_id, artifact_id, content_digest,
                     runtime_lock_hash, manifest_hash, created_at, created_by_type, created_by_id,
-                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json, short_id
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json,
+                    short_id, signature, signer_id
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
                 params![
                     &rev.revision_id,
                     &rev.agent_id,
@@ -58,6 +59,8 @@ impl GatewayStore {
                     &format!("{:?}", rev.status),
                     metadata_json,
                     &short,
+                    rev.signature,
+                    rev.signer_id,
                 ],
             )?;
         let now = chrono::Utc::now().to_rfc3339();
@@ -76,7 +79,8 @@ impl GatewayStore {
         let mut stmt = conn.prepare(
             "SELECT revision_id, agent_id, base_revision_id, artifact_id, content_digest,
                     runtime_lock_hash, manifest_hash, created_at, created_by_type, created_by_id,
-                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json, short_id
+                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json,
+                    short_id, signature, signer_id
              FROM agent_revisions WHERE revision_id = ?1",
         )?;
         let rows = stmt.query_map(params![revision_id], |row| {
@@ -110,6 +114,8 @@ impl GatewayStore {
                 status,
                 metadata_json,
                 short_id: short_id.unwrap_or_default(),
+                signature: row.get(17).ok().flatten(),
+                signer_id: row.get(18).ok().flatten(),
             })
         })?;
         let mut results = Vec::new();
@@ -124,7 +130,8 @@ impl GatewayStore {
         let mut stmt = conn.prepare(
             "SELECT revision_id, agent_id, base_revision_id, artifact_id, content_digest,
                     runtime_lock_hash, manifest_hash, created_at, created_by_type, created_by_id,
-                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json, short_id
+                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json,
+                    short_id, signature, signer_id
              FROM agent_revisions WHERE agent_id = ?1 ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map(params![agent_id], |row| {
@@ -158,6 +165,8 @@ impl GatewayStore {
                 status,
                 metadata_json,
                 short_id: short_id.unwrap_or_default(),
+                signature: row.get(17).ok().flatten(),
+                signer_id: row.get(18).ok().flatten(),
             })
         })?;
         let mut results = Vec::new();
@@ -172,7 +181,8 @@ impl GatewayStore {
         let mut stmt = conn.prepare(
             "SELECT revision_id, agent_id, base_revision_id, artifact_id, content_digest,
                     runtime_lock_hash, manifest_hash, created_at, created_by_type, created_by_id,
-                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json, short_id
+                    source_kind, source_ref, origin_node_id, trust_domain, status, metadata_json,
+                    short_id, signature, signer_id
              FROM agent_revisions ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map(params![], |row| {
@@ -206,6 +216,8 @@ impl GatewayStore {
                 status,
                 metadata_json,
                 short_id: short_id.unwrap_or_default(),
+                signature: row.get(17).ok().flatten(),
+                signer_id: row.get(18).ok().flatten(),
             })
         })?;
         let mut results = Vec::new();

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 23;
+const SCHEMA_VERSION_LATEST: i64 = 24;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -507,6 +507,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_causal_event_enforced_rules_v21(conn)?;
     apply_constitutional_proposals_v22(conn)?;
     apply_approval_hardening_v23(conn)?;
+    apply_revision_signature_v24(conn)?;
 
     Ok(())
 }
@@ -1414,6 +1415,32 @@ fn apply_approval_hardening_v23(conn: &mut Connection) -> Result<()> {
         params![
             23_i64,
             "approval_hardening",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_revision_signature_v24(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 24 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "ALTER TABLE agent_revisions ADD COLUMN signature TEXT;
+         ALTER TABLE agent_revisions ADD COLUMN signer_id TEXT;",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            24_i64,
+            "revision_signature",
             chrono::Utc::now().to_rfc3339()
         ],
     )?;

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -24,6 +24,7 @@ use autonoetic_types::notification::NotificationStatus;
 use rusqlite::{params, Connection};
 use serde::Deserialize;
 use std::path::Path;
+use std::sync::{Arc, Mutex, Weak};
 
 pub use messages::AgentMessageRecord;
 pub(crate) use row_decode::memory_object_from_row;
@@ -97,6 +98,9 @@ pub fn default_gateway_host_id() -> String {
 pub struct GatewayStore {
     conn: std::sync::Mutex<Connection>,
     approval_flood_cap: std::sync::atomic::AtomicUsize,
+    /// Weak ref avoids an `Arc` cycle with [`crate::scheduler::hooks::HookExecutor`], which may
+    /// hold an `Arc<GatewayStore>` for other hooks.
+    policy_hook_executor: Mutex<Option<Weak<crate::scheduler::hooks::HookExecutor>>>,
 }
 
 impl GatewayStore {
@@ -118,6 +122,7 @@ impl GatewayStore {
         let store = Self {
             conn: std::sync::Mutex::new(conn),
             approval_flood_cap: std::sync::atomic::AtomicUsize::new(0),
+            policy_hook_executor: Mutex::new(None),
         };
         {
             let mut conn = store.conn.lock().unwrap();
@@ -138,6 +143,13 @@ impl GatewayStore {
             migrate::backfill_workflow_index(&conn, gateway_dir)?;
         }
         Ok(store)
+    }
+
+    /// Wire the gateway hook executor for [`autonoetic_types::hooks::HookEvent::PolicyDecision`].
+    /// Safe to call once at daemon startup; tests that open the store directly leave this unset.
+    pub fn set_policy_hook_executor(&self, exec: &Arc<crate::scheduler::hooks::HookExecutor>) {
+        let mut g = self.policy_hook_executor.lock().expect("policy_hook_executor mutex poisoned");
+        *g = Some(Arc::downgrade(exec));
     }
 
     pub fn migrate(&self) -> Result<()> {

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -162,30 +162,39 @@ impl GatewayStore {
         &self,
         event: &autonoetic_types::causal_chain::CausalEventRecord,
     ) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO causal_events (
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO causal_events (
                 event_id, agent_id, session_id, turn_id, event_seq, timestamp,
                 category, action, status, enforced_rules, target, payload, payload_ref, evidence_ref, reason
             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
-            params![
-                &event.event_id,
-                &event.agent_id,
-                &event.session_id,
-                event.turn_id.as_deref(),
-                event.event_seq as i64,
-                &event.timestamp,
-                &event.category,
-                &event.action,
-                &event.status,
-                serde_json::to_string(&event.enforced_rules)?,
-                event.target.as_deref(),
-                event.payload.as_deref(),
-                event.payload_ref.as_deref(),
-                event.evidence_ref.as_deref(),
-                event.reason.as_deref(),
-            ],
-        )?;
+                params![
+                    &event.event_id,
+                    &event.agent_id,
+                    &event.session_id,
+                    event.turn_id.as_deref(),
+                    event.event_seq as i64,
+                    &event.timestamp,
+                    &event.category,
+                    &event.action,
+                    &event.status,
+                    serde_json::to_string(&event.enforced_rules)?,
+                    event.target.as_deref(),
+                    event.payload.as_deref(),
+                    event.payload_ref.as_deref(),
+                    event.evidence_ref.as_deref(),
+                    event.reason.as_deref(),
+                ],
+            )?;
+        }
+        if let Ok(guard) = self.policy_hook_executor.lock() {
+            if let Some(w) = guard.as_ref() {
+                if let Some(exec) = w.upgrade() {
+                    exec.maybe_dispatch_policy_decision_hook(event);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/scheduled_jobs.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/scheduled_jobs.rs
@@ -123,11 +123,15 @@ pub fn claim_and_advance_due_job(
         Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
         Err(e) => return Err(e.into()),
     };
+    let wall = chrono::Utc::now().to_rfc3339();
     let updated = conn.execute(
         "UPDATE scheduled_jobs
-         SET next_run_at = ?1, generation = generation + 1, updated_at = ?1
-         WHERE job_id = ?2 AND status = 'active' AND generation = ?3",
-        params![new_next_run_at, job_id, current_gen],
+         SET next_run_at = ?1,
+             last_run_at = ?2,
+             updated_at = ?3,
+             generation = generation + 1
+         WHERE job_id = ?4 AND status = 'active' AND generation = ?5",
+        params![new_next_run_at, now_rfc3339, wall, job_id, current_gen],
     )?;
     if updated == 0 {
         return Ok(None);

--- a/autonoetic-gateway/src/scheduler/hooks.rs
+++ b/autonoetic-gateway/src/scheduler/hooks.rs
@@ -57,6 +57,29 @@ impl HookExecutor {
         self.spawn_tx = Some(tx);
     }
 
+    pub fn wants_policy_decision_hooks(&self) -> bool {
+        self.hooks
+            .iter()
+            .any(|h| h.event == HookEvent::PolicyDecision)
+    }
+
+    /// Called by `GatewayStore::create_causal_event` after the row is committed.
+    /// Observer-only: never affects allow/deny.
+    pub fn maybe_dispatch_policy_decision_hook(
+        &self,
+        event: &autonoetic_types::causal_chain::CausalEventRecord,
+    ) {
+        if !self.wants_policy_decision_hooks() {
+            return;
+        }
+        if !autonoetic_types::causal_chain::causal_event_notifies_policy_decision(event) {
+            return;
+        }
+        let root = crate::runtime::content_store::root_session_id(&event.session_id);
+        let ctx = HookContext::for_policy_decision(&root, event);
+        self.dispatch_async(ctx);
+    }
+
     pub fn dispatch(&self, ctx: &HookContext) {
         for hook in &self.hooks {
             if hook.event != ctx.event {
@@ -721,18 +744,9 @@ fn validate_callback_url(
     Ok(parsed)
 }
 
-/// Resolve the URL's hostname and check every returned address against the
-/// same disallow-list used for literal IP validation. This blocks the common
-/// case of a public hostname pointing at RFC-1918 / loopback space.
-///
-/// Limitation: this cannot prevent DNS rebinding (the resolution may change
-/// between this check and the actual TCP connection), but it raises the bar
-/// significantly compared to no check at all.
 async fn check_resolved_ips_not_internal(url: &Url) -> anyhow::Result<()> {
     let host = match url.host() {
         Some(url::Host::Ipv4(_)) | Some(url::Host::Ipv6(_)) => {
-            // IP literals are already validated by validate_callback_url via
-            // is_disallowed_callback_host; no DNS resolution needed.
             return Ok(());
         }
         Some(url::Host::Domain(d)) => d.to_string(),
@@ -819,8 +833,6 @@ fn build_http_callback_delivery_id(ctx: &HookContext, url: &Url, hook: &HookConf
         hasher.update(b"=");
         hasher.update(value.as_bytes());
     }
-    // Include the hook params so that two hooks sharing the same event+URL
-    // but differing in params (e.g. different secret_env) get distinct IDs.
     hasher.update(b"\nhook_params:");
     let mut param_pairs: Vec<_> = hook.params.iter().collect();
     param_pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
@@ -870,8 +882,6 @@ fn load_sanitized_session_report(ctx: &HookContext) -> anyhow::Result<Option<ser
     let raw = match std::fs::read_to_string(&path) {
         Ok(raw) => raw,
         Err(_) => {
-            // For child sessions the report may live under the root session
-            // directory; try the root path as a fallback.
             if session_id != ctx.root_session_id {
                 let root_path = std::path::Path::new(gateway_dir)
                     .join("sessions")
@@ -935,6 +945,52 @@ fn truncate_chars(text: &str, max_chars: usize) -> String {
     text.chars().take(max_chars).collect()
 }
 
+#[cfg(test)]
+mod policy_decision_hook_tests {
+    use autonoetic_types::causal_chain::{
+        causal_event_notifies_policy_decision, default_enforced_rules, CausalEventRecord,
+    };
+
+    fn sample_record(status: &str, enforced_rules: Vec<String>) -> CausalEventRecord {
+        CausalEventRecord {
+            event_id: "e1".into(),
+            agent_id: "a".into(),
+            session_id: "s".into(),
+            turn_id: None,
+            event_seq: 1,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            category: "tool_invoke".into(),
+            action: "completed".into(),
+            status: status.into(),
+            enforced_rules,
+            target: None,
+            payload: None,
+            payload_ref: None,
+            evidence_ref: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn emits_denied_even_if_only_baseline_rule() {
+        let ev = sample_record("DENIED", default_enforced_rules());
+        assert!(causal_event_notifies_policy_decision(&ev));
+    }
+
+    #[test]
+    fn emits_success_when_non_baseline_rule_present() {
+        let mut rules = default_enforced_rules();
+        rules.push("R+16".into());
+        let ev = sample_record("SUCCESS", rules);
+        assert!(causal_event_notifies_policy_decision(&ev));
+    }
+
+    #[test]
+    fn skips_success_when_only_baseline_rule() {
+        let ev = sample_record("SUCCESS", default_enforced_rules());
+        assert!(!causal_event_notifies_policy_decision(&ev));
+    }
+}
 fn sanitize_report_for_publishing(report_json: &str) -> String {
     let mut parsed: serde_json::Value = match serde_json::from_str(report_json) {
         Ok(v) => v,

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -454,6 +454,50 @@ pub fn append_workflow_event(
     Ok(())
 }
 
+/// Append a primary-workflow event when a cron job is cancelled so the chat TUI can show it.
+///
+/// Uses the root session's indexed primary workflow (`workflow_index` / file fallback). If no
+/// workflow is registered yet, logs at debug and returns Ok.
+pub fn append_scheduled_job_cancelled_workflow_event(
+    config: &GatewayConfig,
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    root_session_id: &str,
+    job_id: &str,
+    owner_agent_id: &str,
+    target_agent_id: &str,
+    cron_expr: &str,
+    cancel_reason: &str,
+) -> anyhow::Result<()> {
+    let Some(primary_wf) = resolve_workflow_id_for_root_session(config, root_session_id)? else {
+        tracing::debug!(
+            target: "scheduler",
+            root_session_id = %root_session_id,
+            job_id = %job_id,
+            "No primary workflow index for root session; skipping scheduled_job.cancelled event"
+        );
+        return Ok(());
+    };
+    let occurred_at = chrono::Utc::now().to_rfc3339();
+    let suffix = &uuid::Uuid::new_v4().to_string()[..8];
+    let event = autonoetic_types::workflow::WorkflowEventRecord {
+        event_id: format!("wevt-sjcancel-{job_id}-{suffix}"),
+        workflow_id: primary_wf,
+        task_id: None,
+        event_type: "scheduled_job.cancelled".to_string(),
+        agent_id: Some(target_agent_id.to_string()),
+        payload: serde_json::json!({
+            "job_id": job_id,
+            "owner_agent_id": owner_agent_id,
+            "target_agent_id": target_agent_id,
+            "cron_expr": cron_expr,
+            "root_session_id": root_session_id,
+            "cancel_reason": cancel_reason,
+        }),
+        occurred_at,
+    };
+    append_workflow_event(config, Some(store), &event)
+}
+
 /// Write or replace a task record and refresh `workflow.active_task_ids`.
 pub fn save_task_run(
     config: &GatewayConfig,

--- a/autonoetic-gateway/tests/background_scheduler_integration.rs
+++ b/autonoetic-gateway/tests/background_scheduler_integration.rs
@@ -119,6 +119,8 @@ fn register_revision_mirror(
         status: AgentRevisionStatus::Ready,
         metadata_json: serde_json::json!({}),
         short_id: String::new(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rec)?;
     let alias = AgentAliasRecord {

--- a/autonoetic-gateway/tests/checkpoint_integration.rs
+++ b/autonoetic-gateway/tests/checkpoint_integration.rs
@@ -45,6 +45,7 @@ fn make_checkpoint(
             Message::assistant("Test response"),
         ],
         turn_counter,
+        session_state: Default::default(),
         loop_guard_state: default_guard_state(),
         agent_id: "test-agent".to_string(),
         session_id: session_id.to_string(),

--- a/autonoetic-gateway/tests/constitution_install_signature.rs
+++ b/autonoetic-gateway/tests/constitution_install_signature.rs
@@ -1,12 +1,18 @@
-//! Constitution R+11 / R-9.13: Bundle signature verification at revision create.
+//! Constitution R+11: Gateway auto-signing of agent revision bundles.
 //!
-//! When `trust_unsigned_bundles` is false (the default), every revision must
-//! carry a valid Ed25519 signature over the canonical content digest, verified
-//! against the gateway identity public key.
+//! The gateway automatically signs every revision with its Ed25519 identity key
+//! at creation time. The signature covers the full canonical content digest
+//! (all files: SKILL.md + runtime.lock + artifact files). The signer_id field
+//! records which key produced the signature, enabling key-agnostic verification
+//! for future federation/external signer support.
+//!
+//! `trust_unsigned_bundles: true` is an escape hatch for environments where
+//! the gateway identity key cannot be loaded (e.g. permission errors on the
+//! private key file). In normal operation, the gateway always auto-signs.
 
 mod support;
 
-use autonoetic_gateway::runtime::crypto::{ManifestSigner, ManifestVerifier};
+use autonoetic_gateway::runtime::crypto::GatewayIdentityKey;
 use autonoetic_gateway::runtime::tools::default_registry;
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
@@ -63,28 +69,72 @@ fn config_strict() -> GatewayConfig {
     c
 }
 
-fn config_trust() -> GatewayConfig {
-    let mut c = GatewayConfig::default();
-    c.trust_unsigned_bundles = true;
-    c
+fn build_test_artifact(gw_dir: &std::path::Path) -> String {
+    let artifact_store = autonoetic_gateway::ArtifactStore::new(gw_dir).unwrap();
+    let skill_md = "---\nname: test\ndescription: test agent\nmetadata:\n  autonoetic:\n    version: \"1.0\"\n    runtime:\n      engine: autonoetic\n      gateway_version: \"0.1.0\"\n      sdk_version: \"0.1.0\"\n      type: stateful\n      sandbox: bubblewrap\n      runtime_lock: runtime.lock\n    agent:\n      id: revision.tester\n      name: revision.tester\n      description: test\n    capabilities:\n      - type: AgentRevision\n        patterns: [\"*\"]\n    execution_mode: reasoning\n---\n\nTest instructions.\n";
+    let runtime_lock = r#"{"gateway":{"artifact":"marketplace://gateway/autonoetic-gateway","version":"0.1.0","sha256":"replace-me"},"sdk":{"version":"0.1.0"},"sandbox":{"backend":"bubblewrap"},"dependencies":[],"artifacts":[],"layers":[]}"#;
+
+    let session_id = "test-session-signature";
+    let content_store =
+        autonoetic_gateway::runtime::content_store::ContentStore::new(gw_dir).unwrap();
+    let h1 = content_store.write(skill_md.as_bytes()).unwrap();
+    content_store.register_name(session_id, "SKILL.md", &h1).unwrap();
+    let h2 = content_store.write(runtime_lock.as_bytes()).unwrap();
+    content_store
+        .register_name(session_id, "runtime.lock", &h2)
+        .unwrap();
+
+    let bundle = artifact_store
+        .build_with_kind(
+            &["SKILL.md".to_string(), "runtime.lock".to_string()],
+            None,
+            None,
+            autonoetic_types::artifact::ArtifactKind::AgentBundle,
+            session_id,
+        )
+        .unwrap();
+    bundle.artifact_id
 }
 
-#[test]
-fn r11_sign_and_verify_roundtrip() {
-    let secret = [42u8; 32];
-    let signer = ManifestSigner::new(&secret);
-    let content = "test bundle content digest hex";
-    let sig = signer.sign(content);
+fn create_test_revision(
+    temp: &tempfile::TempDir,
+    gw_dir: &std::path::Path,
+    store: &Arc<GatewayStore>,
+) -> (String, autonoetic_types::agent_revision::AgentRevisionRecord) {
+    let manifest = test_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let config = config_strict();
+    let artifact_id = build_test_artifact(gw_dir);
 
-    let public_bytes = signer.public_key_bytes();
-    assert!(
-        ManifestVerifier::verify(&public_bytes, content, &sig).unwrap(),
-        "signature should verify"
+    let args = serde_json::json!({
+        "agent_id": "revision.tester",
+        "artifact_id": artifact_id,
+    });
+
+    let result = registry.execute(
+        "agent_revision_create",
+        &manifest,
+        &policy,
+        temp.path(),
+        Some(gw_dir),
+        &args.to_string(),
+        None,
+        None,
+        Some(&config),
+        Some(store.clone()),
+        None,
     );
-    assert!(
-        !ManifestVerifier::verify(&public_bytes, "tampered content", &sig).unwrap(),
-        "tampered content should not verify"
-    );
+
+    let output = result.expect("revision create should succeed");
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert!(parsed["ok"].as_bool().unwrap());
+    let revision_id = parsed["revision_id"].as_str().unwrap().to_string();
+    let rev = store
+        .get_agent_revision(&revision_id)
+        .unwrap()
+        .expect("revision should exist");
+    (revision_id, rev)
 }
 
 #[test]
@@ -92,22 +142,111 @@ fn r11_config_default_is_strict() {
     let config = GatewayConfig::default();
     assert!(
         !config.trust_unsigned_bundles,
-        "default should require signatures"
+        "default should not trust unsigned bundles"
     );
 }
 
 #[test]
-fn r11_revision_create_rejects_unsigned_when_strict() {
+fn r11_auto_signs_revision_on_create() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+    let (_revision_id, rev) = create_test_revision(&temp, &gw_dir, &store);
+
+    assert!(rev.signature.is_some(), "revision should have a signature");
+    assert!(rev.signer_id.is_some(), "revision should have a signer_id");
+    assert!(
+        rev.signer_id.as_ref().unwrap().starts_with("gateway:"),
+        "signer_id should start with 'gateway:'"
+    );
+}
+
+#[test]
+fn r11_auto_signature_verifies_against_gateway_key() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+    let key = GatewayIdentityKey::load_or_generate(&gw_dir).unwrap();
+    let pub_bytes = key.public_key_bytes();
+
+    let (revision_id, rev) = create_test_revision(&temp, &gw_dir, &store);
+    let sig_b64 = rev.signature.as_ref().expect("should have signature");
+    let digest_hex = revision_id.strip_prefix("rev_sha256:").unwrap();
+
+    assert!(
+        autonoetic_gateway::runtime::crypto::ManifestVerifier::verify(
+            &pub_bytes,
+            digest_hex,
+            sig_b64,
+        )
+        .unwrap(),
+        "auto-generated signature should verify against gateway public key"
+    );
+    assert_eq!(
+        rev.signer_id.as_ref().unwrap(),
+        &format!("gateway:{}", key.fingerprint())
+    );
+}
+
+#[test]
+fn r11_tampered_digest_does_not_verify() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+    let key = GatewayIdentityKey::load_or_generate(&gw_dir).unwrap();
+    let pub_bytes = key.public_key_bytes();
+
+    let (_revision_id, rev) = create_test_revision(&temp, &gw_dir, &store);
+    let sig_b64 = rev.signature.as_ref().unwrap();
+
+    let tampered_digest = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    assert!(
+        !autonoetic_gateway::runtime::crypto::ManifestVerifier::verify(
+            &pub_bytes,
+            tampered_digest,
+            sig_b64,
+        )
+        .unwrap(),
+        "tampered digest should not verify"
+    );
+}
+
+#[test]
+fn r11_wrong_key_does_not_verify() {
+    let temp = tempdir().unwrap();
+    let (gw_dir, store) = setup_gateway(temp.path());
+
+    let (_revision_id, rev) = create_test_revision(&temp, &gw_dir, &store);
+    let sig_b64 = rev.signature.as_ref().unwrap();
+    let digest_hex = rev.revision_id.strip_prefix("rev_sha256:").unwrap();
+
+    let temp2 = tempdir().unwrap();
+    let gw_dir2 = temp2.path().join(".gateway");
+    std::fs::create_dir_all(&gw_dir2).unwrap();
+    let key2 = GatewayIdentityKey::load_or_generate(&gw_dir2).unwrap();
+    let wrong_pub = key2.public_key_bytes();
+
+    assert!(
+        !autonoetic_gateway::runtime::crypto::ManifestVerifier::verify(
+            &wrong_pub,
+            digest_hex,
+            sig_b64,
+        )
+        .unwrap(),
+        "signature should not verify against a different gateway key"
+    );
+}
+
+#[test]
+fn r11_response_includes_signed_by_when_signed() {
     let temp = tempdir().unwrap();
     let (gw_dir, store) = setup_gateway(temp.path());
     let manifest = test_manifest();
     let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
     let registry = default_registry();
     let config = config_strict();
+    let artifact_id = build_test_artifact(&gw_dir);
 
     let args = serde_json::json!({
         "agent_id": "revision.tester",
-        "artifact_id": "art_000000000000",
+        "artifact_id": artifact_id,
     });
 
     let result = registry.execute(
@@ -124,93 +263,15 @@ fn r11_revision_create_rejects_unsigned_when_strict() {
         None,
     );
 
-    let err = result.expect_err("should reject unsigned bundle");
+    let output = result.expect("should succeed");
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert!(
-        err.to_string().contains("R+11"),
-        "error should reference R+11: {}",
-        err
+        parsed.get("signed_by").is_some(),
+        "response should include signed_by field when signed"
     );
-}
-
-#[test]
-fn r11_revision_create_rejects_invalid_signature() {
-    let temp = tempdir().unwrap();
-    let (gw_dir, store) = setup_gateway(temp.path());
-    let manifest = test_manifest();
-    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
-    let registry = default_registry();
-    let config = config_trust();
-
-    let args = serde_json::json!({
-        "agent_id": "revision.tester",
-        "artifact_id": "art_000000000000",
-        "signature": "invalid_base64_not_a_real_sig!!!"
-    });
-
-    let result = registry.execute(
-        "agent_revision_create",
-        &manifest,
-        &policy,
-        temp.path(),
-        Some(&gw_dir),
-        &args.to_string(),
-        None,
-        None,
-        Some(&config),
-        Some(store),
-        None,
+    let signed_by = parsed["signed_by"].as_str().unwrap();
+    assert!(
+        signed_by.starts_with("gateway:"),
+        "signed_by should start with 'gateway:'"
     );
-
-    match result {
-        Ok(_) => {}
-        Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("R+11") {
-                panic!(
-                    "invalid signature should NOT trigger R+11 gate when trust_unsigned_bundles is true: {}",
-                    msg
-                );
-            }
-        }
-    }
-}
-
-#[test]
-fn r11_revision_create_allows_unsigned_when_trusted() {
-    let temp = tempdir().unwrap();
-    let (gw_dir, store) = setup_gateway(temp.path());
-    let manifest = test_manifest();
-    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
-    let registry = default_registry();
-    let config = config_trust();
-
-    let args = serde_json::json!({
-        "agent_id": "revision.tester",
-        "artifact_id": "art_000000000000",
-    });
-
-    let result = registry.execute(
-        "agent_revision_create",
-        &manifest,
-        &policy,
-        temp.path(),
-        Some(&gw_dir),
-        &args.to_string(),
-        None,
-        None,
-        Some(&config),
-        Some(store),
-        None,
-    );
-
-    match result {
-        Ok(_) => {}
-        Err(e) => {
-            assert!(
-                !e.to_string().contains("R+11"),
-                "should not fail with R+11 signature gate when trust_unsigned_bundles is true: {}",
-                e
-            );
-        }
-    }
 }

--- a/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
@@ -117,6 +117,8 @@ fn make_revision_record(revision_id: &str) -> AgentRevisionRecord {
         status: AgentRevisionStatus::Candidate,
         metadata_json: serde_json::Value::Null,
         short_id: revision_id.chars().take(8).collect(),
+        signature: None,
+        signer_id: None,
     }
 }
 

--- a/autonoetic-gateway/tests/full_lifecycle_integration.rs
+++ b/autonoetic-gateway/tests/full_lifecycle_integration.rs
@@ -294,6 +294,7 @@ fn test_session_snapshot_fork() {
     let cp = SessionCheckpoint {
         history: history.clone(),
         turn_counter: 2,
+        session_state: Default::default(),
         loop_guard_state: LoopGuardState {
             max_loops_without_progress: 10,
             max_tool_failures: 5,

--- a/autonoetic-gateway/tests/hook_agent_spawn_integration.rs
+++ b/autonoetic-gateway/tests/hook_agent_spawn_integration.rs
@@ -245,4 +245,8 @@ fn test_hook_event_serde_dotted_names() {
 
     let wj: HookEvent = serde_json::from_str("\"workflow.join.satisfied\"").unwrap();
     assert_eq!(wj, HookEvent::WorkflowJoinSatisfied);
+
+    let pd: HookEvent = serde_json::from_str("\"policy.decision\"").unwrap();
+    assert_eq!(pd, HookEvent::PolicyDecision);
+    assert_eq!(serde_json::to_string(&HookEvent::PolicyDecision).unwrap(), "\"policy.decision\"");
 }

--- a/autonoetic-gateway/tests/knowledge_revision_provenance_integration.rs
+++ b/autonoetic-gateway/tests/knowledge_revision_provenance_integration.rs
@@ -32,6 +32,8 @@ fn seed_revision(store: &GatewayStore, agent_id: &str, revision_id: &str) {
             status: AgentRevisionStatus::Ready,
             metadata_json: serde_json::json!({}),
             short_id: String::new(),
+            signature: None,
+            signer_id: None,
         })
         .unwrap();
 }

--- a/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
+++ b/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
@@ -68,6 +68,8 @@ fn make_revision(agent_id: &str, suffix: &str) -> AgentRevisionRecord {
         status: AgentRevisionStatus::Candidate,
         metadata_json: json!({}),
         short_id: format!("sid{}", &suffix[..8]),
+        signature: None,
+        signer_id: None,
     }
 }
 
@@ -256,6 +258,7 @@ fn test_rollback_restores_previous_alias_target() {
 
     // Materialize SKILL.md for both revisions so the promotion gate can read capabilities.
     let gateway_dir = tmp.path().join(".gateway");
+    materialize_revision_skill(&gateway_dir, agent_id, &rev1.revision_id);
     materialize_revision_skill(&gateway_dir, agent_id, &rev2.revision_id);
 
     let registry = default_registry();

--- a/autonoetic-gateway/tests/phase3_eval_integration.rs
+++ b/autonoetic-gateway/tests/phase3_eval_integration.rs
@@ -249,6 +249,8 @@ fn test_eval_run_persists_with_real_revision() {
         status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
         metadata_json: json!({}),
         short_id: "test1234".to_string(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rev).unwrap();
 
@@ -432,6 +434,8 @@ fn test_agent_revision_diff_reports_modified_files() {
             status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
             metadata_json: json!({}),
             short_id: "testshort".to_string(),
+            signature: None,
+            signer_id: None,
         };
         store.insert_agent_revision(&rec).unwrap();
     }
@@ -515,6 +519,8 @@ fn test_eval_compare_builds_completed_comparison_report() {
             status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
             metadata_json: json!({}),
             short_id: "cmp".to_string(),
+            signature: None,
+            signer_id: None,
         };
         store.insert_agent_revision(&rec).unwrap();
     }
@@ -788,6 +794,8 @@ fn test_eval_run_validates_revision_belongs_to_agent() {
         status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
         metadata_json: json!({}),
         short_id: "test1234".to_string(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rev).unwrap();
 
@@ -898,6 +906,8 @@ fn test_promote_rejects_required_eval_run_for_different_revision() {
         status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
         metadata_json: json!({}),
         short_id: "target111".to_string(),
+        signature: None,
+        signer_id: None,
     };
     let rev_other = autonoetic_types::agent_revision::AgentRevisionRecord {
         revision_id: "rev_sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -918,6 +928,8 @@ fn test_promote_rejects_required_eval_run_for_different_revision() {
         status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
         metadata_json: json!({}),
         short_id: "other222".to_string(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rev_target).unwrap();
     store.insert_agent_revision(&rev_other).unwrap();

--- a/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
+++ b/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
@@ -692,6 +692,8 @@ fn test_promote_rejects_high_risk_with_unresolved_dependencies() {
             "detected_external_imports": ["requests"],
         }),
         short_id: String::new(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rev).unwrap();
 
@@ -828,6 +830,8 @@ fn test_promote_accepts_precreate_records_when_digest_matches() {
         status: AgentRevisionStatus::Candidate,
         metadata_json: serde_json::json!({}),
         short_id: String::new(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rev).unwrap();
 

--- a/autonoetic-gateway/tests/scheduled_jobs_integration.rs
+++ b/autonoetic-gateway/tests/scheduled_jobs_integration.rs
@@ -249,7 +249,9 @@ fn test_claim_and_advance_atomic() -> anyhow::Result<()> {
     assert!(claimed.is_some());
 
     let job = store.get_scheduled_job("sj-atomic-001")?;
-    assert_eq!(job.unwrap().next_run_at, future);
+    let job = job.unwrap();
+    assert_eq!(job.next_run_at, future);
+    assert_eq!(job.last_run_at, Some(now.to_rfc3339()));
 
     let claimed2 = store.claim_and_advance_due_job("sj-atomic-001", &now.to_rfc3339(), &future)?;
     assert!(claimed2.is_none());

--- a/autonoetic-gateway/tests/session_fork_integration.rs
+++ b/autonoetic-gateway/tests/session_fork_integration.rs
@@ -26,6 +26,7 @@ fn test_checkpoint(
     SessionCheckpoint {
         history,
         turn_counter,
+        session_state: Default::default(),
         loop_guard_state: LoopGuardState {
             max_loops_without_progress: 10,
             max_tool_failures: 5,

--- a/autonoetic-gateway/tests/support/mod.rs
+++ b/autonoetic-gateway/tests/support/mod.rs
@@ -345,6 +345,8 @@ pub fn seed_agent_revision(
         status: AgentRevisionStatus::Ready,
         metadata_json: serde_json::json!({}),
         short_id: String::new(),
+        signature: None,
+        signer_id: None,
     };
     store.insert_agent_revision(&rec)?;
     let alias = AgentAliasRecord {

--- a/autonoetic-gateway/tests/turn_continuation_approval_integration.rs
+++ b/autonoetic-gateway/tests/turn_continuation_approval_integration.rs
@@ -109,6 +109,8 @@ fn seed_present_test_agents(
             status: AgentRevisionStatus::Ready,
             metadata_json: serde_json::json!({}),
             short_id: String::new(),
+            signature: None,
+            signer_id: None,
         };
         let _ = store.insert_agent_revision(&rec)?;
         store.upsert_agent_alias(&AgentAliasRecord {

--- a/autonoetic-types/src/agent_revision.rs
+++ b/autonoetic-types/src/agent_revision.rs
@@ -174,6 +174,16 @@ pub struct AgentRevisionRecord {
     /// Collision-safe short ID for LLM-friendly references (e.g., `abc12345`).
     #[serde(default)]
     pub short_id: String,
+    /// Ed25519 signature over the canonical revision content digest (base64).
+    /// Produced by the gateway at revision creation time (R+11 auto-sign).
+    /// Verified against the signer's public key for integrity attestation.
+    #[serde(default)]
+    pub signature: Option<String>,
+    /// Identity of the signer. Format: `gateway:{fingerprint}` for gateway-auto-signed
+    /// revisions, extensible to `peer:{node_id}`, `ci:{pipeline}`, etc.
+    /// A verifier resolves this to a trusted public key from a trust store.
+    #[serde(default)]
+    pub signer_id: Option<String>,
 }
 
 /// Mutable alias binding from a stable name to a revision.

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -74,6 +74,24 @@ pub struct CausalEventRecord {
     pub reason: Option<String>,
 }
 
+/// Whether this causal row should drive policy-decision notifications (hooks, chat TUI policy pane).
+///
+/// Semantics: `DENIED` / `ERROR` always; `SUCCESS` only when any enforced rule is not the baseline
+/// attribution rule ([`RULE_ID_EVENT_ATTRIBUTION`]).
+pub fn causal_event_notifies_policy_decision(event: &CausalEventRecord) -> bool {
+    let s = event.status.as_str();
+    if s.eq_ignore_ascii_case("DENIED") || s.eq_ignore_ascii_case("ERROR") {
+        return true;
+    }
+    if s.eq_ignore_ascii_case("SUCCESS") {
+        return event
+            .enforced_rules
+            .iter()
+            .any(|r| r.as_str() != RULE_ID_EVENT_ATTRIBUTION);
+    }
+    false
+}
+
 /// Execution trace record for storage in gateway.db execution_traces table.
 /// Stores structured tool execution results for agent learning.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -669,12 +669,11 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub allow_runtime_lock_drift: bool,
 
-    /// When true, accept unsigned agent bundle revisions at
-    /// `agent_revision_create` and `agent_revision_create_from_intent`
-    /// (R+11 / R-9.13). Intended for local development only. In production,
-    /// every revision must carry a valid Ed25519 signature over the canonical
-    /// content digest, verified against the gateway identity public key.
-    /// Default: false (signatures required).
+    /// When true, allow revision creation to proceed without a gateway signature
+    /// when the gateway identity key is unavailable (e.g. first boot on a read-only
+    /// filesystem, permission errors). In normal operation the gateway auto-signs every
+    /// revision — this flag is only an escape hatch for environments where the key
+    /// cannot be loaded or generated. Default: false.
     #[serde(default)]
     pub trust_unsigned_bundles: bool,
 

--- a/autonoetic-types/src/hooks.rs
+++ b/autonoetic-types/src/hooks.rs
@@ -21,6 +21,10 @@ pub enum HookEvent {
     AgentPromoted,
     #[serde(rename = "emergency_stop")]
     EmergencyStop,
+    /// Fired after a row is inserted into `causal_events` when the event matches
+    /// gateway policy-hook filters (observer-only).
+    #[serde(rename = "policy.decision")]
+    PolicyDecision,
 }
 
 impl HookEvent {
@@ -34,6 +38,7 @@ impl HookEvent {
             Self::ArtifactCreated => "artifact.created",
             Self::AgentPromoted => "agent.promoted",
             Self::EmergencyStop => "emergency_stop",
+            Self::PolicyDecision => "policy.decision",
         }
     }
 }
@@ -135,6 +140,80 @@ impl HookContext {
             root_session_id: root_session_id.to_string(),
             session_id: None,
             agent_id: None,
+            gateway_dir: None,
+            fields,
+        }
+    }
+
+    /// Context for [`HookEvent::PolicyDecision`] after a causal event row is persisted.
+    ///
+    /// `fields` keys are stable for `message_template` substitution (same names are also on
+    /// `root_session_id` / `session_id` / `agent_id` for structured consumers):
+    /// `root_session_id`, `session_id`, `agent_id`, `event_id`, `rule_ids`, `primary_rule_id`,
+    /// `decision`, `status`, `category`, `action`, `target`, `reason`, `turn_id`, `source`
+    /// (`causal_events`).
+    pub fn for_policy_decision(
+        root_session_id: &str,
+        event: &crate::causal_chain::CausalEventRecord,
+    ) -> Self {
+        use crate::causal_chain::RULE_ID_EVENT_ATTRIBUTION;
+
+        let rule_ids = event.enforced_rules.join(",");
+        let primary_rule_id = event
+            .enforced_rules
+            .iter()
+            .find(|r| r.as_str() != RULE_ID_EVENT_ATTRIBUTION)
+            .cloned()
+            .or_else(|| event.enforced_rules.first().cloned())
+            .unwrap_or_default();
+
+        let status_u = event.status.to_ascii_uppercase();
+        let decision = match status_u.as_str() {
+            "DENIED" | "ERROR" => "denied",
+            "SUCCESS" => "allowed",
+            _ => "unknown",
+        };
+
+        let reason = event
+            .reason
+            .as_deref()
+            .map(|s| {
+                const MAX: usize = 2048;
+                if s.chars().count() <= MAX {
+                    s.to_string()
+                } else {
+                    s.chars().take(MAX).collect::<String>()
+                }
+            })
+            .unwrap_or_default();
+
+        let mut fields = HashMap::new();
+        fields.insert("root_session_id".to_string(), root_session_id.to_string());
+        fields.insert("session_id".to_string(), event.session_id.clone());
+        fields.insert("agent_id".to_string(), event.agent_id.clone());
+        fields.insert("event_id".to_string(), event.event_id.clone());
+        fields.insert("rule_ids".to_string(), rule_ids);
+        fields.insert("primary_rule_id".to_string(), primary_rule_id);
+        fields.insert("decision".to_string(), decision.to_string());
+        fields.insert("status".to_string(), event.status.clone());
+        fields.insert("category".to_string(), event.category.clone());
+        fields.insert("action".to_string(), event.action.clone());
+        fields.insert(
+            "target".to_string(),
+            event.target.clone().unwrap_or_default(),
+        );
+        fields.insert("reason".to_string(), reason);
+        fields.insert(
+            "turn_id".to_string(),
+            event.turn_id.clone().unwrap_or_default(),
+        );
+        fields.insert("source".to_string(), "causal_events".to_string());
+
+        Self {
+            event: HookEvent::PolicyDecision,
+            root_session_id: root_session_id.to_string(),
+            session_id: Some(event.session_id.clone()),
+            agent_id: Some(event.agent_id.clone()),
             gateway_dir: None,
             fields,
         }

--- a/autonoetic/src/cli/agent.rs
+++ b/autonoetic/src/cli/agent.rs
@@ -2484,6 +2484,8 @@ Use tools when needed.
             status: AgentRevisionStatus::Ready,
             metadata_json: serde_json::json!({}),
             short_id: "abc12345".to_string(),
+            signature: None,
+            signer_id: None,
         };
         store
             .insert_agent_revision(&revision)
@@ -2572,6 +2574,8 @@ Use tools when needed.
                 status: AgentRevisionStatus::Ready,
                 metadata_json: serde_json::json!({}),
                 short_id: "list1234".to_string(),
+                signature: None,
+                signer_id: None,
             })
             .expect("revision insert should succeed");
         store
@@ -2630,6 +2634,8 @@ Use tools when needed.
             status: AgentRevisionStatus::Candidate,
             metadata_json: serde_json::json!({}),
             short_id: "seed1234".to_string(),
+            signature: None,
+            signer_id: None,
         };
         store
             .insert_agent_revision(&revision)

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -820,6 +820,34 @@ fn format_workflow_event_card(
             format!("⏱ [{}] Scheduled job triggered: {}", ts_short, agent_id),
             MessageRole::AgentOutput,
         )),
+        "scheduled_job.cancelled" => {
+            let job_id = event
+                .payload
+                .get("job_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let reason = event
+                .payload
+                .get("cancel_reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let cron = event
+                .payload
+                .get("cron_expr")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let mut line = format!(
+                "🚫 [{}] Scheduled job cancelled: {} (target {})",
+                ts_short, job_id, agent_id
+            );
+            if !cron.is_empty() {
+                line.push_str(&format!(" [{}]", cron));
+            }
+            if !reason.is_empty() {
+                line.push_str(&format!(" — {}", reason));
+            }
+            Some((line, MessageRole::Signal))
+        }
         "task.updated" if status == "runnable" => Some((
             format!("🔁 [{}] Resumed after approval: {}{}", ts_short, task, agent_suffix),
             MessageRole::Signal,

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -70,7 +70,7 @@ approval_timeout_secs: 600
 # Reactive bindings from gateway events to actions.
 # Available events: session.closed, session.suspended, approval.resolved,
 #   approval.requested, workflow.join.satisfied, artifact.created,
-#   agent.promoted, emergency_stop
+#   agent.promoted, emergency_stop, policy.decision
 # Available actions: publish_report, deliver_signal, agent.spawn, http.callback
 #
 # hooks:
@@ -91,6 +91,9 @@ approval_timeout_secs: 600
 #   #   approval.resolved: request_id, decision
 #   #   session.closed:    close_reason, turn_count
 #   #   workflow.join.satisfied: workflow_id, task_ids
+#   #   policy.decision:   root_session_id, session_id, agent_id, event_id, rule_ids,
+#   #                      primary_rule_id, decision, status, category, action, target,
+#   #                      reason, turn_id, source, plus {{event}} -> policy.decision
 #   # allowed_agents restricts which agent IDs the hook may spawn (ACL).
 #   - on: "approval.resolved"
 #     action: "agent.spawn"
@@ -100,6 +103,20 @@ approval_timeout_secs: 600
 #       message_template: "Evaluate approval {{request_id}} (decision: {{decision}})"
 #     allowed_agents:
 #       - evaluator.default       # ACL: only this agent may be spawned by this hook
+#
+#   # Observer-only: after selected causal_events rows (denials/errors, or success with
+#   # non-baseline rule ids). See docs/ARCHITECTURE.md § Constitutional observability.
+#   - on: "policy.decision"
+#     action: "agent.spawn"
+#     async: true
+#     params:
+#       agent_id: "constitutional-observer.default"
+#       message_template: |
+#         {{event}} root={{root_session_id}} session={{session_id}} agent={{agent_id}}
+#         status={{status}} decision={{decision}} rules={{rule_ids}} event_id={{event_id}}
+#         category={{category}} action={{action}} target={{target}} reason={{reason}}
+#     allowed_agents:
+#       - constitutional-observer.default
 
 # ── Chat TUI ──────────────────────────────────────────────────────────
 # Inline approval from the chat interface (Ctrl+A).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -830,6 +830,7 @@ hooks:
 | `artifact.created` | A new artifact is built |
 | `agent.promoted` | An agent revision is promoted |
 | `emergency_stop` | Emergency stop is triggered |
+| `policy.decision` | After a `causal_events` row insert matching hook filters (DENIED/ERROR, or SUCCESS with a non-baseline rule such as not only `R+++3`) — observer-only |
 
 ### Available Actions
 
@@ -845,6 +846,42 @@ hooks:
 - **Async hooks** return immediately; the action runs in a background tokio task
 - **Sync hooks** block the triggering operation until the action completes
 - Failed hooks log a warning but do not fail the triggering operation
+
+### Constitutional observability (`policy.decision`)
+
+Hooks with `on: "policy.decision"` run **after** a matching row is inserted into `causal_events`. They are **observer-only**: they cannot change allow/deny outcomes; the gateway has already persisted the audit row.
+
+**When this event is emitted**
+
+| Causal `status` | `enforced_rules` | Emit? |
+|-----------------|------------------|--------|
+| `DENIED` or `ERROR` (any casing) | any | yes |
+| `SUCCESS` | contains at least one rule **other than** `R+++3` | yes |
+| `SUCCESS` | only `R+++3` | no (avoids noise on routine successes) |
+| other (e.g. `active`) | — | no |
+
+**`message_template` placeholders** (also present on `HookContext` where applicable): `{{event}}` → `policy.decision`; plus `{{root_session_id}}`, `{{session_id}}`, `{{agent_id}}`, `{{event_id}}`, `{{rule_ids}}`, `{{primary_rule_id}}`, `{{decision}}`, `{{status}}`, `{{category}}`, `{{action}}`, `{{target}}`, `{{reason}}`, `{{turn_id}}`, `{{source}}`.
+
+**Example: spawn a dedicated observer agent** when a policy-relevant causal row is written. The target agent must exist under `agents_dir`. `agent.spawn` hooks **must** use `async: true`. Use `allowed_agents` so only your observer can be spawned from this hook.
+
+```yaml
+hooks:
+  - on: "policy.decision"
+    action: "agent.spawn"
+    async: true
+    params:
+      agent_id: "constitutional-observer.default"
+      message_template: |
+        Causal policy event: {{event}}
+        root={{root_session_id}} session={{session_id}} agent={{agent_id}}
+        status={{status}} decision={{decision}} primary_rule={{primary_rule_id}} rules={{rule_ids}}
+        category={{category}} action={{action}} target={{target}} event_id={{event_id}} turn={{turn_id}}
+        reason={{reason}}
+    allowed_agents:
+      - constitutional-observer.default
+```
+
+The spawned run uses a dedicated session id (`hook-spawn-…`) under the same **root** session as the triggering context so tree-wide limits and emergency stop still apply.
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -428,7 +428,7 @@ Reactive bindings from gateway events to actions. When an event fires (e.g., ses
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `hooks[].on` | string | required | Event name: `session.closed`, `session.suspended`, `approval.resolved`, `approval.requested`, `workflow.join.satisfied`, `artifact.created`, `agent.promoted`, `emergency_stop` |
+| `hooks[].on` | string | required | Event name: `session.closed`, `session.suspended`, `approval.resolved`, `approval.requested`, `workflow.join.satisfied`, `artifact.created`, `agent.promoted`, `emergency_stop`, `policy.decision` |
 | `hooks[].action` | string | required | Action: `publish_report`, `deliver_signal`, `agent_spawn`, `http.callback` |
 | `hooks[].async` | bool | `false` | If true, the hook runs in a background task without blocking the event |
 | `hooks[].params` | object | `{}` | Action-specific parameters |
@@ -459,6 +459,23 @@ hooks:
     params:
       url: "https://webhook.example.com/autonoetic/session-closed"
       secret_env: "AUTONOETIC_HOOK_SECRET"
+```
+
+`policy.decision` fires after selected `causal_events` inserts; see **Constitutional observability (`policy.decision`)** under [Hook System](ARCHITECTURE.md#hook-system) in `ARCHITECTURE.md`. Example: spawn an observer agent on denials and other policy-tagged outcomes:
+
+```yaml
+hooks:
+  - on: "policy.decision"
+    action: "agent.spawn"
+    async: true
+    params:
+      agent_id: "constitutional-observer.default"
+      message_template: |
+        {{event}} root={{root_session_id}} session={{session_id}} agent={{agent_id}}
+        status={{status}} decision={{decision}} rules={{rule_ids}} event_id={{event_id}}
+        category={{category}} action={{action}} target={{target}} reason={{reason}}
+    allowed_agents:
+      - constitutional-observer.default
 ```
 
 ---

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -429,7 +429,7 @@ Reactive bindings from gateway events to actions. When an event fires (e.g., ses
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `hooks[].on` | string | required | Event name: `session.closed`, `session.suspended`, `approval.resolved`, `approval.requested`, `workflow.join.satisfied`, `artifact.created`, `agent.promoted`, `emergency_stop`, `policy.decision` |
-| `hooks[].action` | string | required | Action: `publish_report`, `deliver_signal`, `agent_spawn`, `http.callback` |
+| `hooks[].action` | string | required | Action: `publish_report`, `deliver_signal`, `agent.spawn`, `http.callback` |
 | `hooks[].async` | bool | `false` | If true, the hook runs in a background task without blocking the event |
 | `hooks[].params` | object | `{}` | Action-specific parameters |
 | `hooks[].callback_allowlist` | list | `[]` | Required for `http.callback`. Allowlist entries use grant-target shapes such as `{ kind: "url_prefix", value: "https://hooks.example.com/autonoetic/" }` |

--- a/docs/revision-signing.md
+++ b/docs/revision-signing.md
@@ -1,0 +1,133 @@
+# Revision Signing (R+11)
+
+## Overview
+
+Every agent revision is automatically signed by the gateway at creation time using the
+gateway's persistent Ed25519 identity key. The signature provides **integrity attestation**
+— proof that the gateway computed the canonical content digest and vouches for the
+revision's contents — and enables tamper detection for auditors and federation.
+
+This is **not** an access control mechanism. The capability gate (`AgentRevision`) already
+controls who can create revisions. The signature answers a different question: _"Is this
+revision exactly what the gateway computed, or has it been tampered with?"_
+
+## What Gets Signed
+
+The signature covers the **revision content digest** — a SHA-256 hash over the complete
+`BTreeMap<String, Vec<u8>>` that materializes on disk:
+
+```
+for each file (in sorted path order):
+    hash(path_bytes || 0x00 || file_content_bytes || 0x00)
+```
+
+This includes:
+
+| Component | Source |
+|-----------|--------|
+| Artifact code files | From the artifact bundle |
+| `SKILL.md` | Agent-authored (`agent_revision_create`) or gateway-rendered (`create_from_intent`) |
+| `runtime.lock` | Always gateway-normalized/canonicalized |
+
+Layers are **not** included directly — they're bound transitively through `runtime.lock`,
+which lists each layer's `layer_id`, `digest`, and `mount_path`.
+
+### One Digest, One Meaning
+
+The `content_digest` field in the revision record always equals the full revision digest
+(`sha256:{hex of complete file map hash}`). This is the same value used to derive the
+`revision_id` and the same value that gets signed. There is no separate "artifact-only"
+digest stored — promotion checks use this same digest, ensuring the promotion gate
+attests to the complete runnable content.
+
+## Auto-Sign Flow
+
+```
+create_revision_from_files()
+    │
+    ├── 1. Normalize runtime.lock, inject into file_map
+    ├── 2. Validate script shebang (if script agent)
+    ├── 3. Compute revision_digest_hex = SHA-256(file_map)
+    ├── 4. revision_id = "rev_sha256:{digest_hex}"
+    ├── 5. content_digest = "sha256:{digest_hex}"  (always the full revision)
+    │
+    ├── 6. Load gateway identity key (auto-generates on first use)
+    │       ├── Success → sign(digest_hex) → store signature + signer_id
+    │       └── Failure + trust_unsigned_bundles → proceed unsigned (dev mode)
+    │       └── Failure + !trust_unsigned_bundles → error
+    │
+    └── 7. Persist revision record with signature + signer_id
+```
+
+## Key-Agnostic Verification
+
+The revision record stores two fields:
+
+- **`signature`**: Base64-encoded Ed25519 signature over the raw hex digest string.
+- **`signer_id`**: Identifies which key produced the signature (e.g. `gateway:a1b2c3d4e5f67890`).
+
+A verifier:
+
+1. Reads `signer_id` to determine which public key to use.
+2. Resolves the public key from a **trust store** (the gateway's `state_attestation.ed25519.pub`
+   for local `gateway:` signers, a federation key store for `peer:` signers, etc.).
+3. Verifies the Ed25519 signature over `revision_digest_hex`.
+
+This design supports future external signers (federation peers, CI pipelines, operator
+consoles) without changing the verification path — only the trust store resolution
+changes.
+
+### Signer ID Format
+
+| Prefix | Meaning | Public key source |
+|--------|---------|-------------------|
+| `gateway:{fingerprint}` | Auto-signed by the local gateway | `state_attestation.ed25519.pub` |
+| `peer:{node_id}` | Signed by a federated gateway (future) | Federation trust store |
+| `ci:{pipeline_id}` | Signed by a CI attestation pipeline (future) | CI public key registry |
+
+## Gateway Identity Key
+
+The signing key is the same `GatewayIdentityKey` used for turn-boundary state attestations
+(R++1):
+
+- **Private**: `.gateway/state_attestation.ed25519` (mode `0o600`, auto-generated on first load)
+- **Public**: `.gateway/state_attestation.ed25519.pub` (32 bytes, Ed25519 verifying key)
+
+## Configuration
+
+### `trust_unsigned_bundles` (default: `false`)
+
+When `false` (default), revision creation fails if the gateway identity key cannot be
+loaded. This should never happen in normal operation (the key auto-generates on first
+access), but protects against environments where the private key file has wrong
+permissions or the filesystem is read-only.
+
+When `true`, revision creation proceeds without a signature if the key is unavailable.
+This is intended only for local development or constrained environments.
+
+### Why This Replaced the Old R+11 Gate
+
+The original R+11 design required the **caller** (agent/CLI) to provide an Ed25519
+signature in the tool arguments. This was a deadlock:
+
+1. The agent doesn't have the gateway's private key, so it can't produce a valid signature.
+2. The gateway doesn't auto-sign, so there's no way to get a signature.
+3. The only escape was `trust_unsigned_bundles: true`, which completely bypassed signing.
+
+The new design recognizes that the signature's purpose is **gateway attestation** ("this
+is what I computed"), not **caller authentication** (the capability gate already handles
+that). Auto-signing inside `create_revision_from_files` — after the gateway has
+canonicalized the content — is the correct place for this operation.
+
+## SQLite Schema
+
+Migration v24 adds two nullable columns to `agent_revisions`:
+
+```sql
+ALTER TABLE agent_revisions ADD COLUMN signature TEXT;
+ALTER TABLE agent_revisions ADD COLUMN signer_id TEXT;
+```
+
+Existing revisions (created before this migration) have `NULL` for both fields.
+Revisions created without a gateway key (`trust_unsigned_bundles: true`) also have
+`NULL` for both fields.


### PR DESCRIPTION
## Summary

Recovers 5 local commits that were lost when local `main` was reset to `origin/main`. These were developed on top of `main` but never pushed before the reset.

### Commits (oldest → newest)
1. **digest: link workflow task/session under agent headers** — live digest now cross-links workflow tasks and sessions under agent entries
2. **feat(gateway): resolve artifact_ref in sandbox_exec** — sandbox execution resolves `artifact_ref` references before dispatching
3. **feat(revision): gateway auto-signing with key-agnostic verification (R+11)** — revision bundles are auto-signed at creation; verification is key-agnostic (works across key rotations)
4. **fix(scheduler): record last_run_at, emit cancel events for TUI** — scheduler records `last_run_at` on job completion and emits cancel causal events so the TUI workflow pane stays accurate
5. **Add policy.decision hook after causal_events insert** — new `PolicyDecision` hook event fires after causal event insertion; observer-only, never affects allow/deny; includes `causal_event_notifies_policy_decision()` filter (emits on DENIED, or SUCCESS when non-baseline rules present)

### Notable changes
- New `HookEvent::PolicyDecision` variant + `HookContext::for_policy_decision()` constructor
- `HookExecutor::maybe_dispatch_policy_decision_hook()` called from `GatewayStore::create_causal_event`
- `causal_event_notifies_policy_decision()` in `autonoetic-types/src/causal_chain.rs`
- Revision signing with Ed25519, verification tolerant of key changes
- Scheduler cancel events + `last_run_at` tracking
- 40 files, ~1000 lines added