### PR TITLE
fix(sentinel): tighten high-entropy-hex FP and require attack-pattern anchors

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/security_redteam.rs
+++ b/autonoetic-gateway/src/runtime/tools/security_redteam.rs
@@ -115,6 +115,15 @@ impl NativeTool for AttackPatternProposeTool {
             "evidence_anchors must be a JSON array"
         );
         anyhow::ensure!(
+            args.evidence_anchors
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false),
+            "evidence_anchors must be a non-empty JSON array — \
+             a proposed pattern without anchors is not testable. \
+             Cite causal_event IDs, skill_md digests, or artifact IDs the sentinel should look at."
+        );
+        anyhow::ensure!(
             args.synthetic_test_case.is_object(),
             "synthetic_test_case must be a JSON object"
         );

--- a/autonoetic-gateway/src/runtime/tools/security_redteam.rs
+++ b/autonoetic-gateway/src/runtime/tools/security_redteam.rs
@@ -77,8 +77,10 @@ impl NativeTool for AttackPatternProposeTool {
                     "evidence_anchors": {
                         "type": "array",
                         "description": "Evidence anchors (causal_event IDs, skill_md digests, etc.) \
-                            the sentinel should look for when this pattern is present.",
-                        "items": { "type": "object" }
+                            the sentinel should look for when this pattern is present. \
+                            Must be non-empty — a proposal without anchors is not testable.",
+                        "items": { "type": "object" },
+                        "minItems": 1
                     },
                     "synthetic_test_case": {
                         "type": "object",

--- a/autonoetic-gateway/src/sentinel/checks/credential.rs
+++ b/autonoetic-gateway/src/sentinel/checks/credential.rs
@@ -97,28 +97,46 @@ pub fn scan_credential_leaks(
     let mut findings = Vec::new();
     for row in rows {
         if let Some((pattern_name, match_len)) = detect_credential(&row.payload) {
-            // `high_entropy_hex` is a heuristic and lands at Warning so it can
-            // never single-handedly block a promotion via the sentinel gate.
-            // All other patterns (specific key formats, bearer tokens) stay at
-            // Critical because the regex shape is highly specific.
-            let severity = if pattern_name == "high_entropy_hex" {
+            // `high_entropy_hex` is a heuristic — its regex matches any 64+
+            // hex string (sha256, AES-256 keys, but also legitimate digests).
+            // It lands at Warning so it cannot single-handedly block a
+            // promotion via the sentinel gate, and its remediation message
+            // calls for verification first rather than immediate rotation.
+            // All other patterns (specific key formats, bearer tokens) stay
+            // at Critical because the regex shape is highly specific to a
+            // known credential format.
+            let is_heuristic = pattern_name == "high_entropy_hex";
+            let severity = if is_heuristic {
                 FindingSeverity::Warning
             } else {
                 FindingSeverity::Critical
             };
-            let confidence = if pattern_name == "high_entropy_hex" { 0.6 } else { 1.0 };
+            let confidence = if is_heuristic { 0.6 } else { 1.0 };
+            let remediation = if is_heuristic {
+                format!(
+                    "Heuristic credential pattern '{}' matched in causal event payload \
+                     (match length: {} chars). This regex matches any high-entropy hex \
+                     string and may be a legitimate sha256 digest, content hash, or \
+                     symmetric key in transit. Investigate via the evidence anchor: \
+                     retrieve the event, identify the matched value, and rotate only \
+                     if it is a real secret. Mark as false_positive otherwise.",
+                    pattern_name, match_len
+                )
+            } else {
+                format!(
+                    "Credential pattern '{}' matched in causal event payload \
+                     (match length: {} chars). The regex shape is specific to a known \
+                     credential format. Rotate any matching credential immediately. \
+                     Use the evidence anchor to retrieve the event under controlled access.",
+                    pattern_name, match_len
+                )
+            };
             let finding = SecurityFinding::new(
                 FindingType::CredentialLeak,
                 severity,
                 confidence,
                 Reproducibility::Deterministic,
-                format!(
-                    "Credential pattern '{}' matched in causal event payload \
-                     (match length: {} chars). Rotate any matching credential \
-                     immediately. Use the evidence anchor to retrieve the event \
-                     under controlled access.",
-                    pattern_name, match_len
-                ),
+                remediation,
                 sentinel_revision_id,
             )
             .with_affected(AffectedEntities {

--- a/autonoetic-gateway/src/sentinel/checks/credential.rs
+++ b/autonoetic-gateway/src/sentinel/checks/credential.rs
@@ -30,9 +30,14 @@ static GITHUB_PAT_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\bgh[poshpr]_[A-Za-z0-9]{36}\b").expect("valid github pat regex")
 });
 
-/// Generic high-entropy hex string (≥ 32 hex chars) — potential raw secret.
+/// Generic high-entropy hex string (≥ 64 hex chars = 256 bits) — potential raw secret.
+///
+/// The lower bound is 64 specifically to exclude git SHAs (40 hex chars) and other
+/// 40-char content digests that are routinely embedded in causal-event payloads.
+/// 64+ hex characters indicate sha256 / 256-bit symmetric keys / similar — the
+/// regime where false positives drop sharply.
 static HIGH_ENTROPY_HEX_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\b[a-fA-F0-9]{32,}\b").expect("valid high-entropy hex regex")
+    Regex::new(r"\b[a-fA-F0-9]{64,}\b").expect("valid high-entropy hex regex")
 });
 
 /// Bearer token still present in payload.
@@ -92,10 +97,20 @@ pub fn scan_credential_leaks(
     let mut findings = Vec::new();
     for row in rows {
         if let Some((pattern_name, match_len)) = detect_credential(&row.payload) {
+            // `high_entropy_hex` is a heuristic and lands at Warning so it can
+            // never single-handedly block a promotion via the sentinel gate.
+            // All other patterns (specific key formats, bearer tokens) stay at
+            // Critical because the regex shape is highly specific.
+            let severity = if pattern_name == "high_entropy_hex" {
+                FindingSeverity::Warning
+            } else {
+                FindingSeverity::Critical
+            };
+            let confidence = if pattern_name == "high_entropy_hex" { 0.6 } else { 1.0 };
             let finding = SecurityFinding::new(
                 FindingType::CredentialLeak,
-                FindingSeverity::Critical,
-                1.0,
+                severity,
+                confidence,
                 Reproducibility::Deterministic,
                 format!(
                     "Credential pattern '{}' matched in causal event payload \
@@ -141,9 +156,7 @@ fn detect_credential(text: &str) -> Option<(&'static str, usize)> {
         return Some(("bearer_token", m.len()));
     }
     if let Some(m) = HIGH_ENTROPY_HEX_RE.find(text) {
-        if m.len() >= 40 {
-            return Some(("high_entropy_hex", m.len()));
-        }
+        return Some(("high_entropy_hex", m.len()));
     }
     None
 }
@@ -202,5 +215,42 @@ mod tests {
         let text = "hash: deadbeef";
         let result = detect_credential(text);
         assert!(result.is_none(), "short hex should not be flagged");
+    }
+
+    #[test]
+    fn no_false_positive_on_git_sha() {
+        // Git SHAs are 40 hex chars and appear constantly in causal-event payloads
+        // (commit refs, content digests, artifact IDs). They must not be flagged.
+        let text = "Updated to commit a1b2c3d4e5f67890123456789012345678901234";
+        let result = detect_credential(text);
+        assert!(
+            result.is_none(),
+            "git SHA (40 hex chars) must not match high_entropy_hex"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_on_short_sha256_truncation() {
+        // Some tools truncate sha256 to 40, 48, or 56 hex chars in display output.
+        // None of those should trigger high_entropy_hex (threshold is 64).
+        for len in [40, 48, 56, 63] {
+            let hex: String = "a".repeat(len);
+            let result = detect_credential(&format!("digest: {}", hex));
+            assert!(
+                result.is_none(),
+                "{}-char hex string must not match high_entropy_hex",
+                len
+            );
+        }
+    }
+
+    #[test]
+    fn detects_full_sha256_as_high_entropy_hex() {
+        // 64 hex chars = sha256, the legitimate detection target.
+        let hex: String = "a".repeat(64);
+        let text = format!("raw secret: {}", hex);
+        let (name, len) = detect_credential(&text).expect("64-char hex must be flagged");
+        assert_eq!(name, "high_entropy_hex");
+        assert_eq!(len, 64);
     }
 }

--- a/autonoetic-gateway/tests/security_redteam_integration.rs
+++ b/autonoetic-gateway/tests/security_redteam_integration.rs
@@ -157,13 +157,39 @@ fn propose_rejects_unknown_category() {
         "category": "not_a_real_category",
         "description": "desc",
         "how_sentinel_should_catch": "catch",
-        "evidence_anchors": [],
+        "evidence_anchors": [{"type": "causal_event", "id": "evt_abc"}],
         "synthetic_test_case": {}
     }).to_string();
 
     let result = run_propose(store, &manifest, &args);
     let err = result.unwrap_err().to_string();
     assert!(err.contains("Unknown attack pattern category"), "{err}");
+}
+
+// ─── 2b. Rejects empty evidence_anchors ──────────────────────────────────────
+// A proposal without anchors is not testable — the design principle "findings
+// without anchors are opinions" applies here too.
+
+#[test]
+fn propose_rejects_empty_evidence_anchors() {
+    let tmp = TempDir::new().unwrap();
+    let store = open_store(&tmp);
+    let manifest = redteam_manifest("security_redteam.default");
+
+    let args = json!({
+        "category": "credential_leak",
+        "description": "desc",
+        "how_sentinel_should_catch": "catch",
+        "evidence_anchors": [],
+        "synthetic_test_case": {"foo": "bar"}
+    }).to_string();
+
+    let result = run_propose(store, &manifest, &args);
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("evidence_anchors must be a non-empty"),
+        "expected non-empty-anchors rejection, got: {err}"
+    );
 }
 
 // ─── 3. Rejects agent without SecurityRedTeam capability ──────────────────────


### PR DESCRIPTION
## Summary

Two behavioural fixes from the post-merge security review of PRs #140–#149. Companion to the docs-only PR #151.

### G6 — high-entropy-hex false-positive class

The credential scan flagged any 40-char hex string as \`Critical\`. Combined with the promotion gate's \"any critical finding blocks the system\" semantics, a single git SHA in a sandbox payload would block all future promotions until triaged.

- Raise the regex lower bound from \`{32,}\` to \`{64,}\` — git SHAs (40 hex), 48/56-char truncations no longer match. 64 hex = 256 bits, the legitimate detection target.
- Demote \`high_entropy_hex\` findings from \`Critical\` (1.0) to \`Warning\` (0.6) so the heuristic class can never single-handedly block a promotion. Specific-format patterns (anthropic, openai, aws, github_pat, bearer) stay at \`Critical\`.

### G8 — require non-empty \`evidence_anchors\`

\`attack_pattern_propose\` accepted \`evidence_anchors: []\`, contradicting the design principle that \"findings without anchors are opinions.\" Add a non-empty check with a remediation message that names valid anchor types.

## Test plan

- [x] \`cargo build -p autonoetic-gateway\` clean.
- [x] \`cargo test sentinel::checks::credential\` — 9/9 (4 new: git SHA, truncated SHAs, full sha256).
- [x] \`cargo test --test security_redteam_integration\` — 9/9 (1 new: \`propose_rejects_empty_evidence_anchors\`).
- [x] \`cargo test --test security_sentinel_integration\` — 31/31, no regressions.

## Follow-ups not in this PR

- **G1** — frozen-baseline reification (separate version-pinned baseline module).
- **G4** — \`ViewerClass\` redaction unit tests in \`autonoetic-types\`.
- **G7** — per-agent scoping for the promotion gate (currently full-store).
- **G10** — replace the \`redact_json_string\` substring fallback with \`log_redaction::redact_text_for_logs\`.
- **G11** — observability-redaction architectural doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)