### PR TITLE
feat(r++10): unified fail-mode table

### DIFF
--- a/autonoetic-gateway/src/fail_mode.rs
+++ b/autonoetic-gateway/src/fail_mode.rs
@@ -6,15 +6,14 @@
 //! | Mode | Meaning |
 //! |---|---|
 //! | `RefuseBoot` | Gateway refuses to start. |
-//! | `RefuseSessionStart` | Gateway refuses to create / resume a session. |
+//! | `RefuseSessionStart` | Gateway refuses to create / resume / continue a session. Applies at session creation and at any mid-session enforcement point where the invariant cannot be verified (e.g. cost-budget catalog unavailable). |
 //! | `Degrade` | Session enters degraded mode (R-7.18). |
 //! | `EmergencyStop` | Session is killed immediately. |
 //! | `LogOnly` | No enforcement action; event is logged for audit. |
 
 use std::fmt;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FailMode {
     RefuseBoot,
     RefuseSessionStart,

--- a/autonoetic-gateway/src/fail_mode.rs
+++ b/autonoetic-gateway/src/fail_mode.rs
@@ -1,0 +1,273 @@
+//! Unified fail-mode table (R++10).
+//!
+//! Every constitutional invariant has a declared failure action in one
+//! place.  The five fail modes are:
+//!
+//! | Mode | Meaning |
+//! |---|---|
+//! | `RefuseBoot` | Gateway refuses to start. |
+//! | `RefuseSessionStart` | Gateway refuses to create / resume a session. |
+//! | `Degrade` | Session enters degraded mode (R-7.18). |
+//! | `EmergencyStop` | Session is killed immediately. |
+//! | `LogOnly` | No enforcement action; event is logged for audit. |
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailMode {
+    RefuseBoot,
+    RefuseSessionStart,
+    Degrade,
+    EmergencyStop,
+    LogOnly,
+}
+
+impl fmt::Display for FailMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FailMode::RefuseBoot => write!(f, "refuse-boot"),
+            FailMode::RefuseSessionStart => write!(f, "refuse-session-start"),
+            FailMode::Degrade => write!(f, "degrade"),
+            FailMode::EmergencyStop => write!(f, "emergency-stop"),
+            FailMode::LogOnly => write!(f, "log-only"),
+        }
+    }
+}
+
+struct FailModeEntry {
+    rule_id: &'static str,
+    fail_mode: FailMode,
+}
+
+const FAIL_MODE_TABLE: &[FailModeEntry] = &[
+    // §0 Rights
+    FailModeEntry { rule_id: "Ri-0.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "Ri-0.2", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "Ri-0.3", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "Ri-0.4", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "Ri-0.5", fail_mode: FailMode::Degrade },
+    FailModeEntry { rule_id: "Ri-0.6", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "Ri-0.7", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "Ri-0.8", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "Ri-0.9", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "Ri-0.10", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "Ri-0.11", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "Ri-0.12", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "Ri-0.13", fail_mode: FailMode::EmergencyStop },
+    // §1 Capability & Rights
+    FailModeEntry { rule_id: "R-1.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.2", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.3", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.4", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.6", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.7", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.8", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.9", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.10", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-1.11", fail_mode: FailMode::RefuseSessionStart },
+    // §2 Approval Gates
+    FailModeEntry { rule_id: "R-2.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-2.2", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-2.3", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-2.4", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-2.5", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-2.6", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-2.7", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-2.8", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-2.9", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-2.10", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-2.11", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-2.12", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-2.13", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-2.14", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-2.15", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-2.16", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-2.17", fail_mode: FailMode::RefuseSessionStart },
+    // §3 Sandbox Isolation
+    FailModeEntry { rule_id: "R-3.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-3.2", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-3.3", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-3.4", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-3.5", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-3.6", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-3.7", fail_mode: FailMode::Degrade },
+    FailModeEntry { rule_id: "R-3.8", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-3.9", fail_mode: FailMode::RefuseSessionStart },
+    // §4 Credential & Secret Protection
+    FailModeEntry { rule_id: "R-4.1", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-4.2", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-4.3", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-4.4", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-4.5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-4.6", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-4.7", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-4.8", fail_mode: FailMode::Degrade },
+    FailModeEntry { rule_id: "R-4.9", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-4.10", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-4.11", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-4.12", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-4.13", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-4.14", fail_mode: FailMode::EmergencyStop },
+    // §5 I/O Schema Validation
+    FailModeEntry { rule_id: "R-5.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.2", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.3", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.4", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-5.5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.6", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.7", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.8", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.9", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.10", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-5.11", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-5.12", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-5.13", fail_mode: FailMode::RefuseSessionStart },
+    // §6 Session, Workflow & Budget
+    FailModeEntry { rule_id: "R-6.1", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.2", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.3", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.4", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-6.6", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.7", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.8", fail_mode: FailMode::Degrade },
+    FailModeEntry { rule_id: "R-6.9", fail_mode: FailMode::Degrade },
+    FailModeEntry { rule_id: "R-6.10", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.11", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.12", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.13", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-6.14", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.15", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.16", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-6.17", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-6.18", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-6.19", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.20", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-6.21", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-6.22", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-6.23", fail_mode: FailMode::RefuseSessionStart },
+    // §7 Abuse / Hard-Stop / Circuit Breakers
+    FailModeEntry { rule_id: "R-7.1", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.2", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.3", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.4", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-7.5", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.6", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.7", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.8", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.9", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.10", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.11", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.12", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.13", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.14", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.15", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.16", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R-7.17", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-7.18", fail_mode: FailMode::Degrade },
+    // §8 Audit & Traceability
+    FailModeEntry { rule_id: "R-8.1", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-8.2", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.3", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.4", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-8.5", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.6", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.7", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.8", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.9", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-8.10", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.11", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-8.12", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-8.13", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.14", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-8.15", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.16", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-8.17", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-8.18", fail_mode: FailMode::LogOnly },
+    // §9 Agent Install & Provenance
+    FailModeEntry { rule_id: "R-9.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.2", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-9.3", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-9.4", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-9.5", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-9.6", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.7", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.8", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-9.9", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.10", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.11", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.12", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-9.13", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-9.14", fail_mode: FailMode::LogOnly },
+    // §10 Federation / Remote
+    FailModeEntry { rule_id: "R-10.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-10.2", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-10.3", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R-10.4", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-10.5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-10.6", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R-10.7", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-10.8", fail_mode: FailMode::RefuseBoot },
+    // §11 Inter-Agent Messaging
+    FailModeEntry { rule_id: "R-11.1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.2", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.3", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.4", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.6", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.7", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R-11.8", fail_mode: FailMode::EmergencyStop },
+    // R+ additions
+    FailModeEntry { rule_id: "R+1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+2", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+3", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+4", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R+5", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+6", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R+7", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+8", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R+9", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R+10", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+11", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+12", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R+13", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R+14", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+15", fail_mode: FailMode::RefuseBoot },
+    FailModeEntry { rule_id: "R+16", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+17", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R+18", fail_mode: FailMode::RefuseSessionStart },
+    // R++ additions
+    FailModeEntry { rule_id: "R++4", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R++7", fail_mode: FailMode::LogOnly },
+    FailModeEntry { rule_id: "R++8", fail_mode: FailMode::Degrade },
+    FailModeEntry { rule_id: "R++9", fail_mode: FailMode::EmergencyStop },
+    FailModeEntry { rule_id: "R++10", fail_mode: FailMode::RefuseBoot },
+    // R+++ additions
+    FailModeEntry { rule_id: "R+++1", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+++2", fail_mode: FailMode::RefuseSessionStart },
+    FailModeEntry { rule_id: "R+++3", fail_mode: FailMode::LogOnly },
+];
+
+pub fn lookup_fail_mode(rule_id: &str) -> Option<FailMode> {
+    FAIL_MODE_TABLE
+        .iter()
+        .find(|entry| entry.rule_id == rule_id)
+        .map(|entry| entry.fail_mode)
+}
+
+pub fn all_entries() -> Vec<(&'static str, FailMode)> {
+    FAIL_MODE_TABLE
+        .iter()
+        .map(|e| (e.rule_id, e.fail_mode))
+        .collect()
+}
+
+pub fn entries_by_fail_mode(mode: FailMode) -> Vec<&'static str> {
+    FAIL_MODE_TABLE
+        .iter()
+        .filter(|e| e.fail_mode == mode)
+        .map(|e| e.rule_id)
+        .collect()
+}

--- a/autonoetic-gateway/src/lib.rs
+++ b/autonoetic-gateway/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bootstrap;
 pub mod causal_chain;
 pub mod config;
 pub mod execution;
+pub mod fail_mode;
 pub mod interaction_answer;
 pub mod layer_store;
 pub mod llm;

--- a/autonoetic-gateway/src/runtime/root_session_budget.rs
+++ b/autonoetic-gateway/src/runtime/root_session_budget.rs
@@ -114,13 +114,19 @@ impl RootSessionBudgetRegistry {
             if c.is_finite() && c >= 0.0 {
                 st.session_cost_usd += c;
             }
-        } else if self.limits.max_session_price_usd.is_some() {
-            anyhow::bail!(
-                "Root session cost-budget enforcement requires price estimation but \
-                 catalog is unavailable (R-6.5, R++10: fail-mode=refuse-session-start). \
-                 Refusing untracked LLM completion (root: {})",
-                root_session_id
-            );
+        } else if let Some(max_price) = self.limits.max_session_price_usd {
+            if max_price >= 0.0 {
+                let mode = crate::fail_mode::lookup_fail_mode("R-6.5")
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| "refuse-session-start".to_string());
+                anyhow::bail!(
+                    "Root session cost-budget enforcement requires price estimation but \
+                     catalog is unavailable (R-6.5, R++10: fail-mode={}). \
+                     Refusing untracked LLM completion (root: {})",
+                    mode,
+                    root_session_id
+                );
+            }
         }
 
         if let Some(max_tok) = self.limits.max_llm_tokens {

--- a/autonoetic-gateway/src/runtime/root_session_budget.rs
+++ b/autonoetic-gateway/src/runtime/root_session_budget.rs
@@ -114,6 +114,13 @@ impl RootSessionBudgetRegistry {
             if c.is_finite() && c >= 0.0 {
                 st.session_cost_usd += c;
             }
+        } else if self.limits.max_session_price_usd.is_some() {
+            anyhow::bail!(
+                "Root session cost-budget enforcement requires price estimation but \
+                 catalog is unavailable (R-6.5, R++10: fail-mode=refuse-session-start). \
+                 Refusing untracked LLM completion (root: {})",
+                root_session_id
+            );
         }
 
         if let Some(max_tok) = self.limits.max_llm_tokens {

--- a/autonoetic-gateway/src/runtime/session_budget.rs
+++ b/autonoetic-gateway/src/runtime/session_budget.rs
@@ -110,13 +110,19 @@ impl SessionBudgetRegistry {
             if c.is_finite() && c >= 0.0 {
                 st.session_cost_usd += c;
             }
-        } else if self.limits.max_session_price_usd.is_some() {
-            anyhow::bail!(
-                "Session cost-budget enforcement requires price estimation but \
-                 catalog is unavailable (R-6.5, R++10: fail-mode=refuse-session-start). \
-                 Refusing untracked LLM completion (scope: {})",
-                scope
-            );
+        } else if let Some(max_price) = self.limits.max_session_price_usd {
+            if max_price >= 0.0 {
+                let mode = crate::fail_mode::lookup_fail_mode("R-6.5")
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| "refuse-session-start".to_string());
+                anyhow::bail!(
+                    "Session cost-budget enforcement requires price estimation but \
+                     catalog is unavailable (R-6.5, R++10: fail-mode={}). \
+                     Refusing untracked LLM completion (scope: {})",
+                    mode,
+                    scope
+                );
+            }
         }
 
         if let Some(max_tok) = self.limits.max_llm_tokens {

--- a/autonoetic-gateway/src/runtime/session_budget.rs
+++ b/autonoetic-gateway/src/runtime/session_budget.rs
@@ -110,6 +110,13 @@ impl SessionBudgetRegistry {
             if c.is_finite() && c >= 0.0 {
                 st.session_cost_usd += c;
             }
+        } else if self.limits.max_session_price_usd.is_some() {
+            anyhow::bail!(
+                "Session cost-budget enforcement requires price estimation but \
+                 catalog is unavailable (R-6.5, R++10: fail-mode=refuse-session-start). \
+                 Refusing untracked LLM completion (scope: {})",
+                scope
+            );
         }
 
         if let Some(max_tok) = self.limits.max_llm_tokens {

--- a/autonoetic-gateway/tests/constitution_fail_mode_table.rs
+++ b/autonoetic-gateway/tests/constitution_fail_mode_table.rs
@@ -10,8 +10,6 @@
 //!    is refuse-session-start, not log-only).
 //! 4. R-6.5 cost-budget catalog unavailability is enforced (no silent-disable).
 
-mod support;
-
 use autonoetic_gateway::fail_mode::{
     all_entries, entries_by_fail_mode, lookup_fail_mode, FailMode,
 };
@@ -192,6 +190,20 @@ fn r_plus_plus_10_no_price_limit_allows_none_cost() {
 #[test]
 fn r_plus_plus_10_lookup_returns_none_for_unknown_rule() {
     assert!(lookup_fail_mode("R-999").is_none());
+}
+
+#[test]
+fn r_plus_plus_10_negative_price_limit_allows_none_cost() {
+    let registry = SessionBudgetRegistry::new(SessionBudgetConfig {
+        max_session_price_usd: Some(-1.0),
+        ..Default::default()
+    });
+
+    let result = registry.record_llm_completion("scope-neg", 100, 50, None);
+    assert!(
+        result.is_ok(),
+        "negative max_session_price_usd must not trigger catalog-unavailable enforcement"
+    );
 }
 
 #[test]

--- a/autonoetic-gateway/tests/constitution_fail_mode_table.rs
+++ b/autonoetic-gateway/tests/constitution_fail_mode_table.rs
@@ -1,0 +1,212 @@
+//! Constitution R++10: Unified fail-mode table.
+//!
+//! Every constitutional invariant has a declared failure action in one
+//! place.  The five modes are: refuse-boot, refuse-session-start,
+//! degrade, emergency-stop, log-only.  This test validates:
+//!
+//! 1. The fail-mode table covers every rule in the constitution.
+//! 2. No rule is missing a fail-mode entry.
+//! 3. Specific archetype rules have the correct fail-mode (e.g. R-6.5
+//!    is refuse-session-start, not log-only).
+//! 4. R-6.5 cost-budget catalog unavailability is enforced (no silent-disable).
+
+mod support;
+
+use autonoetic_gateway::fail_mode::{
+    all_entries, entries_by_fail_mode, lookup_fail_mode, FailMode,
+};
+use autonoetic_gateway::runtime::session_budget::SessionBudgetRegistry;
+use autonoetic_types::config::SessionBudgetConfig;
+
+const CONSTITUTION_RULE_IDS: &[&str] = &[
+    // §0 Rights
+    "Ri-0.1", "Ri-0.2", "Ri-0.3", "Ri-0.4", "Ri-0.5", "Ri-0.6",
+    "Ri-0.7", "Ri-0.8", "Ri-0.9", "Ri-0.10", "Ri-0.11", "Ri-0.12",
+    "Ri-0.13",
+    // §1 Capability & Rights
+    "R-1.1", "R-1.2", "R-1.3", "R-1.4", "R-1.5", "R-1.6", "R-1.7",
+    "R-1.8", "R-1.9", "R-1.10", "R-1.11",
+    // §2 Approval Gates
+    "R-2.1", "R-2.2", "R-2.3", "R-2.4", "R-2.5", "R-2.6", "R-2.7",
+    "R-2.8", "R-2.9", "R-2.10", "R-2.11", "R-2.12", "R-2.13", "R-2.14",
+    "R-2.15", "R-2.16", "R-2.17",
+    // §3 Sandbox Isolation
+    "R-3.1", "R-3.2", "R-3.3", "R-3.4", "R-3.5", "R-3.6", "R-3.7",
+    "R-3.8", "R-3.9",
+    // §4 Credential & Secret Protection
+    "R-4.1", "R-4.2", "R-4.3", "R-4.4", "R-4.5", "R-4.6", "R-4.7",
+    "R-4.8", "R-4.9", "R-4.10", "R-4.11", "R-4.12", "R-4.13", "R-4.14",
+    // §5 I/O Schema Validation
+    "R-5.1", "R-5.2", "R-5.3", "R-5.4", "R-5.5", "R-5.6", "R-5.7",
+    "R-5.8", "R-5.9", "R-5.10", "R-5.11", "R-5.12", "R-5.13",
+    // §6 Session, Workflow & Budget
+    "R-6.1", "R-6.2", "R-6.3", "R-6.4", "R-6.5", "R-6.6", "R-6.7",
+    "R-6.8", "R-6.9", "R-6.10", "R-6.11", "R-6.12", "R-6.13", "R-6.14",
+    "R-6.15", "R-6.16", "R-6.17", "R-6.18", "R-6.19", "R-6.20",
+    "R-6.21", "R-6.22", "R-6.23",
+    // §7 Abuse / Hard-Stop / Circuit Breakers
+    "R-7.1", "R-7.2", "R-7.3", "R-7.4", "R-7.5", "R-7.6", "R-7.7",
+    "R-7.8", "R-7.9", "R-7.10", "R-7.11", "R-7.12", "R-7.13", "R-7.14",
+    "R-7.15", "R-7.16", "R-7.17", "R-7.18",
+    // §8 Audit & Traceability
+    "R-8.1", "R-8.2", "R-8.3", "R-8.4", "R-8.5", "R-8.6", "R-8.7",
+    "R-8.8", "R-8.9", "R-8.10", "R-8.11", "R-8.12", "R-8.13", "R-8.14",
+    "R-8.15", "R-8.16", "R-8.17", "R-8.18",
+    // §9 Agent Install & Provenance
+    "R-9.1", "R-9.2", "R-9.3", "R-9.4", "R-9.5", "R-9.6", "R-9.7",
+    "R-9.8", "R-9.9", "R-9.10", "R-9.11", "R-9.12", "R-9.13", "R-9.14",
+    // §10 Federation / Remote
+    "R-10.1", "R-10.2", "R-10.3", "R-10.4", "R-10.5", "R-10.6",
+    "R-10.7", "R-10.8",
+    // §11 Inter-Agent Messaging
+    "R-11.1", "R-11.2", "R-11.3", "R-11.4", "R-11.5", "R-11.6",
+    "R-11.7", "R-11.8",
+    // R+ additions
+    "R+1", "R+2", "R+3", "R+4", "R+5", "R+6", "R+7", "R+8", "R+9",
+    "R+10", "R+11", "R+12", "R+13", "R+14", "R+15", "R+16", "R+17",
+    "R+18",
+    // R++ additions
+    "R++4", "R++7", "R++8", "R++9", "R++10",
+    // R+++ additions
+    "R+++1", "R+++2", "R+++3",
+];
+
+#[test]
+fn r_plus_plus_10_every_constitutional_rule_has_fail_mode() {
+    let mut missing: Vec<&str> = Vec::new();
+    for rule_id in CONSTITUTION_RULE_IDS {
+        if lookup_fail_mode(rule_id).is_none() {
+            missing.push(rule_id);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "R++10: the following rules are missing fail-mode entries: {:?}",
+        missing
+    );
+}
+
+#[test]
+fn r_plus_plus_10_no_duplicate_entries() {
+    let entries = all_entries();
+    let mut seen = std::collections::HashSet::new();
+    let mut dupes = Vec::new();
+    for (rule_id, _) in &entries {
+        if !seen.insert(rule_id) {
+            dupes.push(rule_id);
+        }
+    }
+    assert!(
+        dupes.is_empty(),
+        "R++10: duplicate fail-mode entries for: {:?}",
+        dupes
+    );
+}
+
+#[test]
+fn r_plus_plus_10_all_five_modes_represented() {
+    let modes: Vec<FailMode> = all_entries()
+        .iter()
+        .map(|(_, m)| *m)
+        .collect();
+    assert!(modes.contains(&FailMode::RefuseBoot), "must have refuse-boot entries");
+    assert!(modes.contains(&FailMode::RefuseSessionStart), "must have refuse-session-start entries");
+    assert!(modes.contains(&FailMode::Degrade), "must have degrade entries");
+    assert!(modes.contains(&FailMode::EmergencyStop), "must have emergency-stop entries");
+    assert!(modes.contains(&FailMode::LogOnly), "must have log-only entries");
+}
+
+#[test]
+fn r_plus_plus_10_r_6_5_is_refuse_session_start() {
+    let mode = lookup_fail_mode("R-6.5")
+        .expect("R-6.5 must have a fail-mode entry");
+    assert_eq!(
+        mode,
+        FailMode::RefuseSessionStart,
+        "R-6.5 (max_session_price_usd) must be refuse-session-start, not log-only"
+    );
+}
+
+#[test]
+fn r_plus_plus_10_r_7_18_is_degrade() {
+    let mode = lookup_fail_mode("R-7.18")
+        .expect("R-7.18 must have a fail-mode entry");
+    assert_eq!(mode, FailMode::Degrade);
+}
+
+#[test]
+fn r_plus_plus_10_r_plus_plus_8_escape_is_degrade() {
+    let mode = lookup_fail_mode("R++8")
+        .expect("R++8 must have a fail-mode entry");
+    assert_eq!(mode, FailMode::Degrade);
+}
+
+#[test]
+fn r_plus_plus_10_catalog_unavailable_refuses_cost_budgeted_session() {
+    let registry = SessionBudgetRegistry::new(SessionBudgetConfig {
+        max_session_price_usd: Some(1.0),
+        ..Default::default()
+    });
+
+    let result = registry.record_llm_completion("scope-1", 100, 50, None);
+    assert!(
+        result.is_err(),
+        "R-6.5/R++10: record_llm_completion with None cost must fail when max_session_price_usd is set"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("R-6.5") || err.contains("catalog is unavailable"),
+        "error message must reference R-6.5 or catalog unavailability, got: {}",
+        err
+    );
+}
+
+#[test]
+fn r_plus_plus_10_catalog_available_succeeds_cost_budgeted_session() {
+    let registry = SessionBudgetRegistry::new(SessionBudgetConfig {
+        max_session_price_usd: Some(1.0),
+        ..Default::default()
+    });
+
+    let result = registry.record_llm_completion("scope-2", 100, 50, Some(0.001));
+    assert!(
+        result.is_ok(),
+        "record_llm_completion with valid cost estimate must succeed"
+    );
+}
+
+#[test]
+fn r_plus_plus_10_no_price_limit_allows_none_cost() {
+    let registry = SessionBudgetRegistry::new(SessionBudgetConfig {
+        max_session_price_usd: None,
+        ..Default::default()
+    });
+
+    let result = registry.record_llm_completion("scope-3", 100, 50, None);
+    assert!(
+        result.is_ok(),
+        "without max_session_price_usd, None cost must be accepted"
+    );
+}
+
+#[test]
+fn r_plus_plus_10_lookup_returns_none_for_unknown_rule() {
+    assert!(lookup_fail_mode("R-999").is_none());
+}
+
+#[test]
+fn r_plus_plus_10_entries_by_fail_mode_returns_correct_subset() {
+    let degrade_entries = entries_by_fail_mode(FailMode::Degrade);
+    assert!(
+        degrade_entries.contains(&"R-7.18"),
+        "R-7.18 must be in degrade entries"
+    );
+    assert!(
+        degrade_entries.contains(&"R++8"),
+        "R++8 must be in degrade entries"
+    );
+    assert!(
+        !degrade_entries.contains(&"R-7.1"),
+        "R-7.1 must NOT be in degrade entries (it is emergency-stop)"
+    );
+}

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -247,7 +247,7 @@ Per-session registries in `runtime/session_budget.rs`,
 | R-6.2 | `max_llm_rounds` gates before each LLM call; incremented after a real provider call. | session-budget.md | `session_budget.rs::check_pre_llm` | ENFORCED |
 | R-6.3 | `max_tool_invocations` gates before each tool batch; all calls in a batch reserve together. | session-budget.md | `reserve_tool_invocations` | ENFORCED |
 | R-6.4 | `max_wall_clock_secs` checked at LLM pre-check. | session-budget.md | `check_pre_llm` | ENFORCED |
-| R-6.5 | `max_session_price_usd` enforced via OpenRouter catalog estimates. | budget-management.md | `record_llm_completion` + catalog | PARTIAL (silent-disable if catalog unavailable — see §12) |
+| R-6.5 | `max_session_price_usd` enforced via OpenRouter catalog estimates. | budget-management.md | `record_llm_completion` + catalog + R++10 fail-mode enforcement | ENFORCED (catalog-unavailable now refuses LLM completion when price limit is set, per R++10 fail-mode table) |
 | R-6.6 | OpenRouter catalog fetches with ~1h TTL; disabled by env. | budget-management.md | `openrouter_catalog.rs::refresh_if_needed` | ENFORCED |
 | R-6.7 | Prompt-budget breakdown is logged before every LLM call. | prompt-budget.md | `prompt_budget.rs` | ENFORCED |
 | R-6.8 | `system_prompt` and `tool_definitions` max-tokens enforced independently. | prompt-budget.md | section caps in prompt-budget | ENFORCED |
@@ -413,7 +413,7 @@ item will move into its numbered category once ENFORCED.
 | R++7 | Cross-gateway causal continuity: cross-gateway events carry a `peer_event_ref` pointing to the corresponding remote chain entry; gateways periodically exchange signed `chain_attestation` digests allowing end-to-end federated trace verification. | P1 | §10 Federation + §8 Audit |
 | R++8 | Sandbox-escape attempts are counted. Kernel-denied syscalls (seccomp), denied mount attempts, ptrace calls, and equivalents on docker/microvm drivers increment a per-session counter. Threshold crossings trigger R-7.18 degraded mode; further escalation triggers emergency stop. | ENFORCED (`sandbox.rs:detect_sandbox_escape_indicators`, `observability.rs:record_sandbox_escape_attempt`, `scheduler.rs:run_scheduler_tick_at`, `constitution_sandbox_escape_accounting.rs`) | §3 Sandbox + §7 Abuse |
 | R++9 | A property test pins gateway determinism: for random valid inputs, the gateway's decision for `(capability-set, tool-call, recorded-state) → verdict` is a pure function — no LLM call, no network fetch with undeclared fallback, no hidden branch. Any future change that adds nondeterminism fails the test. Prevents principle erosion. | P2 | §13 (cross-cutting) |
-| R++10 | Unified fail-mode table: every constitutional invariant has a declared failure action in one place — `refuse-boot`, `refuse-session-start`, `degrade`, `emergency-stop`, or `log-only`. Eliminates silent-disable (R-6.5 OpenRouter-catalog-down default is the archetype to fix). | P1 | §13 (cross-cutting) |
+| R++10 | Unified fail-mode table: every constitutional invariant has a declared failure action in one place — `refuse-boot`, `refuse-session-start`, `degrade`, `emergency-stop`, or `log-only`. Eliminates silent-disable (R-6.5 OpenRouter-catalog-down default is the archetype to fix). | ENFORCED (`fail_mode.rs`, `session_budget.rs` (R-6.5 catalog-unavailable enforcement), `constitution_fail_mode_table.rs`) | §13 (cross-cutting) |
 
 ### Constitutional additions (`R+++`)
 

--- a/docs/gateway-constitution.md
+++ b/docs/gateway-constitution.md
@@ -247,7 +247,7 @@ Per-session registries in `runtime/session_budget.rs`,
 | R-6.2 | `max_llm_rounds` gates before each LLM call; incremented after a real provider call. | session-budget.md | `session_budget.rs::check_pre_llm` | ENFORCED |
 | R-6.3 | `max_tool_invocations` gates before each tool batch; all calls in a batch reserve together. | session-budget.md | `reserve_tool_invocations` | ENFORCED |
 | R-6.4 | `max_wall_clock_secs` checked at LLM pre-check. | session-budget.md | `check_pre_llm` | ENFORCED |
-| R-6.5 | `max_session_price_usd` enforced via OpenRouter catalog estimates. | budget-management.md | `record_llm_completion` + catalog + R++10 fail-mode enforcement | ENFORCED (catalog-unavailable now refuses LLM completion when price limit is set, per R++10 fail-mode table) |
+| R-6.5 | `max_session_price_usd` enforced via OpenRouter catalog estimates. When catalog is unavailable and a price cap is active, LLM completions are refused (no silent-disable). | budget-management.md | `record_llm_completion` + catalog + R++10 fail-mode enforcement (`session_budget.rs`, `root_session_budget.rs`) | ENFORCED (catalog-unavailable refuses LLM completion when price limit is set, per R++10 fail-mode table) |
 | R-6.6 | OpenRouter catalog fetches with ~1h TTL; disabled by env. | budget-management.md | `openrouter_catalog.rs::refresh_if_needed` | ENFORCED |
 | R-6.7 | Prompt-budget breakdown is logged before every LLM call. | prompt-budget.md | `prompt_budget.rs` | ENFORCED |
 | R-6.8 | `system_prompt` and `tool_definitions` max-tokens enforced independently. | prompt-budget.md | section caps in prompt-budget | ENFORCED |


### PR DESCRIPTION
## Summary

Implements **R++10**: a unified fail-mode table declaring the failure action for every constitutional invariant in one place.

## Changes

- **`fail_mode.rs`**: `FailMode` enum (`refuse-boot`, `refuse-session-start`, `degrade`, `emergency-stop`, `log-only`) with a static registry covering all 130+ constitutional rules (§0–§11, R+, R++, R+++)
- **R-6.5 fix**: `session_budget.rs` + `root_session_budget.rs` — catalog-unavailable now refuses LLM completion when `max_session_price_usd` is set (previously silently disabled cost tracking). This is the archetype case R++10 was designed to eliminate.
- **Constitution doc**: R-6.5 upgraded from PARTIAL → ENFORCED; R++10 marked ENFORCED
- **11 tests** in `constitution_fail_mode_table.rs`:
  - Every constitutional rule has a fail-mode entry (completeness)
  - No duplicate entries
  - All five modes represented
  - Archetype rules pinned (R-6.5=refuse-session-start, R-7.18=degrade, R++8=degrade)
  - Catalog-unavailable enforcement verified
  - Unknown rule returns None

## Test plan

```bash
cargo test --test constitution_fail_mode_table
cargo test -p autonoetic-gateway --lib session_budget
cargo build -p autonoetic-gateway
```