### PR TITLE
feat(sentinel): phase 5 — scheduling and promotion-gate integration

### DIFF
--- a/autonoetic-gateway/src/lib.rs
+++ b/autonoetic-gateway/src/lib.rs
@@ -49,6 +49,7 @@ pub use runtime::tools::resolve_target_to_agent_ref;
 pub use runtime_lock::resolve_runtime_lock;
 pub use sandbox::SandboxRunner;
 pub use scheduler::system_agents::reconcile_system_agents;
+pub use sentinel::{ensure_sentinel_scheduled_jobs, run_due_sentinel_jobs};
 pub use server::GatewayServer;
 pub use tracing::session_tracer::{EventScope, EventSeq, SessionId, TraceSession};
 pub use vault::Vault;

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2040,7 +2040,8 @@ impl NativeTool for AgentRevisionPromoteTool {
         }
 
         // Security sentinel pre-promotion gate (fail-closed).
-        // Runs a scoped Phase-1 sweep; blocks promotion on any critical findings.
+        // Runs a full-store Phase-1 sweep — any critical finding in the system
+        // blocks promotion. Per-agent scoping is planned for a future phase.
         if let Some(cfg) = config {
             if cfg.sentinel.enabled && cfg.sentinel.promotion_gate_enabled {
                 match crate::sentinel::check_pre_promotion(

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2039,6 +2039,53 @@ impl NativeTool for AgentRevisionPromoteTool {
             );
         }
 
+        // Security sentinel pre-promotion gate (fail-closed).
+        // Runs a scoped Phase-1 sweep; blocks promotion on any critical findings.
+        if let Some(cfg) = config {
+            if cfg.sentinel.enabled && cfg.sentinel.promotion_gate_enabled {
+                match crate::sentinel::check_pre_promotion(
+                    Arc::clone(&gateway_store),
+                    &cfg.sentinel.sentinel_revision_id,
+                    cfg.sentinel.promotion_gate_timeout_secs,
+                ) {
+                    Ok(crate::sentinel::GateOutcome::Passed) => {
+                        tracing::debug!(
+                            target: "sentinel.promotion_gate",
+                            agent_id = %args.agent_id,
+                            revision_id = %args.revision_id,
+                            "Sentinel pre-promotion gate passed"
+                        );
+                    }
+                    Ok(crate::sentinel::GateOutcome::Blocked { reason, critical_count }) => {
+                        return Ok(serde_json::json!({
+                            "ok": false,
+                            "error_type": "sentinel_gate",
+                            "error": "sentinel_critical_findings_block_promotion",
+                            "message": format!(
+                                "Sentinel pre-promotion gate blocked: {} critical finding(s). Resolve findings before promoting.",
+                                critical_count
+                            ),
+                            "critical_count": critical_count,
+                            "reason": reason,
+                            "repair_hint": "Review findings in the security_findings table, resolve or triage them, then retry promotion.",
+                        })
+                        .to_string());
+                    }
+                    Err(e) => {
+                        // Fail-closed: timeout or sweep error blocks promotion.
+                        return Ok(serde_json::json!({
+                            "ok": false,
+                            "error_type": "sentinel_gate",
+                            "error": "sentinel_gate_failed",
+                            "message": format!("Sentinel pre-promotion gate failed (fail-closed): {}", e),
+                            "repair_hint": "Check gateway logs for sentinel errors. If sentinel is misconfigured, disable promotion_gate_enabled in config.",
+                        })
+                        .to_string());
+                    }
+                }
+            }
+        }
+
         let promotion_id = autonoetic_types::id_format::mint_hashed_prefixed_id(
             "prom-",
             &format!(

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -220,7 +220,18 @@ async fn run_scheduler_tick_at(
         .await?;
     }
 
-    // Process due scheduled jobs
+    // Run due sentinel sweeps directly (not via workflow dispatch).
+    {
+        let cfg = execution.config();
+        if cfg.sentinel.enabled {
+            if let Some(store) = execution.gateway_store() {
+                let agents_dir = cfg.agents_dir.clone();
+                crate::sentinel::run_due_sentinel_jobs(&store, &cfg.sentinel, Some(&agents_dir));
+            }
+        }
+    }
+
+    // Process due scheduled jobs (sentinel-owned jobs are excluded below).
     if let Err(e) = process_due_scheduled_jobs(execution.clone(), now).await {
         tracing::warn!(error = %e, "Failed to process due scheduled jobs");
     }
@@ -1662,6 +1673,17 @@ async fn process_due_scheduled_jobs(
                 continue;
             }
         };
+
+        // Sentinel-owned jobs are executed directly by run_due_sentinel_jobs;
+        // skip them here to avoid spurious workflow dispatch attempts.
+        if claimed.owner_agent_id == crate::sentinel::scheduler::SENTINEL_OWNER {
+            tracing::debug!(
+                target: "scheduler",
+                job_id = %claimed.job_id,
+                "Skipping sentinel job — handled by sentinel scheduler"
+            );
+            continue;
+        }
 
         tracing::info!(
             target: "scheduler",

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -213,6 +213,16 @@ impl GatewayStore {
         scheduled_jobs::load_due_scheduled_jobs(&conn, now_rfc3339, limit)
     }
 
+    pub fn load_due_scheduled_jobs_for_owner(
+        &self,
+        owner_agent_id: &str,
+        now_rfc3339: &str,
+        limit: usize,
+    ) -> Result<Vec<autonoetic_types::scheduled_job::ScheduledJob>> {
+        let conn = self.conn.lock().unwrap();
+        scheduled_jobs::load_due_scheduled_jobs_for_owner(&conn, owner_agent_id, now_rfc3339, limit)
+    }
+
     pub fn claim_due_scheduled_job(
         &self,
         job_id: &str,

--- a/autonoetic-gateway/src/scheduler/gateway_store/scheduled_jobs.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/scheduled_jobs.rs
@@ -162,6 +162,35 @@ pub fn load_due_scheduled_jobs(
     Ok(jobs)
 }
 
+/// Load due scheduled jobs whose `owner_agent_id` matches the given owner.
+///
+/// Unlike [`load_due_scheduled_jobs`] (which loads globally), this query
+/// filters by owner before the LIMIT is applied, preventing sentinel-owned
+/// jobs from being starved by a backlog of non-sentinel due jobs.
+pub fn load_due_scheduled_jobs_for_owner(
+    conn: &Connection,
+    owner_agent_id: &str,
+    now_rfc3339: &str,
+    limit: usize,
+) -> Result<Vec<ScheduledJob>> {
+    let limit = limit as i64;
+    let mut stmt = conn.prepare(
+        "SELECT job_id, owner_agent_id, root_session_id, target_agent_id,
+                target_revision_id, message, metadata_json, cron_expr, timezone, next_run_at,
+                last_run_at, status, created_at, updated_at, last_error, generation
+         FROM scheduled_jobs
+         WHERE owner_agent_id = ?1 AND status = 'active' AND next_run_at <= ?2
+         ORDER BY next_run_at ASC
+         LIMIT ?3",
+    )?;
+    let mut rows = stmt.query(params![owner_agent_id, now_rfc3339, limit])?;
+    let mut jobs = Vec::new();
+    while let Some(row) = rows.next()? {
+        jobs.push(row_to_job(row)?);
+    }
+    Ok(jobs)
+}
+
 pub fn advance_next_run(
     conn: &Connection,
     job_id: &str,

--- a/autonoetic-gateway/src/sentinel/mod.rs
+++ b/autonoetic-gateway/src/sentinel/mod.rs
@@ -40,7 +40,11 @@
 
 pub mod checks;
 pub mod dual_sweep;
+pub mod promotion_gate;
 pub mod runner;
+pub mod scheduler;
 
 pub use dual_sweep::{DualSweepResult, DualSweepRunner};
+pub use promotion_gate::{check_pre_promotion, GateOutcome};
 pub use runner::{SentinelRunner, SweepResult};
+pub use scheduler::{ensure_sentinel_scheduled_jobs, run_due_sentinel_jobs};

--- a/autonoetic-gateway/src/sentinel/promotion_gate.rs
+++ b/autonoetic-gateway/src/sentinel/promotion_gate.rs
@@ -1,16 +1,20 @@
 //! Pre-promotion sentinel gate.
 //!
-//! Before `atomic_promote` is called the gateway runs a scoped Phase-1
-//! sentinel sweep restricted to the agent being promoted. If any `critical`
-//! findings are produced the promotion is blocked (fail-closed). The sweep is
-//! time-boxed: if it does not complete within `timeout_secs` the gate returns
-//! `Err` and the promotion is also blocked.
+//! Before `atomic_promote` is called the gateway runs a Phase-1-only sentinel
+//! sweep of the **full store** (not restricted to the promoting agent — any
+//! critical finding in the system blocks promotion, providing a conservative
+//! fail-closed posture). Per-agent scoping is planned for a future phase.
 //!
-//! Phase-2 (LLM-judgment) checks are skipped — the gate is on the hot path of
-//! an operator action and must be fast and deterministic.
+//! If any `critical` findings exist the promotion is blocked. Scan errors also
+//! block promotion (fail-closed). The sweep is time-boxed: if it does not
+//! complete within `timeout_secs` the gate returns `Err` and the promotion is
+//! also blocked.
+//!
+//! **No findings are persisted by the gate.** Persistence is the job of the
+//! scheduled sweeps so that promotion attempts don't bloat `security_findings`
+//! with duplicate rows. The gate is a read-evaluate-only check.
 
 use anyhow::{anyhow, Result};
-use autonoetic_types::security::FindingSeverity;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,17 +30,17 @@ pub enum GateOutcome {
     Blocked {
         /// Human-readable summary of the blocking findings.
         reason: String,
-        /// Number of critical findings.
+        /// Number of critical Phase-1 findings found.
         critical_count: usize,
     },
 }
 
-/// Run a pre-promotion Phase-1 sentinel sweep for `agent_id`.
+/// Run a pre-promotion Phase-1 sentinel sweep against the full store.
 ///
-/// Returns `Ok(GateOutcome::Passed)` if no critical findings were produced
-/// within `timeout_secs`. Returns `Ok(GateOutcome::Blocked)` if critical
-/// findings were found. Returns `Err` if the sweep timed out or panicked
-/// (fail-closed in both cases).
+/// Returns `Ok(GateOutcome::Passed)` when no critical findings exist and no
+/// scan errors occurred within `timeout_secs`. Returns `Ok(GateOutcome::Blocked)`
+/// if critical findings were detected. Returns `Err` on timeout, scan errors, or
+/// sweep panic — all are fail-closed.
 pub fn check_pre_promotion(
     store: Arc<GatewayStore>,
     sentinel_revision_id: &str,
@@ -49,32 +53,30 @@ pub fn check_pre_promotion(
     std::thread::spawn(move || {
         let runner = SentinelRunner::new(store_clone);
         let outcome = runner
-            .collect_findings(&SweepConfig {
+            .scan_phase1_critical(&SweepConfig {
                 sentinel_revision_id: rev_id,
-                phase1_only: true,
-                // Scan the last 90 days for the promoting agent's findings.
+                // Scan the full history — window_days controls capability-accretion
+                // and approval-denial lookback (90 days).
                 window_days: 90,
-                since_rfc3339: None,
                 ..SweepConfig::default()
             })
-            .and_then(|raw| {
-                // Persist findings to the DB before evaluating (append-only).
-                let result = runner.persist_findings(raw);
-                let critical: Vec<_> = result
-                    .all_findings()
-                    .filter(|f| f.severity == FindingSeverity::Critical)
-                    .collect();
-                if critical.is_empty() {
+            .and_then(|(critical_count, scan_errors)| {
+                // Any scan error is fail-closed: treat as a blocking gate failure.
+                if !scan_errors.is_empty() {
+                    return Err(anyhow!(
+                        "Sentinel scan errors (fail-closed): {}",
+                        scan_errors.join("; ")
+                    ));
+                }
+                if critical_count == 0 {
                     Ok(GateOutcome::Passed)
                 } else {
-                    let reason = critical
-                        .iter()
-                        .map(|f| format!("{} ({})", f.finding_type, f.finding_id))
-                        .collect::<Vec<_>>()
-                        .join(", ");
                     Ok(GateOutcome::Blocked {
-                        reason,
-                        critical_count: critical.len(),
+                        reason: format!(
+                            "{} critical Phase-1 finding(s) in the store",
+                            critical_count
+                        ),
+                        critical_count,
                     })
                 }
             });
@@ -94,8 +96,6 @@ pub fn check_pre_promotion(
 mod tests {
     use super::*;
 
-    // A short timeout test uses a mock that immediately returns Passed.
-    // Full integration is covered in security_sentinel_integration.rs.
     #[test]
     fn gate_outcome_debug() {
         let o = GateOutcome::Passed;

--- a/autonoetic-gateway/src/sentinel/promotion_gate.rs
+++ b/autonoetic-gateway/src/sentinel/promotion_gate.rs
@@ -1,0 +1,110 @@
+//! Pre-promotion sentinel gate.
+//!
+//! Before `atomic_promote` is called the gateway runs a scoped Phase-1
+//! sentinel sweep restricted to the agent being promoted. If any `critical`
+//! findings are produced the promotion is blocked (fail-closed). The sweep is
+//! time-boxed: if it does not complete within `timeout_secs` the gate returns
+//! `Err` and the promotion is also blocked.
+//!
+//! Phase-2 (LLM-judgment) checks are skipped — the gate is on the hot path of
+//! an operator action and must be fast and deterministic.
+
+use anyhow::{anyhow, Result};
+use autonoetic_types::security::FindingSeverity;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::scheduler::gateway_store::GatewayStore;
+use super::runner::{SentinelRunner, SweepConfig};
+
+/// Outcome of a pre-promotion sentinel gate check.
+#[derive(Debug)]
+pub enum GateOutcome {
+    /// No critical findings — promotion may proceed.
+    Passed,
+    /// Critical findings blocked the promotion.
+    Blocked {
+        /// Human-readable summary of the blocking findings.
+        reason: String,
+        /// Number of critical findings.
+        critical_count: usize,
+    },
+}
+
+/// Run a pre-promotion Phase-1 sentinel sweep for `agent_id`.
+///
+/// Returns `Ok(GateOutcome::Passed)` if no critical findings were produced
+/// within `timeout_secs`. Returns `Ok(GateOutcome::Blocked)` if critical
+/// findings were found. Returns `Err` if the sweep timed out or panicked
+/// (fail-closed in both cases).
+pub fn check_pre_promotion(
+    store: Arc<GatewayStore>,
+    sentinel_revision_id: &str,
+    timeout_secs: u64,
+) -> Result<GateOutcome> {
+    let (tx, rx) = std::sync::mpsc::channel::<Result<GateOutcome>>();
+    let store_clone = Arc::clone(&store);
+    let rev_id = sentinel_revision_id.to_string();
+
+    std::thread::spawn(move || {
+        let runner = SentinelRunner::new(store_clone);
+        let outcome = runner
+            .collect_findings(&SweepConfig {
+                sentinel_revision_id: rev_id,
+                phase1_only: true,
+                // Scan the last 90 days for the promoting agent's findings.
+                window_days: 90,
+                since_rfc3339: None,
+                ..SweepConfig::default()
+            })
+            .and_then(|raw| {
+                // Persist findings to the DB before evaluating (append-only).
+                let result = runner.persist_findings(raw);
+                let critical: Vec<_> = result
+                    .all_findings()
+                    .filter(|f| f.severity == FindingSeverity::Critical)
+                    .collect();
+                if critical.is_empty() {
+                    Ok(GateOutcome::Passed)
+                } else {
+                    let reason = critical
+                        .iter()
+                        .map(|f| format!("{} ({})", f.finding_type, f.finding_id))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    Ok(GateOutcome::Blocked {
+                        reason,
+                        critical_count: critical.len(),
+                    })
+                }
+            });
+        let _ = tx.send(outcome);
+    });
+
+    rx.recv_timeout(Duration::from_secs(timeout_secs))
+        .map_err(|_| {
+            anyhow!(
+                "Sentinel pre-promotion gate timed out after {} s (fail-closed)",
+                timeout_secs
+            )
+        })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A short timeout test uses a mock that immediately returns Passed.
+    // Full integration is covered in security_sentinel_integration.rs.
+    #[test]
+    fn gate_outcome_debug() {
+        let o = GateOutcome::Passed;
+        assert!(format!("{:?}", o).contains("Passed"));
+
+        let b = GateOutcome::Blocked {
+            reason: "cred_leak".to_string(),
+            critical_count: 1,
+        };
+        assert!(format!("{:?}", b).contains("Blocked"));
+    }
+}

--- a/autonoetic-gateway/src/sentinel/runner.rs
+++ b/autonoetic-gateway/src/sentinel/runner.rs
@@ -23,7 +23,7 @@
 //! findings to the `security_findings` table only.
 
 use anyhow::Result;
-use autonoetic_types::security::SecurityFinding;
+use autonoetic_types::security::{FindingSeverity, SecurityFinding};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -295,6 +295,31 @@ impl SentinelRunner {
         persist_bucket!(raw.behavioral_anomaly, behavioral_anomaly_findings, "behavioral_anomaly");
 
         result
+    }
+
+    /// Scan Phase-1 checks and return `(critical_count, scan_errors)` without persisting.
+    ///
+    /// Used by the promotion gate to evaluate findings without creating duplicate
+    /// DB rows on every promotion attempt. Any scan error is propagated in the
+    /// returned `Vec<String>` so callers can treat non-empty errors as fail-closed.
+    pub fn scan_phase1_critical(&self, config: &SweepConfig) -> Result<(usize, Vec<String>)> {
+        let raw = self.collect_findings(&SweepConfig {
+            phase1_only: true,
+            ..SweepConfig {
+                sentinel_revision_id: config.sentinel_revision_id.clone(),
+                since_rfc3339: config.since_rfc3339.clone(),
+                scan_limit: config.scan_limit,
+                window_days: config.window_days,
+                accretion_threshold: config.accretion_threshold,
+                denial_threshold: config.denial_threshold,
+                ..SweepConfig::default()
+            }
+        })?;
+        let critical = raw
+            .all_phase1()
+            .filter(|f| f.severity == FindingSeverity::Critical)
+            .count();
+        Ok((critical, raw.scan_errors))
     }
 
     /// Run a full sweep: collect, persist, and return results.

--- a/autonoetic-gateway/src/sentinel/scheduler.rs
+++ b/autonoetic-gateway/src/sentinel/scheduler.rs
@@ -3,12 +3,16 @@
 //! Registers two internal cron jobs for the security sentinel at gateway startup:
 //!
 //! - `sentinel.sweep.full`        — full history sweep (Phase 1 + Phase 2), daily by default.
-//! - `sentinel.sweep.incremental` — last-24-h sweep (Phase 1 + Phase 2), every 6 h by default.
+//! - `sentinel.sweep.incremental` — last-25-h sweep (Phase 1 + Phase 2), every 6 h by default.
 //!
 //! These jobs are owned by the sentinel pseudo-agent `"security_sentinel"` and
-//! are never dispatched to a real agent runtime. The scheduler's
-//! `run_due_sentinel_jobs` function is called by the gateway scheduler loop to
-//! execute sweeps directly, bypassing the agent session machinery.
+//! are **never dispatched to a real agent runtime** — the gateway scheduler loop
+//! skips jobs with this owner ID and instead calls [`run_due_sentinel_jobs`]
+//! directly on each tick.
+//!
+//! Scheduled sweeps use [`super::dual_sweep::DualSweepRunner`] so that
+//! `baseline_agreed` is annotated and `security_sentinel_disagreements` are
+//! recorded in the same way as manually triggered dual sweeps.
 //!
 //! Job metadata encodes the sweep mode:
 //! ```json
@@ -24,7 +28,8 @@ use std::sync::Arc;
 
 use crate::scheduler::cron_parser;
 use crate::scheduler::gateway_store::GatewayStore;
-use super::runner::{SentinelRunner, SweepConfig};
+use super::dual_sweep::DualSweepRunner;
+use super::runner::SweepConfig;
 
 pub const SENTINEL_OWNER: &str = "security_sentinel";
 pub const JOB_ID_FULL: &str = "sentinel.sweep.full";
@@ -120,9 +125,12 @@ pub fn ensure_sentinel_scheduled_jobs(
 
 /// Execute any due sentinel sweep jobs.
 ///
-/// Called from the gateway scheduler loop on each tick. For each due sentinel
-/// job claimed from the store, runs the appropriate sweep synchronously on the
-/// current thread (sweeps are fast I/O-bound operations against local SQLite).
+/// Called from the gateway scheduler loop on each tick. Loads due jobs using a
+/// **owner-filtered SQL query** so sentinel jobs are never starved by a backlog
+/// of non-sentinel jobs (see `load_due_scheduled_jobs_for_owner`).
+///
+/// Each sweep uses [`DualSweepRunner`] so `baseline_agreed` annotation and
+/// `security_sentinel_disagreements` recording match the Phase-3 contract.
 ///
 /// Returns the number of jobs executed.
 pub fn run_due_sentinel_jobs(
@@ -137,19 +145,17 @@ pub fn run_due_sentinel_jobs(
     let now = chrono::Utc::now();
     let now_str = now.to_rfc3339();
 
-    let due = match store.load_due_scheduled_jobs(&now_str, 32) {
+    // Owner-filtered query prevents starvation by non-sentinel due jobs.
+    let due = match store.load_due_scheduled_jobs_for_owner(SENTINEL_OWNER, &now_str, 8) {
         Ok(jobs) => jobs,
         Err(e) => {
-            tracing::warn!(target: "sentinel.scheduler", error = %e, "Failed to load due jobs");
+            tracing::warn!(target: "sentinel.scheduler", error = %e, "Failed to load due sentinel jobs");
             return 0;
         }
     };
 
-    // Filter to sentinel-owned jobs only.
-    let sentinel_due: Vec<_> = due.into_iter().filter(|j| j.owner_agent_id == SENTINEL_OWNER).collect();
-
     let mut executed = 0;
-    for job in &sentinel_due {
+    for job in &due {
         let cron = match cron_parser::parse_schedule(&job.cron_expr) {
             Ok(c) => c,
             Err(_) => continue,
@@ -159,9 +165,26 @@ pub fn run_due_sentinel_jobs(
             None => now_str.clone(),
         };
 
-        // Claim atomically; skip if lost the race.
-        if store.claim_and_advance_due_job(&job.job_id, &now_str, &next_run).is_err() {
-            continue;
+        // Claim atomically; skip on lost race (Ok(None)) or error.
+        match store.claim_and_advance_due_job(&job.job_id, &now_str, &next_run) {
+            Ok(Some(_)) => {} // successfully claimed — proceed
+            Ok(None) => {
+                tracing::debug!(
+                    target: "sentinel.scheduler",
+                    job_id = %job.job_id,
+                    "Sentinel job already claimed or not due — skipping"
+                );
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "sentinel.scheduler",
+                    job_id = %job.job_id,
+                    error = %e,
+                    "Failed to claim sentinel job"
+                );
+                continue;
+            }
         }
 
         let mode = job
@@ -171,32 +194,42 @@ pub fn run_due_sentinel_jobs(
             .and_then(|v| v["mode"].as_str().map(|s| s.to_string()))
             .unwrap_or_else(|| "full".to_string());
 
-        let since = if mode == "incremental" {
-            Some((now - chrono::Duration::hours(25)).to_rfc3339())
+        // Incremental: last 25 h (25 h overlap guards against boundary gaps).
+        // Both `since_rfc3339` and `window_days` are set so all checks stay scoped.
+        let (since, window_days) = if mode == "incremental" {
+            (Some((now - chrono::Duration::hours(25)).to_rfc3339()), 1u32)
         } else {
-            None
+            (None, 30u32)
         };
 
-        let sweep_cfg = SweepConfig {
+        let baseline_cfg = SweepConfig {
+            sentinel_revision_id: config.baseline_revision_id.clone(),
+            phase1_only: true,
+            since_rfc3339: since.clone(),
+            window_days,
+            ..SweepConfig::default()
+        };
+        let current_cfg = SweepConfig {
             sentinel_revision_id: config.sentinel_revision_id.clone(),
             since_rfc3339: since,
+            window_days,
             ..SweepConfig::default()
         };
 
-        let mut runner = SentinelRunner::new(Arc::clone(store));
+        let mut dual = DualSweepRunner::new(Arc::clone(store));
         if let Some(dir) = agents_dir {
-            runner = runner.with_agents_dir(dir.clone());
+            dual = dual.with_agents_dir(dir.clone());
         }
 
-        match runner.collect_findings(&sweep_cfg) {
-            Ok(raw) => {
-                let result = runner.persist_findings(raw);
+        match dual.run(&baseline_cfg, &current_cfg) {
+            Ok(result) => {
                 tracing::info!(
                     target: "sentinel.scheduler",
                     job_id = %job.job_id,
                     mode = %mode,
-                    total = result.total_findings(),
-                    errors = result.persist_errors.len(),
+                    total = result.current.total_findings(),
+                    baseline_agreed = result.baseline_agreed_count,
+                    disagreements = result.disagreements.len(),
                     "Sentinel sweep completed"
                 );
             }

--- a/autonoetic-gateway/src/sentinel/scheduler.rs
+++ b/autonoetic-gateway/src/sentinel/scheduler.rs
@@ -1,0 +1,252 @@
+//! Sentinel scheduled-job registration and execution.
+//!
+//! Registers two internal cron jobs for the security sentinel at gateway startup:
+//!
+//! - `sentinel.sweep.full`        — full history sweep (Phase 1 + Phase 2), daily by default.
+//! - `sentinel.sweep.incremental` — last-24-h sweep (Phase 1 + Phase 2), every 6 h by default.
+//!
+//! These jobs are owned by the sentinel pseudo-agent `"security_sentinel"` and
+//! are never dispatched to a real agent runtime. The scheduler's
+//! `run_due_sentinel_jobs` function is called by the gateway scheduler loop to
+//! execute sweeps directly, bypassing the agent session machinery.
+//!
+//! Job metadata encodes the sweep mode:
+//! ```json
+//! { "sentinel": true, "mode": "full" }
+//! { "sentinel": true, "mode": "incremental" }
+//! ```
+
+use anyhow::Result;
+use autonoetic_types::config::SentinelConfig;
+use autonoetic_types::scheduled_job::{ScheduledJob, ScheduledJobStatus};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::scheduler::cron_parser;
+use crate::scheduler::gateway_store::GatewayStore;
+use super::runner::{SentinelRunner, SweepConfig};
+
+pub const SENTINEL_OWNER: &str = "security_sentinel";
+pub const JOB_ID_FULL: &str = "sentinel.sweep.full";
+pub const JOB_ID_INCREMENTAL: &str = "sentinel.sweep.incremental";
+
+/// Ensure both sentinel sweep jobs exist in the `scheduled_jobs` table.
+///
+/// Idempotent — if a job with the given `job_id` already exists and is
+/// `Active`, it is left unchanged. Called once at gateway startup.
+pub fn ensure_sentinel_scheduled_jobs(
+    store: &Arc<GatewayStore>,
+    config: &SentinelConfig,
+) -> Vec<EnsureJobResult> {
+    if !config.enabled {
+        return vec![
+            EnsureJobResult { job_id: JOB_ID_FULL.to_string(), action: JobAction::SkippedDisabled },
+            EnsureJobResult { job_id: JOB_ID_INCREMENTAL.to_string(), action: JobAction::SkippedDisabled },
+        ];
+    }
+
+    let specs: &[(&str, &str, &str)] = &[
+        (JOB_ID_FULL, &config.full_sweep_schedule, "full"),
+        (JOB_ID_INCREMENTAL, &config.incremental_sweep_schedule, "incremental"),
+    ];
+
+    let mut results = Vec::new();
+    let now = chrono::Utc::now();
+
+    // Load existing sentinel jobs once.
+    let existing = store.list_scheduled_jobs_for_owner(SENTINEL_OWNER, None, None)
+        .unwrap_or_default();
+
+    for (job_id, schedule, mode) in specs {
+        let already_active = existing.iter().any(|j| j.job_id == *job_id && j.status == ScheduledJobStatus::Active);
+        if already_active {
+            results.push(EnsureJobResult { job_id: job_id.to_string(), action: JobAction::SkippedExists });
+            continue;
+        }
+
+        let cron = match cron_parser::parse_schedule(schedule) {
+            Ok(c) => c,
+            Err(e) => {
+                results.push(EnsureJobResult {
+                    job_id: job_id.to_string(),
+                    action: JobAction::Failed(format!("Invalid schedule '{}': {}", schedule, e)),
+                });
+                continue;
+            }
+        };
+
+        let next_run = match cron_parser::next_occurrence(&cron, now) {
+            Some(t) => t,
+            None => {
+                results.push(EnsureJobResult {
+                    job_id: job_id.to_string(),
+                    action: JobAction::Failed("No future occurrence for schedule".to_string()),
+                });
+                continue;
+            }
+        };
+
+        let metadata = serde_json::json!({ "sentinel": true, "mode": mode });
+        let job = ScheduledJob {
+            job_id: job_id.to_string(),
+            owner_agent_id: SENTINEL_OWNER.to_string(),
+            root_session_id: "system".to_string(),
+            target_agent_id: SENTINEL_OWNER.to_string(),
+            target_revision_id: String::new(),
+            message: format!("Sentinel {} sweep", mode),
+            metadata_json: Some(metadata.to_string()),
+            cron_expr: cron.to_string(),
+            timezone: "UTC".to_string(),
+            next_run_at: next_run.to_rfc3339(),
+            last_run_at: None,
+            status: ScheduledJobStatus::Active,
+            created_at: now.to_rfc3339(),
+            updated_at: now.to_rfc3339(),
+            last_error: None,
+            generation: 0,
+        };
+
+        match store.create_scheduled_job(&job) {
+            Ok(()) => results.push(EnsureJobResult { job_id: job_id.to_string(), action: JobAction::Created }),
+            Err(e) => results.push(EnsureJobResult {
+                job_id: job_id.to_string(),
+                action: JobAction::Failed(format!("DB insert error: {}", e)),
+            }),
+        }
+    }
+
+    results
+}
+
+/// Execute any due sentinel sweep jobs.
+///
+/// Called from the gateway scheduler loop on each tick. For each due sentinel
+/// job claimed from the store, runs the appropriate sweep synchronously on the
+/// current thread (sweeps are fast I/O-bound operations against local SQLite).
+///
+/// Returns the number of jobs executed.
+pub fn run_due_sentinel_jobs(
+    store: &Arc<GatewayStore>,
+    config: &SentinelConfig,
+    agents_dir: Option<&PathBuf>,
+) -> usize {
+    if !config.enabled {
+        return 0;
+    }
+
+    let now = chrono::Utc::now();
+    let now_str = now.to_rfc3339();
+
+    let due = match store.load_due_scheduled_jobs(&now_str, 32) {
+        Ok(jobs) => jobs,
+        Err(e) => {
+            tracing::warn!(target: "sentinel.scheduler", error = %e, "Failed to load due jobs");
+            return 0;
+        }
+    };
+
+    // Filter to sentinel-owned jobs only.
+    let sentinel_due: Vec<_> = due.into_iter().filter(|j| j.owner_agent_id == SENTINEL_OWNER).collect();
+
+    let mut executed = 0;
+    for job in &sentinel_due {
+        let cron = match cron_parser::parse_schedule(&job.cron_expr) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let next_run = match cron_parser::next_occurrence(&cron, now) {
+            Some(t) => t.to_rfc3339(),
+            None => now_str.clone(),
+        };
+
+        // Claim atomically; skip if lost the race.
+        if store.claim_and_advance_due_job(&job.job_id, &now_str, &next_run).is_err() {
+            continue;
+        }
+
+        let mode = job
+            .metadata_json
+            .as_deref()
+            .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+            .and_then(|v| v["mode"].as_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "full".to_string());
+
+        let since = if mode == "incremental" {
+            Some((now - chrono::Duration::hours(25)).to_rfc3339())
+        } else {
+            None
+        };
+
+        let sweep_cfg = SweepConfig {
+            sentinel_revision_id: config.sentinel_revision_id.clone(),
+            since_rfc3339: since,
+            ..SweepConfig::default()
+        };
+
+        let mut runner = SentinelRunner::new(Arc::clone(store));
+        if let Some(dir) = agents_dir {
+            runner = runner.with_agents_dir(dir.clone());
+        }
+
+        match runner.collect_findings(&sweep_cfg) {
+            Ok(raw) => {
+                let result = runner.persist_findings(raw);
+                tracing::info!(
+                    target: "sentinel.scheduler",
+                    job_id = %job.job_id,
+                    mode = %mode,
+                    total = result.total_findings(),
+                    errors = result.persist_errors.len(),
+                    "Sentinel sweep completed"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "sentinel.scheduler",
+                    job_id = %job.job_id,
+                    mode = %mode,
+                    error = %e,
+                    "Sentinel sweep failed"
+                );
+            }
+        }
+
+        executed += 1;
+    }
+
+    executed
+}
+
+#[derive(Debug)]
+pub struct EnsureJobResult {
+    pub job_id: String,
+    pub action: JobAction,
+}
+
+#[derive(Debug)]
+pub enum JobAction {
+    Created,
+    SkippedExists,
+    SkippedDisabled,
+    Failed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_are_stable() {
+        assert_eq!(JOB_ID_FULL, "sentinel.sweep.full");
+        assert_eq!(JOB_ID_INCREMENTAL, "sentinel.sweep.incremental");
+        assert_eq!(SENTINEL_OWNER, "security_sentinel");
+    }
+
+    #[test]
+    fn default_sentinel_config_enabled() {
+        let cfg = SentinelConfig::default();
+        assert!(cfg.enabled);
+        assert!(cfg.promotion_gate_enabled);
+        assert_eq!(cfg.promotion_gate_timeout_secs, 30);
+    }
+}

--- a/autonoetic-gateway/tests/security_sentinel_integration.rs
+++ b/autonoetic-gateway/tests/security_sentinel_integration.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the security sentinel (Phases 0–4).
+//! Integration tests for the security sentinel (Phases 0–5).
 //!
 //! Covers:
 //! - `SecurityFinding` serialization and DB round-trip
@@ -7,6 +7,7 @@
 //! - Phase 2 heuristic checks (prompt injection, session cluster)
 //! - Phase 3 dual-sweep: baseline annotation and disagreement recording
 //! - Phase 4 supply-chain auditing: scope violations and provenance gaps
+//! - Phase 5 scheduling and promotion-gate integration
 
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::security::{
@@ -828,4 +829,143 @@ fn supply_chain_provenance_gap_cleared_when_capture_trace_present() {
         gap.is_none(),
         "layer with capture trace in execution_traces must not produce a provenance gap finding"
     );
+}
+
+// ── Phase 5: Scheduling and promotion-gate integration ───────────────────────
+
+#[test]
+fn sentinel_config_defaults_are_sane() {
+    let cfg = autonoetic_types::config::SentinelConfig::default();
+    assert!(cfg.enabled, "sentinel enabled by default");
+    assert!(cfg.promotion_gate_enabled, "promotion gate enabled by default");
+    assert_eq!(cfg.promotion_gate_timeout_secs, 30);
+    assert!(!cfg.full_sweep_schedule.is_empty());
+    assert!(!cfg.incremental_sweep_schedule.is_empty());
+    assert!(!cfg.sentinel_revision_id.is_empty());
+    assert!(!cfg.baseline_revision_id.is_empty());
+}
+
+#[test]
+fn ensure_sentinel_scheduled_jobs_creates_both_jobs() {
+    let (_dir, store) = open_store();
+    let cfg = autonoetic_types::config::SentinelConfig::default();
+    let results = autonoetic_gateway::ensure_sentinel_scheduled_jobs(&store, &cfg);
+
+    assert_eq!(results.len(), 2, "must register exactly 2 sentinel jobs");
+
+    let created: Vec<_> = results
+        .iter()
+        .filter(|r| matches!(r.action, autonoetic_gateway::sentinel::scheduler::JobAction::Created))
+        .collect();
+    assert_eq!(created.len(), 2, "both jobs must be Created on first call");
+
+    // Verify the jobs are queryable in the store.
+    let jobs = store
+        .list_scheduled_jobs_for_owner("security_sentinel", None, None)
+        .expect("list jobs");
+    assert_eq!(jobs.len(), 2);
+    let job_ids: std::collections::HashSet<_> = jobs.iter().map(|j| j.job_id.as_str()).collect();
+    assert!(job_ids.contains("sentinel.sweep.full"));
+    assert!(job_ids.contains("sentinel.sweep.incremental"));
+}
+
+#[test]
+fn ensure_sentinel_scheduled_jobs_is_idempotent() {
+    let (_dir, store) = open_store();
+    let cfg = autonoetic_types::config::SentinelConfig::default();
+
+    // First call creates.
+    let r1 = autonoetic_gateway::ensure_sentinel_scheduled_jobs(&store, &cfg);
+    assert!(r1.iter().all(|r| matches!(r.action, autonoetic_gateway::sentinel::scheduler::JobAction::Created)));
+
+    // Second call skips.
+    let r2 = autonoetic_gateway::ensure_sentinel_scheduled_jobs(&store, &cfg);
+    assert!(
+        r2.iter().all(|r| matches!(r.action, autonoetic_gateway::sentinel::scheduler::JobAction::SkippedExists)),
+        "second call must SkippedExists, got: {:?}",
+        r2.iter().map(|r| format!("{:?}", r.action)).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ensure_sentinel_scheduled_jobs_disabled_skips_all() {
+    let (_dir, store) = open_store();
+    let cfg = autonoetic_types::config::SentinelConfig {
+        enabled: false,
+        ..autonoetic_types::config::SentinelConfig::default()
+    };
+    let results = autonoetic_gateway::ensure_sentinel_scheduled_jobs(&store, &cfg);
+    assert!(
+        results.iter().all(|r| matches!(r.action, autonoetic_gateway::sentinel::scheduler::JobAction::SkippedDisabled)),
+        "disabled sentinel must skip all jobs"
+    );
+    let jobs = store.list_scheduled_jobs_for_owner("security_sentinel", None, None).unwrap();
+    assert!(jobs.is_empty(), "no jobs must be created when sentinel is disabled");
+}
+
+#[test]
+fn promotion_gate_passes_on_clean_store() {
+    // With an empty store (no findings), the gate must return Passed.
+    let (_dir, store) = open_store();
+    let outcome = autonoetic_gateway::sentinel::check_pre_promotion(
+        Arc::clone(&store),
+        "sentinel.test",
+        10,
+    )
+    .expect("gate must not error on clean store");
+
+    assert!(
+        matches!(outcome, autonoetic_gateway::sentinel::GateOutcome::Passed),
+        "gate must pass when no critical findings exist"
+    );
+}
+
+#[test]
+fn promotion_gate_blocks_on_critical_finding() {
+    use autonoetic_gateway::sentinel::runner::{SentinelRunner, SweepConfig};
+
+    let (dir, store) = open_store();
+
+    // Inject a causal event that will trigger a credential-leak (critical) finding.
+    {
+        let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
+        let fake_key = format!("sk-ant-api03-{}-{}", "A".repeat(92), "A".repeat(10));
+        let now = chrono::Utc::now().to_rfc3339();
+        db.execute(
+            "INSERT INTO causal_events
+                 (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
+             VALUES ('evt_gate_crit', 'coder.default', 'sess_gate', 0, ?1, 'tool', 'tool_call', 'success', ?2)",
+            rusqlite::params![now, fake_key],
+        )
+        .unwrap();
+    }
+
+    // Run a sweep so the finding is persisted to security_findings.
+    {
+        let runner = SentinelRunner::new(Arc::clone(&store));
+        runner
+            .run_sweep(&SweepConfig {
+                sentinel_revision_id: "sentinel.test".to_string(),
+                phase1_only: true,
+                ..SweepConfig::default()
+            })
+            .expect("sweep");
+    }
+
+    // Now the gate should detect the critical finding and block.
+    let outcome = autonoetic_gateway::sentinel::check_pre_promotion(
+        Arc::clone(&store),
+        "sentinel.test",
+        10,
+    )
+    .expect("gate must not error");
+
+    match outcome {
+        autonoetic_gateway::sentinel::GateOutcome::Blocked { critical_count, .. } => {
+            assert!(critical_count >= 1, "must report at least one critical finding");
+        }
+        autonoetic_gateway::sentinel::GateOutcome::Passed => {
+            panic!("gate must block when critical findings exist in the store");
+        }
+    }
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -797,6 +797,10 @@ pub struct GatewayConfig {
     /// disable dwell-time enforcement (for tests). Default: 1.0.
     #[serde(default = "default_approval_dwell_multiplier")]
     pub approval_dwell_multiplier: f64,
+
+    /// Security sentinel configuration.
+    #[serde(default)]
+    pub sentinel: SentinelConfig,
 }
 
 fn default_approval_dwell_multiplier() -> f64 {
@@ -845,6 +849,72 @@ fn default_scheduled_jobs_max_per_root() -> usize {
 fn default_scheduled_jobs_max_due_per_tick() -> usize {
     16
 }
+
+/// Security sentinel configuration.
+///
+/// The sentinel runs deterministic and heuristic checks against the gateway's
+/// local SQLite store. It has two operating modes:
+///
+/// - **Scheduled sweeps**: registered as internal cron jobs at gateway startup.
+/// - **Promotion gate**: a scoped sweep fires synchronously before
+///   `atomic_promote` is called; promotion is blocked until it completes or
+///   times out (fail-closed).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentinelConfig {
+    /// Enable the security sentinel. Default: true.
+    #[serde(default = "default_sentinel_enabled")]
+    pub enabled: bool,
+
+    /// Cron schedule for a full (all-history) sentinel sweep. Default: daily at 03:00 UTC.
+    #[serde(default = "default_sentinel_full_sweep_schedule")]
+    pub full_sweep_schedule: String,
+
+    /// Cron schedule for an incremental sweep (last 24 h). Default: every 6 hours.
+    #[serde(default = "default_sentinel_incremental_sweep_schedule")]
+    pub incremental_sweep_schedule: String,
+
+    /// Block agent promotion when the pre-promotion sentinel sweep finds any
+    /// `critical` severity findings. Default: true (fail-closed).
+    #[serde(default = "default_sentinel_promotion_gate_enabled")]
+    pub promotion_gate_enabled: bool,
+
+    /// Maximum seconds the promotion gate waits for the sentinel sweep to complete.
+    /// If the sweep exceeds this limit, promotion is blocked (fail-closed). Default: 30.
+    #[serde(default = "default_sentinel_promotion_gate_timeout_secs")]
+    pub promotion_gate_timeout_secs: u64,
+
+    /// Sentinel revision ID embedded in findings produced by the live sentinel.
+    /// Update this when the sentinel logic changes to track which version flagged
+    /// a finding. Default: "sentinel.current".
+    #[serde(default = "default_sentinel_revision_id")]
+    pub sentinel_revision_id: String,
+
+    /// Sentinel revision ID for the frozen baseline. Default: "sentinel.baseline.frozen".
+    #[serde(default = "default_sentinel_baseline_revision_id")]
+    pub baseline_revision_id: String,
+}
+
+impl Default for SentinelConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_sentinel_enabled(),
+            full_sweep_schedule: default_sentinel_full_sweep_schedule(),
+            incremental_sweep_schedule: default_sentinel_incremental_sweep_schedule(),
+            promotion_gate_enabled: default_sentinel_promotion_gate_enabled(),
+            promotion_gate_timeout_secs: default_sentinel_promotion_gate_timeout_secs(),
+            sentinel_revision_id: default_sentinel_revision_id(),
+            baseline_revision_id: default_sentinel_baseline_revision_id(),
+        }
+    }
+}
+
+fn default_sentinel_enabled() -> bool { true }
+fn default_sentinel_full_sweep_schedule() -> String { "0 3 * * *".to_string() }
+fn default_sentinel_incremental_sweep_schedule() -> String { "0 */6 * * *".to_string() }
+fn default_sentinel_promotion_gate_enabled() -> bool { true }
+fn default_sentinel_promotion_gate_timeout_secs() -> u64 { 30 }
+fn default_sentinel_revision_id() -> String { "sentinel.current".to_string() }
+fn default_sentinel_baseline_revision_id() -> String { "sentinel.baseline.frozen".to_string() }
 
 /// A system agent declaration for gateway-managed background execution.
 ///
@@ -1427,6 +1497,7 @@ impl Default for GatewayConfig {
             allow_runtime_lock_drift: false,
             trust_unsigned_bundles: false,
             approval_dwell_multiplier: default_approval_dwell_multiplier(),
+            sentinel: SentinelConfig::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Pre-promotion gate**: a Phase-1-only sentinel sweep fires synchronously inside `agent_revision_promote` before `atomic_promote`. Critical findings block promotion fail-closed; configurable timeout (default 30 s) also blocks on expiry.
- **Scheduled sweeps**: two cron jobs — `sentinel.sweep.full` (daily) and `sentinel.sweep.incremental` (every 6 h) — registered at startup via the existing `ScheduledJob` infra under pseudo-owner `"security_sentinel"`. Sweeps execute directly without an agent runtime session.
- **`SentinelConfig`**: new config struct added to `GatewayConfig` with safe defaults; fully `#[serde(default)]` so no existing config files break.
- 6 new integration tests (28 total), all passing.

## Files changed

| File | Change |
|---|---|
| `autonoetic-types/src/config.rs` | `SentinelConfig` struct + `GatewayConfig.sentinel` field |
| `autonoetic-gateway/src/sentinel/promotion_gate.rs` | New — pre-promotion gate, thread + `recv_timeout`, fail-closed |
| `autonoetic-gateway/src/sentinel/scheduler.rs` | New — `ensure_sentinel_scheduled_jobs`, `run_due_sentinel_jobs` |
| `autonoetic-gateway/src/sentinel/mod.rs` | Re-exports for new modules |
| `autonoetic-gateway/src/lib.rs` | Re-exports `ensure_sentinel_scheduled_jobs`, `run_due_sentinel_jobs` |
| `autonoetic-gateway/src/runtime/tools/agent_revision.rs` | Sentinel gate wired before `atomic_promote` |
| `autonoetic-gateway/tests/security_sentinel_integration.rs` | 6 new Phase 5 tests |

## Test plan

- [x] `cargo test -p autonoetic-gateway --test security_sentinel_integration` — 28/28 pass
- [x] `cargo build -p autonoetic-gateway` — clean
- [x] Promotion gate: `promotion_gate_passes_on_clean_store` verifies clean DB → `Passed`
- [x] Promotion gate: `promotion_gate_blocks_on_critical_finding` injects credential event → `Blocked`
- [x] Scheduler: `ensure_sentinel_scheduled_jobs_creates_both_jobs` — both jobs created and queryable
- [x] Scheduler: `ensure_sentinel_scheduled_jobs_is_idempotent` — second call returns `SkippedExists`
- [x] Scheduler: disabled sentinel skips all job registration

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)