### PR TITLE
feat(sentinel): per-agent scope for promotion gate (closes #155)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2045,13 +2045,15 @@ impl NativeTool for AgentRevisionPromoteTool {
         }
 
         // Security sentinel pre-promotion gate (fail-closed).
-        // Runs a full-store Phase-1 sweep — any critical finding in the system
-        // blocks promotion. Per-agent scoping is planned for a future phase.
+        // Runs a Phase-1 sweep scoped to the agent being promoted — only
+        // critical findings attributable to this agent block its promotion
+        // (issue #155). Findings against other agents do not interfere.
         if let Some(cfg) = config {
             if cfg.sentinel.enabled && cfg.sentinel.promotion_gate_enabled {
                 match crate::sentinel::check_pre_promotion(
                     Arc::clone(&gateway_store),
                     &cfg.sentinel.sentinel_revision_id,
+                    &args.agent_id,
                     cfg.sentinel.promotion_gate_timeout_secs,
                 ) {
                     Ok(crate::sentinel::GateOutcome::Passed) => {

--- a/autonoetic-gateway/src/sentinel/checks/approval_bypass.rs
+++ b/autonoetic-gateway/src/sentinel/checks/approval_bypass.rs
@@ -17,11 +17,14 @@ use rusqlite::Connection;
 /// Flag root sessions that have more than `denial_threshold` denied approvals
 /// in the past `window_days` days. One finding per offending (root_session_id,
 /// agent_id) pair, using the most-recently-denied session_id for attribution.
+///
+/// `scope_agent_id` filters to a single agent (used by the pre-promotion gate).
 pub fn scan_approval_denials(
     conn: &Connection,
     sentinel_revision_id: &str,
     window_days: u32,
     denial_threshold: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let cutoff = chrono::Utc::now() - chrono::Duration::days(window_days as i64);
     let cutoff_str = cutoff.to_rfc3339();
@@ -44,6 +47,7 @@ pub fn scan_approval_denials(
          FROM approvals ap
          WHERE ap.status = 'denied'
            AND ap.created_at > ?1
+           AND (?3 IS NULL OR ap.agent_id = ?3)
          GROUP BY ap.root_session_id, ap.agent_id
          HAVING cnt > ?2
          ORDER BY cnt DESC",
@@ -57,14 +61,17 @@ pub fn scan_approval_denials(
     }
 
     let rows = stmt
-        .query_map(rusqlite::params![cutoff_str, threshold_i], |row| {
-            Ok(DenialRow {
-                root_session_id: row.get(0)?,
-                agent_id: row.get(1)?,
-                count: row.get(2)?,
-                latest_session_id: row.get(3)?,
-            })
-        })?
+        .query_map(
+            rusqlite::params![cutoff_str, threshold_i, scope_agent_id],
+            |row| {
+                Ok(DenialRow {
+                    root_session_id: row.get(0)?,
+                    agent_id: row.get(1)?,
+                    count: row.get(2)?,
+                    latest_session_id: row.get(3)?,
+                })
+            },
+        )?
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
     let mut findings = Vec::new();
@@ -110,6 +117,7 @@ pub fn scan_exec_without_grant(
     sentinel_revision_id: &str,
     since_rfc3339: Option<&str>,
     limit: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
     let lim = limit as i64;
@@ -121,6 +129,7 @@ pub fn scan_exec_without_grant(
            AND ap.action_type = 'sandbox_exec'
            AND ap.created_at > ?1
            AND ap.root_session_id IS NOT NULL
+           AND (?3 IS NULL OR ap.agent_id = ?3)
            AND NOT EXISTS (
                SELECT 1 FROM session_approval_grants sg
                WHERE sg.root_session_id = ap.root_session_id
@@ -137,13 +146,16 @@ pub fn scan_exec_without_grant(
     }
 
     let rows = stmt
-        .query_map(rusqlite::params![since, lim], |row| {
-            Ok(ApprovalRow {
-                root_session_id: row.get(0)?,
-                session_id: row.get(1)?,
-                agent_id: row.get(2)?,
-            })
-        })?
+        .query_map(
+            rusqlite::params![since, lim, scope_agent_id],
+            |row| {
+                Ok(ApprovalRow {
+                    root_session_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    agent_id: row.get(2)?,
+                })
+            },
+        )?
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
     let mut findings = Vec::new();
@@ -230,7 +242,7 @@ mod tests {
             .unwrap();
         }
 
-        let findings = scan_approval_denials(&conn, "sentinel-rev-1", 7, 5).unwrap();
+        let findings = scan_approval_denials(&conn, "sentinel-rev-1", 7, 5, None).unwrap();
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, FindingSeverity::Warning);
         assert_eq!(findings[0].finding_type, FindingType::ApprovalBypass);
@@ -267,7 +279,7 @@ mod tests {
             .unwrap();
         }
 
-        let findings = scan_approval_denials(&conn, "sentinel-rev-1", 7, 5).unwrap();
+        let findings = scan_approval_denials(&conn, "sentinel-rev-1", 7, 5, None).unwrap();
         assert_eq!(findings.len(), 1, "only agent_a should be flagged");
         assert_eq!(
             findings[0].affected.agent_alias.as_deref(),
@@ -291,7 +303,7 @@ mod tests {
             .unwrap();
         }
 
-        let findings = scan_approval_denials(&conn, "sentinel-rev-1", 7, 5).unwrap();
+        let findings = scan_approval_denials(&conn, "sentinel-rev-1", 7, 5, None).unwrap();
         assert!(findings.is_empty());
     }
 }

--- a/autonoetic-gateway/src/sentinel/checks/capability_accretion.rs
+++ b/autonoetic-gateway/src/sentinel/checks/capability_accretion.rs
@@ -28,11 +28,15 @@ struct AccretionCandidate {
 
 /// Flag agents that have received more than `threshold` promotions in the
 /// past `window_days` days. Returns one finding per flagged agent.
+///
+/// `scope_agent_id` restricts to a single agent (used by the pre-promotion
+/// gate so a sibling agent's accretion doesn't block this promotion).
 pub fn scan_capability_accretion(
     conn: &Connection,
     sentinel_revision_id: &str,
     window_days: u32,
     threshold: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let cutoff = chrono::Utc::now() - chrono::Duration::days(window_days as i64);
     let cutoff_str = cutoff.to_rfc3339();
@@ -59,20 +63,24 @@ pub fn scan_capability_accretion(
                  LIMIT 1) AS latest_revision_id
          FROM promotion_history ph
          WHERE ph.created_at > ?1
+           AND (?3 IS NULL OR ph.agent_id = ?3)
          GROUP BY ph.agent_id
          HAVING cnt > ?2
          ORDER BY cnt DESC",
     )?;
 
     let candidates = stmt
-        .query_map(rusqlite::params![cutoff_str, threshold_i], |row| {
-            Ok(AccretionCandidate {
-                agent_id: row.get(0)?,
-                promotion_count: row.get(1)?,
-                latest_promotion_id: row.get(2)?,
-                latest_revision_id: row.get(3)?,
-            })
-        })?
+        .query_map(
+            rusqlite::params![cutoff_str, threshold_i, scope_agent_id],
+            |row| {
+                Ok(AccretionCandidate {
+                    agent_id: row.get(0)?,
+                    promotion_count: row.get(1)?,
+                    latest_promotion_id: row.get(2)?,
+                    latest_revision_id: row.get(3)?,
+                })
+            },
+        )?
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
     let mut findings = Vec::new();
@@ -152,7 +160,7 @@ mod tests {
             .unwrap();
         }
 
-        let findings = scan_capability_accretion(&conn, "sentinel-rev-1", 7, 5).unwrap();
+        let findings = scan_capability_accretion(&conn, "sentinel-rev-1", 7, 5, None).unwrap();
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].finding_type, FindingType::CapabilityAccretion);
         assert_eq!(findings[0].severity, FindingSeverity::Warning);
@@ -175,7 +183,7 @@ mod tests {
             .unwrap();
         }
 
-        let findings = scan_capability_accretion(&conn, "sentinel-rev-1", 7, 5).unwrap();
+        let findings = scan_capability_accretion(&conn, "sentinel-rev-1", 7, 5, None).unwrap();
         assert!(findings.is_empty());
     }
 }

--- a/autonoetic-gateway/src/sentinel/checks/credential.rs
+++ b/autonoetic-gateway/src/sentinel/checks/credential.rs
@@ -65,11 +65,15 @@ struct EventRow {
 ///
 /// `since_rfc3339` allows incremental sweeps — pass an RFC-3339 timestamp to
 /// scan only events after that point. Pass `None` for a full history sweep.
+/// `scope_agent_id` filters to events attributed to a specific agent (used
+/// by the pre-promotion gate so a leak in agent A's history does not block
+/// promotion of agent B). `None` = no filter.
 pub fn scan_credential_leaks(
     conn: &Connection,
     sentinel_revision_id: &str,
     since_rfc3339: Option<&str>,
     limit: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
     let lim = limit as i64;
@@ -79,12 +83,13 @@ pub fn scan_credential_leaks(
          FROM causal_events
          WHERE payload IS NOT NULL
            AND timestamp > ?1
+           AND (?3 IS NULL OR agent_id = ?3)
          ORDER BY timestamp ASC
          LIMIT ?2",
     )?;
 
     let rows = stmt
-        .query_map(rusqlite::params![since, lim], |row| {
+        .query_map(rusqlite::params![since, lim, scope_agent_id], |row| {
             Ok(EventRow {
                 event_id: row.get(0)?,
                 agent_id: row.get(1)?,

--- a/autonoetic-gateway/src/sentinel/checks/sandbox_escape.rs
+++ b/autonoetic-gateway/src/sentinel/checks/sandbox_escape.rs
@@ -44,11 +44,14 @@ static MOUNT_BIND_ROOT_RE: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Drain new rows from `sandbox_escape_attempts` since `since_rfc3339`.
 /// Each row becomes a `critical` `SandboxEscapeAttempt` finding.
+///
+/// `scope_agent_id` filters to a single agent (used by the pre-promotion gate).
 pub fn scan_escape_attempt_records(
     conn: &Connection,
     sentinel_revision_id: &str,
     since_rfc3339: Option<&str>,
     limit: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
     let lim = limit as i64;
@@ -57,6 +60,7 @@ pub fn scan_escape_attempt_records(
         "SELECT id, session_id, root_session_id, agent_id, indicator, detail, detected_at
          FROM sandbox_escape_attempts
          WHERE detected_at > ?1
+           AND (?3 IS NULL OR agent_id = ?3)
          ORDER BY detected_at ASC
          LIMIT ?2",
     )?;
@@ -70,7 +74,7 @@ pub fn scan_escape_attempt_records(
     }
 
     let rows = stmt
-        .query_map(rusqlite::params![since, lim], |row| {
+        .query_map(rusqlite::params![since, lim, scope_agent_id], |row| {
             Ok(EscapeRow {
                 id: row.get(0)?,
                 session_id: row.get(1)?,
@@ -110,11 +114,14 @@ pub fn scan_escape_attempt_records(
 
 /// Scan recent causal-event payloads for known-bad sandbox-escape command
 /// patterns that may have slipped through runtime detection.
+///
+/// `scope_agent_id` filters to a single agent (used by the pre-promotion gate).
 pub fn scan_escape_patterns_in_events(
     conn: &Connection,
     sentinel_revision_id: &str,
     since_rfc3339: Option<&str>,
     limit: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
     let lim = limit as i64;
@@ -124,6 +131,7 @@ pub fn scan_escape_patterns_in_events(
          FROM causal_events
          WHERE payload IS NOT NULL
            AND timestamp > ?1
+           AND (?3 IS NULL OR agent_id = ?3)
          ORDER BY timestamp ASC
          LIMIT ?2",
     )?;
@@ -136,7 +144,7 @@ pub fn scan_escape_patterns_in_events(
     }
 
     let rows = stmt
-        .query_map(rusqlite::params![since, lim], |row| {
+        .query_map(rusqlite::params![since, lim, scope_agent_id], |row| {
             Ok(EventRow {
                 event_id: row.get(0)?,
                 agent_id: row.get(1)?,

--- a/autonoetic-gateway/src/sentinel/checks/supply_chain.rs
+++ b/autonoetic-gateway/src/sentinel/checks/supply_chain.rs
@@ -71,11 +71,18 @@ fn artifact_id_from_source(source: &str) -> Option<String> {
 /// Severity:
 /// - `critical` when `source = "runtime.lock"` (scope embedded in agent definition)
 /// - `warning` for artifact layers (scope was explicitly approved for a single mount)
+///
+/// `scope_agent_id` filters to a single mounting agent — used by the pre-promotion
+/// gate so a layer-scope finding from agent A does not block promotion of agent B.
+/// The filter keys on the *mounting* agent (`approvals.agent_id`), not the layer's
+/// originating agent, since findings are attributed to and remediated by whoever
+/// approved the mount.
 pub fn scan_layer_scope_violations(
     conn: &Connection,
     sentinel_revision_id: &str,
     since: Option<&str>,
     scan_limit: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     let mut stmt = conn.prepare(
         "SELECT request_id, agent_id, session_id, root_session_id, action_payload, decided_at
@@ -83,12 +90,13 @@ pub fn scan_layer_scope_violations(
          WHERE action_type = 'layer_mount'
            AND status = 'approved'
            AND (?1 IS NULL OR decided_at >= ?1)
+           AND (?3 IS NULL OR agent_id = ?3)
          ORDER BY decided_at DESC, request_id
          LIMIT ?2",
     )?;
 
     let rows: Vec<(String, String, String, Option<String>, String, Option<String>)> = stmt
-        .query_map(params![since, scan_limit as i64], |row| {
+        .query_map(params![since, scan_limit as i64, scope_agent_id], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
@@ -194,10 +202,14 @@ pub fn scan_layer_provenance_gaps(
     sentinel_revision_id: &str,
     since: Option<&str>,
     scan_limit: u32,
+    scope_agent_id: Option<&str>,
 ) -> Result<Vec<SecurityFinding>> {
     // Collect distinct (layer_id, digest, request_id, agent_id, session_id) from
     // approved layer_mount approvals, then filter to those with no capture trace
     // in execution_traces.result JSON (captured_layers[*].layer_id).
+    //
+    // `scope_agent_id` filters on the *mounting* agent so a provenance gap
+    // for a layer mounted by agent A does not block promotion of agent B.
     let mut stmt = conn.prepare(
         "SELECT DISTINCT
              json_extract(l.value, '$.layer_id')  AS layer_id,
@@ -208,6 +220,7 @@ pub fn scan_layer_provenance_gaps(
          WHERE a.action_type = 'layer_mount'
            AND a.status = 'approved'
            AND (?1 IS NULL OR a.decided_at >= ?1)
+           AND (?3 IS NULL OR a.agent_id = ?3)
            AND json_extract(l.value, '$.layer_id') IS NOT NULL
            AND NOT EXISTS (
                SELECT 1 FROM execution_traces et
@@ -220,17 +233,20 @@ pub fn scan_layer_provenance_gaps(
     )?;
 
     let rows: Vec<(String, String, String, String, String, String, Option<String>)> = stmt
-        .query_map(params![since, scan_limit as i64], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, String>(5)?,
-                row.get::<_, Option<String>>(6)?,
-            ))
-        })?
+        .query_map(
+            params![since, scan_limit as i64, scope_agent_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                ))
+            },
+        )?
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
     let mut findings = Vec::new();
@@ -372,7 +388,7 @@ mod tests {
             &conn, "apr-001", "coder.default", "approved",
             r#"[{"layer_id":"layer_abc","digest":"sha256:aabbcc","name":"python-deps","mount_path":"/deps","source":"artifact:art_001","build_time_approved_hosts":["pypi.org"],"unapproved_delta":["pypi.org"]}]"#,
         );
-        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100).unwrap();
+        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100, None).unwrap();
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, FindingSeverity::Warning);
         assert_eq!(findings[0].finding_type, FindingType::SupplyChainScopeViolation);
@@ -389,7 +405,7 @@ mod tests {
             &conn, "apr-002", "coder.default", "approved",
             r#"[{"layer_id":"layer_def","digest":"sha256:ddeeff","name":"locked-deps","mount_path":"/deps","source":"runtime.lock","build_time_approved_hosts":["private.registry.internal"],"unapproved_delta":["private.registry.internal"]}]"#,
         );
-        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100).unwrap();
+        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100, None).unwrap();
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, FindingSeverity::Critical);
         // No ArtifactId anchor for runtime.lock source.
@@ -403,7 +419,7 @@ mod tests {
             &conn, "apr-003", "coder.default", "approved",
             r#"[{"layer_id":"layer_clean","digest":"sha256:112233","name":"cached-deps","mount_path":"/deps","source":"artifact:art_002","build_time_approved_hosts":["pypi.org"],"unapproved_delta":[]}]"#,
         );
-        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100).unwrap();
+        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100, None).unwrap();
         assert!(findings.is_empty(), "empty delta must not produce a scope violation finding");
     }
 
@@ -414,7 +430,7 @@ mod tests {
             &conn, "apr-004", "coder.default", "pending",
             r#"[{"layer_id":"layer_pend","digest":"sha256:445566","name":"py","mount_path":"/deps","source":"artifact:x","build_time_approved_hosts":["pypi.org"],"unapproved_delta":["pypi.org"]}]"#,
         );
-        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100).unwrap();
+        let findings = scan_layer_scope_violations(&conn, "rev-001", None, 100, None).unwrap();
         assert!(findings.is_empty(), "pending approval must not fire");
     }
 
@@ -425,7 +441,7 @@ mod tests {
             &conn, "apr-005", "coder.default", "approved",
             r#"[{"layer_id":"layer_gap","digest":"sha256:778899","name":"unknown-origin","mount_path":"/deps","source":"artifact:art_003","build_time_approved_hosts":[],"unapproved_delta":[]}]"#,
         );
-        let findings = scan_layer_provenance_gaps(&conn, "rev-001", None, 100).unwrap();
+        let findings = scan_layer_provenance_gaps(&conn, "rev-001", None, 100, None).unwrap();
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].finding_type, FindingType::SupplyChainProvenanceGap);
         assert!(findings[0].evidence_anchors.iter().any(|a| matches!(a, EvidenceAnchor::ApprovalRecord { .. })));
@@ -440,7 +456,7 @@ mod tests {
         );
         // Capture trace in execution_traces.result JSON.
         insert_capture_trace(&conn, "trace_001", "layer_known");
-        let findings = scan_layer_provenance_gaps(&conn, "rev-001", None, 100).unwrap();
+        let findings = scan_layer_provenance_gaps(&conn, "rev-001", None, 100, None).unwrap();
         assert!(findings.is_empty(), "layer with capture trace must not produce gap finding");
     }
 
@@ -454,7 +470,7 @@ mod tests {
                 {"layer_id":"layer_b2","digest":"sha256:222222","name":"b","mount_path":"/b","source":"artifact:y","build_time_approved_hosts":["b.com"],"unapproved_delta":[]}
             ]"#,
         );
-        let violations = scan_layer_scope_violations(&conn, "rev-001", None, 100).unwrap();
+        let violations = scan_layer_scope_violations(&conn, "rev-001", None, 100, None).unwrap();
         assert_eq!(violations.len(), 1, "only the layer with delta fires");
         assert!(violations[0].proposed_remediation.contains("a.com"));
     }

--- a/autonoetic-gateway/src/sentinel/dual_sweep.rs
+++ b/autonoetic-gateway/src/sentinel/dual_sweep.rs
@@ -91,6 +91,7 @@ impl DualSweepRunner {
             cluster_window_minutes: baseline_config.cluster_window_minutes,
             failure_burst_threshold: baseline_config.failure_burst_threshold,
             exec_repeat_threshold: baseline_config.exec_repeat_threshold,
+            scope_agent_id: baseline_config.scope_agent_id.clone(),
         };
 
         // 1. Collect baseline findings (Phase 1 only, no prompt-injection scan).

--- a/autonoetic-gateway/src/sentinel/promotion_gate.rs
+++ b/autonoetic-gateway/src/sentinel/promotion_gate.rs
@@ -1,18 +1,32 @@
 //! Pre-promotion sentinel gate.
 //!
 //! Before `atomic_promote` is called the gateway runs a Phase-1-only sentinel
-//! sweep of the **full store** (not restricted to the promoting agent — any
-//! critical finding in the system blocks promotion, providing a conservative
-//! fail-closed posture). Per-agent scoping is planned for a future phase.
+//! sweep **scoped to the agent being promoted** — every Phase-1 check filters
+//! its query by `agent_id = <agent being promoted>`. A critical finding from
+//! agent A no longer blocks promotion of agent B (issue #155).
 //!
-//! If any `critical` findings exist the promotion is blocked. Scan errors also
-//! block promotion (fail-closed). The sweep is time-boxed: if it does not
-//! complete within `timeout_secs` the gate returns `Err` and the promotion is
-//! also blocked.
+//! If any `critical` findings exist for the scoped agent the promotion is
+//! blocked. Scan errors also block promotion (fail-closed). The sweep is
+//! time-boxed: if it does not complete within `timeout_secs` the gate
+//! returns `Err` and the promotion is also blocked.
 //!
 //! **No findings are persisted by the gate.** Persistence is the job of the
 //! scheduled sweeps so that promotion attempts don't bloat `security_findings`
 //! with duplicate rows. The gate is a read-evaluate-only check.
+//!
+//! ### Filter semantics
+//!
+//! Each Phase-1 check applies the scope to the agent attribution column most
+//! relevant to its finding type:
+//!
+//! - `causal_events.agent_id` for credential-leak and sandbox-escape pattern checks.
+//! - `promotion_history.agent_id` for capability-accretion checks.
+//! - `approvals.agent_id` for approval-bypass and supply-chain checks.
+//! - `sandbox_escape_attempts.agent_id` for the recorded-attempt drain.
+//!
+//! Layer-mount findings filter on the *mounting* agent (`approvals.agent_id`),
+//! not the layer's originating build agent — findings are remediated by
+//! whoever approved the mount.
 
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
@@ -35,29 +49,37 @@ pub enum GateOutcome {
     },
 }
 
-/// Run a pre-promotion Phase-1 sentinel sweep against the full store.
+/// Run a pre-promotion Phase-1 sentinel sweep scoped to the agent being promoted.
 ///
-/// Returns `Ok(GateOutcome::Passed)` when no critical findings exist and no
-/// scan errors occurred within `timeout_secs`. Returns `Ok(GateOutcome::Blocked)`
-/// if critical findings were detected. Returns `Err` on timeout, scan errors, or
-/// sweep panic — all are fail-closed.
+/// Every Phase-1 check filters its query by `agent_id = scope_agent_id`, so a
+/// critical finding from a different agent does not block this promotion.
+///
+/// Returns `Ok(GateOutcome::Passed)` when no critical findings exist for the
+/// scoped agent and no scan errors occurred within `timeout_secs`. Returns
+/// `Ok(GateOutcome::Blocked)` if critical findings were detected. Returns
+/// `Err` on timeout, scan errors, or sweep panic — all fail-closed.
 pub fn check_pre_promotion(
     store: Arc<GatewayStore>,
     sentinel_revision_id: &str,
+    scope_agent_id: &str,
     timeout_secs: u64,
 ) -> Result<GateOutcome> {
     let (tx, rx) = std::sync::mpsc::channel::<Result<GateOutcome>>();
     let store_clone = Arc::clone(&store);
     let rev_id = sentinel_revision_id.to_string();
+    let scope = scope_agent_id.to_string();
 
     std::thread::spawn(move || {
         let runner = SentinelRunner::new(store_clone);
+        let scope_for_msg = scope.clone();
         let outcome = runner
             .scan_phase1_critical(&SweepConfig {
                 sentinel_revision_id: rev_id,
-                // Scan the full history — window_days controls capability-accretion
-                // and approval-denial lookback (90 days).
+                // Scan the full history for the scoped agent — window_days
+                // controls capability-accretion and approval-denial lookback
+                // (90 days).
                 window_days: 90,
+                scope_agent_id: Some(scope),
                 ..SweepConfig::default()
             })
             .and_then(|(critical_count, scan_errors)| {
@@ -73,8 +95,8 @@ pub fn check_pre_promotion(
                 } else {
                     Ok(GateOutcome::Blocked {
                         reason: format!(
-                            "{} critical Phase-1 finding(s) in the store",
-                            critical_count
+                            "{} critical Phase-1 finding(s) for agent '{}'",
+                            critical_count, scope_for_msg
                         ),
                         critical_count,
                     })

--- a/autonoetic-gateway/src/sentinel/runner.rs
+++ b/autonoetic-gateway/src/sentinel/runner.rs
@@ -60,6 +60,11 @@ pub struct SweepConfig {
     /// heuristics and prompt-injection scanning. Used by the dual-sweep
     /// orchestrator for the frozen baseline runner.
     pub phase1_only: bool,
+    /// When set, every Phase-1 check filters its query by this agent ID so
+    /// the sweep only sees signal attributable to that agent. Used by the
+    /// pre-promotion gate so a critical finding from agent A does not block
+    /// promotion of agent B (issue #155). `None` = full-store sweep.
+    pub scope_agent_id: Option<String>,
 }
 
 impl Default for SweepConfig {
@@ -75,6 +80,7 @@ impl Default for SweepConfig {
             failure_burst_threshold: 20,
             exec_repeat_threshold: 10,
             phase1_only: false,
+            scope_agent_id: None,
         }
     }
 }
@@ -202,25 +208,30 @@ impl SentinelRunner {
         let cluster_window_minutes = config.cluster_window_minutes;
         let failure_burst_threshold = config.failure_burst_threshold;
         let exec_repeat_threshold = config.exec_repeat_threshold;
+        let scope = config.scope_agent_id.as_deref();
 
         // All DB checks in a single connection borrow.
         let db_results: Vec<Result<Vec<SecurityFinding>>> = self.store.with_conn(|conn| {
             let mut checks = vec![
                 // Phase 1 — deterministic
-                credential::scan_credential_leaks(conn, rev_id, since, scan_limit),
+                credential::scan_credential_leaks(conn, rev_id, since, scan_limit, scope),
                 capability_accretion::scan_capability_accretion(
-                    conn, rev_id, window_days, accretion_threshold,
+                    conn, rev_id, window_days, accretion_threshold, scope,
                 ),
-                approval_bypass::scan_approval_denials(conn, rev_id, window_days, denial_threshold),
-                approval_bypass::scan_exec_without_grant(conn, rev_id, since, scan_limit),
-                sandbox_escape::scan_escape_attempt_records(conn, rev_id, since, scan_limit),
-                sandbox_escape::scan_escape_patterns_in_events(conn, rev_id, since, scan_limit),
+                approval_bypass::scan_approval_denials(
+                    conn, rev_id, window_days, denial_threshold, scope,
+                ),
+                approval_bypass::scan_exec_without_grant(conn, rev_id, since, scan_limit, scope),
+                sandbox_escape::scan_escape_attempt_records(conn, rev_id, since, scan_limit, scope),
+                sandbox_escape::scan_escape_patterns_in_events(conn, rev_id, since, scan_limit, scope),
                 // Phase 1 — supply-chain auditing
-                supply_chain::scan_layer_scope_violations(conn, rev_id, since, scan_limit),
-                supply_chain::scan_layer_provenance_gaps(conn, rev_id, since, scan_limit),
+                supply_chain::scan_layer_scope_violations(conn, rev_id, since, scan_limit, scope),
+                supply_chain::scan_layer_provenance_gaps(conn, rev_id, since, scan_limit, scope),
             ];
             // Phase 2a — cluster heuristics (always rolling window, not `since`).
             // Skipped when phase1_only is set (e.g. frozen baseline runner).
+            // Cluster heuristics are not scoped — they are diagnostic across
+            // sessions and the gate only consumes Phase-1 findings.
             if !config.phase1_only {
                 checks.push(session_cluster::scan_failure_bursts(
                     conn, rev_id, cluster_window_minutes, failure_burst_threshold, scan_limit,
@@ -312,6 +323,7 @@ impl SentinelRunner {
                 window_days: config.window_days,
                 accretion_threshold: config.accretion_threshold,
                 denial_threshold: config.denial_threshold,
+                scope_agent_id: config.scope_agent_id.clone(),
                 ..SweepConfig::default()
             }
         })?;

--- a/autonoetic-gateway/tests/security_sentinel_integration.rs
+++ b/autonoetic-gateway/tests/security_sentinel_integration.rs
@@ -906,69 +906,209 @@ fn ensure_sentinel_scheduled_jobs_disabled_skips_all() {
 
 #[test]
 fn promotion_gate_passes_on_clean_store() {
-    // With an empty store (no findings), the gate must return Passed.
+    // With an empty store (no findings for the scoped agent), the gate must
+    // return Passed.
     let (_dir, store) = open_store();
     let outcome = autonoetic_gateway::sentinel::check_pre_promotion(
         Arc::clone(&store),
         "sentinel.test",
+        "coder.default",
         10,
     )
     .expect("gate must not error on clean store");
 
     assert!(
         matches!(outcome, autonoetic_gateway::sentinel::GateOutcome::Passed),
-        "gate must pass when no critical findings exist"
+        "gate must pass when no critical findings exist for the scoped agent"
     );
 }
 
 #[test]
-fn promotion_gate_blocks_on_critical_finding() {
-    use autonoetic_gateway::sentinel::runner::{SentinelRunner, SweepConfig};
+fn promotion_gate_blocks_on_critical_finding_for_scoped_agent() {
+    let (dir, _store) = open_store();
 
-    let (dir, store) = open_store();
+    // Inject a credential-leak signal attributed to coder.default.
+    insert_credential_leak_event(&dir, "coder.default", "evt_gate_a");
 
-    // Inject a causal event that will trigger a credential-leak (critical) finding.
-    {
-        let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
-        let fake_key = format!("sk-ant-api03-{}-{}", "A".repeat(92), "A".repeat(10));
-        let now = chrono::Utc::now().to_rfc3339();
-        db.execute(
-            "INSERT INTO causal_events
-                 (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
-             VALUES ('evt_gate_crit', 'coder.default', 'sess_gate', 0, ?1, 'tool', 'tool_call', 'success', ?2)",
-            rusqlite::params![now, fake_key],
-        )
-        .unwrap();
-    }
+    // Re-open the store so the gate sees the inserted row.
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(dir.path()).unwrap(),
+    );
 
-    // Run a sweep so the finding is persisted to security_findings.
-    {
-        let runner = SentinelRunner::new(Arc::clone(&store));
-        runner
-            .run_sweep(&SweepConfig {
-                sentinel_revision_id: "sentinel.test".to_string(),
-                phase1_only: true,
-                ..SweepConfig::default()
-            })
-            .expect("sweep");
-    }
-
-    // Now the gate should detect the critical finding and block.
+    // Gate scoped to coder.default — must block.
     let outcome = autonoetic_gateway::sentinel::check_pre_promotion(
-        Arc::clone(&store),
+        store,
         "sentinel.test",
+        "coder.default",
         10,
     )
     .expect("gate must not error");
 
     match outcome {
-        autonoetic_gateway::sentinel::GateOutcome::Blocked { critical_count, .. } => {
+        autonoetic_gateway::sentinel::GateOutcome::Blocked { critical_count, reason } => {
             assert!(critical_count >= 1, "must report at least one critical finding");
+            assert!(
+                reason.contains("coder.default"),
+                "block message must name the scoped agent: {reason}"
+            );
         }
         autonoetic_gateway::sentinel::GateOutcome::Passed => {
-            panic!("gate must block when critical findings exist in the store");
+            panic!("gate must block when scoped agent has critical findings");
         }
     }
+}
+
+// ── Issue #155 acceptance: per-agent scoping ────────────────────────────────
+
+/// Helper: insert a payload that the credential check flags as critical.
+fn insert_credential_leak_event(dir: &tempfile::TempDir, agent_id: &str, event_id: &str) {
+    let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
+    let fake_key = format!("sk-ant-api03-{}-{}", "A".repeat(92), "A".repeat(10));
+    let now = chrono::Utc::now().to_rfc3339();
+    db.execute(
+        "INSERT INTO causal_events
+             (event_id, agent_id, session_id, event_seq, timestamp, category, action, status, payload)
+         VALUES (?1, ?2, 'sess_x', 0, ?3, 'tool', 'tool_call', 'success', ?4)",
+        rusqlite::params![event_id, agent_id, now, fake_key],
+    )
+    .unwrap();
+}
+
+#[test]
+fn promotion_gate_does_not_block_unrelated_agent() {
+    // Critical finding for agent A must not block promotion of agent B.
+    let (dir, _store) = open_store();
+    insert_credential_leak_event(&dir, "agent_a.default", "evt_a_leak");
+
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(dir.path()).unwrap(),
+    );
+
+    let outcome = autonoetic_gateway::sentinel::check_pre_promotion(
+        store,
+        "sentinel.test",
+        "agent_b.default",
+        10,
+    )
+    .expect("gate must not error");
+
+    assert!(
+        matches!(outcome, autonoetic_gateway::sentinel::GateOutcome::Passed),
+        "gate must pass for agent_b when only agent_a has critical findings"
+    );
+}
+
+#[test]
+fn promotion_gate_blocks_same_agent_after_unrelated_findings() {
+    // Findings exist for both agent A and agent B — gate scoped to A must
+    // block; scoped to B must also block; scoped to a third agent C must pass.
+    let (dir, _store) = open_store();
+    insert_credential_leak_event(&dir, "agent_a.default", "evt_a_leak");
+    insert_credential_leak_event(&dir, "agent_b.default", "evt_b_leak");
+
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(dir.path()).unwrap(),
+    );
+
+    let outcome_a = autonoetic_gateway::sentinel::check_pre_promotion(
+        std::sync::Arc::clone(&store),
+        "sentinel.test",
+        "agent_a.default",
+        10,
+    )
+    .expect("gate must not error");
+    assert!(
+        matches!(outcome_a, autonoetic_gateway::sentinel::GateOutcome::Blocked { .. }),
+        "gate must block scoped to agent_a"
+    );
+
+    let outcome_b = autonoetic_gateway::sentinel::check_pre_promotion(
+        std::sync::Arc::clone(&store),
+        "sentinel.test",
+        "agent_b.default",
+        10,
+    )
+    .expect("gate must not error");
+    assert!(
+        matches!(outcome_b, autonoetic_gateway::sentinel::GateOutcome::Blocked { .. }),
+        "gate must block scoped to agent_b"
+    );
+
+    let outcome_c = autonoetic_gateway::sentinel::check_pre_promotion(
+        store,
+        "sentinel.test",
+        "agent_c.default",
+        10,
+    )
+    .expect("gate must not error");
+    assert!(
+        matches!(outcome_c, autonoetic_gateway::sentinel::GateOutcome::Passed),
+        "gate must pass scoped to agent_c (no findings attributed to it)"
+    );
+}
+
+#[test]
+fn promotion_gate_layer_mount_finding_anchors_to_mounting_agent() {
+    // A layer-mount approval recorded by agent A as the mounter must produce
+    // a scope-violation finding only when the gate is scoped to agent A.
+    let (dir, _store) = open_store();
+    {
+        let db = rusqlite::Connection::open(dir.path().join("gateway.db")).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        // Layer mount with non-empty unapproved_delta and source = runtime.lock,
+        // which produces a Critical SupplyChainScopeViolation.
+        let payload = serde_json::json!({
+            "layers": [{
+                "layer_id": "layer_x",
+                "digest": "sha256:abc123def4567890",
+                "name": "node",
+                "source": "runtime.lock",
+                "unapproved_delta": ["evil.example.com"]
+            }]
+        })
+        .to_string();
+        db.execute(
+            "INSERT INTO approvals (
+                request_id, agent_id, session_id, root_session_id, action_type,
+                action_payload, status, created_at, decided_at, approval_level
+             ) VALUES (
+                'req_mounter_a', 'mounter_a.default', 'sess', 'root_x', 'layer_mount',
+                ?1, 'approved', ?2, ?2, 'operator'
+             )",
+            rusqlite::params![payload, now],
+        )
+        .unwrap();
+    }
+
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(dir.path()).unwrap(),
+    );
+
+    // Scoped to mounter_a — must block.
+    let outcome_a = autonoetic_gateway::sentinel::check_pre_promotion(
+        std::sync::Arc::clone(&store),
+        "sentinel.test",
+        "mounter_a.default",
+        10,
+    )
+    .expect("gate must not error");
+    assert!(
+        matches!(outcome_a, autonoetic_gateway::sentinel::GateOutcome::Blocked { .. }),
+        "gate must block scoped to mounter_a (layer-scope critical)"
+    );
+
+    // Scoped to a different agent — must pass (the mount belongs to mounter_a).
+    let outcome_b = autonoetic_gateway::sentinel::check_pre_promotion(
+        store,
+        "sentinel.test",
+        "other_agent.default",
+        10,
+    )
+    .expect("gate must not error");
+    assert!(
+        matches!(outcome_b, autonoetic_gateway::sentinel::GateOutcome::Passed),
+        "gate must pass scoped to a non-mounting agent (cross-agent isolation)"
+    );
 }
 
 // ── Phase 6: Triage store methods ────────────────────────────────────────────

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -185,15 +185,17 @@ evidence_mode: full
 #   # (sets since_rfc3339 = now-25h). UTC.
 #   incremental_sweep_schedule: "0 */6 * * *"
 #   # When true, agent_revision_promote runs an in-memory Phase-1 sentinel
-#   # scan first. Any `critical` finding the scan produces blocks promotion.
-#   # Fail-closed on scan errors and on timeout.
+#   # scan first, SCOPED TO THE AGENT BEING PROMOTED. Each Phase-1 check
+#   # filters its query by agent_id so a critical finding for agent A does
+#   # not block promotion of agent B (issue #155). Any critical finding for
+#   # the scoped agent blocks promotion. Fail-closed on scan errors and timeout.
 #   #
 #   # IMPORTANT: the gate does NOT consult or persist to security_findings —
 #   # it re-evaluates the live event corpus on every promotion attempt.
 #   # Triaging existing rows in security_findings will NOT unblock the gate.
-#   # To unblock: resolve the signal in the underlying data, wait for windowed
-#   # checks to age past their cutoff, raise per-check thresholds, or disable
-#   # this gate.
+#   # To unblock: resolve the signal in the underlying data for this agent,
+#   # wait for windowed checks to age past their cutoff, raise per-check
+#   # thresholds, or disable this gate.
 #   promotion_gate_enabled: true
 #   # Max seconds the gate waits for the in-memory sweep before fail-closing.
 #   promotion_gate_timeout_secs: 30

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -535,12 +535,27 @@ System-tier read-only auditor over causal events, promotion history, approvals, 
 | `sentinel.enabled` | bool | `true` | Master switch. When `false`, sweeps and the promotion gate are skipped. |
 | `sentinel.full_sweep_schedule` | string (cron) | `"0 3 * * *"` | Cron expression for the daily full (non-incremental) dual sweep. Each check still applies its own `scan_limit` (default 10 000 events) and per-check window (e.g. `window_days = 30` for capability accretion / approval denial); "full" means no `since_rfc3339` cutoff is applied, not that every historical row is examined. UTC. |
 | `sentinel.incremental_sweep_schedule` | string (cron) | `"0 */6 * * *"` | Cron expression for the rolling 25 h incremental dual sweep (sets `since_rfc3339 = now-25h`). UTC. |
-| `sentinel.promotion_gate_enabled` | bool | `true` | When `true`, `agent_revision_promote` runs an in-memory Phase-1 sentinel sweep first via `scan_phase1_critical`. Any `critical` finding the scan produces blocks promotion (fail-closed). The gate **does not consult or persist to `security_findings`** — it re-evaluates the live event corpus on every promotion attempt. Therefore triaging existing rows in `security_findings` will *not* unblock the gate; you must remove or age out the underlying data that the scan flags (or disable the gate). |
+| `sentinel.promotion_gate_enabled` | bool | `true` | When `true`, `agent_revision_promote` runs an in-memory Phase-1 sentinel sweep first via `scan_phase1_critical`, **scoped to the agent being promoted**: every Phase-1 check filters its query by `agent_id = <agent_being_promoted>`, so a critical finding attributed to a different agent does not block this promotion (issue #155). Any `critical` finding for the scoped agent blocks promotion (fail-closed). The gate **does not consult or persist to `security_findings`** — it re-evaluates the live event corpus on every promotion attempt. Therefore triaging existing rows in `security_findings` will *not* unblock the gate; you must remove or age out the underlying data that the scan flags (or disable the gate). |
 | `sentinel.promotion_gate_timeout_secs` | u64 | `30` | Maximum seconds the gate waits for the in-memory sweep before fail-closing. |
 | `sentinel.sentinel_revision_id` | string | `"sentinel.current"` | Revision label embedded in findings produced by the live sentinel. Update when the sentinel logic changes to make findings filterable by version. |
 | `sentinel.baseline_revision_id` | string | `"sentinel.baseline.frozen"` | Revision label for the frozen-baseline pass of the dual sweep. Phase-1 disagreements between baseline and current are recorded in `security_sentinel_disagreements`. |
 
-**Promotion-gate semantics.** The gate is a fresh in-memory Phase-1 scan, not a query against the persisted `security_findings` table. On every promotion attempt it scans the live causal-event / promotion-history / approval / sandbox-escape data (subject to the same `scan_limit` and `window_days` defaults as scheduled sweeps), counts critical findings, and blocks if the count is non-zero or if any check errored. It does not write findings; persisted rows in `security_findings` from earlier scheduled sweeps are not consulted. Consequence: the only ways to unblock a stuck gate are (a) resolve the underlying signal in the data the scan reads, (b) wait for the windowed checks to age past their cutoff, (c) raise per-check thresholds in the gate's `SweepConfig`, or (d) set `promotion_gate_enabled: false`. Per-agent scoping of the scan is tracked as a follow-up.
+**Promotion-gate semantics.** The gate is a fresh in-memory Phase-1 scan **scoped to the agent being promoted**, not a query against the persisted `security_findings` table. On every promotion attempt it scans the live causal-event / promotion-history / approval / sandbox-escape / layer-mount data filtered by the agent's ID (subject to the same `scan_limit` and `window_days` defaults as scheduled sweeps), counts critical findings, and blocks if the count is non-zero or if any check errored. It does not write findings; persisted rows in `security_findings` from earlier scheduled sweeps are not consulted.
+
+Per-agent scope (issue #155, fixed). Each Phase-1 check applies the scope to the most relevant agent attribution column:
+
+| Check | Scope column |
+|---|---|
+| `scan_credential_leaks` | `causal_events.agent_id` |
+| `scan_capability_accretion` | `promotion_history.agent_id` |
+| `scan_approval_denials`, `scan_exec_without_grant` | `approvals.agent_id` |
+| `scan_escape_attempt_records` | `sandbox_escape_attempts.agent_id` |
+| `scan_escape_patterns_in_events` | `causal_events.agent_id` |
+| `scan_layer_scope_violations`, `scan_layer_provenance_gaps` | `approvals.agent_id` (the *mounting* agent) |
+
+Consequence: a critical finding for agent A no longer blocks promotion of agent B. Cross-agent isolation is verified by the `promotion_gate_does_not_block_unrelated_agent`, `promotion_gate_blocks_same_agent_after_unrelated_findings`, and `promotion_gate_layer_mount_finding_anchors_to_mounting_agent` integration tests.
+
+If the gate blocks for the agent being promoted, the unblock paths remain: (a) resolve the underlying signal in the data the scan reads, (b) wait for the windowed checks to age past their cutoff, (c) raise per-check thresholds in the gate's `SweepConfig`, or (d) set `promotion_gate_enabled: false`.
 
 Example:
 

--- a/docs/security-sentinel.md
+++ b/docs/security-sentinel.md
@@ -148,7 +148,7 @@ Three scheduling modes, all expressible with the existing scheduler:
 
 1. **Periodic sweeps** — daily full audit; hourly incremental over the new causal-event range. Default cadence tunable; findings batched.
 
-2. **Pre-promotion gate** — on `agent_revision_promote`, the gateway synchronously invokes the sentinel for a bounded review of the candidate revision. Critical findings block the promotion. This generalizes the `promotion_record` severity-gating pattern that already exists for evaluator/auditor evidence.
+2. **Pre-promotion gate** — on `agent_revision_promote`, the gateway synchronously invokes the sentinel for a bounded review of the candidate revision, **scoped to the agent being promoted**. Each Phase-1 check filters its query by `agent_id`, so a critical finding for agent A does not block promotion of agent B (issue #155, fixed). Critical findings for the scoped agent block the promotion. This generalizes the `promotion_record` severity-gating pattern that already exists for evaluator/auditor evidence.
 
 3. **Event-triggered** — new layer captured, capability declared, approval grant escalation. The gateway emits an event; the sentinel runs a scoped sweep covering only the affected scope.
 


### PR DESCRIPTION
## Summary

Closes #155. The promotion gate previously ran a Phase-1 sentinel sweep over the **full event corpus** — any critical finding anywhere in the system blocked any promotion. A credential leak in agent A's history would prevent emergency rollback of agent B.

This PR adds \`scope_agent_id: Option<String>\` to \`SweepConfig\`, threads it through \`collect_findings\` and \`scan_phase1_critical\`, and has every Phase-1 check filter its SQL by the agent attribution column most relevant to its finding type.

| Check | Scope column |
|---|---|
| \`scan_credential_leaks\` | \`causal_events.agent_id\` |
| \`scan_capability_accretion\` | \`promotion_history.agent_id\` |
| \`scan_approval_denials\`, \`scan_exec_without_grant\` | \`approvals.agent_id\` |
| \`scan_escape_attempt_records\` | \`sandbox_escape_attempts.agent_id\` |
| \`scan_escape_patterns_in_events\` | \`causal_events.agent_id\` |
| \`scan_layer_scope_violations\`, \`scan_layer_provenance_gaps\` | \`approvals.agent_id\` (the *mounting* agent) |

Each check uses the \`(?N IS NULL OR col = ?N)\` pattern already used elsewhere, so passing \`None\` preserves the existing full-store behaviour for scheduled sweeps and any other non-gate caller. **Phase-2 cluster heuristics are intentionally NOT scoped** — they are diagnostic-only and the gate consumes only Phase-1 findings.

The gate caller in \`agent_revision.rs::agent_revision_promote\` now passes \`args.agent_id\` so the gate is automatically scoped to the agent being promoted. The blocked-reason message names the scoped agent.

### Test coverage

Three new integration tests covering the issue acceptance criteria:

- \`promotion_gate_does_not_block_unrelated_agent\` — critical for A doesn't block B (the headline case).
- \`promotion_gate_blocks_same_agent_after_unrelated_findings\` — cross-pollination: findings for both A and B, scoping to A blocks A, scoping to B blocks B, scoping to a third agent C passes.
- \`promotion_gate_layer_mount_finding_anchors_to_mounting_agent\` — cross-agent isolation for the layer-mount path.

Plus the existing gate test renamed and updated to assert the agent name appears in the block reason.

### Behaviour for non-gate callers

\`SweepConfig::scope_agent_id\` defaults to \`None\`. Scheduled dual sweeps continue to scan the full corpus. \`DualSweepRunner\` propagates the field if set but the scheduler never sets it. Only \`check_pre_promotion\` passes a non-\`None\` scope today.

### Docs updated

- \`docs/config-reference.md\` — gate description and the scope-column table.
- \`docs/security-sentinel.md\` — pre-promotion gate description.
- \`config/config-template.yaml\` — operator-facing comment.

## Test plan

- [x] \`cargo build -p autonoetic-gateway\` clean.
- [x] \`cargo test --lib sentinel\` — 55/55.
- [x] \`cargo test --test security_sentinel_integration\` — 34/34 (was 31, +3 new).
- [x] \`cargo test --test security_redteam_integration\` — 9/9.
- [ ] Reviewer confirms the supply-chain checks correctly scope on the *mounting* agent rather than the layer's originating agent (the right choice for remediation: findings are owned by whoever approved the mount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)