### PR TITLE
feat(sentinel): Phase 3 — frozen baseline dual-sweep and disagreement recording (#36)

### DIFF
--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 26;
+const SCHEMA_VERSION_LATEST: i64 = 27;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -510,6 +510,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_revision_signature_v24(conn)?;
     apply_sandbox_escape_attempts_v25(conn)?;
     apply_security_findings_v26(conn)?;
+    apply_sentinel_disagreements_v27(conn)?;
 
     Ok(())
 }
@@ -1561,6 +1562,49 @@ fn apply_security_findings_v26(conn: &mut Connection) -> Result<()> {
         params![
             26_i64,
             "security_findings",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_sentinel_disagreements_v27(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 27 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS security_sentinel_disagreements (
+            disagreement_id       TEXT PRIMARY KEY,
+            sweep_at              TEXT NOT NULL,
+            -- 'baseline_only': baseline found this anchor, current sentinel did not.
+            -- 'current_only':  current sentinel found this anchor, baseline did not
+            --                  (only Phase-1 findings are compared; Phase-2 is expected
+            --                  to diverge from the deterministic baseline).
+            direction             TEXT NOT NULL CHECK(direction IN ('baseline_only', 'current_only')),
+            anchor_json           TEXT NOT NULL,
+            baseline_finding_id   TEXT,
+            current_finding_id    TEXT,
+            baseline_sentinel_rev TEXT NOT NULL,
+            current_sentinel_rev  TEXT NOT NULL,
+            created_at            TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_sentinel_disagreements_sweep
+            ON security_sentinel_disagreements(sweep_at);
+        CREATE INDEX IF NOT EXISTS idx_sentinel_disagreements_direction
+            ON security_sentinel_disagreements(direction);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            27_i64,
+            "sentinel_disagreements",
             chrono::Utc::now().to_rfc3339()
         ],
     )?;

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -1595,7 +1595,7 @@ fn apply_sentinel_disagreements_v27(conn: &mut Connection) -> Result<()> {
             created_at            TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_sentinel_disagreements_sweep
-            ON security_sentinel_disagreements(sweep_at);
+            ON security_sentinel_disagreements(sweep_at DESC, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_sentinel_disagreements_direction
             ON security_sentinel_disagreements(direction);",
     )?;

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -15,6 +15,7 @@ mod row_decode;
 mod runtime_control;
 mod scheduled_jobs;
 pub mod security_findings;
+pub mod sentinel_disagreements;
 mod user_interactions;
 mod user_profiles;
 mod util;

--- a/autonoetic-gateway/src/scheduler/gateway_store/sentinel_disagreements.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/sentinel_disagreements.rs
@@ -88,7 +88,7 @@ impl GatewayStore {
                         baseline_sentinel_rev, current_sentinel_rev
                  FROM security_sentinel_disagreements
                  WHERE sweep_at >= ?1
-                 ORDER BY created_at DESC LIMIT ?2",
+                 ORDER BY sweep_at DESC, created_at DESC LIMIT ?2",
             )?;
             let result = stmt.query_map(params![since, lim], decode_disagreement_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -99,7 +99,7 @@ impl GatewayStore {
                         baseline_finding_id, current_finding_id,
                         baseline_sentinel_rev, current_sentinel_rev
                  FROM security_sentinel_disagreements
-                 ORDER BY created_at DESC LIMIT ?1",
+                 ORDER BY sweep_at DESC, created_at DESC LIMIT ?1",
             )?;
             let result = stmt.query_map(params![lim], decode_disagreement_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -128,7 +128,16 @@ fn decode_disagreement_row(
     let direction_str: String = row.get(2)?;
     let direction = match direction_str.as_str() {
         "baseline_only" => DisagreementDirection::BaselineOnly,
-        _ => DisagreementDirection::CurrentOnly,
+        "current_only" => DisagreementDirection::CurrentOnly,
+        other => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::other(format!(
+                    "unknown disagreement direction: {other:?}"
+                ))),
+            ));
+        }
     };
     Ok(SentinelDisagreementRecord {
         disagreement_id: row.get(0)?,

--- a/autonoetic-gateway/src/scheduler/gateway_store/sentinel_disagreements.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/sentinel_disagreements.rs
@@ -1,0 +1,143 @@
+//! Store methods for `security_sentinel_disagreements`.
+//!
+//! Disagreements are recorded when the frozen baseline sentinel and the current
+//! sentinel diverge: the baseline finds something the current missed, or the
+//! current (Phase-1 only) finds something the baseline missed. Phase-2 findings
+//! are expected to diverge from the deterministic baseline and are excluded from
+//! disagreement comparison.
+
+use anyhow::Result;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use super::GatewayStore;
+
+/// Direction of a sentinel disagreement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisagreementDirection {
+    /// The frozen baseline flagged this anchor; the current sentinel did not.
+    BaselineOnly,
+    /// The current sentinel flagged this anchor (Phase 1); the baseline did not.
+    CurrentOnly,
+}
+
+impl std::fmt::Display for DisagreementDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DisagreementDirection::BaselineOnly => write!(f, "baseline_only"),
+            DisagreementDirection::CurrentOnly => write!(f, "current_only"),
+        }
+    }
+}
+
+/// A record of sentinel divergence between the frozen baseline and the current sentinel.
+#[derive(Debug, Clone)]
+pub struct SentinelDisagreementRecord {
+    pub disagreement_id: String,
+    pub sweep_at: String,
+    pub direction: DisagreementDirection,
+    /// JSON of the `EvidenceAnchor` that the diverging sentinel flagged.
+    pub anchor_json: String,
+    /// The `finding_id` from the baseline sweep (None when `direction = current_only`).
+    pub baseline_finding_id: Option<String>,
+    /// The `finding_id` from the current sweep (None when `direction = baseline_only`).
+    pub current_finding_id: Option<String>,
+    pub baseline_sentinel_rev: String,
+    pub current_sentinel_rev: String,
+}
+
+impl GatewayStore {
+    /// Persist a new sentinel disagreement record.
+    pub fn insert_sentinel_disagreement(&self, rec: &SentinelDisagreementRecord) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO security_sentinel_disagreements (
+                disagreement_id, sweep_at, direction, anchor_json,
+                baseline_finding_id, current_finding_id,
+                baseline_sentinel_rev, current_sentinel_rev, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                rec.disagreement_id,
+                rec.sweep_at,
+                rec.direction.to_string(),
+                rec.anchor_json,
+                rec.baseline_finding_id,
+                rec.current_finding_id,
+                rec.baseline_sentinel_rev,
+                rec.current_sentinel_rev,
+                chrono::Utc::now().to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List disagreements since the given RFC-3339 timestamp, newest first.
+    pub fn list_sentinel_disagreements(
+        &self,
+        since: Option<&str>,
+        limit: u32,
+    ) -> Result<Vec<SentinelDisagreementRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let lim = limit as i64;
+
+        let rows = if let Some(since) = since {
+            let mut stmt = conn.prepare(
+                "SELECT disagreement_id, sweep_at, direction, anchor_json,
+                        baseline_finding_id, current_finding_id,
+                        baseline_sentinel_rev, current_sentinel_rev
+                 FROM security_sentinel_disagreements
+                 WHERE sweep_at >= ?1
+                 ORDER BY created_at DESC LIMIT ?2",
+            )?;
+            let result = stmt.query_map(params![since, lim], decode_disagreement_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            result
+        } else {
+            let mut stmt = conn.prepare(
+                "SELECT disagreement_id, sweep_at, direction, anchor_json,
+                        baseline_finding_id, current_finding_id,
+                        baseline_sentinel_rev, current_sentinel_rev
+                 FROM security_sentinel_disagreements
+                 ORDER BY created_at DESC LIMIT ?1",
+            )?;
+            let result = stmt.query_map(params![lim], decode_disagreement_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            result
+        };
+        Ok(rows)
+    }
+
+    /// Count disagreements grouped by direction for monitoring.
+    pub fn count_sentinel_disagreements_by_direction(&self) -> Result<Vec<(String, i64)>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT direction, COUNT(*) FROM security_sentinel_disagreements
+             GROUP BY direction ORDER BY direction",
+        )?;
+        let result = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(result)
+    }
+}
+
+fn decode_disagreement_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<SentinelDisagreementRecord> {
+    let direction_str: String = row.get(2)?;
+    let direction = match direction_str.as_str() {
+        "baseline_only" => DisagreementDirection::BaselineOnly,
+        _ => DisagreementDirection::CurrentOnly,
+    };
+    Ok(SentinelDisagreementRecord {
+        disagreement_id: row.get(0)?,
+        sweep_at: row.get(1)?,
+        direction,
+        anchor_json: row.get(3)?,
+        baseline_finding_id: row.get(4)?,
+        current_finding_id: row.get(5)?,
+        baseline_sentinel_rev: row.get(6)?,
+        current_sentinel_rev: row.get(7)?,
+    })
+}

--- a/autonoetic-gateway/src/sentinel/dual_sweep.rs
+++ b/autonoetic-gateway/src/sentinel/dual_sweep.rs
@@ -1,0 +1,396 @@
+//! Dual-sweep orchestrator: frozen baseline + current sentinel.
+//!
+//! Runs both the frozen baseline sentinel (Phase 1 only) and the current
+//! sentinel (Phase 1 + Phase 2) in a single coordinated sweep, then:
+//!
+//! 1. **Annotates `baseline_agreed`** on current findings whose evidence
+//!    anchors overlap with baseline findings, before the final DB persist.
+//!    (`baseline_agreed` is immutable after insertion due to the append-only
+//!    trigger, so annotation must happen pre-insert.)
+//!
+//! 2. **Records disagreements** in `security_sentinel_disagreements`:
+//!    - `baseline_only` — the baseline found an anchor the current missed
+//!      (possible sentinel regression or configuration drift).
+//!    - `current_only` — the current sentinel's Phase-1 checks found an
+//!      anchor the baseline missed (possible baseline staleness).
+//!    Phase-2 (LLM-judgment) findings are excluded from disagreement
+//!    comparison because the deterministic baseline has no Phase-2 layer.
+//!
+//! ## Recursive-trust note
+//!
+//! The baseline provides a stable reference independent of the current
+//! sentinel. A regressed current sentinel cannot hide its own failure because
+//! the baseline is frozen in the gateway image and cannot be modified by the
+//! agent-promotion pipeline. Updating the baseline requires an explicit
+//! operator CLI action with identity logging — not implemented in this module.
+
+use anyhow::Result;
+use autonoetic_types::security::{EvidenceAnchor, SecurityFinding};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::scheduler::gateway_store::{
+    sentinel_disagreements::{DisagreementDirection, SentinelDisagreementRecord},
+    GatewayStore,
+};
+use super::runner::{RawSweepFindings, SentinelRunner, SweepConfig, SweepResult};
+
+/// Result of a dual sweep (baseline + current).
+pub struct DualSweepResult {
+    /// Findings from the current sentinel, persisted with `baseline_agreed` set.
+    pub current: SweepResult,
+    /// Number of current Phase-1 findings that the baseline also flagged.
+    pub baseline_agreed_count: usize,
+    /// Disagreements recorded in the DB this sweep.
+    pub disagreements: Vec<SentinelDisagreementRecord>,
+}
+
+/// Orchestrates a dual sweep of the frozen baseline and the current sentinel.
+pub struct DualSweepRunner {
+    store: Arc<GatewayStore>,
+    agents_dir: Option<PathBuf>,
+}
+
+impl DualSweepRunner {
+    pub fn new(store: Arc<GatewayStore>) -> Self {
+        Self {
+            store,
+            agents_dir: None,
+        }
+    }
+
+    pub fn with_agents_dir(mut self, agents_dir: PathBuf) -> Self {
+        self.agents_dir = Some(agents_dir);
+        self
+    }
+
+    /// Run the dual sweep: baseline (Phase 1 only) then current (Phase 1 + 2).
+    ///
+    /// The `baseline_config` should have `sentinel_revision_id` set to the
+    /// baseline sentinel revision (e.g. `"sentinel_baseline.frozen"`).
+    /// The `current_config` is the main sentinel's config.
+    pub fn run(
+        &self,
+        baseline_config: &SweepConfig,
+        current_config: &SweepConfig,
+    ) -> Result<DualSweepResult> {
+        let sweep_at = chrono::Utc::now().to_rfc3339();
+
+        // 1. Collect baseline findings (Phase 1 only, no prompt-injection scan).
+        let baseline_runner = SentinelRunner::new(Arc::clone(&self.store));
+        let baseline_raw = baseline_runner.collect_findings(baseline_config)?;
+
+        // 2. Collect current findings (Phase 1 + 2).
+        let mut current_runner = SentinelRunner::new(Arc::clone(&self.store));
+        if let Some(ref dir) = self.agents_dir {
+            current_runner = current_runner.with_agents_dir(dir.clone());
+        }
+        let mut current_raw = current_runner.collect_findings(current_config)?;
+
+        // 3. Match baseline Phase-1 findings to current Phase-1 findings by anchor overlap.
+        let (agreed_current_ids, disagreements) = compare_phase1(
+            &baseline_raw,
+            &current_raw,
+            &sweep_at,
+            &baseline_config.sentinel_revision_id,
+            &current_config.sentinel_revision_id,
+        )?;
+
+        // 4. Annotate baseline_agreed on current findings (before persisting).
+        annotate_baseline_agreed(&mut current_raw, &agreed_current_ids);
+
+        let baseline_agreed_count = agreed_current_ids.len();
+
+        // 5. Persist current findings (now annotated with baseline_agreed).
+        let current_result = current_runner.persist_findings(current_raw);
+
+        // 6. Persist disagreements.
+        for d in &disagreements {
+            if let Err(e) = self.store.insert_sentinel_disagreement(d) {
+                tracing::warn!(
+                    target: "sentinel.dual_sweep",
+                    error = %e,
+                    "Failed to persist sentinel disagreement {}",
+                    d.disagreement_id
+                );
+            }
+        }
+
+        Ok(DualSweepResult {
+            current: current_result,
+            baseline_agreed_count,
+            disagreements,
+        })
+    }
+}
+
+// ── Anchor matching ───────────────────────────────────────────────────────────
+
+/// A stable key derived from an `EvidenceAnchor` for set membership tests.
+fn anchor_key(anchor: &EvidenceAnchor) -> String {
+    match anchor {
+        EvidenceAnchor::CausalEvent { id } => format!("causal_event:{}", id),
+        EvidenceAnchor::SkillMdDigest { value } => format!("skill_md_digest:{}", value),
+        EvidenceAnchor::LayerDigest { value } => format!("layer_digest:{}", value),
+        EvidenceAnchor::ArtifactId { id } => format!("artifact_id:{}", id),
+        EvidenceAnchor::RevisionId { id } => format!("revision_id:{}", id),
+        EvidenceAnchor::PromotionRecord { promotion_id } => {
+            format!("promotion_record:{}", promotion_id)
+        }
+        EvidenceAnchor::SandboxEscapeRecord { rowid } => {
+            format!("sandbox_escape_record:{}", rowid)
+        }
+    }
+}
+
+/// Derive a key set for a finding (all its anchor keys).
+fn finding_anchor_keys(f: &SecurityFinding) -> HashSet<String> {
+    f.evidence_anchors.iter().map(anchor_key).collect()
+}
+
+/// Check whether two findings share at least one evidence anchor.
+fn anchors_overlap(a: &SecurityFinding, b: &SecurityFinding) -> bool {
+    let keys_a = finding_anchor_keys(a);
+    finding_anchor_keys(b).iter().any(|k| keys_a.contains(k))
+}
+
+// ── Comparison logic ──────────────────────────────────────────────────────────
+
+/// Compare Phase-1 baseline and current findings.
+///
+/// Returns:
+/// - A set of `finding_id`s in `current_raw` that the baseline also flagged.
+/// - A vec of `SentinelDisagreementRecord`s to persist.
+fn compare_phase1(
+    baseline_raw: &RawSweepFindings,
+    current_raw: &RawSweepFindings,
+    sweep_at: &str,
+    baseline_rev: &str,
+    current_rev: &str,
+) -> Result<(HashSet<String>, Vec<SentinelDisagreementRecord>)> {
+    let baseline_p1: Vec<&SecurityFinding> = baseline_raw.all_phase1().collect();
+    let current_p1: Vec<&SecurityFinding> = current_raw.all_phase1().collect();
+
+    let mut agreed_current_ids = HashSet::new();
+    let mut disagreements = Vec::new();
+
+    // For each baseline finding, check if any current Phase-1 finding agrees.
+    for bf in &baseline_p1 {
+        let matching_current = current_p1.iter().find(|cf| anchors_overlap(bf, cf));
+        if let Some(cf) = matching_current {
+            // Both agree — mark the current finding as baseline_agreed.
+            agreed_current_ids.insert(cf.finding_id.clone());
+        } else {
+            // Baseline flagged something current missed.
+            let anchor_json = serde_json::to_string(&bf.evidence_anchors)
+                .unwrap_or_else(|_| "[]".to_string());
+            disagreements.push(SentinelDisagreementRecord {
+                disagreement_id: format!("dis_{}", uuid::Uuid::new_v4()),
+                sweep_at: sweep_at.to_string(),
+                direction: DisagreementDirection::BaselineOnly,
+                anchor_json,
+                baseline_finding_id: Some(bf.finding_id.clone()),
+                current_finding_id: None,
+                baseline_sentinel_rev: baseline_rev.to_string(),
+                current_sentinel_rev: current_rev.to_string(),
+            });
+        }
+    }
+
+    // For each current Phase-1 finding NOT matched by baseline, record current_only.
+    for cf in &current_p1 {
+        if agreed_current_ids.contains(&cf.finding_id) {
+            continue;
+        }
+        let baseline_match = baseline_p1.iter().any(|bf| anchors_overlap(bf, cf));
+        if !baseline_match {
+            let anchor_json = serde_json::to_string(&cf.evidence_anchors)
+                .unwrap_or_else(|_| "[]".to_string());
+            disagreements.push(SentinelDisagreementRecord {
+                disagreement_id: format!("dis_{}", uuid::Uuid::new_v4()),
+                sweep_at: sweep_at.to_string(),
+                direction: DisagreementDirection::CurrentOnly,
+                anchor_json,
+                baseline_finding_id: None,
+                current_finding_id: Some(cf.finding_id.clone()),
+                baseline_sentinel_rev: baseline_rev.to_string(),
+                current_sentinel_rev: current_rev.to_string(),
+            });
+        }
+    }
+
+    Ok((agreed_current_ids, disagreements))
+}
+
+/// Set `baseline_agreed = true` on current findings whose `finding_id` is in `agreed`.
+fn annotate_baseline_agreed(current_raw: &mut RawSweepFindings, agreed: &HashSet<String>) {
+    for f in current_raw
+        .credential
+        .iter_mut()
+        .chain(current_raw.capability_accretion.iter_mut())
+        .chain(current_raw.approval_bypass.iter_mut())
+        .chain(current_raw.sandbox_escape.iter_mut())
+    {
+        if agreed.contains(&f.finding_id) {
+            *f = f.clone().with_baseline_agreed(true);
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::security::{
+        AffectedEntities, EvidenceAnchor, FindingSeverity, FindingType, Reproducibility,
+        SecurityFinding,
+    };
+
+    fn make_finding(finding_type: FindingType, anchor: EvidenceAnchor) -> SecurityFinding {
+        SecurityFinding::new(
+            finding_type,
+            FindingSeverity::Warning,
+            0.8,
+            Reproducibility::Deterministic,
+            "remediate",
+            "sentinel-rev-001",
+        )
+        .with_anchors(vec![anchor])
+    }
+
+    #[test]
+    fn anchor_key_is_stable() {
+        let a1 = EvidenceAnchor::CausalEvent { id: "evt_001".to_string() };
+        let a2 = EvidenceAnchor::CausalEvent { id: "evt_001".to_string() };
+        assert_eq!(anchor_key(&a1), anchor_key(&a2));
+    }
+
+    #[test]
+    fn anchor_key_differs_by_type() {
+        let a1 = EvidenceAnchor::RevisionId { id: "rev_001".to_string() };
+        let a2 = EvidenceAnchor::SkillMdDigest { value: "rev_001".to_string() };
+        assert_ne!(anchor_key(&a1), anchor_key(&a2));
+    }
+
+    #[test]
+    fn compare_phase1_both_agree() {
+        let anchor = EvidenceAnchor::CausalEvent { id: "evt_abc".to_string() };
+        let bf = make_finding(FindingType::CredentialLeak, anchor.clone());
+        let cf = make_finding(FindingType::CredentialLeak, anchor.clone());
+
+        let baseline = RawSweepFindings {
+            credential: vec![bf.clone()],
+            ..Default::default()
+        };
+        let current = RawSweepFindings {
+            credential: vec![cf.clone()],
+            ..Default::default()
+        };
+
+        let (agreed, disagreements) = compare_phase1(
+            &baseline, &current, "2026-05-07T00:00:00Z", "baseline-rev", "current-rev",
+        )
+        .unwrap();
+
+        assert!(agreed.contains(&cf.finding_id), "current finding must be agreed");
+        assert!(disagreements.is_empty(), "no disagreements when both agree");
+    }
+
+    #[test]
+    fn compare_phase1_baseline_only() {
+        let anchor = EvidenceAnchor::CausalEvent { id: "evt_xyz".to_string() };
+        let bf = make_finding(FindingType::CredentialLeak, anchor);
+
+        let baseline = RawSweepFindings {
+            credential: vec![bf],
+            ..Default::default()
+        };
+        let current = RawSweepFindings::default();
+
+        let (agreed, disagreements) = compare_phase1(
+            &baseline, &current, "2026-05-07T00:00:00Z", "baseline-rev", "current-rev",
+        )
+        .unwrap();
+
+        assert!(agreed.is_empty());
+        assert_eq!(disagreements.len(), 1);
+        assert_eq!(disagreements[0].direction, DisagreementDirection::BaselineOnly);
+        assert!(disagreements[0].baseline_finding_id.is_some());
+        assert!(disagreements[0].current_finding_id.is_none());
+    }
+
+    #[test]
+    fn compare_phase1_current_only() {
+        let anchor = EvidenceAnchor::CausalEvent { id: "evt_new".to_string() };
+        let cf = make_finding(FindingType::SandboxEscapeAttempt, anchor);
+
+        let baseline = RawSweepFindings::default();
+        let current = RawSweepFindings {
+            sandbox_escape: vec![cf.clone()],
+            ..Default::default()
+        };
+
+        let (agreed, disagreements) = compare_phase1(
+            &baseline, &current, "2026-05-07T00:00:00Z", "baseline-rev", "current-rev",
+        )
+        .unwrap();
+
+        assert!(agreed.is_empty());
+        assert_eq!(disagreements.len(), 1);
+        assert_eq!(disagreements[0].direction, DisagreementDirection::CurrentOnly);
+        assert!(disagreements[0].current_finding_id.is_some());
+        assert!(disagreements[0].baseline_finding_id.is_none());
+    }
+
+    #[test]
+    fn annotate_baseline_agreed_sets_flag() {
+        let anchor = EvidenceAnchor::CausalEvent { id: "evt_abc".to_string() };
+        let f = make_finding(FindingType::CredentialLeak, anchor);
+        let id = f.finding_id.clone();
+
+        let mut raw = RawSweepFindings {
+            credential: vec![f],
+            ..Default::default()
+        };
+        let agreed: HashSet<String> = [id].into();
+        annotate_baseline_agreed(&mut raw, &agreed);
+
+        assert!(raw.credential[0].baseline_agreed, "baseline_agreed must be true after annotation");
+    }
+
+    #[test]
+    fn phase2_findings_excluded_from_disagreement() {
+        // Phase-2 (LLM-judgment) findings in current must not generate current_only disagreements.
+        use autonoetic_types::security::Reproducibility;
+        let anchor = EvidenceAnchor::SkillMdDigest { value: "abc".to_string() };
+        let llm_finding = SecurityFinding::new(
+            FindingType::PromptInjectionSurface,
+            FindingSeverity::Warning,
+            0.6,
+            Reproducibility::LlmJudgment,
+            "review",
+            "current-rev",
+        )
+        .with_anchors(vec![anchor]);
+
+        let baseline = RawSweepFindings::default();
+        let current = RawSweepFindings {
+            // Phase-2 findings go in prompt_injection, not compared by compare_phase1
+            prompt_injection: vec![llm_finding],
+            ..Default::default()
+        };
+
+        let (agreed, disagreements) = compare_phase1(
+            &baseline, &current, "2026-05-07T00:00:00Z", "baseline-rev", "current-rev",
+        )
+        .unwrap();
+
+        assert!(agreed.is_empty());
+        assert!(
+            disagreements.is_empty(),
+            "Phase-2 LLM-judgment findings must not generate disagreements"
+        );
+    }
+}

--- a/autonoetic-gateway/src/sentinel/dual_sweep.rs
+++ b/autonoetic-gateway/src/sentinel/dual_sweep.rs
@@ -26,7 +26,7 @@
 
 use anyhow::Result;
 use autonoetic_types::security::{EvidenceAnchor, SecurityFinding};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -38,6 +38,8 @@ use super::runner::{RawSweepFindings, SentinelRunner, SweepConfig, SweepResult};
 
 /// Result of a dual sweep (baseline + current).
 pub struct DualSweepResult {
+    /// Findings from the baseline sentinel (Phase 1 only), persisted to DB.
+    pub baseline: SweepResult,
     /// Findings from the current sentinel, persisted with `baseline_agreed` set.
     pub current: SweepResult,
     /// Number of current Phase-1 findings that the baseline also flagged.
@@ -77,9 +79,23 @@ impl DualSweepRunner {
     ) -> Result<DualSweepResult> {
         let sweep_at = chrono::Utc::now().to_rfc3339();
 
+        // Enforce Phase-1-only on the baseline regardless of caller config.
+        let baseline_config_p1 = SweepConfig {
+            phase1_only: true,
+            sentinel_revision_id: baseline_config.sentinel_revision_id.clone(),
+            since_rfc3339: baseline_config.since_rfc3339.clone(),
+            scan_limit: baseline_config.scan_limit,
+            window_days: baseline_config.window_days,
+            accretion_threshold: baseline_config.accretion_threshold,
+            denial_threshold: baseline_config.denial_threshold,
+            cluster_window_minutes: baseline_config.cluster_window_minutes,
+            failure_burst_threshold: baseline_config.failure_burst_threshold,
+            exec_repeat_threshold: baseline_config.exec_repeat_threshold,
+        };
+
         // 1. Collect baseline findings (Phase 1 only, no prompt-injection scan).
         let baseline_runner = SentinelRunner::new(Arc::clone(&self.store));
-        let baseline_raw = baseline_runner.collect_findings(baseline_config)?;
+        let baseline_raw = baseline_runner.collect_findings(&baseline_config_p1)?;
 
         // 2. Collect current findings (Phase 1 + 2).
         let mut current_runner = SentinelRunner::new(Arc::clone(&self.store));
@@ -93,7 +109,7 @@ impl DualSweepRunner {
             &baseline_raw,
             &current_raw,
             &sweep_at,
-            &baseline_config.sentinel_revision_id,
+            &baseline_config_p1.sentinel_revision_id,
             &current_config.sentinel_revision_id,
         )?;
 
@@ -102,10 +118,13 @@ impl DualSweepRunner {
 
         let baseline_agreed_count = agreed_current_ids.len();
 
-        // 5. Persist current findings (now annotated with baseline_agreed).
+        // 5. Persist baseline findings so baseline_finding_id references a real DB row.
+        let baseline_result = baseline_runner.persist_findings(baseline_raw);
+
+        // 6. Persist current findings (now annotated with baseline_agreed).
         let current_result = current_runner.persist_findings(current_raw);
 
-        // 6. Persist disagreements.
+        // 7. Persist disagreements.
         for d in &disagreements {
             if let Err(e) = self.store.insert_sentinel_disagreement(d) {
                 tracing::warn!(
@@ -118,6 +137,7 @@ impl DualSweepRunner {
         }
 
         Ok(DualSweepResult {
+            baseline: baseline_result,
             current: current_result,
             baseline_agreed_count,
             disagreements,
@@ -149,12 +169,6 @@ fn finding_anchor_keys(f: &SecurityFinding) -> HashSet<String> {
     f.evidence_anchors.iter().map(anchor_key).collect()
 }
 
-/// Check whether two findings share at least one evidence anchor.
-fn anchors_overlap(a: &SecurityFinding, b: &SecurityFinding) -> bool {
-    let keys_a = finding_anchor_keys(a);
-    finding_anchor_keys(b).iter().any(|k| keys_a.contains(k))
-}
-
 // ── Comparison logic ──────────────────────────────────────────────────────────
 
 /// Compare Phase-1 baseline and current findings.
@@ -172,16 +186,31 @@ fn compare_phase1(
     let baseline_p1: Vec<&SecurityFinding> = baseline_raw.all_phase1().collect();
     let current_p1: Vec<&SecurityFinding> = current_raw.all_phase1().collect();
 
-    let mut agreed_current_ids = HashSet::new();
+    // Build an anchor_key → Vec<current_finding_id> index for O(n+m) matching.
+    let mut current_by_anchor: HashMap<String, Vec<&SecurityFinding>> = HashMap::new();
+    for cf in &current_p1 {
+        for key in finding_anchor_keys(cf) {
+            current_by_anchor.entry(key).or_default().push(cf);
+        }
+    }
+
+    let mut agreed_current_ids: HashSet<String> = HashSet::new();
+    // Track which current findings were matched (for current_only detection below).
+    let mut matched_current_ids: HashSet<&str> = HashSet::new();
     let mut disagreements = Vec::new();
 
-    // For each baseline finding, check if any current Phase-1 finding agrees.
     for bf in &baseline_p1 {
-        let matching_current = current_p1.iter().find(|cf| anchors_overlap(bf, cf));
-        if let Some(cf) = matching_current {
-            // Both agree — mark the current finding as baseline_agreed.
-            agreed_current_ids.insert(cf.finding_id.clone());
-        } else {
+        let mut found_match = false;
+        for key in finding_anchor_keys(bf) {
+            if let Some(matches) = current_by_anchor.get(&key) {
+                for cf in matches {
+                    agreed_current_ids.insert(cf.finding_id.clone());
+                    matched_current_ids.insert(cf.finding_id.as_str());
+                    found_match = true;
+                }
+            }
+        }
+        if !found_match {
             // Baseline flagged something current missed.
             let anchor_json = serde_json::to_string(&bf.evidence_anchors)
                 .unwrap_or_else(|_| "[]".to_string());
@@ -198,13 +227,9 @@ fn compare_phase1(
         }
     }
 
-    // For each current Phase-1 finding NOT matched by baseline, record current_only.
+    // For each current Phase-1 finding NOT matched by any baseline anchor, record current_only.
     for cf in &current_p1 {
-        if agreed_current_ids.contains(&cf.finding_id) {
-            continue;
-        }
-        let baseline_match = baseline_p1.iter().any(|bf| anchors_overlap(bf, cf));
-        if !baseline_match {
+        if !matched_current_ids.contains(cf.finding_id.as_str()) {
             let anchor_json = serde_json::to_string(&cf.evidence_anchors)
                 .unwrap_or_else(|_| "[]".to_string());
             disagreements.push(SentinelDisagreementRecord {
@@ -233,7 +258,7 @@ fn annotate_baseline_agreed(current_raw: &mut RawSweepFindings, agreed: &HashSet
         .chain(current_raw.sandbox_escape.iter_mut())
     {
         if agreed.contains(&f.finding_id) {
-            *f = f.clone().with_baseline_agreed(true);
+            f.baseline_agreed = true;
         }
     }
 }

--- a/autonoetic-gateway/src/sentinel/mod.rs
+++ b/autonoetic-gateway/src/sentinel/mod.rs
@@ -37,6 +37,8 @@
 //! append-only `security_findings` table.
 
 pub mod checks;
+pub mod dual_sweep;
 pub mod runner;
 
+pub use dual_sweep::{DualSweepResult, DualSweepRunner};
 pub use runner::{SentinelRunner, SweepResult};

--- a/autonoetic-gateway/src/sentinel/runner.rs
+++ b/autonoetic-gateway/src/sentinel/runner.rs
@@ -14,6 +14,10 @@
 //! The prompt-injection scan reads SKILL.md bodies from the filesystem via
 //! `agents_dir` (optional — skipped if not set).
 //!
+//! ## Phase 3 dual-sweep
+//! See [`super::dual_sweep::DualSweepRunner`] for the orchestrator that runs
+//! the frozen baseline alongside the current sentinel and records disagreements.
+//!
 //! NOTE: Emission of `security_finding_recorded` events to the causal chain is
 //! planned for Phase 5 (scheduling integration). The current runner persists
 //! findings to the `security_findings` table only.
@@ -101,15 +105,56 @@ impl SweepResult {
             .chain(&self.prompt_injection_findings)
             .chain(&self.behavioral_anomaly_findings)
     }
+
+    /// Return only Phase 1 (deterministic) findings — used for baseline comparison.
+    pub fn phase1_findings(&self) -> impl Iterator<Item = &SecurityFinding> {
+        self.credential_findings
+            .iter()
+            .chain(&self.capability_accretion_findings)
+            .chain(&self.approval_bypass_findings)
+            .chain(&self.sandbox_escape_findings)
+    }
+}
+
+/// Raw findings from a sweep, before persisting. Used internally by the runner
+/// and by the dual-sweep orchestrator to annotate `baseline_agreed` before the
+/// final persist step.
+#[derive(Debug, Default)]
+pub(super) struct RawSweepFindings {
+    pub credential: Vec<SecurityFinding>,
+    pub capability_accretion: Vec<SecurityFinding>,
+    pub approval_bypass: Vec<SecurityFinding>,
+    pub sandbox_escape: Vec<SecurityFinding>,
+    pub prompt_injection: Vec<SecurityFinding>,
+    pub behavioral_anomaly: Vec<SecurityFinding>,
+    pub scan_errors: Vec<String>,
+}
+
+impl RawSweepFindings {
+    pub fn all_phase1(&self) -> impl Iterator<Item = &SecurityFinding> {
+        self.credential
+            .iter()
+            .chain(&self.capability_accretion)
+            .chain(&self.approval_bypass)
+            .chain(&self.sandbox_escape)
+    }
+
+    pub fn all(&self) -> impl Iterator<Item = &SecurityFinding> {
+        self.credential
+            .iter()
+            .chain(&self.capability_accretion)
+            .chain(&self.approval_bypass)
+            .chain(&self.sandbox_escape)
+            .chain(&self.prompt_injection)
+            .chain(&self.behavioral_anomaly)
+    }
 }
 
 /// Runs deterministic (Phase 1) and heuristic (Phase 2) security sweeps.
 pub struct SentinelRunner {
-    store: Arc<GatewayStore>,
-    /// Root directory of the agents tree (e.g. `agents/` in the workspace).
-    /// When set, Phase 2 prompt-injection scans read SKILL.md bodies from here.
-    /// When `None`, the prompt-injection check is skipped.
-    agents_dir: Option<PathBuf>,
+    pub(super) store: Arc<GatewayStore>,
+    /// Root directory of the agents tree for Phase 2 prompt-injection scanning.
+    pub(super) agents_dir: Option<PathBuf>,
 }
 
 impl SentinelRunner {
@@ -126,13 +171,13 @@ impl SentinelRunner {
         self
     }
 
-    /// Run a full sweep according to `config`.
+    /// Run all checks and return raw (unpersisted) findings.
     ///
-    /// Findings are persisted to `security_findings` as they are discovered;
-    /// failures to persist individual findings are collected in
-    /// `SweepResult::persist_errors` rather than aborting the entire run.
-    pub fn run_sweep(&self, config: &SweepConfig) -> Result<SweepResult> {
-        let mut result = SweepResult::default();
+    /// The dual-sweep orchestrator calls this to collect findings from both the
+    /// baseline and current sentinel before annotating `baseline_agreed` and
+    /// persisting. Direct callers should use [`run_sweep`] instead.
+    pub(super) fn collect_findings(&self, config: &SweepConfig) -> Result<RawSweepFindings> {
+        let mut raw = RawSweepFindings::default();
 
         let since = config.since_rfc3339.as_deref();
         let rev_id = &config.sentinel_revision_id;
@@ -144,102 +189,92 @@ impl SentinelRunner {
         let failure_burst_threshold = config.failure_burst_threshold;
         let exec_repeat_threshold = config.exec_repeat_threshold;
 
-        // ── Phase 1: deterministic checks (single connection borrow) ───────────
-        // ── Phase 2a: session-cluster heuristics (SQL, same borrow) ────────────
-        //
-        // Both phases run inside a single `with_conn` borrow for efficiency.
-        // Results are collected in a flat vec; the macro below distributes
-        // them into typed buckets in order.
-        let all_db_checks: Vec<Result<Vec<SecurityFinding>>> = self.store.with_conn(|conn| {
+        // All DB checks in a single connection borrow.
+        let db_results: Vec<Result<Vec<SecurityFinding>>> = self.store.with_conn(|conn| {
             Ok(vec![
                 // Phase 1 — deterministic
                 credential::scan_credential_leaks(conn, rev_id, since, scan_limit),
                 capability_accretion::scan_capability_accretion(
-                    conn,
-                    rev_id,
-                    window_days,
-                    accretion_threshold,
+                    conn, rev_id, window_days, accretion_threshold,
                 ),
                 approval_bypass::scan_approval_denials(conn, rev_id, window_days, denial_threshold),
                 approval_bypass::scan_exec_without_grant(conn, rev_id, since, scan_limit),
                 sandbox_escape::scan_escape_attempt_records(conn, rev_id, since, scan_limit),
                 sandbox_escape::scan_escape_patterns_in_events(conn, rev_id, since, scan_limit),
-                // Phase 2a — cluster heuristics (always use rolling window, not `since`)
+                // Phase 2a — cluster heuristics (always rolling window, not `since`)
                 session_cluster::scan_failure_bursts(
-                    conn,
-                    rev_id,
-                    cluster_window_minutes,
-                    failure_burst_threshold,
-                    scan_limit,
+                    conn, rev_id, cluster_window_minutes, failure_burst_threshold, scan_limit,
                 ),
                 session_cluster::scan_exec_repeats(
-                    conn,
-                    rev_id,
-                    cluster_window_minutes,
-                    exec_repeat_threshold,
-                    scan_limit,
+                    conn, rev_id, cluster_window_minutes, exec_repeat_threshold, scan_limit,
                 ),
             ])
         })?;
 
-        let mut checks_iter = all_db_checks.into_iter();
-
-        macro_rules! collect_check {
+        let mut it = db_results.into_iter();
+        macro_rules! take_check {
             ($bucket:ident, $label:expr) => {
-                match checks_iter.next().expect("result count mismatch") {
-                    Ok(findings) => {
-                        for f in findings {
-                            if let Err(e) = self.store.insert_security_finding(&f) {
-                                result
-                                    .persist_errors
-                                    .push(format!("{} persist: {}", $label, e));
-                            } else {
-                                result.$bucket.push(f);
-                            }
-                        }
+                match it.next().expect("result count mismatch") {
+                    Ok(v) => raw.$bucket.extend(v),
+                    Err(e) => raw.scan_errors.push(format!("{} scan: {}", $label, e)),
+                }
+            };
+        }
+        take_check!(credential, "credential");
+        take_check!(capability_accretion, "accretion");
+        take_check!(approval_bypass, "approval_denial");
+        take_check!(approval_bypass, "exec_without_grant");
+        take_check!(sandbox_escape, "escape_records");
+        take_check!(sandbox_escape, "escape_patterns");
+        take_check!(behavioral_anomaly, "failure_burst");
+        take_check!(behavioral_anomaly, "exec_repeat");
+
+        // Phase 2b — prompt injection (filesystem, optional).
+        if let Some(ref agents_dir) = self.agents_dir {
+            match prompt_injection::scan_prompt_injection(agents_dir, rev_id, scan_limit as usize) {
+                Ok(v) => raw.prompt_injection = v,
+                Err(e) => raw.scan_errors.push(format!("prompt_injection scan: {}", e)),
+            }
+        }
+
+        Ok(raw)
+    }
+
+    /// Persist pre-collected findings and return a structured `SweepResult`.
+    pub(super) fn persist_findings(&self, raw: RawSweepFindings) -> SweepResult {
+        let mut result = SweepResult::default();
+        result.persist_errors = raw.scan_errors;
+
+        macro_rules! persist_bucket {
+            ($raw_field:expr, $result_field:ident, $label:expr) => {
+                for f in $raw_field {
+                    if let Err(e) = self.store.insert_security_finding(&f) {
+                        result
+                            .persist_errors
+                            .push(format!("{} persist: {}", $label, e));
+                    } else {
+                        result.$result_field.push(f);
                     }
-                    Err(e) => result
-                        .persist_errors
-                        .push(format!("{} scan: {}", $label, e)),
                 }
             };
         }
 
-        // Phase 1
-        collect_check!(credential_findings, "credential");
-        collect_check!(capability_accretion_findings, "accretion");
-        collect_check!(approval_bypass_findings, "approval_denial");
-        collect_check!(approval_bypass_findings, "exec_without_grant");
-        collect_check!(sandbox_escape_findings, "escape_records");
-        collect_check!(sandbox_escape_findings, "escape_patterns");
-        // Phase 2a
-        collect_check!(behavioral_anomaly_findings, "failure_burst");
-        collect_check!(behavioral_anomaly_findings, "exec_repeat");
+        persist_bucket!(raw.credential, credential_findings, "credential");
+        persist_bucket!(raw.capability_accretion, capability_accretion_findings, "accretion");
+        persist_bucket!(raw.approval_bypass, approval_bypass_findings, "approval_bypass");
+        persist_bucket!(raw.sandbox_escape, sandbox_escape_findings, "sandbox_escape");
+        persist_bucket!(raw.prompt_injection, prompt_injection_findings, "prompt_injection");
+        persist_bucket!(raw.behavioral_anomaly, behavioral_anomaly_findings, "behavioral_anomaly");
 
-        // 2b. Prompt-injection surface scan (filesystem-backed, optional).
-        if let Some(ref agents_dir) = self.agents_dir {
-            match prompt_injection::scan_prompt_injection(
-                agents_dir,
-                rev_id,
-                scan_limit as usize,
-            ) {
-                Ok(findings) => {
-                    for f in findings {
-                        if let Err(e) = self.store.insert_security_finding(&f) {
-                            result
-                                .persist_errors
-                                .push(format!("prompt_injection persist: {}", e));
-                        } else {
-                            result.prompt_injection_findings.push(f);
-                        }
-                    }
-                }
-                Err(e) => result
-                    .persist_errors
-                    .push(format!("prompt_injection scan: {}", e)),
-            }
-        }
+        result
+    }
 
-        Ok(result)
+    /// Run a full sweep: collect, persist, and return results.
+    ///
+    /// For dual-sweep (baseline + current with disagreement recording) use
+    /// [`super::dual_sweep::DualSweepRunner`] instead.
+    pub fn run_sweep(&self, config: &SweepConfig) -> Result<SweepResult> {
+        let raw = self.collect_findings(config)?;
+        Ok(self.persist_findings(raw))
     }
 }

--- a/autonoetic-gateway/src/sentinel/runner.rs
+++ b/autonoetic-gateway/src/sentinel/runner.rs
@@ -54,6 +54,12 @@ pub struct SweepConfig {
     pub failure_burst_threshold: u32,
     /// Number of identical sandbox_exec targets in `cluster_window_minutes` that triggers a repeat warning.
     pub exec_repeat_threshold: u32,
+
+    // ── Scope control ───────────────────────────────────────────────────
+    /// When `true`, run only Phase-1 (deterministic) checks — skip cluster
+    /// heuristics and prompt-injection scanning. Used by the dual-sweep
+    /// orchestrator for the frozen baseline runner.
+    pub phase1_only: bool,
 }
 
 impl Default for SweepConfig {
@@ -68,6 +74,7 @@ impl Default for SweepConfig {
             cluster_window_minutes: 60,
             failure_burst_threshold: 20,
             exec_repeat_threshold: 10,
+            phase1_only: false,
         }
     }
 }
@@ -191,7 +198,7 @@ impl SentinelRunner {
 
         // All DB checks in a single connection borrow.
         let db_results: Vec<Result<Vec<SecurityFinding>>> = self.store.with_conn(|conn| {
-            Ok(vec![
+            let mut checks = vec![
                 // Phase 1 — deterministic
                 credential::scan_credential_leaks(conn, rev_id, since, scan_limit),
                 capability_accretion::scan_capability_accretion(
@@ -201,14 +208,18 @@ impl SentinelRunner {
                 approval_bypass::scan_exec_without_grant(conn, rev_id, since, scan_limit),
                 sandbox_escape::scan_escape_attempt_records(conn, rev_id, since, scan_limit),
                 sandbox_escape::scan_escape_patterns_in_events(conn, rev_id, since, scan_limit),
-                // Phase 2a — cluster heuristics (always rolling window, not `since`)
-                session_cluster::scan_failure_bursts(
+            ];
+            // Phase 2a — cluster heuristics (always rolling window, not `since`).
+            // Skipped when phase1_only is set (e.g. frozen baseline runner).
+            if !config.phase1_only {
+                checks.push(session_cluster::scan_failure_bursts(
                     conn, rev_id, cluster_window_minutes, failure_burst_threshold, scan_limit,
-                ),
-                session_cluster::scan_exec_repeats(
+                ));
+                checks.push(session_cluster::scan_exec_repeats(
                     conn, rev_id, cluster_window_minutes, exec_repeat_threshold, scan_limit,
-                ),
-            ])
+                ));
+            }
+            Ok(checks)
         })?;
 
         let mut it = db_results.into_iter();
@@ -226,14 +237,18 @@ impl SentinelRunner {
         take_check!(approval_bypass, "exec_without_grant");
         take_check!(sandbox_escape, "escape_records");
         take_check!(sandbox_escape, "escape_patterns");
-        take_check!(behavioral_anomaly, "failure_burst");
-        take_check!(behavioral_anomaly, "exec_repeat");
+        if !config.phase1_only {
+            take_check!(behavioral_anomaly, "failure_burst");
+            take_check!(behavioral_anomaly, "exec_repeat");
+        }
 
-        // Phase 2b — prompt injection (filesystem, optional).
-        if let Some(ref agents_dir) = self.agents_dir {
-            match prompt_injection::scan_prompt_injection(agents_dir, rev_id, scan_limit as usize) {
-                Ok(v) => raw.prompt_injection = v,
-                Err(e) => raw.scan_errors.push(format!("prompt_injection scan: {}", e)),
+        // Phase 2b — prompt injection (filesystem, optional). Skipped for baseline.
+        if !config.phase1_only {
+            if let Some(ref agents_dir) = self.agents_dir {
+                match prompt_injection::scan_prompt_injection(agents_dir, rev_id, scan_limit as usize) {
+                    Ok(v) => raw.prompt_injection = v,
+                    Err(e) => raw.scan_errors.push(format!("prompt_injection scan: {}", e)),
+                }
             }
         }
 

--- a/autonoetic-gateway/tests/security_sentinel_integration.rs
+++ b/autonoetic-gateway/tests/security_sentinel_integration.rs
@@ -485,11 +485,12 @@ fn dual_sweep_sets_baseline_agreed_when_both_find_same_anchor() {
     {
         let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
         let now = chrono::Utc::now().to_rfc3339();
+        let fake_key = format!("sk-ant-api03-{}-{}", "A".repeat(92), "A".repeat(10));
         db.execute(
             "INSERT INTO causal_events
                 (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
-             VALUES ('evt_cred_001', 'coder.default', 'sess_001', 0, ?1, 'tool', 'tool_call', 'success', 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AAAAAAAAAA')",
-            rusqlite::params![now],
+             VALUES ('evt_cred_001', 'coder.default', 'sess_001', 0, ?1, 'tool', 'tool_call', 'success', ?2)",
+            rusqlite::params![now, fake_key],
         ).unwrap();
     }
 
@@ -531,43 +532,67 @@ fn dual_sweep_sets_baseline_agreed_when_both_find_same_anchor() {
 
 #[test]
 fn dual_sweep_records_baseline_only_disagreement() {
-    use autonoetic_gateway::sentinel::{DualSweepRunner};
+    use autonoetic_gateway::sentinel::DualSweepRunner;
     use autonoetic_gateway::sentinel::runner::SweepConfig;
     use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::DisagreementDirection;
 
     let (dir, store) = open_store();
 
-    // Insert a sandbox_escape_attempts row — the baseline (Phase 1) will flag it.
-    // The current sentinel also runs Phase 1 so it will also flag it.
-    // To simulate a baseline_only disagreement we need the current to miss something.
-    // We achieve this by inserting the row AFTER the current config's since_rfc3339,
-    // but both configs here use None (full scan). The disagreement will be current_only
-    // if the current has something the baseline doesn't — we test that path separately.
-    //
-    // For baseline_only, we simulate via the disagreement store directly.
+    // Insert a credential event with a past timestamp so the baseline (no since cutoff)
+    // will find it, but the current sentinel's since_rfc3339 is set to the far future
+    // so it misses everything — producing a baseline_only disagreement.
     {
-        use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::SentinelDisagreementRecord;
-        let rec = SentinelDisagreementRecord {
-            disagreement_id: "dis_test_001".to_string(),
-            sweep_at: chrono::Utc::now().to_rfc3339(),
-            direction: DisagreementDirection::BaselineOnly,
-            anchor_json: r#"[{"type":"causal_event","id":"evt_missing"}]"#.to_string(),
-            baseline_finding_id: Some("finding_baseline_001".to_string()),
-            current_finding_id: None,
-            baseline_sentinel_rev: "sentinel.baseline".to_string(),
-            current_sentinel_rev: "sentinel.current".to_string(),
-        };
-        store.insert_sentinel_disagreement(&rec).expect("insert disagreement");
+        let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
+        let past = "2020-01-01T00:00:00Z";
+        let fake_key = format!("sk-ant-api03-{}-{}", "C".repeat(92), "C".repeat(10));
+        db.execute(
+            "INSERT INTO causal_events
+                (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
+             VALUES ('evt_cred_base_only', 'coder.default', 'sess_base_only', 0, ?1, 'tool', 'tool_call', 'success', ?2)",
+            rusqlite::params![past, fake_key],
+        ).unwrap();
     }
 
+    let runner = DualSweepRunner::new(Arc::clone(&store));
+    // Baseline scans full history (since_rfc3339 = None).
+    let baseline_config = SweepConfig {
+        sentinel_revision_id: "sentinel.baseline".to_string(),
+        since_rfc3339: None,
+        ..SweepConfig::default()
+    };
+    // Current only looks at events from the far future — misses the past event.
+    let current_config = SweepConfig {
+        sentinel_revision_id: "sentinel.current".to_string(),
+        since_rfc3339: Some("2099-01-01T00:00:00Z".to_string()),
+        ..SweepConfig::default()
+    };
+
+    let result = runner.run(&baseline_config, &current_config).expect("dual sweep");
+
+    // Baseline must have found the credential.
+    assert!(
+        !result.baseline.credential_findings.is_empty(),
+        "baseline must find the credential event"
+    );
+    // Current must have found nothing.
+    assert!(
+        result.current.credential_findings.is_empty(),
+        "current must miss the credential event (future since cutoff)"
+    );
+    // A baseline_only disagreement must have been recorded.
+    let baseline_only = result
+        .disagreements
+        .iter()
+        .any(|d| d.direction == DisagreementDirection::BaselineOnly);
+    assert!(baseline_only, "must produce a baseline_only disagreement");
+
+    // Verify it is also in the DB.
     let rows = store.list_sentinel_disagreements(None, 10).expect("list");
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].direction, DisagreementDirection::BaselineOnly);
-    assert_eq!(rows[0].disagreement_id, "dis_test_001");
+    assert!(rows.iter().any(|r| r.direction == DisagreementDirection::BaselineOnly));
 
     let counts = store.count_sentinel_disagreements_by_direction().expect("count");
-    let baseline_only = counts.iter().find(|(d, _)| d == "baseline_only").map(|(_, n)| *n);
-    assert_eq!(baseline_only, Some(1));
+    let n = counts.iter().find(|(d, _)| d == "baseline_only").map(|(_, n)| *n);
+    assert_eq!(n, Some(1));
 }
 
 #[test]
@@ -584,11 +609,12 @@ fn dual_sweep_disagreement_persisted_in_db() {
     {
         let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
         let now = chrono::Utc::now().to_rfc3339();
+        let fake_key = format!("sk-ant-api03-{}-{}", "B".repeat(92), "B".repeat(10));
         db.execute(
             "INSERT INTO causal_events
                 (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
-             VALUES ('evt_cred_dis', 'coder.default', 'sess_dis', 0, ?1, 'tool', 'tool_call', 'success', 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AAAAAAAAAA')",
-            rusqlite::params![now],
+             VALUES ('evt_cred_dis', 'coder.default', 'sess_dis', 0, ?1, 'tool', 'tool_call', 'success', ?2)",
+            rusqlite::params![now, fake_key],
         ).unwrap();
     }
 

--- a/autonoetic-gateway/tests/security_sentinel_integration.rs
+++ b/autonoetic-gateway/tests/security_sentinel_integration.rs
@@ -1,9 +1,11 @@
-//! Integration tests for Phase 0 and Phase 1 of the security sentinel.
+//! Integration tests for the security sentinel (Phases 0–3).
 //!
 //! Covers:
 //! - `SecurityFinding` serialization and DB round-trip
 //! - `security_findings` SQL migration (append-only enforcement)
 //! - Deterministic checks via `SentinelRunner::run_sweep`
+//! - Phase 2 heuristic checks (prompt injection, session cluster)
+//! - Phase 3 dual-sweep: baseline annotation and disagreement recording
 
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::security::{
@@ -445,4 +447,178 @@ fn session_cluster_failure_burst_flagged_by_runner() {
             .any(|f| f.finding_type == FindingType::BehavioralAnomaly),
         "finding_type must be BehavioralAnomaly"
     );
+}
+
+// ── Phase 3: Dual-sweep (frozen baseline + current sentinel) ──────────────────
+
+#[test]
+fn dual_sweep_on_empty_db_produces_no_findings_or_disagreements() {
+    use autonoetic_gateway::sentinel::{DualSweepResult, DualSweepRunner};
+    use autonoetic_gateway::sentinel::runner::SweepConfig;
+
+    let (_dir, store) = open_store();
+    let runner = DualSweepRunner::new(Arc::clone(&store));
+    let baseline_config = SweepConfig {
+        sentinel_revision_id: "sentinel.baseline".to_string(),
+        ..SweepConfig::default()
+    };
+    let current_config = SweepConfig {
+        sentinel_revision_id: "sentinel.current".to_string(),
+        ..SweepConfig::default()
+    };
+    let result: DualSweepResult = runner.run(&baseline_config, &current_config).expect("dual sweep");
+    assert_eq!(result.current.total_findings(), 0);
+    assert_eq!(result.baseline_agreed_count, 0);
+    assert!(result.disagreements.is_empty());
+    assert!(result.current.persist_errors.is_empty());
+}
+
+#[test]
+fn dual_sweep_sets_baseline_agreed_when_both_find_same_anchor() {
+    use autonoetic_gateway::sentinel::{DualSweepRunner};
+    use autonoetic_gateway::sentinel::runner::SweepConfig;
+
+    let (dir, store) = open_store();
+
+    // Insert a credential-pattern event that BOTH baseline and current will flag.
+    // Use a real Anthropic key pattern so the credential scanner fires.
+    {
+        let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        db.execute(
+            "INSERT INTO causal_events
+                (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
+             VALUES ('evt_cred_001', 'coder.default', 'sess_001', 0, ?1, 'tool', 'tool_call', 'success', 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AAAAAAAAAA')",
+            rusqlite::params![now],
+        ).unwrap();
+    }
+
+    let runner = DualSweepRunner::new(Arc::clone(&store));
+    let baseline_config = SweepConfig {
+        sentinel_revision_id: "sentinel.baseline".to_string(),
+        ..SweepConfig::default()
+    };
+    let current_config = SweepConfig {
+        sentinel_revision_id: "sentinel.current".to_string(),
+        ..SweepConfig::default()
+    };
+    let result = runner.run(&baseline_config, &current_config).expect("dual sweep");
+
+    // Both baseline and current must have flagged the credential.
+    // The current finding should have baseline_agreed = true.
+    assert!(
+        result.baseline_agreed_count > 0,
+        "both sweeps must find the credential — baseline_agreed_count must be > 0"
+    );
+    let agreed_finding = result
+        .current
+        .credential_findings
+        .iter()
+        .find(|f| f.baseline_agreed);
+    assert!(
+        agreed_finding.is_some(),
+        "at least one current finding must have baseline_agreed = true"
+    );
+    // No disagreements when both agree.
+    assert!(
+        result.disagreements.iter().all(|d| {
+            use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::DisagreementDirection;
+            d.direction != DisagreementDirection::BaselineOnly
+        }),
+        "no baseline_only disagreements when both find the same anchor"
+    );
+}
+
+#[test]
+fn dual_sweep_records_baseline_only_disagreement() {
+    use autonoetic_gateway::sentinel::{DualSweepRunner};
+    use autonoetic_gateway::sentinel::runner::SweepConfig;
+    use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::DisagreementDirection;
+
+    let (dir, store) = open_store();
+
+    // Insert a sandbox_escape_attempts row — the baseline (Phase 1) will flag it.
+    // The current sentinel also runs Phase 1 so it will also flag it.
+    // To simulate a baseline_only disagreement we need the current to miss something.
+    // We achieve this by inserting the row AFTER the current config's since_rfc3339,
+    // but both configs here use None (full scan). The disagreement will be current_only
+    // if the current has something the baseline doesn't — we test that path separately.
+    //
+    // For baseline_only, we simulate via the disagreement store directly.
+    {
+        use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::SentinelDisagreementRecord;
+        let rec = SentinelDisagreementRecord {
+            disagreement_id: "dis_test_001".to_string(),
+            sweep_at: chrono::Utc::now().to_rfc3339(),
+            direction: DisagreementDirection::BaselineOnly,
+            anchor_json: r#"[{"type":"causal_event","id":"evt_missing"}]"#.to_string(),
+            baseline_finding_id: Some("finding_baseline_001".to_string()),
+            current_finding_id: None,
+            baseline_sentinel_rev: "sentinel.baseline".to_string(),
+            current_sentinel_rev: "sentinel.current".to_string(),
+        };
+        store.insert_sentinel_disagreement(&rec).expect("insert disagreement");
+    }
+
+    let rows = store.list_sentinel_disagreements(None, 10).expect("list");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].direction, DisagreementDirection::BaselineOnly);
+    assert_eq!(rows[0].disagreement_id, "dis_test_001");
+
+    let counts = store.count_sentinel_disagreements_by_direction().expect("count");
+    let baseline_only = counts.iter().find(|(d, _)| d == "baseline_only").map(|(_, n)| *n);
+    assert_eq!(baseline_only, Some(1));
+}
+
+#[test]
+fn dual_sweep_disagreement_persisted_in_db() {
+    use autonoetic_gateway::sentinel::{DualSweepRunner};
+    use autonoetic_gateway::sentinel::runner::SweepConfig;
+    use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::DisagreementDirection;
+
+    let (dir, store) = open_store();
+
+    // Insert a credential event ONLY reachable by the current sentinel's since_rfc3339=None
+    // but craft configs so one sentinel sees it and the other doesn't:
+    // Use baseline with a future `since` so it sees nothing; current sees everything.
+    {
+        let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        db.execute(
+            "INSERT INTO causal_events
+                (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
+             VALUES ('evt_cred_dis', 'coder.default', 'sess_dis', 0, ?1, 'tool', 'tool_call', 'success', 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AAAAAAAAAA')",
+            rusqlite::params![now],
+        ).unwrap();
+    }
+
+    // Give baseline a since_rfc3339 in the far future so it sees nothing.
+    let future = "2099-01-01T00:00:00Z";
+    let runner = DualSweepRunner::new(Arc::clone(&store));
+    let baseline_config = SweepConfig {
+        sentinel_revision_id: "sentinel.baseline".to_string(),
+        since_rfc3339: Some(future.to_string()),
+        ..SweepConfig::default()
+    };
+    let current_config = SweepConfig {
+        sentinel_revision_id: "sentinel.current".to_string(),
+        since_rfc3339: None,
+        ..SweepConfig::default()
+    };
+
+    let result = runner.run(&baseline_config, &current_config).expect("dual sweep");
+
+    // Current found a credential; baseline didn't (it was past its since cutoff).
+    assert!(!result.current.credential_findings.is_empty(), "current must find the credential");
+
+    // This should produce a current_only disagreement.
+    let current_only = result
+        .disagreements
+        .iter()
+        .any(|d| d.direction == DisagreementDirection::CurrentOnly);
+    assert!(current_only, "must record a current_only disagreement");
+
+    // The disagreement must be persisted in the DB.
+    let db_rows = store.list_sentinel_disagreements(None, 100).expect("list");
+    assert!(!db_rows.is_empty(), "disagreements must be persisted to DB");
 }


### PR DESCRIPTION
Closes #36

## Summary

- **Migration v27** adds `security_sentinel_disagreements` table: `direction` (`baseline_only` / `current_only`), `anchor_json`, cross-references to both finding IDs, indexed for fast operator queries.
- **Runner refactor**: separates `collect_findings` (no I/O) from `persist_findings` so the dual-sweep orchestrator can annotate `baseline_agreed` before the final DB insert (the append-only trigger blocks post-insert updates on that field). Fixed a bug where multi-check buckets (approval_bypass, sandbox_escape, behavioral_anomaly) were overwriting instead of accumulating.
- **`DualSweepRunner`** (`sentinel/dual_sweep.rs`): runs baseline (Phase 1 only) then current (Phase 1 + 2), matches findings by evidence anchor overlap, sets `baseline_agreed = true` on agreed findings, records divergence in `security_sentinel_disagreements`. Phase-2 LLM-judgment findings are excluded from disagreement comparison (deterministic baseline has no Phase-2 layer).
- **Store methods**: `insert_sentinel_disagreement`, `list_sentinel_disagreements`, `count_sentinel_disagreements_by_direction`.

**Deferred** (pending dependencies): baseline revision CLI with operator identity logging, ensemble second-model pass (Phase 5), meta-audit / drift detection (#25, #26).

## Test plan

- [ ] All 17 integration tests pass (`cargo test -p autonoetic-gateway --test security_sentinel_integration`)
- [ ] All 42 sentinel unit tests pass (`cargo test -p autonoetic-gateway --lib sentinel`)
- [ ] Empty-DB dual sweep: 0 findings, 0 disagreements
- [ ] Same-anchor scenario: `baseline_agreed = true` set on current finding
- [ ] `current_only` disagreement recorded in DB when baseline misses an event
- [ ] Build clean: `cargo build -p autonoetic-gateway`

🤖 Generated with [Claude Code](https://claude.com/claude-code)