### PR TITLE
feat(security): per-actor-class observability redaction

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/approval.rs
+++ b/autonoetic-gateway/src/runtime/tools/approval.rs
@@ -250,7 +250,12 @@ impl NativeTool for ApprovalWithdrawTool {
 }
 
 fn approval_summary(r: &autonoetic_types::background::ApprovalRequest) -> serde_json::Value {
-    let action_summary = match &r.action {
+    approval_summary_for_viewer(r, autonoetic_types::disclosure::ViewerClass::Agent)
+}
+
+fn approval_summary_for_viewer(r: &autonoetic_types::background::ApprovalRequest, viewer: autonoetic_types::disclosure::ViewerClass) -> serde_json::Value {
+    let redacted = r.action.redact_for_viewer(viewer);
+    let action_summary = match &redacted {
         autonoetic_types::background::ScheduledAction::SandboxExec {
             command,
             detected_hosts,
@@ -276,9 +281,16 @@ fn approval_summary(r: &autonoetic_types::background::ApprovalRequest) -> serde_
             "service": service,
             "credential_id": credential_id,
         }),
+        autonoetic_types::background::ScheduledAction::CredentialRequest {
+            credential_id, url, method, ..
+        } => serde_json::json!({
+            "kind": "credential_request",
+            "credential_id": credential_id,
+            "url": url,
+            "method": method,
+        }),
         other => serde_json::json!({
-            "kind": "other",
-            "detail": format!("{:?}", other),
+            "kind": other.kind(),
         }),
     };
     serde_json::json!({

--- a/autonoetic-gateway/src/runtime/tools/execution.rs
+++ b/autonoetic-gateway/src/runtime/tools/execution.rs
@@ -3,6 +3,7 @@ use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::disclosure::ViewerClass;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -24,7 +25,7 @@ impl NativeTool for ExecutionSearchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Search raw execution traces for tool-level debugging within sessions. Query by tool name, success status, error type, command pattern, or agent ID. Returns full execution details including stdout, stderr, exit codes, and duration. For cross-session discovery of high-level session summaries, use observability.search instead.".to_string(),
+            description: "Search raw execution traces for tool-level debugging within sessions. Query by tool name, success status, error type, command pattern, or agent ID. Returns execution metadata including exit codes, duration, and error info. For cross-session discovery of high-level session summaries, use observability.search instead.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -103,6 +104,8 @@ impl NativeTool for ExecutionSearchTool {
 
         let limit = args.limit.unwrap_or(10).min(100) as i64;
 
+        let viewer = ViewerClass::Agent;
+
         let traces = store.search_execution_traces(
             args.tool_name.as_deref(),
             args.success,
@@ -115,26 +118,7 @@ impl NativeTool for ExecutionSearchTool {
 
         let items: Vec<serde_json::Value> = traces
             .into_iter()
-            .map(|t| {
-                serde_json::json!({
-                    "trace_id": t.trace_id,
-                    "agent_id": t.agent_id,
-                    "session_id": t.session_id,
-                    "turn_id": t.turn_id,
-                    "timestamp": t.timestamp,
-                    "tool_name": t.tool_name,
-                    "command": t.command,
-                    "exit_code": t.exit_code,
-                    "stdout": t.stdout,
-                    "stderr": t.stderr,
-                    "duration_ms": t.duration_ms,
-                    "success": t.success == 1,
-                    "error_type": t.error_type,
-                    "error_summary": t.error_summary,
-                    "approval_required": t.approval_required == Some(1),
-                    "approval_request_id": t.approval_request_id,
-                })
-            })
+            .map(|t| t.to_json_for_viewer(viewer))
             .collect();
 
         serde_json::to_string(&serde_json::json!({

--- a/autonoetic-gateway/src/scheduler/hooks.rs
+++ b/autonoetic-gateway/src/scheduler/hooks.rs
@@ -299,13 +299,14 @@ impl HookExecutor {
         let mut html_handle: Option<String> = None;
         let html_path = session_dir.join("session_report_final.html");
         if let Ok(html_body) = std::fs::read_to_string(&html_path) {
+            let sanitized_html = sanitize_html_for_publishing(&html_body);
             let h =
-                crate::runtime::content_store::ContentStore::compute_handle(html_body.as_bytes());
+                crate::runtime::content_store::ContentStore::compute_handle(sanitized_html.as_bytes());
             html_handle = Some(h);
             if let Ok(content_store) =
                 crate::runtime::content_store::ContentStore::new(&gateway_dir)
             {
-                let _ = content_store.write(html_body.as_bytes());
+                let _ = content_store.write(sanitized_html.as_bytes());
             }
         }
 
@@ -1034,6 +1035,10 @@ fn sanitize_report_for_publishing(report_json: &str) -> String {
     }
 
     serde_json::to_string(&parsed).unwrap_or_else(|_| report_json.to_string())
+}
+
+fn sanitize_html_for_publishing(html: &str) -> String {
+    crate::log_redaction::redact_text_for_logs(html)
 }
 
 /// Renders a `message_template` string by replacing `{{key}}` placeholders

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -297,6 +297,162 @@ impl ScheduledAction {
         }
         self
     }
+
+    const REDACTED: &'static str = "***REDACTED***";
+
+    fn redact_headers(headers: &std::collections::HashMap<String, String>, viewer: super::disclosure::ViewerClass) -> std::collections::HashMap<String, String> {
+        match viewer {
+            super::disclosure::ViewerClass::Admin => headers.clone(),
+            _ => {
+                let mut out = std::collections::HashMap::new();
+                for (k, v) in headers {
+                    if is_sensitive_key(k) || looks_like_secret_value(v) {
+                        out.insert(k.clone(), Self::REDACTED.to_string());
+                    } else {
+                        out.insert(k.clone(), v.clone());
+                    }
+                }
+                out
+            }
+        }
+    }
+
+    fn redact_json_value(value: &serde_json::Value, viewer: super::disclosure::ViewerClass) -> serde_json::Value {
+        match viewer {
+            super::disclosure::ViewerClass::Admin => value.clone(),
+            _ => Self::redact_json_value_inner(value),
+        }
+    }
+
+    fn redact_json_value_inner(value: &serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut out = serde_json::Map::new();
+                for (k, v) in map {
+                    if is_sensitive_key(k) {
+                        out.insert(k.clone(), serde_json::Value::String(Self::REDACTED.to_string()));
+                    } else {
+                        out.insert(k.clone(), Self::redact_json_value_inner(v));
+                    }
+                }
+                serde_json::Value::Object(out)
+            }
+            serde_json::Value::Array(items) => {
+                serde_json::Value::Array(items.iter().map(Self::redact_json_value_inner).collect())
+            }
+            serde_json::Value::String(s) => {
+                if looks_like_secret_value(s) {
+                    serde_json::Value::String(Self::REDACTED.to_string())
+                } else {
+                    serde_json::Value::String(s.clone())
+                }
+            }
+            other => other.clone(),
+        }
+    }
+
+    pub fn redact_for_viewer(&self, viewer: super::disclosure::ViewerClass) -> Self {
+        match viewer {
+            super::disclosure::ViewerClass::Admin => self.clone(),
+            super::disclosure::ViewerClass::Operator => self.redact_for_operator(),
+            super::disclosure::ViewerClass::Agent => self.redact_for_agent(),
+        }
+    }
+
+    fn redact_for_operator(&self) -> Self {
+        match self {
+            Self::CredentialRequest {
+                credential_id,
+                url,
+                method,
+                headers,
+                body,
+                inject_secret_as,
+                payload,
+            } => Self::CredentialRequest {
+                credential_id: credential_id.clone(),
+                url: url.clone(),
+                method: method.clone(),
+                headers: headers.as_ref().map(|h| Self::redact_headers(h, super::disclosure::ViewerClass::Operator)),
+                body: body.as_ref().map(|b| Self::redact_json_value(b, super::disclosure::ViewerClass::Operator)),
+                inject_secret_as: inject_secret_as.clone(),
+                payload: payload.as_ref().map(|p| Self::redact_json_value(p, super::disclosure::ViewerClass::Operator)),
+            },
+            other => other.clone(),
+        }
+    }
+
+    fn redact_for_agent(&self) -> Self {
+        match self {
+            Self::CredentialRequest {
+                credential_id,
+                url,
+                method,
+                ..
+            } => Self::CredentialRequest {
+                credential_id: credential_id.clone(),
+                url: url.clone(),
+                method: method.clone(),
+                headers: Some(std::collections::HashMap::new()),
+                body: None,
+                inject_secret_as: None,
+                payload: None,
+            },
+            Self::SandboxExec {
+                command,
+                dependencies,
+                requires_approval,
+                detected_hosts,
+                ..
+            } => Self::SandboxExec {
+                command: command.clone(),
+                dependencies: dependencies.clone(),
+                requires_approval: *requires_approval,
+                evidence_ref: None,
+                detected_hosts: detected_hosts.clone(),
+            },
+            Self::WriteFile {
+                path,
+                requires_approval,
+                ..
+            } => Self::WriteFile {
+                path: path.clone(),
+                content: Self::REDACTED.to_string(),
+                requires_approval: *requires_approval,
+                evidence_ref: None,
+            },
+            other => other.clone(),
+        }
+    }
+
+    pub fn redact_for_display(&self) -> Self {
+        self.redact_for_viewer(super::disclosure::ViewerClass::Operator)
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    k.contains("secret")
+        || k.contains("token")
+        || k.contains("password")
+        || k.contains("api_key")
+        || k.contains("apikey")
+        || k.contains("authorization")
+        || k.contains("access_key")
+        || k.contains("access_token")
+        || k.contains("refresh_token")
+        || k.contains("client_secret")
+}
+
+fn looks_like_secret_value(text: &str) -> bool {
+    let t = text.trim();
+    if t.is_empty() {
+        return false;
+    }
+    let lower = t.to_ascii_lowercase();
+    lower.contains("bearer ")
+        || t.starts_with("sk-")
+        || t.contains("-----BEGIN")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -139,7 +139,7 @@ impl ExecutionTraceRecord {
                 turn_id: self.turn_id.clone(),
                 timestamp: self.timestamp.clone(),
                 tool_name: self.tool_name.clone(),
-                command: self.command.clone(),
+                command: self.command.as_ref().map(|_| "***REDACTED***".to_string()),
                 exit_code: self.exit_code,
                 stdout: None,
                 stderr: None,

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -187,6 +187,7 @@ impl CausalEventRecord {
                 if let Some(ref payload) = self.payload {
                     out.payload = Some(redact_json_string(payload));
                 }
+                out.payload_ref = None;
                 out
             }
             super::disclosure::ViewerClass::Agent => Self {
@@ -202,7 +203,7 @@ impl CausalEventRecord {
                 enforced_rules: self.enforced_rules.clone(),
                 target: self.target.clone(),
                 payload: None,
-                payload_ref: self.payload_ref.clone(),
+                payload_ref: None,
                 evidence_ref: None,
                 reason: None,
             },

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -117,6 +117,165 @@ pub struct ExecutionTraceRecord {
     pub result: Option<String>,
 }
 
+impl ExecutionTraceRecord {
+    pub fn redact_for_viewer(&self, viewer: super::disclosure::ViewerClass) -> Self {
+        match viewer {
+            super::disclosure::ViewerClass::Admin => self.clone(),
+            super::disclosure::ViewerClass::Operator => {
+                let mut out = self.clone();
+                if let Some(ref args) = self.arguments {
+                    out.arguments = Some(redact_json_string(args));
+                }
+                if let Some(ref result) = self.result {
+                    out.result = Some(redact_json_string(result));
+                }
+                out
+            }
+            super::disclosure::ViewerClass::Agent => Self {
+                trace_id: self.trace_id.clone(),
+                event_id: self.event_id.clone(),
+                agent_id: self.agent_id.clone(),
+                session_id: self.session_id.clone(),
+                turn_id: self.turn_id.clone(),
+                timestamp: self.timestamp.clone(),
+                tool_name: self.tool_name.clone(),
+                command: self.command.clone(),
+                exit_code: self.exit_code,
+                stdout: None,
+                stderr: None,
+                duration_ms: self.duration_ms,
+                success: self.success,
+                error_type: self.error_type.clone(),
+                error_summary: self.error_summary.clone(),
+                approval_required: self.approval_required,
+                approval_request_id: self.approval_request_id.clone(),
+                arguments: None,
+                result: None,
+            },
+        }
+    }
+
+    pub fn to_json_for_viewer(&self, viewer: super::disclosure::ViewerClass) -> serde_json::Value {
+        let r = self.redact_for_viewer(viewer);
+        serde_json::json!({
+            "trace_id": r.trace_id,
+            "agent_id": r.agent_id,
+            "session_id": r.session_id,
+            "turn_id": r.turn_id,
+            "timestamp": r.timestamp,
+            "tool_name": r.tool_name,
+            "command": r.command,
+            "exit_code": r.exit_code,
+            "stdout": r.stdout,
+            "stderr": r.stderr,
+            "duration_ms": r.duration_ms,
+            "success": r.success == 1,
+            "error_type": r.error_type,
+            "error_summary": r.error_summary,
+            "approval_required": r.approval_required == Some(1),
+            "approval_request_id": r.approval_request_id,
+        })
+    }
+}
+
+impl CausalEventRecord {
+    pub fn redact_for_viewer(&self, viewer: super::disclosure::ViewerClass) -> Self {
+        match viewer {
+            super::disclosure::ViewerClass::Admin => self.clone(),
+            super::disclosure::ViewerClass::Operator => {
+                let mut out = self.clone();
+                if let Some(ref payload) = self.payload {
+                    out.payload = Some(redact_json_string(payload));
+                }
+                out
+            }
+            super::disclosure::ViewerClass::Agent => Self {
+                event_id: self.event_id.clone(),
+                agent_id: self.agent_id.clone(),
+                session_id: self.session_id.clone(),
+                turn_id: self.turn_id.clone(),
+                event_seq: self.event_seq,
+                timestamp: self.timestamp.clone(),
+                category: self.category.clone(),
+                action: self.action.clone(),
+                status: self.status.clone(),
+                enforced_rules: self.enforced_rules.clone(),
+                target: self.target.clone(),
+                payload: None,
+                payload_ref: self.payload_ref.clone(),
+                evidence_ref: None,
+                reason: None,
+            },
+        }
+    }
+}
+
+fn redact_json_string(s: &str) -> String {
+    match serde_json::from_str::<serde_json::Value>(s) {
+        Ok(v) => serde_json::to_string(&redact_json_value(&v)).unwrap_or_else(|_| "***REDACTED***".to_string()),
+        Err(_) => {
+            let lower = s.to_ascii_lowercase();
+            if lower.contains("token")
+                || lower.contains("secret")
+                || lower.contains("authorization")
+                || lower.contains("api_key")
+                || lower.contains("apikey")
+            {
+                "***REDACTED***".to_string()
+            } else {
+                s.to_string()
+            }
+        }
+    }
+}
+
+fn redact_json_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                if is_sensitive_key(k) {
+                    out.insert(k.clone(), serde_json::Value::String("***REDACTED***".to_string()));
+                } else {
+                    out.insert(k.clone(), redact_json_value(v));
+                }
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(redact_json_value).collect())
+        }
+        serde_json::Value::String(s) => {
+            let t = s.trim();
+            if !t.is_empty() {
+                let lower = t.to_ascii_lowercase();
+                if lower.contains("bearer ")
+                    || t.starts_with("sk-")
+                    || t.contains("-----BEGIN")
+                {
+                    return serde_json::Value::String("***REDACTED***".to_string());
+                }
+            }
+            serde_json::Value::String(s.clone())
+        }
+        other => other.clone(),
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    k.contains("secret")
+        || k.contains("token")
+        || k.contains("password")
+        || k.contains("api_key")
+        || k.contains("apikey")
+        || k.contains("authorization")
+        || k.contains("access_key")
+        || k.contains("access_token")
+        || k.contains("refresh_token")
+        || k.contains("client_secret")
+}
+
 /// Session transcript record for storage in gateway.db session_transcripts table.
 /// Used for full-text search across conversation history.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/autonoetic-types/src/disclosure.rs
+++ b/autonoetic-types/src/disclosure.rs
@@ -1,9 +1,41 @@
 //! Disclosure Policy Types
 //!
-//! Defines how sensitive information should be handled in assistant replies.
-//! Simplified to a binary model: content is either public or restricted.
+//! Defines how sensitive information should be handled based on who is viewing.
+//! Two layers:
+//! - **DisclosureClass** — controls what the LLM may repeat in assistant replies (user-facing).
+//! - **ViewerClass** — controls how observability data is redacted based on the viewer's role
+//!   (agent, operator, admin). See issue #11.
 
 use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Viewer class (per-actor redaction — issue #11)
+// ---------------------------------------------------------------------------
+
+/// Who is viewing observability/approval data. Determines the redaction level applied.
+///
+/// - **Agent**: sees own traces + published reports. Secrets, credential headers/body,
+///   and other agents' internal reasoning are redacted. Execution traces from other
+///   sessions show only metadata (tool name, success, duration) — no stdout/stderr.
+/// - **Operator**: sees all traces within scope. Secrets are masked but credential
+///   names, host patterns, and command structure are visible. stdout/stderr shown.
+/// - **Admin**: sees everything unredacted including raw evidence, cross-session
+///   correlation, and credential headers/body values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ViewerClass {
+    /// Agent viewing via observability/approval tools.
+    Agent,
+    /// Human operator via CLI / chat TUI.
+    #[default]
+    Operator,
+    /// Admin with full access.
+    Admin,
+}
+
+// ---------------------------------------------------------------------------
+// Disclosure class (LLM reply filtering)
+// ---------------------------------------------------------------------------
 
 /// The disclosure classification of a piece of information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Closes #11, Closes #4

Applies different redaction levels to observability output based on who is viewing — agents see less than operators, operators see less than admins.

### ViewerClass (new — #11)

| Class | Execution traces | Approval actions | Causal events |
|-------|-----------------|------------------|---------------|
| **Agent** | Metadata only (no stdout/stderr/arguments/result/command) | No headers/body/inject_secret_as, no evidence_ref | No payload/payload_ref/evidence_ref/reason |
| **Operator** | Full + redacted arguments/result | Secret headers/body masked via key scanning + heuristics | Payload redacted, payload_ref cleared |
| **Admin** | Unredacted | Unredacted | Unredacted |

### Issue #4 — Redaction Phase 4

Resolves all deferred items from #4:

- **HTML report sanitization**: `sanitize_html_for_publishing()` now applies `redact_text_for_logs()` before content-store storage. Previously only JSON was sanitized; the HTML blob (containing error summaries, approval reasons, timeline details) was stored raw.
- **Execution trace redaction**: `ViewerClass::Agent` strips stdout/stderr/arguments/result/command from `execution_search` output.
- **Causal event redaction**: `CausalEventRecord.redact_for_viewer()` strips payload/payload_ref/evidence_ref/reason for Agent/Operator.
- **Approval summary redaction**: No longer uses `Debug` format (which leaked entire action payloads). Uses `redact_for_viewer()` with per-variant structured output.

### Changes

- **`autonoetic-types/src/disclosure.rs`** — `ViewerClass` enum (`Agent`, `Operator`, `Admin`)
- **`autonoetic-types/src/background.rs`** — `ScheduledAction::redact_for_viewer(ViewerClass)` with 3 tiers; `redact_for_display()` now delegates to `Operator`
- **`autonoetic-types/src/causal_chain.rs`** — `ExecutionTraceRecord::redact_for_viewer()` + `to_json_for_viewer()`; `CausalEventRecord::redact_for_viewer()`
- **`autonoetic-gateway/src/runtime/tools/execution.rs`** — `execution_search` now uses `ViewerClass::Agent`
- **`autonoetic-gateway/src/runtime/tools/approval.rs`** — `approval_summary()` uses `redact_for_viewer(Agent)` with per-variant structured output instead of `Debug` format
- **`autonoetic-gateway/src/scheduler/hooks.rs`** — HTML report blob sanitized before content-store storage

### Commits

1. `16346bf` — feat: ViewerClass + redact_for_viewer on ScheduledAction/ExecutionTraceRecord/CausalEventRecord, wire into execution_search and approval_summary
2. `4ea9df0` — fix: clear payload_ref for non-admin viewers in CausalEventRecord (review feedback)
3. `7f8525d` — fix: sanitize HTML report blob + redact command field for Agent viewer (closes #4)