### PR TITLE
test(types): unit-test ViewerClass redaction surface (closes #154)

### DIFF
--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -895,3 +895,311 @@ pub struct SessionApprovalGrant {
     pub expires_at: Option<String>,
     pub targets: Vec<GrantTarget>,
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for `ScheduledAction::redact_for_viewer`.
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+    use crate::disclosure::ViewerClass;
+    use std::collections::HashMap;
+
+    /// Substrings that must never appear in any field of an Agent-class
+    /// redaction output. Same vocabulary as the causal_chain tests.
+    const SECRET_TOKENS: &[&str] = &[
+        "Bearer eyJhbGc",
+        "sk-test-12345",
+        "AKIAIOSFODNN",
+        "ghp_realtoken",
+        "-----BEGIN PRIVATE KEY-----",
+        "PASSWORD=hunter2",
+        "verysecret",
+    ];
+
+    fn blob_for(action: &ScheduledAction, viewer: ViewerClass) -> String {
+        let r = action.redact_for_viewer(viewer);
+        serde_json::to_string(&r).unwrap_or_default()
+    }
+
+    fn credential_request_with_secrets() -> ScheduledAction {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".into(), "Bearer eyJhbGc.foo.bar".into());
+        headers.insert("X-Custom".into(), "ordinary".into());
+        ScheduledAction::CredentialRequest {
+            credential_id: "github_token".into(),
+            url: "https://api.github.com/user".into(),
+            method: Some("GET".into()),
+            headers: Some(headers),
+            body: Some(serde_json::json!({
+                "client_secret": "verysecret",
+                "scope": "read:user",
+            })),
+            inject_secret_as: Some("Authorization".into()),
+            payload: Some(serde_json::json!({
+                "api_key": "sk-test-12345abcdefghij",
+                "ok": true,
+            })),
+        }
+    }
+
+    /// SandboxExec fixture with a benign command — used by the property test.
+    /// SandboxExec with a secret-bearing command is covered separately by
+    /// `agent_viewer_sandbox_exec_command_currently_preserves_secrets` which
+    /// pins the known leak documented in issue #158.
+    fn sandbox_exec_benign() -> ScheduledAction {
+        ScheduledAction::SandboxExec {
+            command: "ls -la /tmp".into(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: Some("evidence_handle_xyz".into()),
+            detected_hosts: Some(vec!["x.example.com".into()]),
+        }
+    }
+
+    fn sandbox_exec_with_secret_bearing_command() -> ScheduledAction {
+        ScheduledAction::SandboxExec {
+            command: "curl -H 'Authorization: Bearer eyJhbGc.foo' https://x".into(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: Some("evidence_handle_xyz".into()),
+            detected_hosts: Some(vec!["x.example.com".into()]),
+        }
+    }
+
+    fn write_file_with_secrets() -> ScheduledAction {
+        ScheduledAction::WriteFile {
+            path: "/tmp/keys.txt".into(),
+            content: "PASSWORD=hunter2\nAKIAIOSFODNN1234567X".into(),
+            requires_approval: true,
+            evidence_ref: Some("evidence_xyz".into()),
+        }
+    }
+
+    fn agent_install_payload() -> ScheduledAction {
+        ScheduledAction::AgentInstall {
+            agent_id: "coder.default".into(),
+            summary: "install coder".into(),
+            requested_by_agent_id: "planner.default".into(),
+            install_fingerprint: "fp_abc".into(),
+            payload: Some(serde_json::json!({
+                "secret_token": "verysecret",
+                "ok": true,
+            })),
+        }
+    }
+
+    // ── Admin: identity ──────────────────────────────────────────────────
+
+    #[test]
+    fn admin_viewer_round_trips_credential_request() {
+        let original = credential_request_with_secrets();
+        let r = original.redact_for_viewer(ViewerClass::Admin);
+        // Compare via JSON: PartialEq on ScheduledAction is derived but
+        // HashMap equality is order-independent, so JSON is the safest check.
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            serde_json::to_value(&original).unwrap(),
+        );
+    }
+
+    #[test]
+    fn admin_viewer_round_trips_sandbox_exec() {
+        let original = sandbox_exec_benign();
+        let r = original.redact_for_viewer(ViewerClass::Admin);
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            serde_json::to_value(&original).unwrap(),
+        );
+    }
+
+    #[test]
+    fn admin_viewer_round_trips_write_file() {
+        let original = write_file_with_secrets();
+        let r = original.redact_for_viewer(ViewerClass::Admin);
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            serde_json::to_value(&original).unwrap(),
+        );
+    }
+
+    // ── Agent: maximum redaction ─────────────────────────────────────────
+
+    #[test]
+    fn agent_viewer_credential_request_strips_headers_body_payload() {
+        let r = credential_request_with_secrets().redact_for_viewer(ViewerClass::Agent);
+        match r {
+            ScheduledAction::CredentialRequest {
+                credential_id,
+                url,
+                method,
+                headers,
+                body,
+                inject_secret_as,
+                payload,
+            } => {
+                // Identifying / structural fields preserved.
+                assert_eq!(credential_id, "github_token");
+                assert_eq!(url, "https://api.github.com/user");
+                assert_eq!(method.as_deref(), Some("GET"));
+                // Headers blanked to an empty map; body / payload / inject blanked.
+                assert!(headers.unwrap().is_empty(), "headers must be empty for Agent");
+                assert!(body.is_none(), "body must be None for Agent");
+                assert!(payload.is_none(), "payload must be None for Agent");
+                assert!(inject_secret_as.is_none(), "inject_secret_as must be None for Agent");
+            }
+            other => panic!("expected CredentialRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_viewer_sandbox_exec_clears_evidence_ref() {
+        let r = sandbox_exec_benign().redact_for_viewer(ViewerClass::Agent);
+        match r {
+            ScheduledAction::SandboxExec {
+                command,
+                evidence_ref,
+                detected_hosts,
+                requires_approval,
+                ..
+            } => {
+                // Command stays visible to the Agent class — see issue #158
+                // for the open question on whether this is correct.
+                assert!(command.contains("ls"));
+                // Evidence ref is cleared (would resolve to a content-store blob).
+                assert_eq!(evidence_ref, None);
+                // Detected hosts and approval flag preserved.
+                assert!(detected_hosts.is_some());
+                assert!(requires_approval);
+            }
+            other => panic!("expected SandboxExec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_viewer_sandbox_exec_command_currently_preserves_secrets() {
+        // KNOWN GAP (#158): SandboxExec.command is preserved verbatim for
+        // ViewerClass::Agent, so a command embedding a Bearer token, AWS key,
+        // or similar leaks to agent-class consumers (e.g. an approver agent
+        // looking at approval_summary). This pin documents the current
+        // behaviour. When #158 is fixed, this test FLIPS — assert the secret
+        // is NOT in the redacted command — and the SandboxExec fixture is
+        // re-included in `agent_viewer_no_secrets_leak_property`.
+        let r =
+            sandbox_exec_with_secret_bearing_command().redact_for_viewer(ViewerClass::Agent);
+        match r {
+            ScheduledAction::SandboxExec { command, .. } => {
+                assert!(
+                    command.contains("Bearer eyJhbGc"),
+                    "regression: SandboxExec.command no longer leaks the bearer token \
+                     for ViewerClass::Agent — flip this assertion and close issue #158"
+                );
+            }
+            other => panic!("expected SandboxExec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_viewer_write_file_redacts_content_only() {
+        let r = write_file_with_secrets().redact_for_viewer(ViewerClass::Agent);
+        match r {
+            ScheduledAction::WriteFile {
+                path,
+                content,
+                requires_approval,
+                evidence_ref,
+            } => {
+                // Path is visible (operationally needed); content is redacted;
+                // evidence_ref cleared.
+                assert_eq!(path, "/tmp/keys.txt");
+                assert_eq!(content, "***REDACTED***");
+                assert!(requires_approval);
+                assert_eq!(evidence_ref, None);
+            }
+            other => panic!("expected WriteFile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_viewer_falls_through_for_agent_install_today() {
+        // Variants without explicit redaction in `redact_for_agent` fall through
+        // to `other.clone()`. AgentInstall is one of them today; this pin will
+        // FAIL if a future change exposes secrets via that path without explicit
+        // handling, prompting the author to add a redact arm.
+        let original = agent_install_payload();
+        let r = original.redact_for_viewer(ViewerClass::Agent);
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            serde_json::to_value(&original).unwrap(),
+            "AgentInstall currently falls through unmodified — when this pin breaks, \
+             explicitly redact the variant in ScheduledAction::redact_for_agent \
+             rather than weakening the test"
+        );
+    }
+
+    // ── Operator: targeted redaction in CredentialRequest ────────────────
+
+    #[test]
+    fn operator_viewer_credential_request_redacts_sensitive_headers() {
+        let r = credential_request_with_secrets().redact_for_viewer(ViewerClass::Operator);
+        match r {
+            ScheduledAction::CredentialRequest {
+                headers, body, payload, ..
+            } => {
+                let headers = headers.expect("headers preserved structurally");
+                assert_eq!(
+                    headers.get("Authorization").map(|s| s.as_str()),
+                    Some("***REDACTED***"),
+                    "Authorization header must be redacted for Operator"
+                );
+                assert_eq!(
+                    headers.get("X-Custom").map(|s| s.as_str()),
+                    Some("ordinary"),
+                    "non-sensitive header must survive: {headers:?}"
+                );
+                let body = body.expect("body preserved structurally");
+                assert_eq!(body["client_secret"], "***REDACTED***");
+                assert_eq!(body["scope"], "read:user");
+                let payload = payload.expect("payload preserved structurally");
+                assert_eq!(payload["api_key"], "***REDACTED***");
+                assert_eq!(payload["ok"], true);
+            }
+            other => panic!("expected CredentialRequest, got {other:?}"),
+        }
+    }
+
+    // ── Property: no secrets leak via Agent class ────────────────────────
+
+    #[test]
+    fn agent_viewer_no_secrets_leak_property() {
+        // SandboxExec is excluded from this assertion until issue #158 lands —
+        // its command field currently leaks. AgentInstall is excluded because
+        // it falls through unmodified today (pinned separately above).
+        let actions = [
+            credential_request_with_secrets(),
+            sandbox_exec_benign(), // benign command — exercises non-command fields only
+            write_file_with_secrets(),
+        ];
+        for action in actions.iter() {
+            let blob = blob_for(action, ViewerClass::Agent);
+            for token in SECRET_TOKENS {
+                assert!(
+                    !blob.contains(token),
+                    "Agent-class redacted {action:?} must not contain '{token}'\nblob: {blob}"
+                );
+            }
+        }
+    }
+
+    // ── Helper visibility ────────────────────────────────────────────────
+
+    #[test]
+    fn looks_like_secret_value_recognises_documented_patterns() {
+        assert!(looks_like_secret_value("Bearer eyJhbGc.foo"));
+        assert!(looks_like_secret_value("sk-abc12345"));
+        assert!(looks_like_secret_value("-----BEGIN RSA PRIVATE KEY-----"));
+        assert!(!looks_like_secret_value("plain text"));
+        assert!(!looks_like_secret_value(""));
+        assert!(!looks_like_secret_value("   "));
+    }
+}

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -314,3 +314,328 @@ pub struct PublishedSessionReportRecord {
     pub generated_at: String,
     pub report_version: i32,
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for `redact_for_viewer` on ExecutionTraceRecord and CausalEventRecord.
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+    use crate::disclosure::ViewerClass;
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// Substrings that must never appear in any field of an `Agent`-class
+    /// redaction output. Used by property-style assertions.
+    const SECRET_TOKENS: &[&str] = &[
+        "Bearer eyJhbGc",
+        "sk-test-12345",
+        "sk-ant-secret",
+        "AKIAIOSFODNN",
+        "ghp_realtoken",
+        "-----BEGIN PRIVATE KEY-----",
+        "PASSWORD=hunter2",
+        "api_key=verysecret",
+    ];
+
+    /// A trace fixture stuffed with every secret-bearing string we care about.
+    fn trace_with_secrets() -> ExecutionTraceRecord {
+        ExecutionTraceRecord {
+            trace_id: "trc_001".into(),
+            event_id: Some("evt_001".into()),
+            agent_id: "coder.default".into(),
+            session_id: "sess_001".into(),
+            turn_id: Some("turn_001".into()),
+            timestamp: "2026-05-08T12:00:00Z".into(),
+            tool_name: "sandbox_exec".into(),
+            command: Some("curl -H 'Authorization: Bearer eyJhbGc.foo.bar' https://api".into()),
+            exit_code: Some(0),
+            stdout: Some("PASSWORD=hunter2 was set".into()),
+            stderr: Some("warning: -----BEGIN PRIVATE KEY----- detected".into()),
+            duration_ms: 42,
+            success: 1,
+            error_type: None,
+            error_summary: Some("benign error message".into()),
+            approval_required: Some(0),
+            approval_request_id: None,
+            arguments: Some(
+                r#"{"token":"sk-test-12345abcdefghij","host":"github.com"}"#.into(),
+            ),
+            result: Some(
+                r#"{"api_key":"verysecret","ok":true,"items":["a","b"]}"#.into(),
+            ),
+        }
+    }
+
+    /// A causal-event fixture stuffed with every secret-bearing string we care about.
+    fn event_with_secrets() -> CausalEventRecord {
+        CausalEventRecord {
+            event_id: "evt_001".into(),
+            agent_id: "coder.default".into(),
+            session_id: "sess_001".into(),
+            turn_id: Some("turn_001".into()),
+            event_seq: 7,
+            timestamp: "2026-05-08T12:00:00Z".into(),
+            category: "tool".into(),
+            action: "sandbox_exec".into(),
+            status: "SUCCESS".into(),
+            enforced_rules: vec!["R+++3".into()],
+            target: Some("api.github.com".into()),
+            payload: Some(
+                r#"{"authorization":"Bearer eyJhbGc.foo.bar","user_id":42}"#.into(),
+            ),
+            payload_ref: Some("artifact_handle_xyz".into()),
+            evidence_ref: Some("evidence_xyz".into()),
+            reason: Some("contains AKIAIOSFODNN1234567 in error".into()),
+        }
+    }
+
+    /// Stringify a record's redacted form into a single blob for property
+    /// assertions — any secret leaking into any field will show up here.
+    fn trace_blob_for(record: &ExecutionTraceRecord, viewer: ViewerClass) -> String {
+        let r = record.redact_for_viewer(viewer);
+        serde_json::to_string(&r).unwrap_or_default()
+    }
+
+    fn event_blob_for(record: &CausalEventRecord, viewer: ViewerClass) -> String {
+        let r = record.redact_for_viewer(viewer);
+        serde_json::to_string(&r).unwrap_or_default()
+    }
+
+    // ── ExecutionTraceRecord ─────────────────────────────────────────────
+
+    #[test]
+    fn trace_admin_viewer_round_trips() {
+        let original = trace_with_secrets();
+        let redacted = original.redact_for_viewer(ViewerClass::Admin);
+        // Every field must equal the original — Admin is identity.
+        assert_eq!(redacted.command, original.command);
+        assert_eq!(redacted.stdout, original.stdout);
+        assert_eq!(redacted.stderr, original.stderr);
+        assert_eq!(redacted.arguments, original.arguments);
+        assert_eq!(redacted.result, original.result);
+    }
+
+    #[test]
+    fn trace_agent_viewer_blanks_secret_bearing_fields() {
+        let r = trace_with_secrets().redact_for_viewer(ViewerClass::Agent);
+        assert_eq!(r.command.as_deref(), Some("***REDACTED***"));
+        assert_eq!(r.stdout, None);
+        assert_eq!(r.stderr, None);
+        assert_eq!(r.arguments, None);
+        assert_eq!(r.result, None);
+    }
+
+    #[test]
+    fn trace_agent_viewer_preserves_metadata() {
+        let original = trace_with_secrets();
+        let r = original.redact_for_viewer(ViewerClass::Agent);
+        // Structural / metadata fields are visible to the Agent class.
+        assert_eq!(r.trace_id, original.trace_id);
+        assert_eq!(r.agent_id, original.agent_id);
+        assert_eq!(r.session_id, original.session_id);
+        assert_eq!(r.tool_name, original.tool_name);
+        assert_eq!(r.exit_code, original.exit_code);
+        assert_eq!(r.success, original.success);
+        assert_eq!(r.duration_ms, original.duration_ms);
+        assert_eq!(r.error_summary, original.error_summary);
+    }
+
+    #[test]
+    fn trace_operator_viewer_redacts_arguments_and_result_json_secrets() {
+        let r = trace_with_secrets().redact_for_viewer(ViewerClass::Operator);
+        let args = r.arguments.expect("arguments preserved structurally");
+        let result = r.result.expect("result preserved structurally");
+        assert!(
+            !args.contains("sk-test-12345"),
+            "operator must not see openai-style key in arguments: {args}"
+        );
+        assert!(
+            args.contains("github.com"),
+            "operator must keep non-secret arg fields: {args}"
+        );
+        assert!(
+            !result.contains("verysecret"),
+            "operator must not see api_key value in result: {result}"
+        );
+        assert!(
+            result.contains("\"items\""),
+            "operator must keep non-secret result fields: {result}"
+        );
+    }
+
+    #[test]
+    fn trace_command_field_is_visible_to_operator() {
+        // The Operator class shows the command structure (only Agent class
+        // blanks it). This is intentional: operators triage commands;
+        // the redaction layer for command secrets is log_redaction at write time.
+        let original = trace_with_secrets();
+        let r = original.redact_for_viewer(ViewerClass::Operator);
+        assert_eq!(r.command, original.command);
+    }
+
+    #[test]
+    fn trace_agent_viewer_property_no_secrets_leak() {
+        let blob = trace_blob_for(&trace_with_secrets(), ViewerClass::Agent);
+        for token in SECRET_TOKENS {
+            assert!(
+                !blob.contains(token),
+                "Agent-class redacted trace must not contain '{token}' — full blob: {blob}"
+            );
+        }
+    }
+
+    #[test]
+    fn trace_to_json_for_viewer_omits_command_for_agent() {
+        let v = trace_with_secrets().to_json_for_viewer(ViewerClass::Agent);
+        assert_eq!(v["command"].as_str(), Some("***REDACTED***"));
+        assert_eq!(v["stdout"].as_str(), None);
+        assert_eq!(v["stderr"].as_str(), None);
+    }
+
+    // ── CausalEventRecord ────────────────────────────────────────────────
+
+    #[test]
+    fn event_admin_viewer_round_trips() {
+        let original = event_with_secrets();
+        let redacted = original.redact_for_viewer(ViewerClass::Admin);
+        assert_eq!(redacted.payload, original.payload);
+        assert_eq!(redacted.payload_ref, original.payload_ref);
+        assert_eq!(redacted.evidence_ref, original.evidence_ref);
+        assert_eq!(redacted.reason, original.reason);
+    }
+
+    #[test]
+    fn event_agent_viewer_blanks_payload_and_refs() {
+        let r = event_with_secrets().redact_for_viewer(ViewerClass::Agent);
+        assert_eq!(r.payload, None);
+        assert_eq!(r.payload_ref, None);
+        assert_eq!(r.evidence_ref, None);
+        assert_eq!(r.reason, None);
+    }
+
+    #[test]
+    fn event_agent_viewer_preserves_attribution_and_action() {
+        let original = event_with_secrets();
+        let r = original.redact_for_viewer(ViewerClass::Agent);
+        // Attribution and action fields must remain so agents can correlate
+        // their own causal chain; redaction strips only the contents.
+        assert_eq!(r.event_id, original.event_id);
+        assert_eq!(r.agent_id, original.agent_id);
+        assert_eq!(r.session_id, original.session_id);
+        assert_eq!(r.turn_id, original.turn_id);
+        assert_eq!(r.event_seq, original.event_seq);
+        assert_eq!(r.timestamp, original.timestamp);
+        assert_eq!(r.category, original.category);
+        assert_eq!(r.action, original.action);
+        assert_eq!(r.status, original.status);
+        assert_eq!(r.target, original.target);
+        assert_eq!(r.enforced_rules, original.enforced_rules);
+    }
+
+    #[test]
+    fn event_operator_viewer_redacts_payload_keys_and_clears_payload_ref() {
+        // The fix in commit 4ea9df0 (#4): payload_ref must be cleared for
+        // non-Admin viewers because resolving it would expose the underlying
+        // artifact body. This test pins that contract.
+        let r = event_with_secrets().redact_for_viewer(ViewerClass::Operator);
+        let payload = r.payload.expect("payload preserved structurally for Operator");
+        assert!(
+            !payload.contains("Bearer eyJhbGc"),
+            "operator must not see authorization value: {payload}"
+        );
+        assert!(
+            payload.contains("user_id"),
+            "operator must keep non-secret payload keys: {payload}"
+        );
+        assert_eq!(
+            r.payload_ref, None,
+            "payload_ref must be cleared for Operator (issue #4 fix)"
+        );
+    }
+
+    #[test]
+    fn event_agent_viewer_property_no_secrets_leak() {
+        let blob = event_blob_for(&event_with_secrets(), ViewerClass::Agent);
+        for token in SECRET_TOKENS {
+            assert!(
+                !blob.contains(token),
+                "Agent-class redacted event must not contain '{token}' — full blob: {blob}"
+            );
+        }
+    }
+
+    // ── redact_json_string / redact_json_value internals ─────────────────
+
+    #[test]
+    fn redact_json_value_redacts_object_keys_named_like_secrets() {
+        let v = serde_json::json!({
+            "client_secret": "abc",
+            "access_token": "def",
+            "refresh_token": "ghi",
+            "ok": true,
+        });
+        let out = redact_json_value(&v);
+        assert_eq!(out["client_secret"], "***REDACTED***");
+        assert_eq!(out["access_token"], "***REDACTED***");
+        assert_eq!(out["refresh_token"], "***REDACTED***");
+        assert_eq!(out["ok"], true);
+    }
+
+    #[test]
+    fn redact_json_value_redacts_string_values_that_look_like_secrets() {
+        let v = serde_json::json!({
+            "header": "Bearer eyJhbGc.tail",
+            "key_blob": "-----BEGIN RSA PRIVATE KEY-----\nXXX\n-----END RSA PRIVATE KEY-----",
+            "openai_key": "sk-abc123def456ghi789",
+            "innocuous": "tokenizer config",
+        });
+        let out = redact_json_value(&v);
+        assert_eq!(out["header"], "***REDACTED***");
+        assert_eq!(out["key_blob"], "***REDACTED***");
+        assert_eq!(out["openai_key"], "***REDACTED***");
+        // Note: the current implementation over-redacts the substring "token"
+        // via the non-JSON fallback path; tracked in issue #156. This direct
+        // value-path is more precise — the literal "tokenizer config" does NOT
+        // start with sk-, contain bearer, or contain BEGIN, so it survives.
+        assert_eq!(out["innocuous"], "tokenizer config");
+    }
+
+    #[test]
+    fn is_sensitive_key_matches_documented_substrings() {
+        // Underscore-form keys: covered by the substring match.
+        for k in &[
+            "secret",
+            "TOKEN",
+            "user_password",
+            "api_key",
+            "Authorization",
+            "AWS_ACCESS_KEY_ID",
+            "access_token",
+            "refresh_token",
+            "client_secret",
+        ] {
+            assert!(is_sensitive_key(k), "expected sensitive: {k}");
+        }
+        for k in &["user_id", "agent_id", "session_id", "items", "ok"] {
+            assert!(!is_sensitive_key(k), "expected non-sensitive: {k}");
+        }
+    }
+
+    #[test]
+    fn is_sensitive_key_misses_hyphenated_api_key() {
+        // KNOWN GAP: `X-API-Key` (hyphenated) does NOT match — `is_sensitive_key`
+        // looks for `api_key` and `apikey`, neither of which is a substring of
+        // `x-api-key`. Hyphenated `*-Token` names do match (substring `token`)
+        // and hyphenated `*-Authorization`/`*-Password` would match too.
+        // This pin documents the specific gap that should be closed in issue #156.
+        assert!(
+            !is_sensitive_key("X-API-Key"),
+            "regression: X-API-Key is now matched — update both \
+             is_sensitive_key (add 'api-key' substring) and this pin together"
+        );
+        // Counter-cases that already work via existing substrings:
+        assert!(is_sensitive_key("X-Auth-Token"), "contains 'token'");
+        assert!(is_sensitive_key("X-Access-Token"), "contains 'token'");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #154. Adds **27 unit tests** covering \`ExecutionTraceRecord\`, \`CausalEventRecord\`, and \`ScheduledAction\` redaction across all three viewer classes (Admin / Operator / Agent). Before this PR, the \`redact_for_viewer\` surface introduced by #143 had zero unit-test coverage.

### Coverage added

**\`autonoetic-types/src/causal_chain.rs\` (16 tests):**
- \`ExecutionTraceRecord\`: Admin round-trip, Agent blanks command/stdout/stderr/arguments/result, Agent preserves metadata, Operator redacts JSON-key secrets in arguments/result, Operator preserves command, Agent no-secret-leak property, \`to_json_for_viewer\` Agent shape.
- \`CausalEventRecord\`: Admin round-trip, Agent blanks payload/payload_ref/evidence_ref/reason, Agent preserves attribution, Operator redacts payload secret keys and **clears \`payload_ref\` (pins the #4 fix in commit 4ea9df0)**, Agent no-secret-leak property.
- \`redact_json_value\` internals: object-key match, string-value match.
- \`is_sensitive_key\` substrings + a pin documenting the **\`X-API-Key\` hyphen gap** (linked to #156 for fix).

**\`autonoetic-types/src/background.rs\` (11 tests):**
- Admin round-trips for \`CredentialRequest\`, \`SandboxExec\`, \`WriteFile\`.
- Agent class: \`CredentialRequest\` blanks headers/body/payload/inject_secret_as; \`SandboxExec\` clears evidence_ref; \`WriteFile\` redacts content; \`AgentInstall\` fall-through pin (catches future variants forgetting to redact).
- Operator class: \`CredentialRequest\` redacts \`Authorization\` header, \`client_secret\` in body, \`api_key\` in payload, while preserving non-sensitive fields.
- Property: no \`SECRET_TOKENS\` leak via Agent class for the redacting variants.
- \`looks_like_secret_value\` helper coverage.

## Gap surfaced and tracked: issue #158

The property test caught a real leak: **\`ScheduledAction::SandboxExec.command\` is preserved verbatim for \`ViewerClass::Agent\`**. A command embedding a Bearer token, AWS key, or similar leaks to any agent-class consumer of the approval (e.g. an approver agent reading \`approval_summary\`). This contrasts with \`ExecutionTraceRecord\` where commit 7f8525d explicitly redacts \`command\` to \`***REDACTED***\` for the Agent class.

Filed [#158](https://github.com/mandubian/autonoetic/issues/158) for the fix. This PR pins the current (leaky) behaviour in \`agent_viewer_sandbox_exec_command_currently_preserves_secrets\` so the eventual fix mechanically flips the assertion.

## Test plan

- [x] \`cargo test -p autonoetic-types --lib redaction_tests\` → 27/27 green.
- [x] \`cargo build -p autonoetic-types\` → clean.
- [x] \`cargo build -p autonoetic-gateway\` → clean (warnings unchanged from main).
- [ ] Reviewer confirms the \`X-API-Key\` and \`SandboxExec.command\` pins are referencing the right follow-up issues (#156, #158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)