### PR TITLE
feat(protected-agents): mechanical eval gate for critical agent promotion

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2065,9 +2065,9 @@ impl NativeTool for AgentRevisionPromoteTool {
                         "message": format!(
                             "Agent '{}' is protected (issue #21). Promotion requires a passed eval run as evidence. \
                              Provide `required_eval_run_id` referencing a successful eval run for this revision.",
-                            args.agent_id
+                            &args.agent_id
                         ),
-                        "protected_agent": args.agent_id,
+                        "protected_agent": &args.agent_id,
                         "repair_hint": "Run an eval suite against this revision, then retry promotion with `required_eval_run_id` pointing to the passed run.",
                     })
                     .to_string());

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2044,6 +2044,37 @@ impl NativeTool for AgentRevisionPromoteTool {
             );
         }
 
+        // Protected-agent promotion gate (issue #21).
+        // Critical agents (e.g. agent-factory.default) cannot be promoted
+        // without eval evidence. This closes the recursive-trust loop: a
+        // regressed agent-factory is exactly the agent that cannot be trusted
+        // to fix itself without independent verification.
+        if let Some(cfg) = config {
+            if cfg.protected_agents.enabled
+                && cfg
+                    .protected_agents
+                    .agents
+                    .iter()
+                    .any(|a| a == &args.agent_id)
+            {
+                if args.required_eval_run_id.is_none() {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "error_type": "permission",
+                        "error": "protected_agent_requires_eval_run",
+                        "message": format!(
+                            "Agent '{}' is protected (issue #21). Promotion requires a passed eval run as evidence. \
+                             Provide `required_eval_run_id` referencing a successful eval run for this revision.",
+                            args.agent_id
+                        ),
+                        "protected_agent": args.agent_id,
+                        "repair_hint": "Run an eval suite against this revision, then retry promotion with `required_eval_run_id` pointing to the passed run.",
+                    })
+                    .to_string());
+                }
+            }
+        }
+
         // Security sentinel pre-promotion gate (fail-closed).
         // Runs a full-store Phase-1 sweep — any critical finding in the system
         // blocks promotion. Per-agent scoping is planned for a future phase.

--- a/autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs
+++ b/autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs
@@ -1,0 +1,356 @@
+//! Protected-agent promotion gate (issue #21).
+//!
+//! Critical agents (e.g. agent-factory.default) cannot be promoted without
+//! eval-run evidence. This closes the recursive-trust loop: a regressed
+//! agent-factory cannot silently replace itself.
+//!
+//! Tests:
+//!   - protected agent without eval run → blocked
+//!   - protected agent with passed eval run → proceeds (to remaining gates)
+//!   - non-protected agent → no extra gate (existing behavior)
+//!   - gate disabled → protected agent promotes without eval
+//!   - protected agent with failed eval run → blocked by eval gate
+//!   - protected agent with eval run for wrong revision → blocked by eval gate
+
+mod support;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::agent_revision::{
+    AgentAliasRecord, AgentRevisionRecord, AgentRevisionStatus,
+};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::{GatewayConfig, ProtectedAgentsConfig};
+use autonoetic_types::evaluation::{EvalRunRecord, EvalRunStatus};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+const AGENT_ID: &str = "agent-factory.default";
+const OTHER_AGENT_ID: &str = "coder.default";
+const OUTGOING_REVISION: &str = "rev_outgoing";
+const INCOMING_REVISION: &str = "rev_incoming";
+
+fn manifest_with_revision_cap(agent_id: &str) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: agent_id.to_string(),
+            name: agent_id.to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![Capability::AgentRevision {
+            patterns: vec!["*".to_string()],
+        }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+    }
+}
+
+fn skill_md(agent_id: &str) -> String {
+    format!(
+        "---\nversion: \"1.0\"\nruntime:\n  engine: autonoetic\n  gateway_version: \"0.1.0\"\n  sdk_version: \"0.1.0\"\n  type: stateful\n  sandbox: bubblewrap\n  runtime_lock: runtime.lock\nagent:\n  id: {}\n  name: {}\n  description: test\n---\n# Test\n",
+        agent_id, agent_id,
+    )
+}
+
+fn write_revision_skill(
+    gateway_dir: &std::path::Path,
+    agent_id: &str,
+    revision_id: &str,
+) {
+    let dir = gateway_dir
+        .join("revisions/agents")
+        .join(agent_id)
+        .join(revision_id);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("SKILL.md"), skill_md(agent_id)).unwrap();
+}
+
+fn make_revision_record(agent_id: &str, revision_id: &str) -> AgentRevisionRecord {
+    AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: agent_id.to_string(),
+        base_revision_id: None,
+        artifact_id: None,
+        content_digest: format!("sha256:{}", revision_id),
+        runtime_lock_hash: "sha256:lock".to_string(),
+        manifest_hash: "sha256:manifest".to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        created_by_type: "user".to_string(),
+        created_by_id: "test".to_string(),
+        source_kind: "artifact".to_string(),
+        source_ref: None,
+        origin_node_id: "local".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Candidate,
+        metadata_json: serde_json::Value::Null,
+        short_id: revision_id.chars().take(8).collect(),
+        signature: None,
+        signer_id: None,
+    }
+}
+
+fn make_eval_run(
+    eval_run_id: &str,
+    agent_id: &str,
+    revision_id: &str,
+    status: EvalRunStatus,
+) -> EvalRunRecord {
+    EvalRunRecord {
+        eval_run_id: eval_run_id.to_string(),
+        suite_id: "suite-test".to_string(),
+        subject_agent_id: agent_id.to_string(),
+        subject_revision_id: revision_id.to_string(),
+        baseline_revision_id: None,
+        status,
+        queued_at: chrono::Utc::now().to_rfc3339(),
+        started_at: Some(chrono::Utc::now().to_rfc3339()),
+        completed_at: Some(chrono::Utc::now().to_rfc3339()),
+        summary_json: serde_json::json!({}),
+        report_handle: None,
+        origin_node_id: "local".to_string(),
+    }
+}
+
+struct PromoteHarness {
+    _temp: tempfile::TempDir,
+    store: Arc<GatewayStore>,
+    agent_dir: std::path::PathBuf,
+    gateway_dir: std::path::PathBuf,
+    config: GatewayConfig,
+}
+
+fn setup_harness(agent_id: &str) -> PromoteHarness {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join("agents");
+    let agent_dir = agents_dir.join(agent_id);
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = Arc::new(GatewayStore::open(&gateway_dir).expect("store opens"));
+
+    write_revision_skill(&gateway_dir, agent_id, OUTGOING_REVISION);
+    write_revision_skill(&gateway_dir, agent_id, INCOMING_REVISION);
+
+    store
+        .insert_agent_revision(&make_revision_record(agent_id, OUTGOING_REVISION))
+        .unwrap();
+    store
+        .insert_agent_revision(&make_revision_record(agent_id, INCOMING_REVISION))
+        .unwrap();
+
+    let alias = AgentAliasRecord {
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: OUTGOING_REVISION.to_string(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        updated_by_type: "user".to_string(),
+        updated_by_id: "test".to_string(),
+        reason: None,
+    };
+    store.upsert_agent_alias(&alias).unwrap();
+
+    let mut config = GatewayConfig::default();
+    config.agents_dir = agents_dir.clone();
+    config.sentinel.enabled = false;
+    config.protected_agents = ProtectedAgentsConfig {
+        enabled: true,
+        agents: vec![AGENT_ID.to_string()],
+    };
+
+    PromoteHarness {
+        _temp: temp,
+        store,
+        agent_dir,
+        gateway_dir,
+        config,
+    }
+}
+
+fn invoke_promote_raw(
+    h: &PromoteHarness,
+    agent_id: &str,
+    revision_id: &str,
+    eval_run_id: Option<&str>,
+) -> Result<String, String> {
+    let manifest = manifest_with_revision_cap(agent_id);
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let mut args = serde_json::json!({
+        "agent_id": agent_id,
+        "revision_id": revision_id,
+    });
+    if let Some(eval_id) = eval_run_id {
+        args["required_eval_run_id"] = serde_json::json!(eval_id);
+    }
+    match registry.execute(
+        "agent_revision_promote",
+        &manifest,
+        &policy,
+        &h.agent_dir,
+        Some(&h.gateway_dir),
+        &args.to_string(),
+        Some("test-session"),
+        Some("turn-000001"),
+        Some(&h.config),
+        Some(h.store.clone()),
+        None,
+    ) {
+        Ok(raw) => Ok(raw),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+fn invoke_promote(
+    h: &PromoteHarness,
+    agent_id: &str,
+    revision_id: &str,
+    eval_run_id: Option<&str>,
+) -> serde_json::Value {
+    let raw = invoke_promote_raw(h, agent_id, revision_id, eval_run_id)
+        .expect("execute should not error for normal cases");
+    serde_json::from_str(&raw).expect("response is JSON")
+}
+
+#[test]
+fn protected_agent_without_eval_run_is_blocked() {
+    let h = setup_harness(AGENT_ID);
+    let result = invoke_promote(&h, AGENT_ID, INCOMING_REVISION, None);
+
+    assert_eq!(result["ok"], false);
+    assert_eq!(result["error"], "protected_agent_requires_eval_run");
+    assert_eq!(result["protected_agent"], AGENT_ID);
+    assert!(
+        result["message"]
+            .as_str()
+            .unwrap()
+            .contains("protected"),
+        "{}",
+        result
+    );
+}
+
+#[test]
+fn protected_agent_with_passed_eval_run_proceeds() {
+    let h = setup_harness(AGENT_ID);
+
+    let eval_run = make_eval_run(
+        "eval-passed-001",
+        AGENT_ID,
+        INCOMING_REVISION,
+        EvalRunStatus::Passed,
+    );
+    h.store.insert_eval_run(&eval_run).unwrap();
+
+    let result = invoke_promote(&h, AGENT_ID, INCOMING_REVISION, Some("eval-passed-001"));
+
+    assert_eq!(result["ok"], true, "unexpected: {:?}", result);
+    assert_eq!(result["status"], "promoted");
+}
+
+#[test]
+fn non_protected_agent_not_gated() {
+    let h = setup_harness(OTHER_AGENT_ID);
+    let mut config = GatewayConfig::default();
+    config.agents_dir = h._temp.path().join("agents");
+    config.sentinel.enabled = false;
+    config.protected_agents = ProtectedAgentsConfig {
+        enabled: true,
+        agents: vec![AGENT_ID.to_string()],
+    };
+    let h = PromoteHarness {
+        config,
+        ..h
+    };
+
+    let result = invoke_promote(&h, OTHER_AGENT_ID, INCOMING_REVISION, None);
+
+    assert_eq!(result["ok"], true, "unexpected: {:?}", result);
+    assert_eq!(result["status"], "promoted");
+}
+
+#[test]
+fn gate_disabled_allows_promotion_without_eval() {
+    let h = setup_harness(AGENT_ID);
+    let mut config = GatewayConfig::default();
+    config.agents_dir = h._temp.path().join("agents");
+    config.sentinel.enabled = false;
+    config.protected_agents = ProtectedAgentsConfig {
+        enabled: false,
+        agents: vec![AGENT_ID.to_string()],
+    };
+    let h = PromoteHarness {
+        config,
+        ..h
+    };
+
+    let result = invoke_promote(&h, AGENT_ID, INCOMING_REVISION, None);
+
+    assert_eq!(result["ok"], true, "unexpected: {:?}", result);
+    assert_eq!(result["status"], "promoted");
+}
+
+#[test]
+fn protected_agent_with_failed_eval_run_is_blocked() {
+    let h = setup_harness(AGENT_ID);
+
+    let eval_run = make_eval_run(
+        "eval-failed-001",
+        AGENT_ID,
+        INCOMING_REVISION,
+        EvalRunStatus::Failed,
+    );
+    h.store.insert_eval_run(&eval_run).unwrap();
+
+    let result = invoke_promote_raw(&h, AGENT_ID, INCOMING_REVISION, Some("eval-failed-001"));
+    let err = result.expect_err("failed eval run should error");
+    assert!(
+        err.contains("did not pass"),
+        "{}",
+        err
+    );
+}
+
+#[test]
+fn protected_agent_with_eval_run_for_wrong_revision_is_blocked() {
+    let h = setup_harness(AGENT_ID);
+
+    let eval_run = make_eval_run(
+        "eval-wrong-rev-001",
+        AGENT_ID,
+        OUTGOING_REVISION,
+        EvalRunStatus::Passed,
+    );
+    h.store.insert_eval_run(&eval_run).unwrap();
+
+    let result = invoke_promote_raw(&h, AGENT_ID, INCOMING_REVISION, Some("eval-wrong-rev-001"));
+    let err = result.expect_err("wrong revision eval run should error");
+    assert!(
+        err.contains("was for revision"),
+        "{}",
+        err
+    );
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -803,8 +803,9 @@ pub struct GatewayConfig {
     pub sentinel: SentinelConfig,
 
     /// Protected agents configuration (issue #21).
-    /// Agents listed here require an eval run + sentinel gate pass before
-    /// programmatic promotion is allowed.
+    /// Agents listed here require a passed eval run before programmatic
+    /// promotion is allowed. The sentinel gate (if enabled) still fires
+    /// independently for all promotions.
     #[serde(default)]
     pub protected_agents: ProtectedAgentsConfig,
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -801,6 +801,12 @@ pub struct GatewayConfig {
     /// Security sentinel configuration.
     #[serde(default)]
     pub sentinel: SentinelConfig,
+
+    /// Protected agents configuration (issue #21).
+    /// Agents listed here require an eval run + sentinel gate pass before
+    /// programmatic promotion is allowed.
+    #[serde(default)]
+    pub protected_agents: ProtectedAgentsConfig,
 }
 
 fn default_approval_dwell_multiplier() -> f64 {
@@ -915,6 +921,46 @@ fn default_sentinel_promotion_gate_enabled() -> bool { true }
 fn default_sentinel_promotion_gate_timeout_secs() -> u64 { 30 }
 fn default_sentinel_revision_id() -> String { "sentinel.current".to_string() }
 fn default_sentinel_baseline_revision_id() -> String { "sentinel.baseline.frozen".to_string() }
+
+/// Protected agents configuration (issue #21).
+///
+/// Protected agents are critical agents whose promotion is mechanically gated
+/// beyond the normal artifact + capability-delta gates. This closes the
+/// recursive-trust problem: a regressed agent-factory cannot silently
+/// replace itself without passing an independent check.
+///
+/// The gate enforces that:
+/// 1. A passed eval run (`required_eval_run_id`) must be provided.
+/// 2. The eval run must target the exact revision being promoted.
+/// 3. The sentinel pre-promotion gate must pass (if enabled).
+///
+/// Operators can still promote by hand via the CLI, but the programmatic
+/// path (agent-driven `agent_revision_promote`) is mechanically blocked
+/// for protected agents unless the eval evidence is presented.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProtectedAgentsConfig {
+    /// List of agent IDs that are protected. Default: empty (no extra gate).
+    #[serde(default)]
+    pub agents: Vec<String>,
+
+    /// Whether the protected-agent gate is enabled. Default: true.
+    /// Set to false to disable in development.
+    #[serde(default = "default_protected_agents_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for ProtectedAgentsConfig {
+    fn default() -> Self {
+        Self {
+            agents: Vec::new(),
+            enabled: default_protected_agents_enabled(),
+        }
+    }
+}
+
+fn default_protected_agents_enabled() -> bool {
+    true
+}
 
 /// A system agent declaration for gateway-managed background execution.
 ///
@@ -1498,6 +1544,7 @@ impl Default for GatewayConfig {
             trust_unsigned_bundles: false,
             approval_dwell_multiplier: default_approval_dwell_multiplier(),
             sentinel: SentinelConfig::default(),
+            protected_agents: ProtectedAgentsConfig::default(),
         }
     }
 }

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -423,3 +423,15 @@ llm_preset_mapping:
 #     schedule: "0 */4 * * *"
 #     message: "Run evolution analysis cycle"
 #     enabled: true
+
+# ── Protected Agents (issue #21) ───────────────────────────────────────
+# Critical agents whose promotion requires eval-run evidence.
+# A regressed agent-factory cannot silently replace itself without
+# passing an independent eval suite first.
+#
+# protected_agents:
+#   enabled: true
+#   agents:
+#     - agent-factory.default
+#     - specialized_builder.default
+#     - evolution-orchestrator.default

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -164,6 +164,56 @@ See `docs/response-validation-gate.md` for implementation details and `docs/iter
 
 ---
 
+## Protected Agents
+
+Controls the protected-agent promotion gate (issue #21). Agents listed here
+require a passed eval run (`required_eval_run_id`) before programmatic
+promotion via `agent_revision_promote` is allowed. This closes the
+recursive-trust problem: a regressed agent-factory cannot silently replace
+itself without independent verification.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `protected_agents.enabled` | bool | `true` | Enable the protected-agent gate. Set to `false` to disable in development. |
+| `protected_agents.agents` | list\<string\> | `[]` | Agent IDs that require eval evidence for promotion. |
+
+The gate fires after the standard capability-delta and artifact promotion
+gates but before the sentinel gate. When a protected agent is promoted:
+
+1. `required_eval_run_id` must be provided and must reference a **passed**
+   eval run targeting the exact revision being promoted.
+2. The standard capability-delta gate (R++2) still fires for any broadening.
+3. The sentinel pre-promotion gate still fires (if enabled).
+
+When the gate blocks promotion, the error response includes:
+- `error: "protected_agent_requires_eval_run"` — identifies the gate
+- `protected_agent` — the agent ID
+- `repair_hint` — how to satisfy the gate
+
+Example:
+
+```yaml
+protected_agents:
+  enabled: true
+  agents:
+    - agent-factory.default
+    - specialized_builder.default
+    - evolution-orchestrator.default
+```
+
+For manual recovery of a protected agent (e.g. when the eval suite is
+unavailable), use the CLI:
+
+```bash
+# Direct alias pin bypasses the programmatic gate
+autonoetic agent revision rollback agent-factory.default
+autonoetic agent revision promote <rev-id> --alias agent-factory.default
+```
+
+See `docs/protected-agents.md` for the full manual recovery procedure.
+
+---
+
 ## Revision Promotion Approval
 
 Controls when `agent_revision_promote` requires human approval before proceeding. The gateway gates high-risk promotions (bundles with broad capabilities or detected remote access) the same way it previously gated `agent.install`.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -202,12 +202,14 @@ protected_agents:
 ```
 
 For manual recovery of a protected agent (e.g. when the eval suite is
-unavailable), use the CLI:
+unavailable), use the CLI escape hatch:
 
 ```bash
-# Direct alias pin bypasses the programmatic gate
+# Rollback to previous revision (bypasses eval gate)
 autonoetic agent revision rollback agent-factory.default
-autonoetic agent revision promote <rev-id> --alias agent-factory.default
+
+# Or: seed a specific revision directly (bypasses all gates)
+autonoetic agent seed agent-factory.default <revision-id> --reason "manual recovery"
 ```
 
 See `docs/protected-agents.md` for the full manual recovery procedure.

--- a/docs/protected-agents.md
+++ b/docs/protected-agents.md
@@ -1,0 +1,166 @@
+# Protected Agents & Manual Recovery
+
+This document covers two safety mechanisms for critical agents:
+
+1. **Protected-agent promotion gate** — mechanical eval-run requirement for programmatic promotion
+2. **Manual bootstrap recovery** — the operator procedure when the normal pipeline is untrusted
+
+## The Recursive Trust Problem
+
+`agent-factory.default` is the canonical path for creating and evolving agents. The pipeline is:
+
+```
+planner → agent-factory → specialized_builder → agent_revision_promote
+```
+
+This pipeline cannot be used to improve agent-factory itself without a circular trust dependency: a regressed agent-factory is exactly the agent that cannot be trusted to fix itself.
+
+The same problem applies to other evolution-tier agents: `specialized_builder.default`, `evolution-orchestrator.default`, `memory-curator.default`, `evolution-steward.default`.
+
+## Protected-Agent Promotion Gate
+
+### How It Works
+
+The gateway enforces a mechanical gate for agents listed in `protected_agents`:
+
+```yaml
+protected_agents:
+  enabled: true
+  agents:
+    - agent-factory.default
+    - specialized_builder.default
+    - evolution-orchestrator.default
+```
+
+When a protected agent is promoted via `agent_revision_promote`:
+
+1. **Eval evidence required**: `required_eval_run_id` must be provided and must reference a **passed** eval run for the exact revision being promoted.
+2. **Standard gates still fire**: capability-delta (R++2), artifact promotion, sentinel pre-promotion gate.
+3. **No eval run = blocked**: the tool returns `protected_agent_requires_eval_run` with a repair hint.
+
+### Disabling the Gate
+
+For development environments, set `protected_agents.enabled: false` or omit agents from the list. The gate is opt-in per agent ID.
+
+## Manual Bootstrap Recovery
+
+When the normal pipeline is untrusted (agent-factory regressed, eval suite unavailable, or the gateway is in emergency stop), operators can bypass the programmatic path and directly manipulate the agent revision system.
+
+### When to Use This Procedure
+
+- Agent-factory produces broken agents after a SKILL.md change
+- The evolution pipeline is stuck in a failure loop
+- The eval suite is unavailable and you need to restore a known-good agent
+- Emergency stop was triggered and you need to restore critical agents
+
+### Prerequisites
+
+- CLI access on the gateway machine
+- The known-good SKILL.md content (from git history, backup, or manual edit)
+- Gateway must be running (or startable)
+
+### Step-by-Step Procedure
+
+#### 1. Identify the known-good revision
+
+```bash
+# List revision history for the agent
+autonoetic agent revision list agent-factory.default
+
+# Inspect the currently-active revision
+autonoetic agent revision inspect agent-factory.default
+```
+
+If the current revision is broken, find the previous one from the promotion history. Each promotion records the previous revision ID.
+
+#### 2. Rollback to the known-good revision
+
+```bash
+# Rollback to the immediately previous revision
+autonoetic agent revision rollback agent-factory.default
+
+# Or rollback to a specific known-good revision
+autonoetic agent revision rollback agent-factory.default --to <revision-id>
+```
+
+Rollback is the **preferred path** — it's atomic, reversible, and recorded in the causal chain.
+
+#### 3. If rollback is insufficient: direct edit + revision create
+
+If the agent needs changes (not just a rollback), edit the SKILL.md directly:
+
+```bash
+# 1. Edit the agent's SKILL.md directly
+vim agents/evolution/agent-factory.default/SKILL.md
+
+# 2. Re-bootstrap the agent (creates a new revision from the edited files)
+autonoetic agent bootstrap --agent-id agent-factory.default
+
+# 3. The new revision is auto-promoted to active
+```
+
+`agent bootstrap` computes the content digest, creates a revision record, signs it with the gateway identity key, and atomically promotes it — bypassing the eval-run requirement since it's a CLI-initiated operation.
+
+#### 4. If bootstrap is unavailable: manual revision creation
+
+In extreme cases (broken `bootstrap` command, corrupted store):
+
+```bash
+# 1. Edit the SKILL.md
+vim agents/evolution/agent-factory.default/SKILL.md
+
+# 2. Create a revision from the agent directory
+autonoetic agent revision create \
+  --agent-id agent-factory.default \
+  --from-dir agents/evolution/agent-factory.default
+
+# 3. Promote (CLI does not enforce the protected-agent gate)
+autonoetic agent revision promote <new-revision-id> --alias agent-factory.default
+```
+
+The CLI `revision promote` command does **not** enforce the protected-agent eval gate — it's a direct operator action, equivalent to the manual alias pin.
+
+#### 5. Verify the fix
+
+```bash
+# Test the restored agent with a simple task
+autonoetic agent spawn agent-factory.default --message "List your capabilities"
+
+# Check the alias points to the right revision
+autonoetic agent revision inspect agent-factory.default
+```
+
+### Warnings
+
+- **Never edit files in `.gateway/revisions/` directly**. Always use the CLI commands. The content-addressed store computes digests from file contents; editing files in place corrupts the digest chain.
+- **Record the reason**. Always pass `--reason` to rollback/promote commands so the causal chain documents why the recovery happened.
+- **Test before trusting**. After recovery, run a simple task through the restored agent before resuming normal operations.
+- **Re-enable the protected-agent gate** after recovery if you disabled it.
+
+### Recovery from Complete Gateway Failure
+
+If the gateway itself cannot start:
+
+1. The agent data is in `<agents_dir>/.gateway/` — this directory is self-contained (SQLite store + revision files).
+2. Back up `.gateway/` before any manual intervention.
+3. Start the gateway with a minimal config pointing to the same `agents_dir`.
+4. Follow the procedure above.
+
+## Protected Agents in the Evolution Pipeline
+
+The evolution-orchestrator already maintains an **exempt agents** list that prevents the automated evolution pipeline from modifying critical agents:
+
+```
+planner.default, coder.default, evaluator.default, auditor.default,
+specialized_builder.default, agent-factory.default,
+evolution-orchestrator.default, memory-curator.default,
+evolution-steward.default, agent-adapter.default
+```
+
+This list is enforced by the orchestrator's instructions (not gateway code). The protected-agent gate provides a **mechanical** backstop: even if the exempt list is bypassed, the eval-run requirement blocks silent promotion.
+
+## Future Work
+
+- **Golden eval suites**: Pre-defined eval suites for each protected agent that serve as the canonical regression test. Any new revision must pass the golden suite.
+- **Factory of last resort**: A minimal, frozen, gateway-shipped creator that can rebuild any specialist including agent-factory itself. Never runs in normal operation; activated only when the normal pipeline is untrusted.
+- **Per-agent protected config**: Override eval suite requirements, minimum pass thresholds, and rollback targets per protected agent.

--- a/docs/protected-agents.md
+++ b/docs/protected-agents.md
@@ -85,40 +85,43 @@ autonoetic agent revision rollback agent-factory.default --to <revision-id>
 
 Rollback is the **preferred path** — it's atomic, reversible, and recorded in the causal chain.
 
-#### 3. If rollback is insufficient: direct edit + revision create
+#### 3. If rollback is insufficient: direct edit + bootstrap
 
 If the agent needs changes (not just a rollback), edit the SKILL.md directly:
 
 ```bash
 # 1. Edit the agent's SKILL.md directly
-vim agents/evolution/agent-factory.default/SKILL.md
+#    The path is relative to config.agents_dir (e.g. ./agents/agent-factory.default/SKILL.md)
+vim agents/agent-factory.default/SKILL.md
 
 # 2. Re-bootstrap the agent (creates a new revision from the edited files)
-autonoetic agent bootstrap --agent-id agent-factory.default
+autonoetic agent bootstrap
 
 # 3. The new revision is auto-promoted to active
 ```
 
-`agent bootstrap` computes the content digest, creates a revision record, signs it with the gateway identity key, and atomically promotes it — bypassing the eval-run requirement since it's a CLI-initiated operation.
+`agent bootstrap` scans all agent directories under `agents_dir`, computes content digests, creates revision records, signs them with the gateway identity key, and atomically promotes them — bypassing the eval-run requirement since it's a CLI-initiated operation.
 
-#### 4. If bootstrap is unavailable: manual revision creation
+#### 4. If bootstrap is unavailable: seed a known-good revision
 
-In extreme cases (broken `bootstrap` command, corrupted store):
+In extreme cases (broken `bootstrap` command, corrupted store), use `agent seed` to
+directly move the alias to a specific revision. This bypasses all gates including the
+protected-agent eval gate:
 
 ```bash
-# 1. Edit the SKILL.md
-vim agents/evolution/agent-factory.default/SKILL.md
+# 1. Find a known-good revision ID (from promotion history or git)
+autonoetic agent alias --agent-id agent-factory.default
 
-# 2. Create a revision from the agent directory
-autonoetic agent revision create \
-  --agent-id agent-factory.default \
-  --from-dir agents/evolution/agent-factory.default
+# 2. Seed the alias directly to that revision (bypasses all gates)
+autonoetic agent seed agent-factory.default <revision-id> --reason "manual recovery: agent-factory regression"
 
-# 3. Promote (CLI does not enforce the protected-agent gate)
-autonoetic agent revision promote <new-revision-id> --alias agent-factory.default
+# Or: create a fresh revision from an artifact, then seed
+autonoetic agent revision create agent-factory.default <artifact-id>
+autonoetic agent seed agent-factory.default <new-revision-id> --reason "manual recovery"
 ```
 
-The CLI `revision promote` command does **not** enforce the protected-agent eval gate — it's a direct operator action, equivalent to the manual alias pin.
+`agent seed` calls `store.atomic_promote()` directly — it is the operator-level escape hatch
+that bypasses the protected-agent eval gate, capability-delta gate, and sentinel gate.
 
 #### 5. Verify the fix
 


### PR DESCRIPTION
Closes #21.

## Summary

Implements options (1) and (2) from the issue proposal.

**Option 1: Manual bootstrap recovery path**
- docs/protected-agents.md — complete operator procedure for recovering a regressed agent-factory, including rollback, direct edit + bootstrap, and manual revision creation paths

**Option 2: CI-style promotion gate**
- ProtectedAgentsConfig in config.rs — configurable list of protected agent IDs
- Protected-agent gate in agent_revision_promote — blocks programmatic promotion without a passed eval run
- CLI revision promote is not gated (operator action)
- Standard capability-delta, artifact, and sentinel gates still fire

## Files Changed

- autonoetic-types/src/config.rs — ProtectedAgentsConfig struct + gateway field
- autonoetic-gateway/src/runtime/tools/agent_revision.rs — protected-agent gate
- config/config-template.yaml — commented-out protected_agents section
- docs/config-reference.md — documented new config fields
- docs/protected-agents.md — manual recovery procedure
- autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs — 6 tests

## Tests

All 6 tests pass: blocked without eval, proceeds with passed eval, non-protected not gated, gate disabled allows promotion, failed eval blocked, wrong revision blocked.