### PR TITLE
refactor(redaction): centralise helpers in autonoetic-types::redaction (closes #156)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "hex",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/autonoetic-gateway/src/log_redaction.rs
+++ b/autonoetic-gateway/src/log_redaction.rs
@@ -15,10 +15,8 @@ use serde_json::Value;
 
 pub use autonoetic_types::redaction::{
     looks_like_secret_collection_prompt, looks_like_secret_value, redact_embedded_secrets,
-    redact_json_value, redact_text_for_logs,
+    redact_json_value, redact_text_for_logs, REDACTED,
 };
-
-const REDACTED: &str = "***REDACTED***";
 
 #[derive(Debug, Clone)]
 pub struct RedactedPayload(Value);

--- a/autonoetic-gateway/src/log_redaction.rs
+++ b/autonoetic-gateway/src/log_redaction.rs
@@ -4,10 +4,19 @@
 //! causal-chain append. Callers must wrap payloads through one of the
 //! constructors; raw `serde_json::Value` cannot be passed to
 //! [`CausalLogger::log`] or [`CausalLogger::log_durable`].
+//!
+//! The redaction primitives themselves now live in the workspace's
+//! `autonoetic-types::redaction` module, shared with the per-actor
+//! viewer redaction in `causal_chain` and `background`. This file
+//! re-exports them so existing call sites (`crate::log_redaction::…`)
+//! continue to work unchanged.
 
-use regex::Regex;
 use serde_json::Value;
-use std::sync::LazyLock;
+
+pub use autonoetic_types::redaction::{
+    looks_like_secret_collection_prompt, looks_like_secret_value, redact_embedded_secrets,
+    redact_json_value, redact_text_for_logs,
+};
 
 const REDACTED: &str = "***REDACTED***";
 
@@ -21,9 +30,7 @@ impl RedactedPayload {
 
     pub fn from_raw_str(text: &str) -> Self {
         let redacted = redact_text_for_logs(text);
-        Self(
-            serde_json::from_str(&redacted).unwrap_or(Value::String(redacted)),
-        )
+        Self(serde_json::from_str(&redacted).unwrap_or(Value::String(redacted)))
     }
 
     pub fn from_redacted(value: Value) -> Self {
@@ -45,199 +52,66 @@ impl From<Value> for RedactedPayload {
     }
 }
 
-static ENV_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?i)\b([A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|ACCESS[_-]?KEY|ACCESS[_-]?TOKEN|REFRESH[_-]?TOKEN|AUTHORIZATION)[A-Z0-9_]*)=("[^"]*"|'[^']*'|[^\s&;]+)"#,
-    )
-    .expect("valid env assignment redaction regex")
-});
-
-static QUERY_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?i)([?&](?:api[_-]?key|apikey|appid|token|access_token|refresh_token|client_secret|password|secret|authorization)=)([^&#\s]+)",
-    )
-    .expect("valid query assignment redaction regex")
-});
-
-static BEARER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(bearer\s+)([^\s,;]+)").expect("valid bearer redaction regex")
-});
-
-static SECRET_ENV_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?i)\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|ACCESS[_-]?TOKEN|AUTHORIZATION)[A-Z0-9_]*\s*=\s*\S+",
-    )
-    .expect("valid secret env assignment regex")
-});
-
-static LONG_HEX_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\b[a-fA-F0-9]{24,}\b").expect("valid long hex regex"));
-
-static JWT_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\b[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
-        .expect("valid jwt regex")
-});
-
-fn is_sensitive_key(key: &str) -> bool {
-    let k = key.to_ascii_lowercase();
-    k.contains("secret")
-        || k.contains("token")
-        || k.contains("password")
-        || k.contains("api_key")
-        || k.contains("apikey")
-        || k.contains("authorization")
-        || k.contains("access_key")
-        || k.contains("access_token")
-        || k.contains("refresh_token")
-        || k.contains("client_secret")
-}
-
-fn redact_json_value(value: &Value) -> Value {
-    match value {
-        Value::Object(map) => {
-            let mut out = serde_json::Map::new();
-            for (k, v) in map {
-                if is_sensitive_key(k) {
-                    out.insert(k.clone(), Value::String(REDACTED.to_string()));
-                } else {
-                    out.insert(k.clone(), redact_json_value(v));
-                }
-            }
-            Value::Object(out)
-        }
-        Value::Array(items) => Value::Array(items.iter().map(redact_json_value).collect()),
-        Value::String(s) => Value::String(redact_embedded_secrets(s)),
-        other => other.clone(),
-    }
-}
-
-fn redact_embedded_secrets(text: &str) -> String {
-    let masked_env = ENV_ASSIGN_RE
-        .replace_all(text, "${1}=***REDACTED***")
-        .to_string();
-    let masked_query = QUERY_ASSIGN_RE
-        .replace_all(&masked_env, "${1}***REDACTED***")
-        .to_string();
-    let masked_bearer = BEARER_RE
-        .replace_all(&masked_query, "${1}***REDACTED***")
-        .to_string();
-    if masked_bearer.starts_with("sk-") {
-        return REDACTED.to_string();
-    }
-    masked_bearer
-}
-
-/// Detect whether free-form text appears to contain secret material.
-pub fn looks_like_secret_value(text: &str) -> bool {
-    let t = text.trim();
-    if t.is_empty() {
-        return false;
-    }
-    let lower = t.to_ascii_lowercase();
-    lower.contains("bearer ")
-        || lower.contains("api_key")
-        || lower.contains("apikey")
-        || lower.contains("access_token")
-        || t.starts_with("sk-")
-        || t.contains("-----BEGIN")
-        || SECRET_ENV_ASSIGN_RE.is_match(t)
-        || LONG_HEX_RE.is_match(t)
-        || JWT_RE.is_match(t)
-}
-
-/// Detect whether a prompt appears to solicit secret input from users.
-pub fn looks_like_secret_collection_prompt(text: &str) -> bool {
-    let s = text.to_ascii_lowercase();
-    s.contains("api key")
-        || s.contains("apikey")
-        || s.contains("token")
-        || s.contains("password")
-        || s.contains("secret")
-        || s.contains("private key")
-        || s.contains("bearer")
-        || s.contains("credential value")
-        || s.contains("paste the key")
-        || s.contains("paste your key")
-        || s.contains("enter your key")
-}
-
-/// Redact potentially sensitive content for structured logging.
-pub fn redact_text_for_logs(text: &str) -> String {
-    match serde_json::from_str::<Value>(text) {
-        Ok(v) => {
-            serde_json::to_string(&redact_json_value(&v)).unwrap_or_else(|_| REDACTED.to_string())
-        }
-        Err(_) => {
-            let lower = text.to_ascii_lowercase();
-            if lower.contains("token")
-                || lower.contains("secret")
-                || lower.contains("authorization")
-            {
-                return REDACTED.to_string();
-            }
-
-            let redacted = redact_embedded_secrets(text);
-            if redacted != text {
-                return redacted;
-            }
-
-            // Non-JSON payloads: avoid accidentally dumping long secrets.
-            if lower.contains("api_key") || lower.contains("apikey") {
-                REDACTED.to_string()
-            } else {
-                text.to_string()
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::redact_text_for_logs;
+    use super::*;
+
+    // The redaction logic itself is tested in `autonoetic-types::redaction::tests`.
+    // These tests cover the gateway-side `RedactedPayload` wrapper and pin the
+    // public API the rest of the gateway relies on.
 
     #[test]
-    fn test_redacts_sensitive_json_keys() {
-        let input = r#"{"token":"abc","nested":{"client_secret":"xyz"},"safe":"ok"}"#;
-        let out = redact_text_for_logs(input);
-        assert!(out.contains("***REDACTED***"));
-        assert!(out.contains("\"safe\":\"ok\""));
-        assert!(!out.contains("\"abc\""));
-        assert!(!out.contains("\"xyz\""));
+    fn redacted_payload_from_raw_redacts_sensitive_keys() {
+        let v = serde_json::json!({"token": "abc", "safe": "ok"});
+        let payload = RedactedPayload::from_raw(v);
+        let inner = payload.as_inner();
+        assert_eq!(inner["token"], REDACTED);
+        assert_eq!(inner["safe"], "ok");
     }
 
     #[test]
-    fn test_redacts_secret_like_plain_text() {
-        let out = redact_text_for_logs("Authorization: Bearer very-secret-value");
-        assert_eq!(out, "***REDACTED***");
+    fn redacted_payload_from_raw_str_handles_json() {
+        let text = r#"{"client_secret":"abc","ok":true}"#;
+        let payload = RedactedPayload::from_raw_str(text);
+        let inner = payload.as_inner();
+        assert_eq!(inner["client_secret"], REDACTED);
+        assert_eq!(inner["ok"], true);
     }
 
     #[test]
-    fn test_redacts_api_key_assignment_in_json_string_value() {
-        let input = r#"{"command":"export OPENWEATHER_API_KEY=testplaceholder_not_a_real_key_0000 && python3 /tmp/weather.py"}"#;
-        let out = redact_text_for_logs(input);
-        assert!(out.contains("OPENWEATHER_API_KEY=***REDACTED***"));
-        assert!(!out.contains("testplaceholder_not_a_real_key_0000"));
+    fn redacted_payload_from_raw_str_handles_plain_text() {
+        let payload = RedactedPayload::from_raw_str("plain log line, nothing secret");
+        match payload.as_inner() {
+            Value::String(s) => {
+                assert_eq!(s, "plain log line, nothing secret");
+            }
+            other => panic!("expected string variant, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_redacts_api_key_in_query_string() {
-        let input = "http://api.openweathermap.org/data/2.5/weather?appid=testplaceholder_not_a_real_key_0000&q=Paris";
-        let out = redact_text_for_logs(input);
-        assert!(out.contains("appid=***REDACTED***"));
-        assert!(!out.contains("testplaceholder_not_a_real_key_0000"));
+    fn redacted_payload_from_raw_str_masks_embedded_bearer() {
+        let payload =
+            RedactedPayload::from_raw_str("Authorization: Bearer eyJhbGc.foo plus context");
+        match payload.as_inner() {
+            Value::String(s) => {
+                assert!(s.contains("Bearer ***REDACTED***"));
+                assert!(s.contains("plus context"));
+                assert!(!s.contains("eyJhbGc"));
+            }
+            other => panic!("expected string variant, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_detects_secret_like_value() {
-        assert!(super::looks_like_secret_value(
-            "OPENWEATHER_API_KEY=testplaceholder_not_a_real_key_0000"
-        ));
+    fn looks_like_secret_value_reexport_works() {
+        assert!(looks_like_secret_value("Bearer eyJhbGc.foo"));
+        assert!(!looks_like_secret_value("plain"));
     }
 
     #[test]
-    fn test_detects_secret_collection_prompt() {
-        assert!(super::looks_like_secret_collection_prompt(
-            "Please paste your API key to continue"
-        ));
+    fn looks_like_secret_collection_prompt_reexport_works() {
+        assert!(looks_like_secret_collection_prompt("Please paste your API key"));
+        assert!(!looks_like_secret_collection_prompt("Hello"));
     }
 }

--- a/autonoetic-gateway/src/scheduler/hooks.rs
+++ b/autonoetic-gateway/src/scheduler/hooks.rs
@@ -1275,7 +1275,22 @@ mod tests {
         );
         assert_eq!(request.body_json["delivery_id"], delivery_id);
         assert_eq!(request.body_json["event"], "session.closed");
-        assert_eq!(request.body_json["fields"]["close_reason"], "***REDACTED***");
+        // close_reason was set to "token=top-secret" in session_closed_ctx.
+        // The canonical redaction (autonoetic-types::redaction) now masks the
+        // value in place via ENV_ASSIGN_RE rather than wholesale-redacting the
+        // string. Still no secret leak — `top-secret` is gone — but the
+        // assignment shape `token=…` is preserved for operator triage.
+        assert_eq!(
+            request.body_json["fields"]["close_reason"],
+            "token=***REDACTED***"
+        );
+        assert!(
+            !request.body_json["fields"]["close_reason"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("top-secret"),
+            "secret value must not leak"
+        );
         assert!(
             request.body_json["report"]["agents"]["coder.default"]["input_preview"].is_null()
         );

--- a/autonoetic-types/Cargo.toml
+++ b/autonoetic-types/Cargo.toml
@@ -12,3 +12,4 @@ chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 hex = "0.4"
 uuid = { version = "1", features = ["v4"] }
+regex = "1"

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -306,7 +306,9 @@ impl ScheduledAction {
             _ => {
                 let mut out = std::collections::HashMap::new();
                 for (k, v) in headers {
-                    if is_sensitive_key(k) || looks_like_secret_value(v) {
+                    if super::redaction::is_sensitive_key(k)
+                        || super::redaction::looks_like_secret_value(v)
+                    {
                         out.insert(k.clone(), Self::REDACTED.to_string());
                     } else {
                         out.insert(k.clone(), v.clone());
@@ -320,34 +322,14 @@ impl ScheduledAction {
     fn redact_json_value(value: &serde_json::Value, viewer: super::disclosure::ViewerClass) -> serde_json::Value {
         match viewer {
             super::disclosure::ViewerClass::Admin => value.clone(),
-            _ => Self::redact_json_value_inner(value),
-        }
-    }
-
-    fn redact_json_value_inner(value: &serde_json::Value) -> serde_json::Value {
-        match value {
-            serde_json::Value::Object(map) => {
-                let mut out = serde_json::Map::new();
-                for (k, v) in map {
-                    if is_sensitive_key(k) {
-                        out.insert(k.clone(), serde_json::Value::String(Self::REDACTED.to_string()));
-                    } else {
-                        out.insert(k.clone(), Self::redact_json_value_inner(v));
-                    }
-                }
-                serde_json::Value::Object(out)
-            }
-            serde_json::Value::Array(items) => {
-                serde_json::Value::Array(items.iter().map(Self::redact_json_value_inner).collect())
-            }
-            serde_json::Value::String(s) => {
-                if looks_like_secret_value(s) {
-                    serde_json::Value::String(Self::REDACTED.to_string())
-                } else {
-                    serde_json::Value::String(s.clone())
-                }
-            }
-            other => other.clone(),
+            // Delegate to the canonical helper (issue #156). The previous
+            // local copy did not perform in-place masking on string values,
+            // wholesale-redacting any string for which `looks_like_secret_value`
+            // returned true. The canonical version masks bearer tokens,
+            // env-var assignments, and URL query secrets in place — better
+            // for operator review — and falls back to wholesale redaction
+            // only for shapes that can't be masked locally (PEM, raw `sk-…`).
+            _ => super::redaction::redact_json_value(value),
         }
     }
 
@@ -428,31 +410,6 @@ impl ScheduledAction {
     pub fn redact_for_display(&self) -> Self {
         self.redact_for_viewer(super::disclosure::ViewerClass::Operator)
     }
-}
-
-fn is_sensitive_key(key: &str) -> bool {
-    let k = key.to_ascii_lowercase();
-    k.contains("secret")
-        || k.contains("token")
-        || k.contains("password")
-        || k.contains("api_key")
-        || k.contains("apikey")
-        || k.contains("authorization")
-        || k.contains("access_key")
-        || k.contains("access_token")
-        || k.contains("refresh_token")
-        || k.contains("client_secret")
-}
-
-fn looks_like_secret_value(text: &str) -> bool {
-    let t = text.trim();
-    if t.is_empty() {
-        return false;
-    }
-    let lower = t.to_ascii_lowercase();
-    lower.contains("bearer ")
-        || t.starts_with("sk-")
-        || t.contains("-----BEGIN")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -1195,6 +1152,7 @@ mod redaction_tests {
 
     #[test]
     fn looks_like_secret_value_recognises_documented_patterns() {
+        use crate::redaction::looks_like_secret_value;
         assert!(looks_like_secret_value("Bearer eyJhbGc.foo"));
         assert!(looks_like_secret_value("sk-abc12345"));
         assert!(looks_like_secret_value("-----BEGIN RSA PRIVATE KEY-----"));

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -211,70 +211,13 @@ impl CausalEventRecord {
     }
 }
 
+// Redaction primitives are centralised in `crate::redaction`. This local
+// thin wrapper is the only call site needed in this module; the previous
+// inline copy used a wholesale-redaction fallback that nuked benign strings
+// like "tokenizer config" — see issue #156.
+
 fn redact_json_string(s: &str) -> String {
-    match serde_json::from_str::<serde_json::Value>(s) {
-        Ok(v) => serde_json::to_string(&redact_json_value(&v)).unwrap_or_else(|_| "***REDACTED***".to_string()),
-        Err(_) => {
-            let lower = s.to_ascii_lowercase();
-            if lower.contains("token")
-                || lower.contains("secret")
-                || lower.contains("authorization")
-                || lower.contains("api_key")
-                || lower.contains("apikey")
-            {
-                "***REDACTED***".to_string()
-            } else {
-                s.to_string()
-            }
-        }
-    }
-}
-
-fn redact_json_value(value: &serde_json::Value) -> serde_json::Value {
-    match value {
-        serde_json::Value::Object(map) => {
-            let mut out = serde_json::Map::new();
-            for (k, v) in map {
-                if is_sensitive_key(k) {
-                    out.insert(k.clone(), serde_json::Value::String("***REDACTED***".to_string()));
-                } else {
-                    out.insert(k.clone(), redact_json_value(v));
-                }
-            }
-            serde_json::Value::Object(out)
-        }
-        serde_json::Value::Array(items) => {
-            serde_json::Value::Array(items.iter().map(redact_json_value).collect())
-        }
-        serde_json::Value::String(s) => {
-            let t = s.trim();
-            if !t.is_empty() {
-                let lower = t.to_ascii_lowercase();
-                if lower.contains("bearer ")
-                    || t.starts_with("sk-")
-                    || t.contains("-----BEGIN")
-                {
-                    return serde_json::Value::String("***REDACTED***".to_string());
-                }
-            }
-            serde_json::Value::String(s.clone())
-        }
-        other => other.clone(),
-    }
-}
-
-fn is_sensitive_key(key: &str) -> bool {
-    let k = key.to_ascii_lowercase();
-    k.contains("secret")
-        || k.contains("token")
-        || k.contains("password")
-        || k.contains("api_key")
-        || k.contains("apikey")
-        || k.contains("authorization")
-        || k.contains("access_key")
-        || k.contains("access_token")
-        || k.contains("refresh_token")
-        || k.contains("client_secret")
+    crate::redaction::redact_text_for_logs(s)
 }
 
 /// Session transcript record for storage in gateway.db session_transcripts table.
@@ -565,7 +508,11 @@ mod redaction_tests {
         }
     }
 
-    // ── redact_json_string / redact_json_value internals ─────────────────
+    // ── Direct delegation to canonical helpers ───────────────────────────
+    // These tests pin the integration: `causal_chain::redact_for_viewer`
+    // now routes string redaction through `crate::redaction`. The canonical
+    // module's own unit tests (`crate::redaction::tests`) cover finer-grained
+    // behavior; the assertions here verify the wiring stays correct.
 
     #[test]
     fn redact_json_value_redacts_object_keys_named_like_secrets() {
@@ -575,7 +522,7 @@ mod redaction_tests {
             "refresh_token": "ghi",
             "ok": true,
         });
-        let out = redact_json_value(&v);
+        let out = crate::redaction::redact_json_value(&v);
         assert_eq!(out["client_secret"], "***REDACTED***");
         assert_eq!(out["access_token"], "***REDACTED***");
         assert_eq!(out["refresh_token"], "***REDACTED***");
@@ -583,27 +530,27 @@ mod redaction_tests {
     }
 
     #[test]
-    fn redact_json_value_redacts_string_values_that_look_like_secrets() {
+    fn redact_json_value_handles_each_secret_shape_appropriately() {
         let v = serde_json::json!({
             "header": "Bearer eyJhbGc.tail",
             "key_blob": "-----BEGIN RSA PRIVATE KEY-----\nXXX\n-----END RSA PRIVATE KEY-----",
             "openai_key": "sk-abc123def456ghi789",
             "innocuous": "tokenizer config",
         });
-        let out = redact_json_value(&v);
-        assert_eq!(out["header"], "***REDACTED***");
+        let out = crate::redaction::redact_json_value(&v);
+        // Bearer: in-place masking preserves the prefix, masks the value.
+        assert_eq!(out["header"], "Bearer ***REDACTED***");
+        // PEM: can't be masked in place; fallback wholesale redact via
+        // `looks_like_secret_value` ⇒ `REDACTED`.
         assert_eq!(out["key_blob"], "***REDACTED***");
+        // Bare `sk-…`: handled by `redact_embedded_secrets`'s sk- prefix branch.
         assert_eq!(out["openai_key"], "***REDACTED***");
-        // Note: the current implementation over-redacts the substring "token"
-        // via the non-JSON fallback path; tracked in issue #156. This direct
-        // value-path is more precise — the literal "tokenizer config" does NOT
-        // start with sk-, contain bearer, or contain BEGIN, so it survives.
+        // Benign `tokenizer config`: no in-place mask, no secret shape ⇒ kept.
         assert_eq!(out["innocuous"], "tokenizer config");
     }
 
     #[test]
     fn is_sensitive_key_matches_documented_substrings() {
-        // Underscore-form keys: covered by the substring match.
         for k in &[
             "secret",
             "TOKEN",
@@ -615,27 +562,51 @@ mod redaction_tests {
             "refresh_token",
             "client_secret",
         ] {
-            assert!(is_sensitive_key(k), "expected sensitive: {k}");
+            assert!(crate::redaction::is_sensitive_key(k), "expected sensitive: {k}");
         }
         for k in &["user_id", "agent_id", "session_id", "items", "ok"] {
-            assert!(!is_sensitive_key(k), "expected non-sensitive: {k}");
+            assert!(!crate::redaction::is_sensitive_key(k), "expected non-sensitive: {k}");
         }
     }
 
     #[test]
     fn is_sensitive_key_misses_hyphenated_api_key() {
-        // KNOWN GAP: `X-API-Key` (hyphenated) does NOT match — `is_sensitive_key`
-        // looks for `api_key` and `apikey`, neither of which is a substring of
-        // `x-api-key`. Hyphenated `*-Token` names do match (substring `token`)
-        // and hyphenated `*-Authorization`/`*-Password` would match too.
-        // This pin documents the specific gap that should be closed in issue #156.
+        // KNOWN GAP: `X-API-Key` (hyphenated) does NOT match — the substring
+        // catalogue uses `api_key` (underscore). Hyphenated `*-Token` does
+        // match via the `token` substring. This pin documents the gap.
         assert!(
-            !is_sensitive_key("X-API-Key"),
-            "regression: X-API-Key is now matched — update both \
-             is_sensitive_key (add 'api-key' substring) and this pin together"
+            !crate::redaction::is_sensitive_key("X-API-Key"),
+            "regression: X-API-Key now matches — update is_sensitive_key in \
+             autonoetic-types::redaction and this pin together"
         );
-        // Counter-cases that already work via existing substrings:
-        assert!(is_sensitive_key("X-Auth-Token"), "contains 'token'");
-        assert!(is_sensitive_key("X-Access-Token"), "contains 'token'");
+        assert!(crate::redaction::is_sensitive_key("X-Auth-Token"));
+        assert!(crate::redaction::is_sensitive_key("X-Access-Token"));
+    }
+
+    // ── Bug-fix coverage for issue #156 (delegated path) ─────────────────
+
+    #[test]
+    fn benign_substrings_do_not_nuke_full_string_via_redact_json_string() {
+        // The bug: `redact_json_string("Updated tokenizer config")` used to
+        // return "***REDACTED***" wholesale because the string contained the
+        // substring "token". After the migration to `redact_text_for_logs`
+        // it round-trips.
+        for input in &[
+            "Updated tokenizer config in v2",
+            "secretary-general announcement",
+            "the authorization process is documented in section 4",
+        ] {
+            let out = redact_json_string(input);
+            assert_eq!(out, *input, "benign string '{input}' must round-trip");
+        }
+    }
+
+    #[test]
+    fn real_secrets_still_masked_via_redact_json_string() {
+        // Bearer token in a non-JSON string — masked in place, prose preserved.
+        let out = redact_json_string("Authorization: Bearer eyJhbGc.foo plus context");
+        assert!(out.contains("Bearer ***REDACTED***"));
+        assert!(out.contains("plus context"));
+        assert!(!out.contains("eyJhbGc"));
     }
 }

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -540,8 +540,8 @@ mod redaction_tests {
         let out = crate::redaction::redact_json_value(&v);
         // Bearer: in-place masking preserves the prefix, masks the value.
         assert_eq!(out["header"], "Bearer ***REDACTED***");
-        // PEM: can't be masked in place; fallback wholesale redact via
-        // `looks_like_secret_value` ⇒ `REDACTED`.
+        // PEM: can't be masked in place; fallback wholesale redact via the
+        // narrow `s.contains("-----BEGIN")` branch in `redact_json_value`.
         assert_eq!(out["key_blob"], "***REDACTED***");
         // Bare `sk-…`: handled by `redact_embedded_secrets`'s sk- prefix branch.
         assert_eq!(out["openai_key"], "***REDACTED***");

--- a/autonoetic-types/src/lib.rs
+++ b/autonoetic-types/src/lib.rs
@@ -19,6 +19,7 @@ pub mod layer;
 pub mod memory;
 pub mod notification;
 pub mod promotion;
+pub mod redaction;
 pub mod runtime_lock;
 pub mod scheduled_job;
 pub mod schema_enforcement;

--- a/autonoetic-types/src/redaction.rs
+++ b/autonoetic-types/src/redaction.rs
@@ -1,0 +1,382 @@
+//! Canonical redaction helpers shared across the workspace.
+//!
+//! These primitives detect and mask credential-shaped content in arbitrary
+//! text or JSON payloads. They are used by:
+//!
+//! - **`autonoetic-types::causal_chain`** — when applying `redact_for_viewer`
+//!   to non-Admin observers of `ExecutionTraceRecord` / `CausalEventRecord`.
+//! - **`autonoetic-types::background`** — same, for `ScheduledAction`.
+//! - **`autonoetic-gateway::log_redaction`** — when wrapping causal-chain
+//!   payloads via `RedactedPayload` (the gateway-side R+9 invariant).
+//!
+//! Centralising them here removes the prior triplication (one copy in each
+//! of those modules) and prevents drift.
+//!
+//! ## Design choice: precise masking over wholesale redaction
+//!
+//! An earlier implementation in both `redact_text_for_logs` (gateway) and
+//! `redact_json_string` (causal_chain) replaced *the entire input string*
+//! with `***REDACTED***` whenever a substring like `token`, `secret`, or
+//! `authorization` was present. That over-redacts strings such as
+//! `"Updated tokenizer config"`, `"secretary-general announcement"`, or
+//! `"apikey-generator-doc"`, and also leaks an oracle (the branch decision
+//! is observable, letting an attacker probe whether arbitrary text contains
+//! one of those substrings). The canonical implementation here uses the
+//! `redact_embedded_secrets` regex catalogue to mask only the credential-
+//! shaped fragments, leaving the surrounding prose intact.
+
+use regex::Regex;
+use serde_json::Value;
+use std::sync::LazyLock;
+
+/// Replacement marker used everywhere a redacted value is emitted.
+pub const REDACTED: &str = "***REDACTED***";
+
+// ── Regex catalogue ──────────────────────────────────────────────────────────
+
+/// `KEY=value` style env-var assignment carrying a credential-shaped name.
+///
+/// The leading `[A-Z0-9_]*` (zero-or-more) is intentional so a bare
+/// `PASSWORD=…` matches in addition to prefixed forms like `MY_PASSWORD=…`
+/// and `OPENWEATHER_API_KEY=…`. (The previous `[A-Z][A-Z0-9_]*` required at
+/// least one prefix character, which silently missed unprefixed names.)
+static ENV_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|ACCESS[_-]?KEY|ACCESS[_-]?TOKEN|REFRESH[_-]?TOKEN|AUTHORIZATION)[A-Z0-9_]*)=("[^"]*"|'[^']*'|[^\s&;]+)"#,
+    )
+    .expect("valid env assignment redaction regex")
+});
+
+/// URL-style `?foo=bar&baz=qux` assignment carrying a credential-shaped key.
+static QUERY_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)([?&](?:api[_-]?key|apikey|appid|token|access_token|refresh_token|client_secret|password|secret|authorization)=)([^&#\s]+)",
+    )
+    .expect("valid query assignment redaction regex")
+});
+
+/// `Bearer <token>` HTTP authorization header.
+static BEARER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(bearer\s+)([^\s,;]+)").expect("valid bearer redaction regex")
+});
+
+/// Plain `KEY=value` form used by `looks_like_secret_value`.
+///
+/// Same `[A-Z0-9_]*` (zero-or-more) prefix as `ENV_ASSIGN_RE` so unprefixed
+/// names like `PASSWORD=…` are detected.
+static SECRET_ENV_ASSIGN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b[A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|ACCESS[_-]?TOKEN|AUTHORIZATION)[A-Z0-9_]*\s*=\s*\S+",
+    )
+    .expect("valid secret env assignment regex")
+});
+
+/// Generic long hex string (≥ 24 hex chars) — likely a raw secret in a
+/// non-JSON context.
+static LONG_HEX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[a-fA-F0-9]{24,}\b").expect("valid long hex regex"));
+
+/// JWT-shaped token (three base64url segments separated by dots).
+static JWT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
+        .expect("valid jwt regex")
+});
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Returns `true` if the supplied JSON object key looks credential-shaped.
+///
+/// Matches the substring catalogue: `secret`, `token`, `password`, `api_key`,
+/// `apikey`, `authorization`, `access_key`, `access_token`, `refresh_token`,
+/// `client_secret` (case-insensitive).
+///
+/// Known gap: hyphenated names like `X-API-Key` do NOT match because the
+/// catalogue uses the underscore form `api_key`. Adding `api-key` as an
+/// alternative would fix this; left as a future change to keep the rule list
+/// auditable.
+pub fn is_sensitive_key(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    k.contains("secret")
+        || k.contains("token")
+        || k.contains("password")
+        || k.contains("api_key")
+        || k.contains("apikey")
+        || k.contains("authorization")
+        || k.contains("access_key")
+        || k.contains("access_token")
+        || k.contains("refresh_token")
+        || k.contains("client_secret")
+}
+
+/// Returns `true` if a free-form string value looks credential-bearing.
+pub fn looks_like_secret_value(text: &str) -> bool {
+    let t = text.trim();
+    if t.is_empty() {
+        return false;
+    }
+    let lower = t.to_ascii_lowercase();
+    lower.contains("bearer ")
+        || lower.contains("api_key")
+        || lower.contains("apikey")
+        || lower.contains("access_token")
+        || t.starts_with("sk-")
+        || t.contains("-----BEGIN")
+        || SECRET_ENV_ASSIGN_RE.is_match(t)
+        || LONG_HEX_RE.is_match(t)
+        || JWT_RE.is_match(t)
+}
+
+/// Detects whether free-form text appears to *solicit* secret input from a
+/// human (as opposed to *containing* one).
+pub fn looks_like_secret_collection_prompt(text: &str) -> bool {
+    let s = text.to_ascii_lowercase();
+    s.contains("api key")
+        || s.contains("apikey")
+        || s.contains("token")
+        || s.contains("password")
+        || s.contains("secret")
+        || s.contains("private key")
+        || s.contains("bearer")
+        || s.contains("credential value")
+        || s.contains("paste the key")
+        || s.contains("paste your key")
+        || s.contains("enter your key")
+}
+
+/// Mask credential-shaped fragments embedded in plain text.
+///
+/// This is the precise version: it leaves the surrounding text intact and
+/// only replaces the credential value.
+pub fn redact_embedded_secrets(text: &str) -> String {
+    let masked_env = ENV_ASSIGN_RE
+        .replace_all(text, "${1}=***REDACTED***")
+        .to_string();
+    let masked_query = QUERY_ASSIGN_RE
+        .replace_all(&masked_env, "${1}***REDACTED***")
+        .to_string();
+    let masked_bearer = BEARER_RE
+        .replace_all(&masked_query, "${1}***REDACTED***")
+        .to_string();
+    // A bare `sk-…` in the entire string (no JSON context) is treated as a
+    // raw secret; we cannot mask just the value without a delimiter.
+    if masked_bearer.starts_with("sk-") {
+        return REDACTED.to_string();
+    }
+    masked_bearer
+}
+
+/// Recursively redact a JSON value: object keys matching `is_sensitive_key`
+/// get their values replaced with `REDACTED`; string values are passed
+/// through `redact_embedded_secrets` so embedded credentials are masked
+/// without nuking the surrounding payload. As a backstop for credential
+/// shapes that can't be masked in place (PEM blocks specifically),
+/// strings matching that narrow pattern are wholesale-redacted.
+///
+/// **Why narrower than `looks_like_secret_value` for the fallback:** in JSON
+/// payloads, content digests, revision IDs, and delivery IDs routinely look
+/// like long hex strings or JWT-shaped tokens. Falling back on those shapes
+/// would over-redact identifiers (`"delivery_id":"hook-<sha256>"`,
+/// `"revision_id":"<40-char-sha>"`). PEM blocks are the only widespread
+/// shape that genuinely contains a secret and can't be masked in place,
+/// so the fallback is restricted to that.
+pub fn redact_json_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                if is_sensitive_key(k) {
+                    out.insert(k.clone(), Value::String(REDACTED.to_string()));
+                } else {
+                    out.insert(k.clone(), redact_json_value(v));
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(redact_json_value).collect()),
+        Value::String(s) => {
+            let masked = redact_embedded_secrets(s);
+            if masked != *s {
+                // In-place mask handled it (bearer, env-var, query secret, sk-).
+                Value::String(masked)
+            } else if s.contains("-----BEGIN") {
+                // PEM block — can't mask only the key body cleanly because it
+                // spans multiple base64 lines between the BEGIN/END markers.
+                // Wholesale-redact the whole value.
+                Value::String(REDACTED.to_string())
+            } else {
+                Value::String(s.clone())
+            }
+        }
+        other => other.clone(),
+    }
+}
+
+/// Redact potentially sensitive content for structured logging.
+///
+/// If `text` parses as JSON, recursively redact via `redact_json_value` and
+/// re-serialize. Otherwise mask credential-shaped fragments via
+/// `redact_embedded_secrets` while preserving the surrounding prose.
+///
+/// **The non-JSON path no longer nukes the entire string when a benign
+/// substring like `token` or `secret` appears.** That over-redaction is
+/// the bug fixed in issue #156.
+pub fn redact_text_for_logs(text: &str) -> String {
+    match serde_json::from_str::<Value>(text) {
+        Ok(v) => serde_json::to_string(&redact_json_value(&v))
+            .unwrap_or_else(|_| REDACTED.to_string()),
+        Err(_) => redact_embedded_secrets(text),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Bug-fix coverage: benign substrings round-trip ───────────────────
+
+    #[test]
+    fn benign_substrings_no_longer_nuke_full_string() {
+        // The cases that previously got wholesale-redacted because they
+        // contained "token", "secret", "authorization", "api_key", or
+        // "apikey" as innocuous substrings.
+        for input in &[
+            "Updated tokenizer config in v2",
+            "secretary-general announcement",
+            "apikey-generator-doc.md",
+            "the authorization process is documented in section 4",
+            "Updated token bucket rate limiter",
+        ] {
+            let out = redact_text_for_logs(input);
+            assert_eq!(
+                out, *input,
+                "benign string '{input}' must round-trip — got '{out}'"
+            );
+        }
+    }
+
+    // ── Real secrets still get masked precisely ──────────────────────────
+
+    #[test]
+    fn bearer_token_value_is_masked_in_place() {
+        let input = "Authorization: Bearer eyJhbGc.foo.bar plus context";
+        let out = redact_text_for_logs(input);
+        assert!(out.contains("Bearer ***REDACTED***"));
+        assert!(out.contains("plus context"), "surrounding text preserved: {out}");
+        assert!(!out.contains("eyJhbGc"));
+    }
+
+    #[test]
+    fn env_assignment_value_is_masked_in_place() {
+        let input = "running with PASSWORD=hunter2 and other args";
+        let out = redact_text_for_logs(input);
+        assert!(out.contains("PASSWORD=***REDACTED***"));
+        assert!(out.contains("and other args"));
+        assert!(!out.contains("hunter2"));
+    }
+
+    #[test]
+    fn url_query_secret_is_masked_in_place() {
+        let input = "fetch http://api.example.com/data?api_key=abc123def456&q=Paris";
+        let out = redact_text_for_logs(input);
+        assert!(out.contains("api_key=***REDACTED***"));
+        assert!(out.contains("q=Paris"));
+        assert!(!out.contains("abc123def456"));
+    }
+
+    #[test]
+    fn bare_sk_prefix_is_redacted_wholesale() {
+        // `sk-…` at the start of a non-JSON string is treated as a raw
+        // secret since there's no delimiter to mask just the value.
+        let out = redact_text_for_logs("sk-abc123def456ghi789");
+        assert_eq!(out, REDACTED);
+    }
+
+    // ── JSON path ────────────────────────────────────────────────────────
+
+    #[test]
+    fn json_redacts_sensitive_keys_and_preserves_structure() {
+        let input = r#"{"token":"abc","nested":{"client_secret":"xyz"},"safe":"ok"}"#;
+        let out = redact_text_for_logs(input);
+        assert!(out.contains("***REDACTED***"));
+        assert!(out.contains("\"safe\":\"ok\""));
+        assert!(!out.contains("\"abc\""));
+        assert!(!out.contains("\"xyz\""));
+    }
+
+    #[test]
+    fn json_string_value_with_embedded_secret_is_masked() {
+        let input = r#"{"command":"export OPENWEATHER_API_KEY=secret_value_xyz && curl"}"#;
+        let out = redact_text_for_logs(input);
+        assert!(out.contains("OPENWEATHER_API_KEY=***REDACTED***"));
+        assert!(!out.contains("secret_value_xyz"));
+        assert!(out.contains("export"));
+        assert!(out.contains("curl"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_sensitive_key_documented_substrings() {
+        for k in &[
+            "secret",
+            "TOKEN",
+            "user_password",
+            "api_key",
+            "Authorization",
+            "access_token",
+            "refresh_token",
+            "client_secret",
+        ] {
+            assert!(is_sensitive_key(k), "expected sensitive: {k}");
+        }
+        for k in &["user_id", "agent_id", "items", "ok"] {
+            assert!(!is_sensitive_key(k), "expected non-sensitive: {k}");
+        }
+    }
+
+    #[test]
+    fn is_sensitive_key_overflags_token_containing_keys() {
+        // Documented over-flagging: the substring catalogue treats any key
+        // containing `token` as sensitive, so `tokenizer`, `tokenization`,
+        // and `notification_token_count` all match. This is the conservative
+        // behaviour preserved from the prior implementation; widening the
+        // catalogue (e.g. to require word boundaries) would risk under-
+        // detection. The precision win in #156 is at the *string-value*
+        // level via `redact_embedded_secrets`, not at the *JSON-key* level.
+        for k in &["tokenizer", "tokenization", "notification_token_count"] {
+            assert!(
+                is_sensitive_key(k),
+                "regression: '{k}' is no longer flagged — confirm intent before \
+                 narrowing the catalogue"
+            );
+        }
+    }
+
+    #[test]
+    fn looks_like_secret_value_recognises_documented_patterns() {
+        assert!(looks_like_secret_value("Bearer eyJhbGc.foo"));
+        assert!(looks_like_secret_value("sk-abc12345"));
+        assert!(looks_like_secret_value("-----BEGIN RSA PRIVATE KEY-----"));
+        assert!(looks_like_secret_value("PASSWORD=hunter2"));
+        assert!(!looks_like_secret_value("plain text"));
+        assert!(!looks_like_secret_value(""));
+        assert!(!looks_like_secret_value("   "));
+    }
+
+    #[test]
+    fn looks_like_secret_collection_prompt_recognises_solicitations() {
+        assert!(looks_like_secret_collection_prompt("Please paste your API key"));
+        assert!(looks_like_secret_collection_prompt("Enter your token here"));
+        assert!(!looks_like_secret_collection_prompt("Hello, please continue"));
+    }
+
+    #[test]
+    fn redact_json_value_array_passthrough() {
+        let v = serde_json::json!([{"token": "abc"}, {"safe": "ok"}]);
+        let out = redact_json_value(&v);
+        assert_eq!(out[0]["token"], "***REDACTED***");
+        assert_eq!(out[1]["safe"], "ok");
+    }
+}

--- a/autonoetic-types/src/redaction.rs
+++ b/autonoetic-types/src/redaction.rs
@@ -195,7 +195,7 @@ pub fn redact_json_value(value: &Value) -> Value {
         Value::Array(items) => Value::Array(items.iter().map(redact_json_value).collect()),
         Value::String(s) => {
             let masked = redact_embedded_secrets(s);
-            if masked != *s {
+            if masked != s.as_str() {
                 // In-place mask handled it (bearer, env-var, query secret, sk-).
                 Value::String(masked)
             } else if s.contains("-----BEGIN") {


### PR DESCRIPTION
## Summary

Closes #156. The substring fallback in \`causal_chain::redact_json_string\` and \`gateway::log_redaction::redact_text_for_logs\` wholesale-redacted any string containing the substring \`token\`, \`secret\`, \`authorization\`, \`api_key\`, or \`apikey\`. So benign strings like \`\"Updated tokenizer config\"\`, \`\"secretary-general announcement\"\`, and \`\"apikey-generator-doc.md\"\` were silently nuked.

This refactor:

1. **Creates \`autonoetic-types/src/redaction.rs\`** — canonical home for the previously-triplicated helpers (\`is_sensitive_key\`, \`looks_like_secret_value\`, \`looks_like_secret_collection_prompt\`, \`redact_embedded_secrets\`, \`redact_json_value\`, \`redact_text_for_logs\`). Adds \`regex\` to the types crate.
2. **Fixes the over-redaction**: the non-JSON path now relies on \`redact_embedded_secrets\` (precise regex catalogue) rather than wholesale-nuking on substring match. Bearer tokens, env-var assignments, URL query secrets are masked in place; benign strings round-trip.
3. **Keeps a narrow PEM fallback** in \`redact_json_value\`: PEM blocks span multiple base64 lines and can't be masked locally, so they still wholesale-redact. JWT/long-hex shapes are intentionally NOT used as fallbacks because content digests, revision IDs, and hook delivery IDs (\`hook-<sha256>\`) routinely match those shapes.
4. **Migrates the duplicate copies** in \`causal_chain.rs\` and \`background.rs\` to delegate. Removes ~80 LOC of duplication.
5. **Migrates \`log_redaction.rs\`** to re-export the canonical helpers while keeping \`RedactedPayload\` (the gateway-side R+9 wrapper) local. Public API of \`crate::log_redaction::*\` unchanged.
6. **Bonus fix**: the \`KEY=value\` matcher previously required a non-empty alphabetic prefix (\`[A-Z][A-Z0-9_]*…\`), so a bare \`PASSWORD=hunter2\` slipped through. The leading group is now \`[A-Z0-9_]*\` (zero-or-more) and unprefixed names are caught.

## One existing-test assertion updated

\`scheduler::hooks::tests::test_http_callback_delivers_signed_redacted_payload_and_persists_delivery\` set \`close_reason = \"token=top-secret\"\` and asserted wholesale \`\"***REDACTED***\"\`. With precise masking the output is \`\"token=***REDACTED***\"\` — still no secret leak (\`top-secret\` is gone), but the assignment shape is preserved for operator triage. Test updated; an explicit \`top-secret\`-not-present assertion added so the spirit of the original test is pinned.

## Test plan

- [x] \`cargo test -p autonoetic-types --lib\` → 102/102.
- [x] \`cargo test -p autonoetic-gateway --lib log_redaction\` → 6/6.
- [x] \`disclosure_integration\` 1/1, \`security_sentinel_integration\` 31/31, \`security_redteam_integration\` 9/9, \`constitution_secret_redaction_ordering\` 6/6, \`constitution_private_reasoning\` 15/15.
- [x] Pre-existing 21 unrelated lib-test failures on origin/main confirmed unchanged.
- [ ] Reviewer sanity-check: the narrow PEM-only fallback is correct (rather than the broader \`looks_like_secret_value\` fallback) for JSON value paths where context implies the field is an identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)