### PR TITLE
feat: R+13 approval grant TTL — default 24h expiry

### DIFF
--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -75,6 +75,9 @@ async fn run_scheduler_tick_at(
         }
         // Cleanup stale notifications (e.g., older than 24h)
         let _ = store.cleanup_stale_notifications(24);
+        if let Err(e) = store.prune_expired_grants() {
+            tracing::warn!(error = %e, "Failed to prune expired session approval grants");
+        }
     }
 
     let config = execution.config();

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -1102,6 +1102,21 @@ fn decide_request_with_options(
                             options.grant_targets.clone()
                         };
                         let session_id = decision.session_id.as_str();
+                        let computed_expiry = if options.grant_expires_at.is_none()
+                            && config.default_grant_ttl_secs > 0
+                        {
+                            let t = chrono::Utc::now()
+                                + chrono::Duration::seconds(
+                                    config.default_grant_ttl_secs as i64,
+                                );
+                            Some(t.to_rfc3339())
+                        } else {
+                            None
+                        };
+                        let expires_at = options
+                            .grant_expires_at
+                            .as_deref()
+                            .or(computed_expiry.as_deref());
                         if let Err(e) = store.insert_session_grant(
                             root_sid,
                             session_id,
@@ -1111,7 +1126,7 @@ fn decide_request_with_options(
                             &decision.decided_by,
                             &decision.decided_at,
                             Some(&decision.request_id),
-                            options.grant_expires_at.as_deref(),
+                            expires_at,
                         ) {
                             tracing::warn!(
                                 target: "approval",

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -1105,10 +1105,12 @@ fn decide_request_with_options(
                         let computed_expiry = if options.grant_expires_at.is_none()
                             && config.default_grant_ttl_secs > 0
                         {
-                            let t = chrono::Utc::now()
-                                + chrono::Duration::seconds(
-                                    config.default_grant_ttl_secs as i64,
-                                );
+                            let ttl_secs = i64::try_from(config.default_grant_ttl_secs)
+                                .unwrap_or(i64::MAX);
+                            let base = chrono::DateTime::parse_from_rfc3339(&decision.decided_at)
+                                .map(|dt| dt.with_timezone(&chrono::Utc))
+                                .unwrap_or_else(|_| chrono::Utc::now());
+                            let t = base + chrono::Duration::seconds(ttl_secs);
                             Some(t.to_rfc3339())
                         } else {
                             None

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -662,33 +662,25 @@ impl GatewayStore {
     }
 
     pub fn prune_expired_grants(&self) -> Result<usize> {
-        let now = chrono::Utc::now();
+        let now = chrono::Utc::now().to_rfc3339();
         let conn = self.conn.lock().unwrap();
         let expired_ids: Vec<i64> = {
             let mut stmt = conn.prepare(
-                "SELECT id, expires_at FROM session_approval_grants WHERE expires_at IS NOT NULL",
+                "SELECT id FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",
             )?;
-            let rows = stmt.query_map([], |row| {
-                let id: i64 = row.get(0)?;
-                let expires_at: String = row.get(1)?;
-                Ok((id, expires_at))
-            })?;
-            rows.filter_map(|r| r.ok())
-                .filter(|(_, exp)| {
-                    chrono::DateTime::parse_from_rfc3339(exp)
-                        .map(|dt| dt.with_timezone(&chrono::Utc) < now)
-                        .unwrap_or(false)
-                })
-                .map(|(id, _)| id)
-                .collect()
+            let rows = stmt.query_map(params![now], |row| row.get(0))?;
+            rows.filter_map(|r| r.ok()).collect()
         };
+        if expired_ids.is_empty() {
+            return Ok(0);
+        }
+        let count = expired_ids.len();
         for gid in &expired_ids {
             let _ = conn.execute(
                 "DELETE FROM session_approval_grant_targets WHERE grant_id = ?1",
                 params![gid],
             );
         }
-        let count = expired_ids.len();
         for gid in &expired_ids {
             let _ = conn.execute(
                 "DELETE FROM session_approval_grants WHERE id = ?1",

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -158,6 +158,89 @@ impl GatewayStore {
         Ok(())
     }
 
+    pub fn emit_vault_key_probe_event(
+        &self,
+        result: &crate::vault::KeyProbeResult,
+    ) -> anyhow::Result<()> {
+        let now = chrono::Utc::now();
+        let mut rules = autonoetic_types::causal_chain::default_enforced_rules();
+        rules.push("R+8".to_string());
+        let (status, source_str, payload) = match result {
+            crate::vault::KeyProbeResult::Present { source } => (
+                autonoetic_types::causal_chain::EntryStatus::Success.to_string(),
+                match source {
+                    crate::vault::KeySource::EnvVar => "AUTONOETIC_VAULT_KEY",
+                    crate::vault::KeySource::FilePath => "AUTONOETIC_VAULT_KEY_PATH",
+                },
+                serde_json::json!({ "source": match source {
+                    crate::vault::KeySource::EnvVar => "env_var",
+                    crate::vault::KeySource::FilePath => "file_path",
+                }}),
+            ),
+            crate::vault::KeyProbeResult::Missing { source, path } => (
+                "MISSING".to_string(),
+                match source {
+                    crate::vault::KeySource::EnvVar => "AUTONOETIC_VAULT_KEY",
+                    crate::vault::KeySource::FilePath => "AUTONOETIC_VAULT_KEY_PATH",
+                },
+                serde_json::json!({
+                    "source": match source {
+                        crate::vault::KeySource::EnvVar => "env_var",
+                        crate::vault::KeySource::FilePath => "file_path",
+                    },
+                    "path": path,
+                }),
+            ),
+            crate::vault::KeyProbeResult::Invalid { source, reason } => (
+                "ERROR".to_string(),
+                match source {
+                    crate::vault::KeySource::EnvVar => "AUTONOETIC_VAULT_KEY",
+                    crate::vault::KeySource::FilePath => "AUTONOETIC_VAULT_KEY_PATH",
+                },
+                serde_json::json!({
+                    "source": match source {
+                        crate::vault::KeySource::EnvVar => "env_var",
+                        crate::vault::KeySource::FilePath => "file_path",
+                    },
+                    "reason": reason,
+                }),
+            ),
+            crate::vault::KeyProbeResult::NotConfigured => (
+                "NOT_CONFIGURED".to_string(),
+                "none",
+                serde_json::json!({ "source": "none" }),
+            ),
+        };
+
+        if let Err(e) = self.create_causal_event(
+            &autonoetic_types::causal_chain::CausalEventRecord {
+                event_id: uuid::Uuid::new_v4().to_string(),
+                agent_id: "gateway".to_string(),
+                session_id: "system".to_string(),
+                turn_id: None,
+                event_seq: now.timestamp_millis().max(0) as u64,
+                timestamp: now.to_rfc3339(),
+                category: "vault".to_string(),
+                action: "key_probe".to_string(),
+                status,
+                enforced_rules: rules,
+                target: None,
+                payload: serde_json::to_string(&payload).ok(),
+                payload_ref: None,
+                evidence_ref: None,
+                reason: Some(format!("Vault key source: {source_str}")),
+            },
+        ) {
+            tracing::warn!(
+                target: "gateway_store",
+                error = %e,
+                "Failed to record vault.key_probe causal event"
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn create_causal_event(
         &self,
         event: &autonoetic_types::causal_chain::CausalEventRecord,

--- a/autonoetic-gateway/src/server/mod.rs
+++ b/autonoetic-gateway/src/server/mod.rs
@@ -53,6 +53,24 @@ impl GatewayServer {
         )?);
         gateway_store.set_approval_flood_cap(self.config.max_pending_approvals_per_root);
 
+        {
+            let probe_result = crate::vault::probe_master_key();
+            if !probe_result.is_present() {
+                tracing::warn!(
+                    target: "vault",
+                    result = ?probe_result,
+                    "Vault master key not available — credential operations will fail at runtime (R+8)"
+                );
+            }
+            if let Err(e) = gateway_store.emit_vault_key_probe_event(&probe_result) {
+                tracing::warn!(
+                    target: "vault",
+                    error = %e,
+                    "Failed to emit vault.key_probe causal event"
+                );
+            }
+        }
+
         // Apply data retention policy on startup
         if let Err(e) = gateway_store.apply_retention_policy(&self.config.retention) {
             tracing::warn!(

--- a/autonoetic-gateway/src/vault.rs
+++ b/autonoetic-gateway/src/vault.rs
@@ -213,6 +213,75 @@ pub fn ensure_default_key(agents_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Probe whether a vault master key is available without creating one.
+///
+/// Returns a [`KeyProbeResult`] describing which source (if any) is configured.
+/// Unlike [`ensure_default_key`], this function is read-only and has no side effects.
+pub fn probe_master_key() -> KeyProbeResult {
+    if let Ok(key_hex) = std::env::var(VAULT_KEY_ENV) {
+        if hex_to_key(&key_hex).is_some() {
+            return KeyProbeResult::Present {
+                source: KeySource::EnvVar,
+            };
+        }
+        return KeyProbeResult::Invalid {
+            source: KeySource::EnvVar,
+            reason: "AUTONOETIC_VAULT_KEY is set but not a valid 64-char hex string".to_string(),
+        };
+    }
+    if let Ok(key_path) = std::env::var(VAULT_KEY_PATH_ENV) {
+        let path = PathBuf::from(&key_path);
+        if !path.exists() {
+            return KeyProbeResult::Missing {
+                source: KeySource::FilePath,
+                path: key_path,
+            };
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(key_hex) if hex_to_key(key_hex.trim()).is_some() => {
+                return KeyProbeResult::Present {
+                    source: KeySource::FilePath,
+                };
+            }
+            Ok(_) => {
+                return KeyProbeResult::Invalid {
+                    source: KeySource::FilePath,
+                    reason: format!(
+                        "AUTONOETIC_VAULT_KEY_PATH points to file with invalid key content"
+                    ),
+                };
+            }
+            Err(e) => {
+                return KeyProbeResult::Invalid {
+                    source: KeySource::FilePath,
+                    reason: format!("Failed to read vault key file: {e}"),
+                };
+            }
+        }
+    }
+    KeyProbeResult::NotConfigured
+}
+
+#[derive(Debug, Clone)]
+pub enum KeySource {
+    EnvVar,
+    FilePath,
+}
+
+#[derive(Debug, Clone)]
+pub enum KeyProbeResult {
+    Present { source: KeySource },
+    Missing { source: KeySource, path: String },
+    Invalid { source: KeySource, reason: String },
+    NotConfigured,
+}
+
+impl KeyProbeResult {
+    pub fn is_present(&self) -> bool {
+        matches!(self, KeyProbeResult::Present { .. })
+    }
+}
+
 /// Return the default vault file path: `{agents_dir}/.gateway/vault.enc.json`.
 pub fn default_vault_path(agents_dir: &Path) -> PathBuf {
     agents_dir.join(".gateway").join("vault.enc.json")

--- a/autonoetic-gateway/tests/constitution_approval_grant_ttl.rs
+++ b/autonoetic-gateway/tests/constitution_approval_grant_ttl.rs
@@ -1,0 +1,198 @@
+//! Constitution R+13: Approval grant TTL.
+//!
+//! Session approval grants must have a default TTL (24h). When a grant
+//! expires, it re-opens the approval gate — the target must be re-approved.
+//! The scheduler tick prunes expired grant rows from the database.
+
+mod support;
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::background::{GrantScope, GrantTarget};
+use std::sync::Arc;
+
+fn seed_grant(
+    store: &Arc<GatewayStore>,
+    root_session_id: &str,
+    agent_id: &str,
+    hosts: &[&str],
+    expires_at: Option<&str>,
+) -> anyhow::Result<()> {
+    let targets: Vec<GrantTarget> = hosts
+        .iter()
+        .map(|h| GrantTarget::ExactHost(h.to_string()))
+        .collect();
+    store.insert_session_grant(
+        root_session_id,
+        root_session_id,
+        agent_id,
+        &GrantScope::RootSession,
+        &targets,
+        "operator",
+        &chrono::Utc::now().to_rfc3339(),
+        None,
+        expires_at,
+    )
+}
+
+#[test]
+fn r_plus_13_grant_with_default_ttl_is_born_with_expires_at() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let config = autonoetic_types::config::GatewayConfig {
+        default_grant_ttl_secs: 3600,
+        ..Default::default()
+    };
+
+    assert_eq!(config.default_grant_ttl_secs, 3600);
+    assert!(config.default_grant_ttl_secs > 0);
+
+    let now = chrono::Utc::now();
+    let expires_at = now + chrono::Duration::seconds(config.default_grant_ttl_secs as i64);
+    seed_grant(
+        &store,
+        "root-1",
+        "agent-1",
+        &["example.com"],
+        Some(expires_at.to_rfc3339().as_str()),
+    )?;
+
+    let grants = store.get_session_grants_structured("root-1")?;
+    assert_eq!(grants.len(), 1);
+    assert!(grants[0].expires_at.is_some(), "grant must have expires_at set");
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_expired_grant_does_not_cover_targets() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let past = chrono::Utc::now() - chrono::Duration::seconds(3600);
+    seed_grant(
+        &store,
+        "root-2",
+        "agent-2",
+        &["expired.example.com"],
+        Some(past.to_rfc3339().as_str()),
+    )?;
+
+    let targets = vec!["expired.example.com".to_string()];
+    let covers = store.session_grants_cover_targets("root-2", &targets);
+
+    assert!(
+        !covers,
+        "expired grant must NOT cover targets — approval gate must re-open"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_valid_grant_covers_targets() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let future = chrono::Utc::now() + chrono::Duration::seconds(86400);
+    seed_grant(
+        &store,
+        "root-3",
+        "agent-3",
+        &["valid.example.com"],
+        Some(future.to_rfc3339().as_str()),
+    )?;
+
+    let targets = vec!["valid.example.com".to_string()];
+    let covers = store.session_grants_cover_targets("root-3", &targets);
+
+    assert!(
+        covers,
+        "non-expired grant must cover targets"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_grant_without_expiry_covers_targets_forever() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    seed_grant(
+        &store,
+        "root-4",
+        "agent-4",
+        &["permanent.example.com"],
+        None,
+    )?;
+
+    let targets = vec!["permanent.example.com".to_string()];
+    let covers = store.session_grants_cover_targets("root-4", &targets);
+
+    assert!(
+        covers,
+        "grant without expires_at must cover targets indefinitely"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_prune_expired_grants_removes_expired_rows() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let past = chrono::Utc::now() - chrono::Duration::seconds(3600);
+    let future = chrono::Utc::now() + chrono::Duration::seconds(86400);
+
+    seed_grant(
+        &store,
+        "root-5",
+        "agent-5",
+        &["expired.example.com"],
+        Some(past.to_rfc3339().as_str()),
+    )?;
+    seed_grant(
+        &store,
+        "root-5",
+        "agent-5",
+        &["valid.example.com"],
+        Some(future.to_rfc3339().as_str()),
+    )?;
+
+    let grants_before = store.get_session_grants_structured("root-5")?;
+    assert_eq!(grants_before.len(), 2);
+
+    let pruned = store.prune_expired_grants()?;
+    assert_eq!(pruned, 1, "one expired grant should be pruned");
+
+    let grants_after = store.get_session_grants_structured("root-5")?;
+    assert_eq!(grants_after.len(), 1);
+    assert!(grants_after[0].expires_at.is_some());
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_config_default_grant_ttl_secs_is_24h() {
+    let config = autonoetic_types::config::GatewayConfig::default();
+    assert_eq!(
+        config.default_grant_ttl_secs, 86400,
+        "default TTL must be 24h (86400 seconds)"
+    );
+}
+
+#[test]
+fn r_plus_13_zero_ttl_disables_auto_expiry() {
+    let config = autonoetic_types::config::GatewayConfig {
+        default_grant_ttl_secs: 0,
+        ..Default::default()
+    };
+    assert_eq!(config.default_grant_ttl_secs, 0);
+}

--- a/autonoetic-gateway/tests/constitution_approval_grant_ttl.rs
+++ b/autonoetic-gateway/tests/constitution_approval_grant_ttl.rs
@@ -7,7 +7,10 @@
 mod support;
 
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
-use autonoetic_types::background::{GrantScope, GrantTarget};
+use autonoetic_gateway::scheduler::{approve_request_with_options, ApproveOptions};
+use autonoetic_types::background::{
+    ApprovalLevel, ApprovalRequest, GrantScope, GrantTarget, ScheduledAction,
+};
 use std::sync::Arc;
 
 fn seed_grant(
@@ -35,7 +38,7 @@ fn seed_grant(
 }
 
 #[test]
-fn r_plus_13_grant_with_default_ttl_is_born_with_expires_at() -> anyhow::Result<()> {
+fn r_plus_13_grant_roundtrip_with_expires_at() -> anyhow::Result<()> {
     let tempdir = tempfile::tempdir()?;
     let gateway_dir = tempdir.path().join(".gateway");
     let store = Arc::new(GatewayStore::open(&gateway_dir)?);
@@ -195,4 +198,172 @@ fn r_plus_13_zero_ttl_disables_auto_expiry() {
         ..Default::default()
     };
     assert_eq!(config.default_grant_ttl_secs, 0);
+}
+
+fn make_sandbox_exec_request(
+    request_id: &str,
+    root_session_id: &str,
+    hosts: Vec<&str>,
+) -> ApprovalRequest {
+    ApprovalRequest {
+        request_id: request_id.to_string(),
+        agent_id: "coder.default".to_string(),
+        session_id: format!("{}/coder-1", root_session_id),
+        root_session_id: Some(root_session_id.to_string()),
+        workflow_id: None,
+        task_id: None,
+        action: ScheduledAction::SandboxExec {
+            command: "curl https://api.example.com".to_string(),
+            detected_hosts: Some(hosts.into_iter().map(String::from).collect()),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+        },
+        created_at: (chrono::Utc::now() - chrono::Duration::seconds(30)).to_rfc3339(),
+        reason: Some("test approval".to_string()),
+        evidence_ref: None,
+        status: None,
+        decided_at: None,
+        decided_by: None,
+        decision_reason: None,
+        approval_level: ApprovalLevel::Operator,
+        similar_to_request_id: None,
+        similarity_score: None,
+        min_dwell_ms: None,
+        confirm_phrase: None,
+    }
+}
+
+#[test]
+fn r_plus_13_approval_resolution_auto_computes_expiry_when_default_ttl_set() -> anyhow::Result<()>
+{
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let config = autonoetic_types::config::GatewayConfig {
+        default_grant_ttl_secs: 3600,
+        approval_dwell_multiplier: 0.0,
+        ..Default::default()
+    };
+
+    let mut req = make_sandbox_exec_request("apr-ttl-auto", "root-ttl-auto", vec!["api.example.com"]);
+    store.create_approval(&mut req)?;
+
+    let before = chrono::Utc::now();
+    let decision = approve_request_with_options(
+        &config,
+        Some(&store),
+        "apr-ttl-auto",
+        "operator",
+        Some("approved".to_string()),
+        None,
+        Some(&ApprovalLevel::Operator),
+        None,
+        ApproveOptions::default(),
+    )?;
+    assert_eq!(decision.status, autonoetic_types::background::ApprovalStatus::Approved);
+
+    let grants = store.get_session_grants_structured("root-ttl-auto")?;
+    assert_eq!(grants.len(), 1, "approval should auto-insert one grant");
+    let grant = &grants[0];
+    assert!(
+        grant.expires_at.is_some(),
+        "grant must have expires_at auto-computed from default_grant_ttl_secs"
+    );
+    let expires_at = grant.expires_at.as_ref().unwrap();
+    let parsed = chrono::DateTime::parse_from_rfc3339(expires_at)?;
+    let expected_min = before + chrono::Duration::seconds(3600) - chrono::Duration::seconds(5);
+    let expected_max = before + chrono::Duration::seconds(3600) + chrono::Duration::seconds(5);
+    assert!(
+        parsed.with_timezone(&chrono::Utc) >= expected_min
+            && parsed.with_timezone(&chrono::Utc) <= expected_max,
+        "expires_at should be approximately decided_at + default_grant_ttl_secs, got {}",
+        expires_at
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_approval_resolution_no_expiry_when_default_ttl_zero() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let config = autonoetic_types::config::GatewayConfig {
+        default_grant_ttl_secs: 0,
+        approval_dwell_multiplier: 0.0,
+        ..Default::default()
+    };
+
+    let mut req = make_sandbox_exec_request("apr-ttl-zero", "root-ttl-zero", vec!["api.example.com"]);
+    store.create_approval(&mut req)?;
+
+    let decision = approve_request_with_options(
+        &config,
+        Some(&store),
+        "apr-ttl-zero",
+        "operator",
+        Some("approved".to_string()),
+        None,
+        Some(&ApprovalLevel::Operator),
+        None,
+        ApproveOptions::default(),
+    )?;
+    assert_eq!(decision.status, autonoetic_types::background::ApprovalStatus::Approved);
+
+    let grants = store.get_session_grants_structured("root-ttl-zero")?;
+    assert_eq!(grants.len(), 1);
+    assert!(
+        grants[0].expires_at.is_none(),
+        "grant must NOT have expires_at when default_grant_ttl_secs is 0"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn r_plus_13_approval_resolution_explicit_ttl_overrides_default() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let config = autonoetic_types::config::GatewayConfig {
+        default_grant_ttl_secs: 86400,
+        approval_dwell_multiplier: 0.0,
+        ..Default::default()
+    };
+
+    let mut req = make_sandbox_exec_request("apr-ttl-explicit", "root-ttl-explicit", vec!["api.example.com"]);
+    store.create_approval(&mut req)?;
+
+    let explicit_expiry = (chrono::Utc::now() + chrono::Duration::seconds(600)).to_rfc3339();
+    let decision = approve_request_with_options(
+        &config,
+        Some(&store),
+        "apr-ttl-explicit",
+        "operator",
+        Some("approved".to_string()),
+        None,
+        Some(&ApprovalLevel::Operator),
+        None,
+        ApproveOptions {
+            grant_expires_at: Some(explicit_expiry.clone()),
+            ..Default::default()
+        },
+    )?;
+    assert_eq!(decision.status, autonoetic_types::background::ApprovalStatus::Approved);
+
+    let grants = store.get_session_grants_structured("root-ttl-explicit")?;
+    assert_eq!(grants.len(), 1);
+    assert!(grants[0].expires_at.is_some());
+    let explicit_prefix = &explicit_expiry[..20];
+    let grant_prefix = &grants[0].expires_at.as_deref().unwrap()[..20];
+    assert_eq!(
+        grant_prefix, explicit_prefix,
+        "explicit grant_expires_at must override default TTL"
+    );
+
+    Ok(())
 }

--- a/autonoetic-gateway/tests/constitution_vault_startup_probe.rs
+++ b/autonoetic-gateway/tests/constitution_vault_startup_probe.rs
@@ -1,0 +1,213 @@
+//! Constitution R+8: Vault master-key presence probe at gateway startup.
+//!
+//! The gateway must probe the vault master key at boot and emit a
+//! `vault.key_probe` causal event. This ensures misconfiguration is
+//! caught early rather than failing on first secret access at runtime.
+
+mod support;
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::vault::{probe_master_key, KeyProbeResult, KeySource};
+use serial_test::serial;
+
+fn clear_vault_env() {
+    std::env::remove_var("AUTONOETIC_VAULT_KEY");
+    std::env::remove_var("AUTONOETIC_VAULT_KEY_PATH");
+}
+
+#[test]
+#[serial]
+fn r_plus_8_probe_key_present_via_env() {
+    clear_vault_env();
+    let key_hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    std::env::set_var("AUTONOETIC_VAULT_KEY", key_hex);
+
+    let result = probe_master_key();
+    assert!(result.is_present());
+    assert!(matches!(
+        result,
+        KeyProbeResult::Present {
+            source: KeySource::EnvVar
+        }
+    ));
+
+    clear_vault_env();
+}
+
+#[test]
+#[serial]
+fn r_plus_8_probe_key_present_via_file() {
+    clear_vault_env();
+    let key_hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    let temp = tempfile::tempdir().unwrap();
+    let key_path = temp.path().join("vault.key");
+    std::fs::write(&key_path, key_hex).unwrap();
+    std::env::set_var("AUTONOETIC_VAULT_KEY_PATH", &key_path);
+
+    let result = probe_master_key();
+    assert!(result.is_present());
+    assert!(matches!(
+        result,
+        KeyProbeResult::Present {
+            source: KeySource::FilePath
+        }
+    ));
+
+    clear_vault_env();
+}
+
+#[test]
+#[serial]
+fn r_plus_8_probe_not_configured() {
+    clear_vault_env();
+    let result = probe_master_key();
+    assert!(!result.is_present());
+    assert!(matches!(result, KeyProbeResult::NotConfigured));
+}
+
+#[test]
+#[serial]
+fn r_plus_8_probe_file_missing() {
+    clear_vault_env();
+    std::env::set_var("AUTONOETIC_VAULT_KEY_PATH", "/nonexistent/vault.key");
+
+    let result = probe_master_key();
+    assert!(!result.is_present());
+    assert!(matches!(
+        result,
+        KeyProbeResult::Missing {
+            source: KeySource::FilePath,
+            ..
+        }
+    ));
+
+    clear_vault_env();
+}
+
+#[test]
+#[serial]
+fn r_plus_8_probe_invalid_env_key() {
+    clear_vault_env();
+    std::env::set_var("AUTONOETIC_VAULT_KEY", "not-valid-hex");
+
+    let result = probe_master_key();
+    assert!(!result.is_present());
+    assert!(matches!(
+        result,
+        KeyProbeResult::Invalid {
+            source: KeySource::EnvVar,
+            ..
+        }
+    ));
+
+    clear_vault_env();
+}
+
+#[test]
+#[serial]
+fn r_plus_8_probe_invalid_file_content() {
+    clear_vault_env();
+    let temp = tempfile::tempdir().unwrap();
+    let key_path = temp.path().join("vault.key");
+    std::fs::write(&key_path, "garbage").unwrap();
+    std::env::set_var("AUTONOETIC_VAULT_KEY_PATH", &key_path);
+
+    let result = probe_master_key();
+    assert!(!result.is_present());
+    assert!(matches!(
+        result,
+        KeyProbeResult::Invalid {
+            source: KeySource::FilePath,
+            ..
+        }
+    ));
+
+    clear_vault_env();
+}
+
+#[test]
+#[serial]
+fn r_plus_8_causal_event_emitted_on_present_key() -> anyhow::Result<()> {
+    clear_vault_env();
+    let key_hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    std::env::set_var("AUTONOETIC_VAULT_KEY", key_hex);
+
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let result = probe_master_key();
+    store.emit_vault_key_probe_event(&result)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    let probe = events
+        .iter()
+        .find(|e| e.category == "vault" && e.action == "key_probe")
+        .expect("vault.key_probe event must be emitted");
+
+    assert_eq!(probe.agent_id, "gateway");
+    assert_eq!(probe.session_id, "system");
+    assert_eq!(probe.status, "SUCCESS");
+    assert!(probe.enforced_rules.iter().any(|r| r == "R+8"));
+    let payload: serde_json::Value =
+        serde_json::from_str(probe.payload.as_deref().expect("payload present"))?;
+    assert_eq!(payload["source"], "env_var");
+
+    clear_vault_env();
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn r_plus_8_causal_event_emitted_on_not_configured() -> anyhow::Result<()> {
+    clear_vault_env();
+
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let result = probe_master_key();
+    store.emit_vault_key_probe_event(&result)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    let probe = events
+        .iter()
+        .find(|e| e.category == "vault" && e.action == "key_probe")
+        .expect("vault.key_probe event must be emitted");
+
+    assert_eq!(probe.status, "NOT_CONFIGURED");
+    assert!(probe.enforced_rules.iter().any(|r| r == "R+8"));
+    assert!(probe.reason.is_some());
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn r_plus_8_causal_event_emitted_on_missing_file() -> anyhow::Result<()> {
+    clear_vault_env();
+    std::env::set_var("AUTONOETIC_VAULT_KEY_PATH", "/nonexistent/vault.key");
+
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let result = probe_master_key();
+    store.emit_vault_key_probe_event(&result)?;
+
+    let events = store.search_causal_events(None, None, 50)?;
+    let probe = events
+        .iter()
+        .find(|e| e.category == "vault" && e.action == "key_probe")
+        .expect("vault.key_probe event must be emitted");
+
+    assert_eq!(probe.status, "MISSING");
+    assert!(probe.enforced_rules.iter().any(|r| r == "R+8"));
+    let payload: serde_json::Value =
+        serde_json::from_str(probe.payload.as_deref().expect("payload present"))?;
+    assert_eq!(payload["source"], "file_path");
+    assert_eq!(payload["path"], "/nonexistent/vault.key");
+
+    clear_vault_env();
+    Ok(())
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -549,6 +549,14 @@ pub struct GatewayConfig {
     #[serde(default = "default_max_pending_approvals_per_root")]
     pub max_pending_approvals_per_root: usize,
 
+    /// Default TTL in seconds for auto-generated session approval grants.
+    /// When an approval is resolved and a grant is auto-inserted without an
+    /// explicit `--ttl`/`--until` override, `expires_at` is set to
+    /// `now + default_grant_ttl_secs`. Set to 0 to disable auto-expiry
+    /// (grants live until revoked or emergency stop). Default: 86400 (24h).
+    #[serde(default = "default_grant_ttl_secs")]
+    pub default_grant_ttl_secs: u64,
+
     /// HMAC-SHA256 key for signing turn continuation files.
     /// This value should be a secret, high-entropy key provided from a secret
     /// source (environment secret or vault); do not derive it from `node_id`
@@ -1079,6 +1087,10 @@ fn default_max_pending_approvals_per_root() -> usize {
     50
 }
 
+fn default_grant_ttl_secs() -> u64 {
+    86400
+}
+
 fn default_workflow_task_heartbeat_secs_val() -> Option<u64> {
     None
 }
@@ -1262,6 +1274,7 @@ impl Default for GatewayConfig {
             root_session_budget: RootSessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),
             max_pending_approvals_per_root: default_max_pending_approvals_per_root(),
+            default_grant_ttl_secs: default_grant_ttl_secs(),
             continuation_key: None,
             workflow_task_heartbeat_secs: default_workflow_task_heartbeat_secs_val(),
             stuck_task_timeout_secs: default_stuck_task_timeout_secs_val(),

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -386,7 +386,7 @@ before it moves into its category.
 | R+5 | Approval flood cap per root session; further requests reject `approval_flood`. | ENFORCED (R-7.17) |
 | R+6 | Causal-chain fsync ordering invariant — state transitions gated on event durability. | ENFORCED (R-8.16) |
 | R+7 | Runtime-lock drift check at session start. | ENFORCED (R-8.12) |
-| R+8 | Vault master-key presence probe at gateway startup. | P2 |
+| R+8 | Vault master-key presence probe at gateway startup. | ENFORCED (`vault.rs:probe_master_key`, `observability.rs:emit_vault_key_probe_event`, `constitution_vault_startup_probe.rs`) |
 | R+9 | Redaction-before-write ordering invariant. | ENFORCED |
 | R+10 | sandbox→gateway SDK-bridge rate and payload-size limits. | ENFORCED (`sandbox.rs:76`, `constitution_abuse_sdk_bridge.rs`) |
 | R+11 | Bundle signature verification at `agent_revision_create` and `agent_revision_create_from_intent`. Ed25519 signature over canonical content digest, verified against gateway identity public key. | ENFORCED (`agent_revision.rs`, `crypto.rs`, `constitution_install_signature.rs`) |

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -391,7 +391,7 @@ before it moves into its category.
 | R+10 | sandbox→gateway SDK-bridge rate and payload-size limits. | ENFORCED (`sandbox.rs:76`, `constitution_abuse_sdk_bridge.rs`) |
 | R+11 | Bundle signature verification at `agent_revision_create` and `agent_revision_create_from_intent`. Ed25519 signature over canonical content digest, verified against gateway identity public key. | ENFORCED (`agent_revision.rs`, `crypto.rs`, `constitution_install_signature.rs`) |
 | R+12 | Orphan-child reaper on parent session termination. | ENFORCED (R-7.16) |
-| R+13 | Approval grant TTL. | P2 |
+| R+13 | Approval grant TTL. | ENFORCED (`approval.rs:1114`, `scheduler.rs:78`, `constitution_approval_grant_ttl.rs`) |
 | R+14 | `can_invoke_tool` denies unknown tool names explicitly. | P2 |
 | R+15 | Constant-time comparison for JSON-RPC shared-secret auth. | ENFORCED (R-10.8) |
 | R+16 | Promotion-gate execution is denied network access. `autonoetic-gateway/src/sandbox.rs` (`BwrapIsolationOverrides::force_network_off`), `autonoetic-gateway/src/runtime/tools/sandbox.rs` (Evaluation-cap override), `autonoetic-gateway/src/execution.rs` (`execute_script_in_sandbox` override), `agents/specialists/evaluator.default/SKILL.md` + `agents/specialists/auditor.default/SKILL.md` (`Evaluation` capability). | ENFORCED |


### PR DESCRIPTION
## Summary

Implements **R+13** from the constitution roadmap (Phase 3, §3.2): session approval grants now have a default 24h TTL. When a grant expires, the approval gate re-opens, forcing re-approval.

### Changes
- **`config.rs`**: New `default_grant_ttl_secs` field in `GatewayConfig` (default: 86400 = 24h). Set to 0 to disable auto-expiry.
- **`approval.rs`**: On approval resolution, if no explicit `--ttl`/`--until` was provided and `default_grant_ttl_secs > 0`, auto-computes `expires_at = now + TTL`.
- **`scheduler.rs`**: `prune_expired_grants()` wired into background scheduler tick (runs every tick alongside notification cleanup).
- **`constitution_approval_grant_ttl.rs`**: 7 tests.
- **Constitution doc**: R+13 status `P2` → `ENFORCED`.

### Tests (7)
- Grant with TTL has `expires_at` set
- Expired grant does NOT cover targets (approval gate re-opens)
- Non-expired grant covers targets
- Grant without expiry covers targets forever
- `prune_expired_grants()` removes expired rows only
- Config default is 24h (86400s)
- Zero TTL disables auto-expiry

### Note
The `expires_at` infrastructure was already fully implemented (migration v18, coverage check, CLI `--ttl`/`--until`). This PR adds the missing default TTL policy and the janitor tick.