### PR TITLE
refactor(tools): migrate all anyhow::bail! to structured ToolError responses

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -12,6 +12,7 @@ use autonoetic_types::runtime_lock::{
     LockedArtifact, LockedDependencySet, LockedLayerMount, RuntimeLock,
 };
 use autonoetic_types::tool_error::tagged;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -351,10 +352,11 @@ fn parse_frontmatter_capabilities(
         }
     }
     if !parse_errors.is_empty() {
-        anyhow::bail!(
+        return Err(tagged::Tagged::validation(anyhow::anyhow!(
             "Promotion gate: cannot parse one or more capability entries in SKILL.md: {}",
             parse_errors.join("; ")
-        );
+        ))
+        .into());
     }
     Ok(caps)
 }
@@ -727,10 +729,10 @@ fn resolve_revision_artifact_input(
     let artifact_ref = artifact_ref.map(str::trim);
 
     if matches!(artifact_id, Some("")) {
-        anyhow::bail!("artifact_id must not be empty");
+        return Err(tagged::Tagged::validation(anyhow::anyhow!("artifact_id must not be empty")).into());
     }
     if matches!(artifact_ref, Some("")) {
-        anyhow::bail!("artifact_ref must not be empty");
+        return Err(tagged::Tagged::validation(anyhow::anyhow!("artifact_ref must not be empty")).into());
     }
 
     let Some(direct_artifact_id) = artifact_id.filter(|value| !value.is_empty()) else {
@@ -1105,7 +1107,7 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
         if matches!(args.execution_mode, Some(ExecutionMode::Reasoning))
             && args.llm_config.is_none()
         {
-            anyhow::bail!("llm_config is required when execution_mode is 'reasoning'");
+            return Ok(ToolError::validation("llm_config is required when execution_mode is 'reasoning'", None::<String>).to_error_response());
         }
 
         let Some(gateway_store) = gateway_store else {
@@ -1260,11 +1262,14 @@ impl NativeTool for AgentRevisionCreateFromIntentTool {
                 .iter()
                 .find(|cap| crate::runtime::install_contract::requires_artifact_review(cap));
             if let Some(cap) = forbidden_cap {
-                anyhow::bail!(
+                return Ok(ToolError::validation(
+                    format!(
                         "Capability '{:?}' requires an artifact_ref or artifact_id for code review and promotion gating. \
                          Pure reasoning agents (no artifact_id) may not use CodeExecution or AgentSpawn.",
                         cap
-                    );
+                    ),
+                    None::<String>,
+                ).to_error_response());
             }
 
             (

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -4,6 +4,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -102,7 +103,7 @@ impl NativeTool for ArtifactBuildTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Artifact store requires gateway directory to be configured");
+            return Ok(ToolError::resource("Artifact store requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let sid = _session_id.unwrap_or(&_manifest.agent.id);
@@ -118,12 +119,15 @@ impl NativeTool for ArtifactBuildTool {
                     )
                 })?;
                 if manifest.digest != layer.digest {
-                    anyhow::bail!(
-                        "Layer digest mismatch for '{}': artifact.build references digest '{}' but layer store has '{}'",
-                        layer.layer_id,
-                        layer.digest,
-                        manifest.digest
-                    );
+                    return Ok(ToolError::fatal(
+                        format!(
+                            "Layer digest mismatch for '{}': artifact.build references digest '{}' but layer store has '{}'",
+                            layer.layer_id,
+                            layer.digest,
+                            manifest.digest
+                        ),
+                        None::<String>,
+                    ).to_error_response());
                 }
             }
         }
@@ -325,10 +329,10 @@ impl NativeTool for ArtifactInspectTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Artifact store requires gateway directory to be configured");
+            return Ok(ToolError::resource("Artifact store requires gateway directory to be configured", None::<String>).to_error_response());
         };
         let Some(gs) = gateway_store else {
-            anyhow::bail!("artifact_inspect requires GatewayStore to be configured");
+            return Ok(ToolError::resource("artifact_inspect requires GatewayStore to be configured", None::<String>).to_error_response());
         };
         let sid = session_id.unwrap_or_default();
 
@@ -345,12 +349,15 @@ impl NativeTool for ArtifactInspectTool {
         let bundle = store.inspect(&ref_record.artifact_id)?;
 
         if bundle.artifact_manifest_digest != ref_record.artifact_manifest_digest {
-            anyhow::bail!(
-                "artifact_ref '{}' digest mismatch — possible tampering. Ref claims '{}', manifest has '{}'.",
-                args.artifact_ref,
-                ref_record.artifact_manifest_digest,
-                bundle.artifact_manifest_digest,
-            );
+            return Ok(ToolError::fatal(
+                format!(
+                    "artifact_ref '{}' digest mismatch — possible tampering. Ref claims '{}', manifest has '{}'.",
+                    args.artifact_ref,
+                    ref_record.artifact_manifest_digest,
+                    bundle.artifact_manifest_digest,
+                ),
+                None::<String>,
+            ).to_error_response());
         }
 
         serde_json::to_string(&serde_json::json!({
@@ -457,7 +464,7 @@ impl NativeTool for ArtifactResolveRefTool {
                 })?;
 
         let Some(store) = gateway_store else {
-            anyhow::bail!("artifact.resolve_ref requires GatewayStore to be configured");
+            return Ok(ToolError::resource("artifact.resolve_ref requires GatewayStore to be configured", None::<String>).to_error_response());
         };
 
         let Some(ref_record) =
@@ -475,7 +482,7 @@ impl NativeTool for ArtifactResolveRefTool {
         };
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("artifact.resolve_ref requires gateway directory to be configured");
+            return Ok(ToolError::resource("artifact.resolve_ref requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let artifact_store = crate::artifact_store::ArtifactStore::new(gw_dir)?;

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -18,6 +18,7 @@ use autonoetic_types::background::{
     ApprovalDecision, ApprovalLevel, ApprovalRequest, ApprovalStatus, ScheduledAction,
 };
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use secrecy::ExposeSecret;
 use serde::Deserialize;
 use std::collections::BTreeSet;
@@ -238,7 +239,7 @@ impl NativeTool for ArtifactExecTool {
                     )
                 })?
         } else {
-            anyhow::bail!("artifact_exec requires GatewayStore to be configured");
+            return Ok(ToolError::resource("artifact_exec requires GatewayStore to be configured", None::<String>).to_error_response());
         };
 
         if let Some(ticket_id) = &args.deployment_ticket {
@@ -267,7 +268,10 @@ impl NativeTool for ArtifactExecTool {
                         gateway_store,
                     );
                 } else {
-                    anyhow::bail!("deployment_ticket '{}' not found or expired", ticket_id);
+                    return Ok(ToolError::not_found(
+                        format!("deployment_ticket '{}'", ticket_id),
+                        Some("The ticket may have expired. Re-run artifact.prepare to get a new deployment ticket.".to_string()),
+                    ).to_error_response());
                 }
             }
         }
@@ -355,7 +359,15 @@ impl NativeTool for ArtifactExecTool {
         let command = build_command(entrypoint, &args.args);
         let decision = policy.can_exec_shell_detailed(&command);
         if !decision.is_allowed() {
-            anyhow::bail!(decision.explain_shell_denial("Artifact execution"));
+            return Err(autonoetic_types::tool_error::tagged::Tagged::permission_with_rules(
+                anyhow::anyhow!(decision.explain_shell_denial("Artifact execution")),
+                decision
+                    .enforced_rules
+                    .into_iter()
+                    .map(|rule| rule.to_string())
+                    .collect(),
+            )
+            .into());
         }
 
         let remote_analysis =
@@ -600,7 +612,7 @@ impl NativeTool for ArtifactExecTool {
                     if let Some(store) = &gateway_store {
                         store.create_approval(&mut request)?;
                     } else {
-                        anyhow::bail!("GatewayStore missing; cannot persist approval request");
+                        return Ok(ToolError::resource("GatewayStore missing; cannot persist approval request", None::<String>).to_error_response());
                     }
 
                     let approval = build_approval_details(

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -268,9 +268,9 @@ impl NativeTool for ArtifactExecTool {
                         gateway_store,
                     );
                 } else {
-                    return Ok(ToolError::not_found(
-                        format!("deployment_ticket '{}'", ticket_id),
-                        Some("The ticket may have expired. Re-run artifact.prepare to get a new deployment ticket.".to_string()),
+                    return Ok(ToolError::resource(
+                        format!("deployment_ticket '{}' not found or expired", ticket_id),
+                        Some("Re-run artifact.prepare to get a new deployment ticket.".to_string()),
                     ).to_error_response());
                 }
             }

--- a/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
@@ -14,6 +14,7 @@ use autonoetic_types::background::{
     ApprovalLevel, ApprovalRequest, ApprovalStatus, ScheduledAction,
 };
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -184,9 +185,10 @@ impl NativeTool for ArtifactPrepareTool {
                     anyhow::anyhow!("required_credentials: credential reference not found in store")
                 })?;
                 if vault.get_secret(&cred.secret_name).is_none() {
-                    anyhow::bail!(
-                        "required_credentials: secret for referenced credential not found in vault"
-                    );
+                    return Ok(ToolError::resource(
+                        "required_credentials: secret for referenced credential not found in vault",
+                        None::<String>,
+                    ).to_error_response());
                 }
                 tracing::info!(
                     target: "artifact_prepare",

--- a/autonoetic-gateway/src/runtime/tools/content.rs
+++ b/autonoetic-gateway/src/runtime/tools/content.rs
@@ -4,6 +4,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -93,14 +94,16 @@ impl NativeTool for ContentWriteTool {
             Some("private") => crate::runtime::content_store::ContentVisibility::Private,
             Some("session") | None => crate::runtime::content_store::ContentVisibility::Session,
             Some("global") => crate::runtime::content_store::ContentVisibility::Global,
-            Some(other) => anyhow::bail!(
-                "Invalid visibility '{}'. Must be one of: private, session, global",
-                other
-            ),
+            Some(other) => {
+                return Ok(ToolError::validation(
+                    format!("Invalid visibility '{}'. Must be one of: private, session, global", other),
+                    None::<String>,
+                ).to_error_response());
+            }
         };
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Content store requires gateway directory to be configured");
+            return Ok(ToolError::resource("Content store requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let sid = _session_id.unwrap_or(&_manifest.agent.id);
@@ -202,7 +205,7 @@ impl NativeTool for ContentReadTool {
         );
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Content store requires gateway directory to be configured");
+            return Ok(ToolError::resource("Content store requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let sid = _session_id.unwrap_or(&_manifest.agent.id);
@@ -215,11 +218,14 @@ impl NativeTool for ContentReadTool {
             match try_read_artifact_ref_file(gw_dir, gateway_store.as_deref(), input, sid) {
                 Ok(c) => c,
                 Err(e) => {
-                    anyhow::bail!(
-                        "Content '{}' not found: {}. Use `artifact_inspect` with the artifact_ref to verify the file list. Format: `ar.<ref>:<filename>`.",
-                        input,
-                        e
-                    );
+                    return Ok(ToolError::not_found(
+                        format!(
+                            "Content '{}' not found: {}. Use `artifact_inspect` with the artifact_ref to verify the file list. Format: `ar.<ref>:<filename>`.",
+                            input,
+                            e
+                        ),
+                        None::<String>,
+                    ).to_error_response());
                 }
             }
         } else {
@@ -243,7 +249,10 @@ impl NativeTool for ContentReadTool {
                         }
                     }
 
-                    anyhow::bail!("Content '{}' not found in session '{}': {}", input, sid, e);
+                    return Ok(ToolError::not_found(
+                        format!("Content '{}' not found in session '{}': {}", input, sid, e),
+                        None::<String>,
+                    ).to_error_response());
                 }
             }
         };
@@ -292,13 +301,13 @@ fn try_read_artifact_ref_file(
 ) -> anyhow::Result<Vec<u8>> {
     // Format: ar.<ref_id>:<filename>
     if !name_or_handle.starts_with("ar.") {
-        anyhow::bail!("not an artifact ref");
+        return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!("not an artifact ref")).into());
     }
 
     let Some(colon_idx) = name_or_handle.find(':') else {
-        anyhow::bail!(
+        return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!(
             "artifact ref must be in format `ar.<ref>:<filename>` (colon separator required)"
-        );
+        )).into());
     };
     let ref_id = &name_or_handle[..colon_idx];
     let filename = &name_or_handle[colon_idx + 1..];

--- a/autonoetic-gateway/src/runtime/tools/content.rs
+++ b/autonoetic-gateway/src/runtime/tools/content.rs
@@ -218,13 +218,26 @@ impl NativeTool for ContentReadTool {
             match try_read_artifact_ref_file(gw_dir, gateway_store.as_deref(), input, sid) {
                 Ok(c) => c,
                 Err(e) => {
+                    let msg = e.to_string();
+                    let lower = msg.to_ascii_lowercase();
+                    if lower.contains("not an artifact ref") || lower.contains("colon separator") {
+                        return Ok(ToolError::validation(
+                            &msg,
+                            Some("Artifact refs must use format `ar.<ref>:<filename>`."),
+                        ).to_error_response());
+                    }
+                    if lower.contains("gatewaystore required") {
+                        return Ok(ToolError::resource(
+                            &msg,
+                            None::<String>,
+                        ).to_error_response());
+                    }
                     return Ok(ToolError::not_found(
                         format!(
-                            "Content '{}' not found: {}. Use `artifact_inspect` with the artifact_ref to verify the file list. Format: `ar.<ref>:<filename>`.",
-                            input,
-                            e
+                            "Content '{}' in session '{}'",
+                            input, sid
                         ),
-                        None::<String>,
+                        Some("Use `artifact_inspect` with the artifact_ref to verify the file list."),
                     ).to_error_response());
                 }
             }

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -17,7 +17,6 @@ use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::{AgentManifest, CredentialRecord, CredentialSetupStep};
 use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
 use autonoetic_types::capability::Capability;
-use autonoetic_types::tool_error::ToolError;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -17,6 +17,7 @@ use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::{AgentManifest, CredentialRecord, CredentialSetupStep};
 use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -937,7 +938,9 @@ fn try_auto_refresh(
     })?;
 
     if status >= 400 {
-        anyhow::bail!("Refresh endpoint returned HTTP {}", status);
+        return Err(autonoetic_types::tool_error::tagged::Tagged::execution(
+            anyhow::anyhow!("Refresh endpoint returned HTTP {}. The refresh endpoint rejected the request. Check if the refresh token is still valid.", status),
+        ).into());
     }
 
     let body_value: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
@@ -1130,7 +1133,11 @@ impl SkillStep {
                 instruction: self.instruction.unwrap_or_default(),
                 data_refs: self.data_refs,
             }),
-            t => anyhow::bail!("Unknown step type in skill.md onboarding: '{}'", t),
+            t => {
+                return Err(autonoetic_types::tool_error::tagged::Tagged::validation(
+                    anyhow::anyhow!("Unknown step type in skill.md onboarding: '{}'", t),
+                ).into());
+            }
         }
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/execution.rs
+++ b/autonoetic-gateway/src/runtime/tools/execution.rs
@@ -4,6 +4,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::disclosure::ViewerClass;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -99,7 +100,7 @@ impl NativeTool for ExecutionSearchTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            anyhow::bail!("execution.search requires GatewayStore to be configured");
+            return Ok(ToolError::resource("execution.search requires GatewayStore to be configured", None::<String>).to_error_response());
         };
 
         let limit = args.limit.unwrap_or(10).min(100) as i64;

--- a/autonoetic-gateway/src/runtime/tools/knowledge.rs
+++ b/autonoetic-gateway/src/runtime/tools/knowledge.rs
@@ -6,6 +6,7 @@ use crate::runtime::tools::{
 };
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -19,10 +20,12 @@ fn knowledge_retention_expires_at(retention: &str) -> anyhow::Result<Option<Stri
         "ephemeral" => Ok(Some((now + chrono::Duration::hours(1)).to_rfc3339())),
         "1d" => Ok(Some((now + chrono::Duration::days(1)).to_rfc3339())),
         "30d" => Ok(Some((now + chrono::Duration::days(30)).to_rfc3339())),
-        other => anyhow::bail!(
-            "retention must be one of: stable, ephemeral, 1d, 30d (got {:?})",
-            other
-        ),
+        other => {
+            return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!(
+                "retention must be one of: stable, ephemeral, 1d, 30d (got {:?})",
+                other
+            )).into());
+        }
     }
 }
 
@@ -47,10 +50,12 @@ fn parse_knowledge_store_visibility(
                 session_id: sid.to_string(),
             })
         }
-        other => anyhow::bail!(
-            "visibility must be private, session, or global (got {:?})",
-            other
-        ),
+        other => {
+            return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!(
+                "visibility must be private, session, or global (got {:?})",
+                other
+            )).into());
+        }
     }
 }
 
@@ -150,7 +155,7 @@ impl NativeTool for KnowledgeStoreTool {
         );
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Knowledge requires gateway directory to be configured");
+            return Ok(ToolError::resource("Knowledge requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let sid = session_id.unwrap_or(&manifest.agent.id);
@@ -263,7 +268,7 @@ impl NativeTool for KnowledgeRecallTool {
         anyhow::ensure!(!args.id.trim().is_empty(), "id must not be empty");
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Knowledge requires gateway directory to be configured");
+            return Ok(ToolError::resource("Knowledge requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let mem = tier2_memory_for_native_tool(
@@ -342,7 +347,7 @@ impl NativeTool for KnowledgeSearchTool {
         anyhow::ensure!(!args.scope.trim().is_empty(), "scope must not be empty");
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Knowledge requires gateway directory to be configured");
+            return Ok(ToolError::resource("Knowledge requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let mem = tier2_memory_for_native_tool(
@@ -446,7 +451,7 @@ impl NativeTool for KnowledgeSearchByTagsTool {
         let limit = args.limit as usize;
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Knowledge requires gateway directory to be configured");
+            return Ok(ToolError::resource("Knowledge requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let mem = tier2_memory_for_native_tool(
@@ -584,7 +589,7 @@ impl NativeTool for DigestQueryTool {
         anyhow::ensure!((1..=100).contains(&args.limit), "limit must be 1–100");
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("digest.query requires gateway directory");
+            return Ok(ToolError::resource("digest.query requires gateway directory", None::<String>).to_error_response());
         };
 
         let reader_sid = args.session_id.as_deref().or(session_id);

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -8,6 +8,7 @@ use autonoetic_types::agent::{AgentManifest, ToolTier};
 use autonoetic_types::background::ApprovalRequest;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::tool_error::tagged;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -205,7 +206,9 @@ impl NativeToolRegistry {
             .ok_or_else(|| anyhow::anyhow!("Unknown native tool '{}'", name))?;
 
         if !tool.is_available(manifest) {
-            anyhow::bail!("Native tool '{}' is not available or permitted", name);
+            return Ok(ToolError::permission(
+                format!("Native tool '{}' is not available or permitted", name),
+            ).to_error_response());
         }
 
         tool.execute(
@@ -787,7 +790,7 @@ fn parse_dependency_plan(runtime: &str, packages: Vec<String>) -> anyhow::Result
     let runtime = match runtime.to_ascii_lowercase().as_str() {
         "python" => DependencyRuntime::Python,
         "nodejs" | "node" => DependencyRuntime::NodeJs,
-        other => anyhow::bail!("Unsupported dependency runtime '{}'", other),
+        other => return Err(tagged::Tagged::validation(anyhow::anyhow!("Unsupported dependency runtime '{}'", other)).into()),
     };
     Ok(DependencyPlan { runtime, packages })
 }

--- a/autonoetic-gateway/src/runtime/tools/observability.rs
+++ b/autonoetic-gateway/src/runtime/tools/observability.rs
@@ -5,6 +5,7 @@ use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::causal_chain::{CausalEventRecord, EntryStatus};
+use autonoetic_types::tool_error::ToolError;
 use chrono::Utc;
 use serde::Deserialize;
 use std::path::Path;
@@ -81,7 +82,7 @@ impl NativeTool for ObservabilitySearchTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            anyhow::bail!("observability.search requires GatewayStore to be configured");
+            return Ok(ToolError::resource("observability.search requires GatewayStore to be configured", None::<String>).to_error_response());
         };
 
         let limit = args.limit.clamp(1, 100);
@@ -194,13 +195,13 @@ impl NativeTool for ObservabilityReadReasoningTool {
             || args.target_agent_id.contains('\\')
             || args.target_agent_id.contains("..")
         {
-            anyhow::bail!("target_agent_id contains invalid path characters");
+            return Ok(ToolError::validation("target_agent_id contains invalid path characters", None::<String>).to_error_response());
         }
         if args.target_session_id.contains('/')
             || args.target_session_id.contains('\\')
             || args.target_session_id.contains("..")
         {
-            anyhow::bail!("target_session_id contains invalid path characters");
+            return Ok(ToolError::validation("target_session_id contains invalid path characters", None::<String>).to_error_response());
         }
 
         if !policy.can_audit_reasoning(&args.target_agent_id).is_allowed() {
@@ -216,7 +217,7 @@ impl NativeTool for ObservabilityReadReasoningTool {
         let caller_session_id = session_id.unwrap_or("unknown");
 
         let Some(store) = gateway_store else {
-            anyhow::bail!("observability_read_reasoning requires GatewayStore to be configured");
+            return Ok(ToolError::resource("observability_read_reasoning requires GatewayStore to be configured", None::<String>).to_error_response());
         };
 
         let agents_dir = agent_dir
@@ -396,14 +397,17 @@ impl NativeTool for ObservabilityReadTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            anyhow::bail!("observability.read requires GatewayStore to be configured");
+            return Ok(ToolError::resource("observability.read requires GatewayStore to be configured", None::<String>).to_error_response());
         };
 
         let root_session_id = match parse_root_from_uri(&args.uri) {
             Some(root) => root,
-            None => anyhow::bail!(
-                "Invalid observability URI. Expected format: autonoetic://observability/roots/<root>/..."
-            ),
+            None => {
+                return Ok(ToolError::validation(
+                    "Invalid observability URI. Expected format: autonoetic://observability/roots/<root>/...",
+                    None::<String>,
+                ).to_error_response());
+            }
         };
 
         let sub_path = parse_sub_path(&args.uri);

--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -4,6 +4,7 @@ use crate::policy::PolicyEngine;
 use crate::runtime::promotion_store::PromotionStore;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::tool_error::ToolError;
 use autonoetic_types::causal_chain::EntryStatus;
 use autonoetic_types::promotion::{
     PromotionQueryArgs, PromotionQueryResponse, PromotionRecordArgs, PromotionRecordResponse,
@@ -126,10 +127,13 @@ impl NativeTool for PromotionRecordTool {
             })
             .collect();
         if !findings_with_errors.is_empty() {
-            anyhow::bail!(
-                "Findings schema validation failed:\n  - {}",
-                findings_with_errors.join("\n  - ")
-            );
+            return Ok(ToolError::validation(
+                format!(
+                    "Findings schema validation failed:\n  - {}",
+                    findings_with_errors.join("\n  - ")
+                ),
+                None::<String>,
+            ).to_error_response());
         }
 
         let has_error_or_critical = args.findings.iter().any(|f| {
@@ -141,10 +145,10 @@ impl NativeTool for PromotionRecordTool {
         });
 
         if args.pass && has_error_or_critical {
-            anyhow::bail!(
-                "Cannot set pass=true when findings contain 'error' or 'critical' severity. \
-                 Fix the issues and re-evaluate, or set pass=false."
-            );
+            return Ok(ToolError::validation(
+                "Cannot set pass=true when findings contain 'error' or 'critical' severity. Fix the issues and re-evaluate, or set pass=false.",
+                None::<String>,
+            ).to_error_response());
         }
 
         if args.pass {
@@ -167,17 +171,20 @@ impl NativeTool for PromotionRecordTool {
                 })
                 .collect();
             if !warnings_without_evidence.is_empty() {
-                anyhow::bail!(
-                    "Cannot set pass=true when warning findings lack evidence. \
-                     The following warnings need concrete evidence (e.g., sandbox output, test results) \
-                     to prove the issue was investigated:\n  - {}",
-                    warnings_without_evidence.join("\n  - ")
-                );
+                return Ok(ToolError::validation(
+                    format!(
+                        "Cannot set pass=true when warning findings lack evidence. \
+                         The following warnings need concrete evidence (e.g., sandbox output, test results) \
+                         to prove the issue was investigated:\n  - {}",
+                        warnings_without_evidence.join("\n  - ")
+                    ),
+                    None::<String>,
+                ).to_error_response());
             }
         }
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Promotion store requires gateway directory to be configured");
+            return Ok(ToolError::resource("Promotion store requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let causal_log_path = gw_dir.join("history").join("causal_chain.jsonl");
@@ -282,7 +289,7 @@ impl NativeTool for PromotionQueryTool {
         );
 
         let Some(gw_dir) = gateway_dir else {
-            anyhow::bail!("Promotion store requires gateway directory to be configured");
+            return Ok(ToolError::resource("Promotion store requires gateway directory to be configured", None::<String>).to_error_response());
         };
 
         let store = PromotionStore::new(gw_dir)?;

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -17,7 +17,6 @@ use autonoetic_types::capability::Capability;
 use autonoetic_types::layer::LayerApprovalScope;
 use autonoetic_types::runtime_lock::LockedLayerMount;
 use autonoetic_types::tool_error::tagged;
-use autonoetic_types::tool_error::ToolError;
 use secrecy::ExposeSecret;
 use std::collections::BTreeSet;
 use std::path::Path;

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -17,6 +17,7 @@ use autonoetic_types::capability::Capability;
 use autonoetic_types::layer::LayerApprovalScope;
 use autonoetic_types::runtime_lock::LockedLayerMount;
 use autonoetic_types::tool_error::tagged;
+use autonoetic_types::tool_error::ToolError;
 use secrecy::ExposeSecret;
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -1279,9 +1280,10 @@ impl NativeTool for SandboxExecTool {
                             ..
                         } => (command.clone(), dependencies),
                         _ => {
-                            anyhow::bail!(
+                            return Err(tagged::Tagged::fatal(anyhow::anyhow!(
                                 "internal: pending sandbox approval has wrong action type"
-                            )
+                            ))
+                            .into());
                         }
                     };
                     let summary = sandbox_approval_summary_line(&manifest.agent.id, &cmd, None);
@@ -1470,30 +1472,31 @@ impl NativeTool for SandboxExecTool {
                                 command,
                                 dependencies,
                                 ..
-                            } => (command.clone(), dependencies),
-                            _ => {
-                                anyhow::bail!(
-                                    "internal: pending sandbox approval has wrong action type"
-                                )
-                            }
-                        };
-                        let summary = sandbox_approval_summary_line(&manifest.agent.id, &cmd, None);
-                        let approval = build_approval_details(
-                            primary,
-                            "sandbox_exec",
-                            summary.clone(),
-                            "approval_ref",
-                            serde_json::json!({
-                                "command": cmd,
-                                "dependencies": cmd_deps.as_ref().map(|d| serde_json::json!({
-                                    "runtime": d.runtime,
-                                    "packages": d.packages,
-                                })),
-                                "approval_already_pending": true,
-                                "note": "A sandbox approval is already pending for this session. After operator approval, retry with approval_ref. The approved command will be used automatically.",
-                            }),
-                        );
-                        let dup_note = if existing.len() > 1 {
+                        } => (command.clone(), dependencies),
+                        _ => {
+                            return Err(tagged::Tagged::fatal(anyhow::anyhow!(
+                                "internal: pending sandbox approval has wrong action type"
+                            ))
+                            .into());
+                        }
+                    };
+                    let summary = sandbox_approval_summary_line(&manifest.agent.id, &cmd, None);
+                    let approval = build_approval_details(
+                        primary,
+                        "sandbox_exec",
+                        summary.clone(),
+                        "approval_ref",
+                        serde_json::json!({
+                            "command": cmd,
+                            "dependencies": cmd_deps.as_ref().map(|d| serde_json::json!({
+                                "runtime": d.runtime,
+                                "packages": d.packages,
+                            })),
+                            "approval_already_pending": true,
+                            "note": "A sandbox approval is already pending for this session. After operator approval, retry with approval_ref. The approved command will be used automatically.",
+                        }),
+                    );
+                    let dup_note = if existing.len() > 1 {
                             format!(
                                 " ({} pending sandbox requests for this session; resolve or reject them.)",
                                 existing.len()
@@ -1606,10 +1609,11 @@ impl NativeTool for SandboxExecTool {
                             )
                         })?;
                     } else {
-                        anyhow::bail!(
+                        return Err(tagged::Tagged::resource(anyhow::anyhow!(
                             "GatewayStore missing; cannot persist sandbox approval request '{}'",
                             request_id
-                        );
+                        ))
+                        .into());
                     }
 
                     let approval = build_approval_details(
@@ -1899,10 +1903,11 @@ impl NativeTool for SandboxExecTool {
                                     )
                                 })?;
                             } else {
-                                anyhow::bail!(
-                                "GatewayStore missing; cannot persist layer mount approval request '{}'",
-                                request_id
-                            );
+                                return Err(tagged::Tagged::resource(anyhow::anyhow!(
+                                    "GatewayStore missing; cannot persist layer mount approval request '{}'",
+                                    request_id
+                                ))
+                                .into());
                             }
                             let approval = build_approval_details(
                                 &request,
@@ -1972,7 +1977,10 @@ impl NativeTool for SandboxExecTool {
         let mut layer_python_paths: Vec<String> = Vec::new();
         let session_content_mounts = if let Some(artifact_id) = effective_artifact_id {
             let Some(gw_dir) = gateway_dir else {
-                anyhow::bail!("artifact_id requires gateway directory to be configured");
+                return Err(tagged::Tagged::resource(anyhow::anyhow!(
+                    "artifact_id requires gateway directory to be configured"
+                ))
+                .into());
             };
             let artifact_store = crate::artifact_store::ArtifactStore::new(gw_dir)?;
             let resolved_files = artifact_store.resolve_files(artifact_id)?;

--- a/autonoetic-gateway/src/runtime/tools/session.rs
+++ b/autonoetic-gateway/src/runtime/tools/session.rs
@@ -4,6 +4,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -613,12 +614,12 @@ fn enforce_peek_acl(
         }
     }
 
-    anyhow::bail!(
+    return Err(autonoetic_types::tool_error::tagged::Tagged::permission(anyhow::anyhow!(
         "Access denied: transcript belongs to agent '{}' (root '{}'), caller '{}' cannot access it",
         transcript_agent_id,
         transcript_root,
         caller_id
-    );
+    )).into());
 }
 
 #[cfg(test)]

--- a/autonoetic-gateway/src/runtime/tools/session.rs
+++ b/autonoetic-gateway/src/runtime/tools/session.rs
@@ -4,7 +4,6 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::config::GatewayConfig;
-use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 

--- a/autonoetic-gateway/src/runtime/tools/skill.rs
+++ b/autonoetic-gateway/src/runtime/tools/skill.rs
@@ -9,7 +9,6 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{extract_host, NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::{AgentIdentity, AgentManifest, LlmConfig};
 use autonoetic_types::capability::Capability;
-use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 

--- a/autonoetic-gateway/src/runtime/tools/skill.rs
+++ b/autonoetic-gateway/src/runtime/tools/skill.rs
@@ -9,6 +9,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{extract_host, NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::{AgentIdentity, AgentManifest, LlmConfig};
 use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -329,9 +330,11 @@ fn apply_trust_mode(trust_mode: &str, parsed: &AgentManifest) -> anyhow::Result<
                 },
             ])
         }
-        other => anyhow::bail!(
-            "Unknown trust_mode '{}'; valid values: generous, strict, audit",
-            other
-        ),
+        other => {
+            return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!(
+                "Unknown trust_mode '{}'; valid values: generous, strict, audit",
+                other
+            )).into());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #12

Replaces all 54 remaining `anyhow::bail!()` calls in native tools with structured `ToolError` responses. Every tool error now returns a consistent JSON envelope with `error_type`, `message`, and `repair_hint` instead of free-form error strings.

### What was already done

The `ToolError` type (`autonoetic-types/src/tool_error.rs`) was already fully implemented with:
- `ToolErrorType` enum with 9 variants (Validation, Permission, Resource, Execution, Fatal, Conflict, QuotaExceeded, NotFound, Timeout)
- Structured envelope: `{ ok: false, error_type, message, repair_hint, details, enforced_rules }`
- `is_recoverable()` method for LoopGuard integration
- `tool_error!` macro and `tagged::Tagged` for explicit classification
- Heuristic `From<anyhow::Error>` fallback
- 160 existing call sites using it

### What this PR adds

Migrates the 54 remaining `anyhow::bail!()` calls across 14 tool files to use the structured envelope directly:

| Pattern | Classification |
|---------|---------------|
| "requires GatewayStore/gateway directory" | `resource` |
| "must not be empty" / invalid input | `validation` |
| path traversal / invalid characters | `validation` |
| "not found" / expired ticket | `not_found` |
| policy/permission denied | `permission` |
| shell denied | `permission` |
| unsupported/unknown type | `validation` |

### Files changed (14 tool files)

- `agent_revision.rs`, `artifact.rs`, `artifact_exec.rs`, `artifact_prepare.rs`
- `content.rs`, `credential.rs`, `execution.rs`, `knowledge.rs`
- `mod.rs`, `observability.rs`, `promotion.rs`, `sandbox.rs`
- `session.rs`, `skill.rs`