### PR TITLE
feat(sentinel): reify frozen baseline as separate module (closes #153)

### DIFF
--- a/autonoetic-gateway/src/sentinel/baseline/approval_bypass.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/approval_bypass.rs
@@ -5,7 +5,8 @@
 //! Frozen snapshot of `super::checks::approval_bypass` (issue #153).
 //! See `super::baseline::credential` for the full editing-rules rationale.
 //!
-//! Last frozen: PR landing #153.
+//! Last frozen at `BASELINE_VERSION = 1.0.0` (issue #153, initial freeze).
+//! See `super::BASELINE_VERSION` for the version pin and bump policy.
 
 #![allow(dead_code)]
 

--- a/autonoetic-gateway/src/sentinel/baseline/approval_bypass.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/approval_bypass.rs
@@ -1,0 +1,191 @@
+//! Approval-bypass pattern detection — **FROZEN BASELINE**.
+//!
+//! ## DO NOT EDIT WITHOUT EXPLICIT OPERATOR ACTION.
+//!
+//! Frozen snapshot of `super::checks::approval_bypass` (issue #153).
+//! See `super::baseline::credential` for the full editing-rules rationale.
+//!
+//! Last frozen: PR landing #153.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use autonoetic_types::security::{
+    AffectedEntities, EvidenceAnchor, FindingSeverity, FindingType, Reproducibility,
+    SecurityFinding,
+};
+use rusqlite::Connection;
+
+/// Flag root sessions that have more than `denial_threshold` denied approvals
+/// in the past `window_days` days. One finding per offending (root_session_id,
+/// agent_id) pair, using the most-recently-denied session_id for attribution.
+///
+/// `scope_agent_id` filters to a single agent (used by the pre-promotion gate).
+pub fn scan_approval_denials(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    window_days: u32,
+    denial_threshold: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(window_days as i64);
+    let cutoff_str = cutoff.to_rfc3339();
+    let threshold_i = denial_threshold as i64;
+
+    // Group by (root_session_id, agent_id) so every selected column is
+    // part of the group key — avoids SQLite returning arbitrary values for
+    // non-aggregated columns that were previously projected without grouping.
+    // The most-recent session_id is fetched via a correlated subquery.
+    let mut stmt = conn.prepare(
+        "SELECT ap.root_session_id,
+                ap.agent_id,
+                COUNT(*) AS cnt,
+                (SELECT session_id FROM approvals a2
+                 WHERE a2.root_session_id = ap.root_session_id
+                   AND a2.agent_id = ap.agent_id
+                   AND a2.status = 'denied'
+                   AND a2.created_at > ?1
+                 ORDER BY a2.created_at DESC LIMIT 1) AS latest_session_id
+         FROM approvals ap
+         WHERE ap.status = 'denied'
+           AND ap.created_at > ?1
+           AND (?3 IS NULL OR ap.agent_id = ?3)
+         GROUP BY ap.root_session_id, ap.agent_id
+         HAVING cnt > ?2
+         ORDER BY cnt DESC",
+    )?;
+
+    struct DenialRow {
+        root_session_id: String,
+        agent_id: String,
+        count: i64,
+        latest_session_id: Option<String>,
+    }
+
+    let rows = stmt
+        .query_map(
+            rusqlite::params![cutoff_str, threshold_i, scope_agent_id],
+            |row| {
+                Ok(DenialRow {
+                    root_session_id: row.get(0)?,
+                    agent_id: row.get(1)?,
+                    count: row.get(2)?,
+                    latest_session_id: row.get(3)?,
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+    for r in rows {
+        let session_id = r.latest_session_id.unwrap_or_else(|| r.root_session_id.clone());
+        let finding = SecurityFinding::new(
+            FindingType::ApprovalBypass,
+            FindingSeverity::Warning,
+            0.8,
+            Reproducibility::Deterministic,
+            format!(
+                "Root session '{}' (agent '{}') accumulated {} denied approval requests \
+                 in the past {} days. Review the session's causal chain for repeated \
+                 attempts to perform disallowed operations.",
+                r.root_session_id, r.agent_id, r.count, window_days
+            ),
+            sentinel_revision_id,
+        )
+        .with_affected(AffectedEntities {
+            agent_alias: Some(r.agent_id.clone()),
+            session_id: Some(session_id),
+            ..Default::default()
+        })
+        .with_anchors(vec![EvidenceAnchor::CausalEvent {
+            id: format!("approval_denial_root:{}", r.root_session_id),
+        }]);
+        findings.push(finding);
+    }
+    Ok(findings)
+}
+
+/// Flag root sessions that have approved `sandbox_exec` actions but no
+/// matching `session_approval_grants` row. This is a structural check:
+/// every approved sandbox_exec should produce a grant; its absence may
+/// indicate a grant-recording failure or a bypass.
+///
+/// The check is scoped to `action_type = 'sandbox_exec'` and requires that
+/// the NOT EXISTS matches on both `root_session_id` and `agent_id` to avoid
+/// false positives from grants belonging to a different agent in the same
+/// root session.
+pub fn scan_exec_without_grant(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    since_rfc3339: Option<&str>,
+    limit: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
+    let lim = limit as i64;
+
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT ap.root_session_id, ap.session_id, ap.agent_id
+         FROM approvals ap
+         WHERE ap.status = 'approved'
+           AND ap.action_type = 'sandbox_exec'
+           AND ap.created_at > ?1
+           AND ap.root_session_id IS NOT NULL
+           AND (?3 IS NULL OR ap.agent_id = ?3)
+           AND NOT EXISTS (
+               SELECT 1 FROM session_approval_grants sg
+               WHERE sg.root_session_id = ap.root_session_id
+                 AND sg.agent_id = ap.agent_id
+           )
+         ORDER BY ap.created_at ASC
+         LIMIT ?2",
+    )?;
+
+    struct ApprovalRow {
+        root_session_id: String,
+        session_id: String,
+        agent_id: String,
+    }
+
+    let rows = stmt
+        .query_map(
+            rusqlite::params![since, lim, scope_agent_id],
+            |row| {
+                Ok(ApprovalRow {
+                    root_session_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    agent_id: row.get(2)?,
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+    for r in rows {
+        let finding = SecurityFinding::new(
+            FindingType::ApprovalBypass,
+            FindingSeverity::Warning,
+            0.75,
+            Reproducibility::Deterministic,
+            format!(
+                "Root session '{}' (agent '{}') has an approved sandbox_exec action \
+                 but no corresponding session_approval_grant for that agent. \
+                 This may indicate a grant-recording failure or a bypass. \
+                 Review approvals and session_approval_grants for this root session.",
+                r.root_session_id, r.agent_id
+            ),
+            sentinel_revision_id,
+        )
+        .with_affected(AffectedEntities {
+            agent_alias: Some(r.agent_id.clone()),
+            session_id: Some(r.session_id.clone()),
+            ..Default::default()
+        })
+        .with_anchors(vec![EvidenceAnchor::CausalEvent {
+            id: format!("approval_grant_gap:{}:{}", r.root_session_id, r.agent_id),
+        }]);
+        findings.push(finding);
+    }
+    Ok(findings)
+}
+

--- a/autonoetic-gateway/src/sentinel/baseline/capability_accretion.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/capability_accretion.rs
@@ -1,0 +1,120 @@
+//! Capability-accretion detection — **FROZEN BASELINE**.
+//!
+//! ## DO NOT EDIT WITHOUT EXPLICIT OPERATOR ACTION.
+//!
+//! Frozen snapshot of `super::checks::capability_accretion` (issue #153).
+//! See `super::baseline::credential` for the full editing-rules rationale —
+//! summary: changes to detection logic go to `super::checks`, not here, so the
+//! dual-sweep can detect a regression in the canonical sentinel.
+//!
+//! Last frozen: PR landing #153.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use autonoetic_types::security::{
+    AffectedEntities, EvidenceAnchor, FindingSeverity, FindingType, Reproducibility,
+    SecurityFinding,
+};
+use rusqlite::Connection;
+
+/// An agent with a suspiciously high promotion rate.
+struct AccretionCandidate {
+    agent_id: String,
+    promotion_count: i64,
+    /// The `promotion_id` of the most recent promotion (by `created_at`).
+    latest_promotion_id: String,
+    /// The `new_revision_id` corresponding to the most recent promotion.
+    latest_revision_id: String,
+}
+
+/// Flag agents that have received more than `threshold` promotions in the
+/// past `window_days` days. Returns one finding per flagged agent.
+///
+/// `scope_agent_id` restricts to a single agent (used by the pre-promotion
+/// gate so a sibling agent's accretion doesn't block this promotion).
+pub fn scan_capability_accretion(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    window_days: u32,
+    threshold: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(window_days as i64);
+    let cutoff_str = cutoff.to_rfc3339();
+    let threshold_i = threshold as i64;
+
+    // Two-step approach: first count promotions per agent in the window, then
+    // fetch the most recent promotion separately to anchor the finding.
+    // Using a scalar subquery for the anchor avoids JOIN multiplication when
+    // multiple rows share the same MAX(created_at) timestamp.
+    let mut stmt = conn.prepare(
+        "SELECT ph.agent_id,
+                COUNT(*) AS cnt,
+                (SELECT p2.promotion_id
+                 FROM promotion_history p2
+                 WHERE p2.agent_id = ph.agent_id
+                   AND p2.created_at > ?1
+                 ORDER BY p2.created_at DESC, p2.promotion_id DESC
+                 LIMIT 1) AS latest_promotion_id,
+                (SELECT p2.new_revision_id
+                 FROM promotion_history p2
+                 WHERE p2.agent_id = ph.agent_id
+                   AND p2.created_at > ?1
+                 ORDER BY p2.created_at DESC, p2.promotion_id DESC
+                 LIMIT 1) AS latest_revision_id
+         FROM promotion_history ph
+         WHERE ph.created_at > ?1
+           AND (?3 IS NULL OR ph.agent_id = ?3)
+         GROUP BY ph.agent_id
+         HAVING cnt > ?2
+         ORDER BY cnt DESC",
+    )?;
+
+    let candidates = stmt
+        .query_map(
+            rusqlite::params![cutoff_str, threshold_i, scope_agent_id],
+            |row| {
+                Ok(AccretionCandidate {
+                    agent_id: row.get(0)?,
+                    promotion_count: row.get(1)?,
+                    latest_promotion_id: row.get(2)?,
+                    latest_revision_id: row.get(3)?,
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+    for c in candidates {
+        let finding = SecurityFinding::new(
+            FindingType::CapabilityAccretion,
+            FindingSeverity::Warning,
+            0.7,
+            Reproducibility::Deterministic,
+            format!(
+                "Agent '{}' received {} promotions in the last {} days (threshold: {}). \
+                 Review promotion history for gradual capability scope expansion. \
+                 Use 'autonoetic agent revision list {}' to inspect each revision.",
+                c.agent_id, c.promotion_count, window_days, threshold, c.agent_id
+            ),
+            sentinel_revision_id,
+        )
+        .with_affected(AffectedEntities {
+            agent_alias: Some(c.agent_id.clone()),
+            revision_id: Some(c.latest_revision_id.clone()),
+            ..Default::default()
+        })
+        .with_anchors(vec![
+            EvidenceAnchor::PromotionRecord {
+                promotion_id: c.latest_promotion_id.clone(),
+            },
+            EvidenceAnchor::RevisionId {
+                id: c.latest_revision_id.clone(),
+            },
+        ]);
+        findings.push(finding);
+    }
+    Ok(findings)
+}
+

--- a/autonoetic-gateway/src/sentinel/baseline/capability_accretion.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/capability_accretion.rs
@@ -7,7 +7,8 @@
 //! summary: changes to detection logic go to `super::checks`, not here, so the
 //! dual-sweep can detect a regression in the canonical sentinel.
 //!
-//! Last frozen: PR landing #153.
+//! Last frozen at `BASELINE_VERSION = 1.0.0` (issue #153, initial freeze).
+//! See `super::BASELINE_VERSION` for the version pin and bump policy.
 
 #![allow(dead_code)]
 

--- a/autonoetic-gateway/src/sentinel/baseline/credential.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/credential.rs
@@ -1,0 +1,208 @@
+//! Credential-pattern regex scan over causal-event payloads — **FROZEN BASELINE**.
+//!
+//! ## DO NOT EDIT WITHOUT EXPLICIT OPERATOR ACTION.
+//!
+//! This file is a frozen snapshot of `super::checks::credential` (issue #153).
+//! Its purpose is to provide an independent reference for the dual-sweep:
+//! a regex regression in `super::checks::credential` will not propagate here,
+//! so the baseline pass will continue to flag the regressed-out anchor and
+//! `dual_sweep::compare_phase1` will record a `baseline_only` disagreement,
+//! catching the regression at the next sweep.
+//!
+//! **Editing rules:**
+//!
+//! - The default expectation is that this file is *never* edited. Improvements
+//!   to credential detection go to `super::checks::credential` so the canonical
+//!   sentinel benefits, while this baseline keeps a stable reference.
+//! - The frozen baseline is updated only when the operator deliberately wants
+//!   the *baseline* to evolve (e.g. retiring an obsolete credential format).
+//!   Such commits should carry a `[baseline-update]` prefix in the commit
+//!   message and be reviewed as a separate PR from any `super::checks::*`
+//!   change. PRs that touch both `checks/` and `baseline/` for the same
+//!   pattern defeat the purpose of having a baseline.
+//!
+//! Last frozen: PR landing #153. Pattern vocabulary mirrors
+//! `super::checks::credential` at the time this file was created.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use autonoetic_types::security::{
+    AffectedEntities, EvidenceAnchor, FindingSeverity, FindingType, Reproducibility,
+    SecurityFinding,
+};
+use regex::Regex;
+use rusqlite::Connection;
+use std::sync::LazyLock;
+
+// ── credential pattern vocabulary ────────────────────────────────────────────
+
+/// AWS access key: AKIA… (20 uppercase alphanumeric chars)
+static AWS_ACCESS_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bAKIA[A-Z0-9]{16}\b").expect("valid aws access key regex")
+});
+
+/// OpenAI API key: sk-…
+static OPENAI_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bsk-[A-Za-z0-9]{20,}\b").expect("valid openai key regex")
+});
+
+/// GitHub personal access token: ghp_…, gho_…, ghs_…, ghr_…
+static GITHUB_PAT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bgh[poshpr]_[A-Za-z0-9]{36}\b").expect("valid github pat regex")
+});
+
+/// Generic high-entropy hex string (≥ 64 hex chars = 256 bits) — potential raw secret.
+///
+/// The lower bound is 64 specifically to exclude git SHAs (40 hex chars) and other
+/// 40-char content digests that are routinely embedded in causal-event payloads.
+/// 64+ hex characters indicate sha256 / 256-bit symmetric keys / similar — the
+/// regime where false positives drop sharply.
+static HIGH_ENTROPY_HEX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b[a-fA-F0-9]{64,}\b").expect("valid high-entropy hex regex")
+});
+
+/// Bearer token still present in payload.
+static BEARER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bbearer\s+[A-Za-z0-9\-._~+/]{16,}").expect("valid bearer regex")
+});
+
+/// Anthropic API key: sk-ant-…
+static ANTHROPIC_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bsk-ant-[A-Za-z0-9\-]{20,}\b").expect("valid anthropic key regex")
+});
+
+// ── row type from the query ───────────────────────────────────────────────────
+
+struct EventRow {
+    event_id: String,
+    agent_id: String,
+    session_id: String,
+    payload: String,
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Scan recent causal-event payloads for credential-pattern matches.
+///
+/// `since_rfc3339` allows incremental sweeps — pass an RFC-3339 timestamp to
+/// scan only events after that point. Pass `None` for a full history sweep.
+/// `scope_agent_id` filters to events attributed to a specific agent (used
+/// by the pre-promotion gate so a leak in agent A's history does not block
+/// promotion of agent B). `None` = no filter.
+pub fn scan_credential_leaks(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    since_rfc3339: Option<&str>,
+    limit: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
+    let lim = limit as i64;
+
+    let mut stmt = conn.prepare(
+        "SELECT event_id, agent_id, session_id, payload
+         FROM causal_events
+         WHERE payload IS NOT NULL
+           AND timestamp > ?1
+           AND (?3 IS NULL OR agent_id = ?3)
+         ORDER BY timestamp ASC
+         LIMIT ?2",
+    )?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![since, lim, scope_agent_id], |row| {
+            Ok(EventRow {
+                event_id: row.get(0)?,
+                agent_id: row.get(1)?,
+                session_id: row.get(2)?,
+                payload: row.get(3)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+    for row in rows {
+        if let Some((pattern_name, match_len)) = detect_credential(&row.payload) {
+            // `high_entropy_hex` is a heuristic — its regex matches any 64+
+            // hex string (sha256, AES-256 keys, but also legitimate digests).
+            // It lands at Warning so it cannot single-handedly block a
+            // promotion via the sentinel gate, and its remediation message
+            // calls for verification first rather than immediate rotation.
+            // All other patterns (specific key formats, bearer tokens) stay
+            // at Critical because the regex shape is highly specific to a
+            // known credential format.
+            let is_heuristic = pattern_name == "high_entropy_hex";
+            let severity = if is_heuristic {
+                FindingSeverity::Warning
+            } else {
+                FindingSeverity::Critical
+            };
+            let confidence = if is_heuristic { 0.6 } else { 1.0 };
+            let remediation = if is_heuristic {
+                format!(
+                    "Heuristic credential pattern '{}' matched in causal event payload \
+                     (match length: {} chars). This regex matches any high-entropy hex \
+                     string and may be a legitimate sha256 digest, content hash, or \
+                     symmetric key in transit. Investigate via the evidence anchor: \
+                     retrieve the event, identify the matched value, and rotate only \
+                     if it is a real secret. Mark as false_positive otherwise.",
+                    pattern_name, match_len
+                )
+            } else {
+                format!(
+                    "Credential pattern '{}' matched in causal event payload \
+                     (match length: {} chars). The regex shape is specific to a known \
+                     credential format. Rotate any matching credential immediately. \
+                     Use the evidence anchor to retrieve the event under controlled access.",
+                    pattern_name, match_len
+                )
+            };
+            let finding = SecurityFinding::new(
+                FindingType::CredentialLeak,
+                severity,
+                confidence,
+                Reproducibility::Deterministic,
+                remediation,
+                sentinel_revision_id,
+            )
+            .with_affected(AffectedEntities {
+                agent_alias: Some(row.agent_id.clone()),
+                session_id: Some(row.session_id.clone()),
+                ..Default::default()
+            })
+            .with_anchors(vec![EvidenceAnchor::CausalEvent {
+                id: row.event_id.clone(),
+            }]);
+            findings.push(finding);
+        }
+    }
+    Ok(findings)
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+/// Returns `(pattern_name, match_length)` — intentionally no matched text to
+/// prevent re-introducing credential material into the findings store.
+fn detect_credential(text: &str) -> Option<(&'static str, usize)> {
+    if let Some(m) = ANTHROPIC_KEY_RE.find(text) {
+        return Some(("anthropic_api_key", m.len()));
+    }
+    if let Some(m) = OPENAI_KEY_RE.find(text) {
+        return Some(("openai_api_key", m.len()));
+    }
+    if let Some(m) = AWS_ACCESS_KEY_RE.find(text) {
+        return Some(("aws_access_key", m.len()));
+    }
+    if let Some(m) = GITHUB_PAT_RE.find(text) {
+        return Some(("github_pat", m.len()));
+    }
+    if let Some(m) = BEARER_RE.find(text) {
+        return Some(("bearer_token", m.len()));
+    }
+    if let Some(m) = HIGH_ENTROPY_HEX_RE.find(text) {
+        return Some(("high_entropy_hex", m.len()));
+    }
+    None
+}
+

--- a/autonoetic-gateway/src/sentinel/baseline/credential.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/credential.rs
@@ -21,8 +21,10 @@
 //!   change. PRs that touch both `checks/` and `baseline/` for the same
 //!   pattern defeat the purpose of having a baseline.
 //!
-//! Last frozen: PR landing #153. Pattern vocabulary mirrors
-//! `super::checks::credential` at the time this file was created.
+//! Last frozen at `BASELINE_VERSION = 1.0.0` (issue #153, initial freeze).
+//! Pattern vocabulary mirrors `super::checks::credential` at the time this
+//! file was created. See `super::BASELINE_VERSION` for the version pin and
+//! the bump policy.
 
 #![allow(dead_code)]
 

--- a/autonoetic-gateway/src/sentinel/baseline/mod.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/mod.rs
@@ -39,8 +39,13 @@
 //!   2. Land as a *separate PR* from any concurrent change to
 //!      `super::checks`. PRs that touch both `checks/` and `baseline/` for
 //!      the same pattern defeat the disagreement-detection contract.
-//!   3. Document the rationale in the PR description and bump the
-//!      "Last frozen:" line in each touched baseline file.
+//!   3. Bump [`BASELINE_VERSION`] following the convention documented on
+//!      that constant.
+//!   4. Document the rationale in the PR description.
+//!
+//! Today these rules are enforced solely by code review. An automated CI
+//! guard rejecting concurrent edits without `[baseline-update]` is tracked
+//! as issue #165.
 //!
 //! ## Why duplicate the code instead of generating it?
 //!
@@ -49,6 +54,27 @@
 //! reflection) would propagate into the baseline. Hand-written, hand-frozen
 //! copies are the strongest separation we have without a separate crate or
 //! versioned binary, both of which would add far more workspace machinery.
+
+/// Version pin for the frozen baseline.
+///
+/// Bump on each `[baseline-update]` PR. The version is referenced from every
+/// baseline file's header and surfaced as the `BASELINE_VERSION` constant
+/// for tooling (CLI, docs, future CI guards) so the pin is unambiguous —
+/// PR numbers can collide across forks/renames, dates do not uniquely
+/// identify the snapshot, and commit SHAs are not known until merge time.
+///
+/// **Versioning convention:** semver-style `MAJOR.MINOR.PATCH`.
+///
+/// - `MAJOR` bumps when a check is added or removed (the *shape* of what
+///   the baseline detects changes).
+/// - `MINOR` bumps when a check's detection logic is updated (a regex
+///   tightened, a threshold adjusted) without changing what categories
+///   are detected.
+/// - `PATCH` bumps for purely mechanical changes (rename, doc tweak,
+///   refactor that does not alter SQL or regex literals).
+///
+/// Initial freeze for issue #153: `1.0.0`.
+pub const BASELINE_VERSION: &str = "1.0.0";
 
 pub mod approval_bypass;
 pub mod capability_accretion;

--- a/autonoetic-gateway/src/sentinel/baseline/mod.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/mod.rs
@@ -1,0 +1,57 @@
+//! Frozen-baseline copies of the deterministic Phase-1 checks.
+//!
+//! ## Purpose
+//!
+//! The dual-sweep orchestrator ([`super::dual_sweep::DualSweepRunner`])
+//! recursive-trust mitigation runs the same SQL queries and regexes twice:
+//! once via the canonical [`super::checks`] module (the "current" sentinel)
+//! and once via this `baseline` module. When a regression is introduced into
+//! `super::checks` — a regex narrowed too far, a SQL filter that drops a
+//! finding, a threshold weakened — the canonical pass misses the anchor.
+//! The baseline pass continues to flag it, and `compare_phase1` records a
+//! `baseline_only` disagreement which surfaces to the operator.
+//!
+//! This is the "frozen anchor" claim from the design doc made architectural
+//! rather than just a configuration label.
+//!
+//! ## What's here
+//!
+//! Frozen copies of the five Phase-1 deterministic checks:
+//!
+//! - [`credential`]
+//! - [`capability_accretion`]
+//! - [`approval_bypass`]
+//! - [`sandbox_escape`]
+//! - [`supply_chain`]
+//!
+//! Phase-2 (LLM-judgment) checks are intentionally NOT mirrored here — the
+//! baseline is `phase1_only` by contract.
+//!
+//! ## Editing rules
+//!
+//! - Default expectation: this directory is *never* edited. Improvements to
+//!   detection logic go to `super::checks` so the canonical sentinel benefits;
+//!   the baseline keeps a stable reference for disagreement detection.
+//! - Updating the baseline is a deliberate operator action, e.g. retiring a
+//!   detection class that has been definitively superseded. Such commits
+//!   should:
+//!   1. Carry a `[baseline-update]` prefix in the commit message.
+//!   2. Land as a *separate PR* from any concurrent change to
+//!      `super::checks`. PRs that touch both `checks/` and `baseline/` for
+//!      the same pattern defeat the disagreement-detection contract.
+//!   3. Document the rationale in the PR description and bump the
+//!      "Last frozen:" line in each touched baseline file.
+//!
+//! ## Why duplicate the code instead of generating it?
+//!
+//! Build-time generation would couple the baseline to the canonical source —
+//! a regression in the source generator (or a careless `cargo expand`-style
+//! reflection) would propagate into the baseline. Hand-written, hand-frozen
+//! copies are the strongest separation we have without a separate crate or
+//! versioned binary, both of which would add far more workspace machinery.
+
+pub mod approval_bypass;
+pub mod capability_accretion;
+pub mod credential;
+pub mod sandbox_escape;
+pub mod supply_chain;

--- a/autonoetic-gateway/src/sentinel/baseline/sandbox_escape.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/sandbox_escape.rs
@@ -5,7 +5,8 @@
 //! Frozen snapshot of `super::checks::sandbox_escape` (issue #153).
 //! See `super::baseline::credential` for the full editing-rules rationale.
 //!
-//! Last frozen: PR landing #153.
+//! Last frozen at `BASELINE_VERSION = 1.0.0` (issue #153, initial freeze).
+//! See `super::BASELINE_VERSION` for the version pin and bump policy.
 
 #![allow(dead_code)]
 

--- a/autonoetic-gateway/src/sentinel/baseline/sandbox_escape.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/sandbox_escape.rs
@@ -1,0 +1,212 @@
+//! Sandbox-escape pattern detection — **FROZEN BASELINE**.
+//!
+//! ## DO NOT EDIT WITHOUT EXPLICIT OPERATOR ACTION.
+//!
+//! Frozen snapshot of `super::checks::sandbox_escape` (issue #153).
+//! See `super::baseline::credential` for the full editing-rules rationale.
+//!
+//! Last frozen: PR landing #153.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use autonoetic_types::security::{
+    AffectedEntities, EvidenceAnchor, FindingSeverity, FindingType, Reproducibility,
+    SecurityFinding,
+};
+use regex::Regex;
+use rusqlite::Connection;
+use std::sync::LazyLock;
+
+// ── known-bad command patterns ────────────────────────────────────────────────
+
+/// `nsenter` — enter a running container namespace, a classic escape vector.
+static NSENTER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bnsenter\b").expect("valid nsenter regex"));
+
+/// `docker run --privileged` or `docker run -v /:/` — mounting host root.
+static DOCKER_PRIVILEGED_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"docker\s+run\s+.*--privileged|docker\s+run\s+.*-v\s+/:/")
+        .expect("valid docker privileged regex")
+});
+
+/// `chroot /` with a following command — classic jailbreak pattern.
+static CHROOT_ROOT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bchroot\s+/\s+").expect("valid chroot root regex")
+});
+
+/// Writing to `/proc/sysrq-trigger` — kernel escape.
+static SYSRQ_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"/proc/sysrq-trigger").expect("valid sysrq regex")
+});
+
+/// `mount --bind /` — bind-mounting host root.
+static MOUNT_BIND_ROOT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bmount\s+--bind\s+/").expect("valid mount bind root regex")
+});
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Drain new rows from `sandbox_escape_attempts` since `since_rfc3339`.
+/// Each row becomes a `critical` `SandboxEscapeAttempt` finding.
+///
+/// `scope_agent_id` filters to a single agent (used by the pre-promotion gate).
+pub fn scan_escape_attempt_records(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    since_rfc3339: Option<&str>,
+    limit: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
+    let lim = limit as i64;
+
+    let mut stmt = conn.prepare(
+        "SELECT id, session_id, root_session_id, agent_id, indicator, detail, detected_at
+         FROM sandbox_escape_attempts
+         WHERE detected_at > ?1
+           AND (?3 IS NULL OR agent_id = ?3)
+         ORDER BY detected_at ASC
+         LIMIT ?2",
+    )?;
+
+    struct EscapeRow {
+        id: i64,
+        session_id: String,
+        agent_id: String,
+        indicator: String,
+        detail: Option<String>,
+    }
+
+    let rows = stmt
+        .query_map(rusqlite::params![since, lim, scope_agent_id], |row| {
+            Ok(EscapeRow {
+                id: row.get(0)?,
+                session_id: row.get(1)?,
+                agent_id: row.get(3)?,
+                indicator: row.get(4)?,
+                detail: row.get(5)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+    for r in rows {
+        let detail = r.detail.as_deref().unwrap_or("(no detail)");
+        let finding = SecurityFinding::new(
+            FindingType::SandboxEscapeAttempt,
+            FindingSeverity::Critical,
+            1.0,
+            Reproducibility::Deterministic,
+            format!(
+                "Sandbox escape attempt recorded for agent '{}' in session '{}'. \
+                 Indicator: '{}'. Detail: {}. \
+                 Investigate immediately and consider revoking the session.",
+                r.agent_id, r.session_id, r.indicator, detail
+            ),
+            sentinel_revision_id,
+        )
+        .with_affected(AffectedEntities {
+            agent_alias: Some(r.agent_id.clone()),
+            session_id: Some(r.session_id.clone()),
+            ..Default::default()
+        })
+        .with_anchors(vec![EvidenceAnchor::SandboxEscapeRecord { rowid: r.id }]);
+        findings.push(finding);
+    }
+    Ok(findings)
+}
+
+/// Scan recent causal-event payloads for known-bad sandbox-escape command
+/// patterns that may have slipped through runtime detection.
+///
+/// `scope_agent_id` filters to a single agent (used by the pre-promotion gate).
+pub fn scan_escape_patterns_in_events(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    since_rfc3339: Option<&str>,
+    limit: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let since = since_rfc3339.unwrap_or("1970-01-01T00:00:00Z");
+    let lim = limit as i64;
+
+    let mut stmt = conn.prepare(
+        "SELECT event_id, agent_id, session_id, payload
+         FROM causal_events
+         WHERE payload IS NOT NULL
+           AND timestamp > ?1
+           AND (?3 IS NULL OR agent_id = ?3)
+         ORDER BY timestamp ASC
+         LIMIT ?2",
+    )?;
+
+    struct EventRow {
+        event_id: String,
+        agent_id: String,
+        session_id: String,
+        payload: String,
+    }
+
+    let rows = stmt
+        .query_map(rusqlite::params![since, lim, scope_agent_id], |row| {
+            Ok(EventRow {
+                event_id: row.get(0)?,
+                agent_id: row.get(1)?,
+                session_id: row.get(2)?,
+                payload: row.get(3)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+    for r in rows {
+        if let Some(pattern_name) = detect_escape_pattern(&r.payload) {
+            let finding = SecurityFinding::new(
+                FindingType::SandboxEscapeAttempt,
+                FindingSeverity::Critical,
+                0.95,
+                Reproducibility::Deterministic,
+                format!(
+                    "Known sandbox-escape command pattern '{}' detected in causal event \
+                     payload for agent '{}' session '{}'. \
+                     Review the event and the agent's execution history.",
+                    pattern_name, r.agent_id, r.session_id
+                ),
+                sentinel_revision_id,
+            )
+            .with_affected(AffectedEntities {
+                agent_alias: Some(r.agent_id.clone()),
+                session_id: Some(r.session_id.clone()),
+                ..Default::default()
+            })
+            .with_anchors(vec![EvidenceAnchor::CausalEvent {
+                id: r.event_id.clone(),
+            }]);
+            findings.push(finding);
+        }
+    }
+    Ok(findings)
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+fn detect_escape_pattern(text: &str) -> Option<&'static str> {
+    if NSENTER_RE.is_match(text) {
+        return Some("nsenter");
+    }
+    if DOCKER_PRIVILEGED_RE.is_match(text) {
+        return Some("docker_privileged_mount");
+    }
+    if CHROOT_ROOT_RE.is_match(text) {
+        return Some("chroot_root");
+    }
+    if SYSRQ_RE.is_match(text) {
+        return Some("sysrq_trigger");
+    }
+    if MOUNT_BIND_ROOT_RE.is_match(text) {
+        return Some("mount_bind_root");
+    }
+    None
+}
+

--- a/autonoetic-gateway/src/sentinel/baseline/supply_chain.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/supply_chain.rs
@@ -1,0 +1,287 @@
+//! Supply-chain auditing checks (Phase 4, deterministic) — **FROZEN BASELINE**.
+//!
+//! ## DO NOT EDIT WITHOUT EXPLICIT OPERATOR ACTION.
+//!
+//! Frozen snapshot of `super::checks::supply_chain` (issue #153).
+//! See `super::baseline::credential` for the full editing-rules rationale.
+//!
+//! Last frozen: PR landing #153.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use autonoetic_types::security::{
+    AffectedEntities, EvidenceAnchor, FindingSeverity, FindingType, Reproducibility,
+    SecurityFinding,
+};
+use rusqlite::{params, Connection};
+use serde::Deserialize;
+
+// ── JSON payload shapes ───────────────────────────────────────────────────────
+
+/// Mirrors the `layers` array element written by sandbox.rs when requesting a
+/// `layer_mount` approval (shape of `LayerMountScopeInfo` serialised to JSON).
+#[derive(Debug, Deserialize)]
+struct LayerApprovalEntry {
+    #[serde(default)]
+    layer_id: String,
+    #[serde(default)]
+    digest: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    unapproved_delta: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayerMountPayload {
+    #[serde(default)]
+    layers: Vec<LayerApprovalEntry>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Extract a content-addressed artifact ID from the `source` field when it is
+/// in the form `"artifact:<id>"`, returning `None` for `"runtime.lock"` or
+/// other non-artifact sources.
+fn artifact_id_from_source(source: &str) -> Option<String> {
+    source.strip_prefix("artifact:").map(|s| s.to_string())
+}
+
+// ── Check 1: scope violations ─────────────────────────────────────────────────
+
+/// Scan approved `layer_mount` approvals for layers whose build-time scope was
+/// not subsumed by the mounting session's grants. Each approved scope expansion
+/// is audited as a `SupplyChainScopeViolation` finding.
+///
+/// Severity:
+/// - `critical` when `source = "runtime.lock"` (scope embedded in agent definition)
+/// - `warning` for artifact layers (scope was explicitly approved for a single mount)
+///
+/// `scope_agent_id` filters to a single mounting agent — used by the pre-promotion
+/// gate so a layer-scope finding from agent A does not block promotion of agent B.
+/// The filter keys on the *mounting* agent (`approvals.agent_id`), not the layer's
+/// originating agent, since findings are attributed to and remediated by whoever
+/// approved the mount.
+pub fn scan_layer_scope_violations(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    since: Option<&str>,
+    scan_limit: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    let mut stmt = conn.prepare(
+        "SELECT request_id, agent_id, session_id, root_session_id, action_payload, decided_at
+         FROM approvals
+         WHERE action_type = 'layer_mount'
+           AND status = 'approved'
+           AND (?1 IS NULL OR decided_at >= ?1)
+           AND (?3 IS NULL OR agent_id = ?3)
+         ORDER BY decided_at DESC, request_id
+         LIMIT ?2",
+    )?;
+
+    let rows: Vec<(String, String, String, Option<String>, String, Option<String>)> = stmt
+        .query_map(params![since, scan_limit as i64, scope_agent_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+
+    for (request_id, agent_id, session_id, root_session_id, action_payload, _decided_at) in rows {
+        let payload: LayerMountPayload = match serde_json::from_str(&action_payload) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        for entry in &payload.layers {
+            if entry.unapproved_delta.is_empty() {
+                continue;
+            }
+
+            let is_runtime_lock = entry.source == "runtime.lock";
+            let severity = if is_runtime_lock {
+                FindingSeverity::Critical
+            } else {
+                FindingSeverity::Warning
+            };
+
+            let remediation = if is_runtime_lock {
+                format!(
+                    "Layer '{}' (runtime.lock, digest {}) was built with {} host(s) [{}] not in \
+                     session scope. Review SKILL.md runtime.lock layers and rebuild with a \
+                     narrower network scope.",
+                    entry.name,
+                    &entry.digest[..entry.digest.len().min(16)],
+                    entry.unapproved_delta.len(),
+                    entry.unapproved_delta.join(", ")
+                )
+            } else {
+                format!(
+                    "Layer '{}' (artifact, digest {}) was built with {} host(s) [{}] not in \
+                     session scope. Review whether those hosts are still required and re-capture \
+                     the layer with a narrower scope.",
+                    entry.name,
+                    &entry.digest[..entry.digest.len().min(16)],
+                    entry.unapproved_delta.len(),
+                    entry.unapproved_delta.join(", ")
+                )
+            };
+
+            // Anchor on the layer digest (primary) and the approval record (for DB traceability).
+            // For artifact sources, also anchor the content-addressed artifact ID.
+            let mut anchors = vec![
+                EvidenceAnchor::LayerDigest { value: entry.digest.clone() },
+                EvidenceAnchor::ApprovalRecord { request_id: request_id.clone() },
+            ];
+            if let Some(art_id) = artifact_id_from_source(&entry.source) {
+                anchors.push(EvidenceAnchor::ArtifactId { id: art_id });
+            }
+
+            let effective_session = root_session_id
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&session_id);
+
+            findings.push(
+                SecurityFinding::new(
+                    FindingType::SupplyChainScopeViolation,
+                    severity,
+                    1.0,
+                    Reproducibility::Deterministic,
+                    remediation,
+                    sentinel_revision_id,
+                )
+                .with_affected(AffectedEntities {
+                    agent_alias: Some(agent_id.clone()),
+                    session_id: Some(effective_session.to_string()),
+                    layer_digest: Some(entry.digest.clone()),
+                    ..Default::default()
+                })
+                .with_anchors(anchors),
+            );
+        }
+    }
+
+    Ok(findings)
+}
+
+// ── Check 2: provenance gaps ──────────────────────────────────────────────────
+
+/// Scan approved `layer_mount` approvals for layers that have no capture trace
+/// in `execution_traces` (`tool_name='sandbox_exec'`, `success=1`, `result`
+/// JSON referencing the layer ID in `captured_layers[*].layer_id`).
+///
+/// A gap means: the operator approved mounting supply-chain content that this
+/// gateway cannot trace back to a known capture session. This may be benign
+/// (layer built on another gateway instance) but warrants operator review.
+pub fn scan_layer_provenance_gaps(
+    conn: &Connection,
+    sentinel_revision_id: &str,
+    since: Option<&str>,
+    scan_limit: u32,
+    scope_agent_id: Option<&str>,
+) -> Result<Vec<SecurityFinding>> {
+    // Collect distinct (layer_id, digest, request_id, agent_id, session_id) from
+    // approved layer_mount approvals, then filter to those with no capture trace
+    // in execution_traces.result JSON (captured_layers[*].layer_id).
+    //
+    // `scope_agent_id` filters on the *mounting* agent so a provenance gap
+    // for a layer mounted by agent A does not block promotion of agent B.
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT
+             json_extract(l.value, '$.layer_id')  AS layer_id,
+             json_extract(l.value, '$.digest')    AS digest,
+             json_extract(l.value, '$.source')    AS source,
+             a.request_id, a.agent_id, a.session_id, a.root_session_id
+         FROM approvals a, json_each(json_extract(a.action_payload, '$.layers')) AS l
+         WHERE a.action_type = 'layer_mount'
+           AND a.status = 'approved'
+           AND (?1 IS NULL OR a.decided_at >= ?1)
+           AND (?3 IS NULL OR a.agent_id = ?3)
+           AND json_extract(l.value, '$.layer_id') IS NOT NULL
+           AND NOT EXISTS (
+               SELECT 1 FROM execution_traces et
+               WHERE et.tool_name = 'sandbox_exec'
+                 AND et.success = 1
+                 AND et.result LIKE '%' || json_extract(l.value, '$.layer_id') || '%'
+           )
+         ORDER BY a.decided_at DESC, a.request_id, layer_id
+         LIMIT ?2",
+    )?;
+
+    let rows: Vec<(String, String, String, String, String, String, Option<String>)> = stmt
+        .query_map(
+            params![since, scan_limit as i64, scope_agent_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                ))
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut findings = Vec::new();
+
+    for (layer_id, digest, source, request_id, agent_id, session_id, root_session_id) in rows {
+        let effective_session = root_session_id
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&session_id);
+
+        let remediation = format!(
+            "Layer '{}' (digest {}) was approved for mounting but has no capture trace in this \
+             gateway's execution_traces. Verify the layer was built under known conditions and \
+             consider re-capturing it with full provenance.",
+            layer_id,
+            &digest[..digest.len().min(16)],
+        );
+
+        let mut anchors = vec![
+            EvidenceAnchor::LayerDigest { value: digest.clone() },
+            EvidenceAnchor::ApprovalRecord { request_id: request_id.clone() },
+        ];
+        if let Some(art_id) = artifact_id_from_source(&source) {
+            anchors.push(EvidenceAnchor::ArtifactId { id: art_id });
+        }
+
+        findings.push(
+            SecurityFinding::new(
+                FindingType::SupplyChainProvenanceGap,
+                FindingSeverity::Warning,
+                0.8,
+                Reproducibility::Deterministic,
+                remediation,
+                sentinel_revision_id,
+            )
+            .with_affected(AffectedEntities {
+                agent_alias: Some(agent_id.clone()),
+                session_id: Some(effective_session.to_string()),
+                layer_digest: Some(digest),
+                ..Default::default()
+            })
+            .with_anchors(anchors),
+        );
+    }
+
+    Ok(findings)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+

--- a/autonoetic-gateway/src/sentinel/baseline/supply_chain.rs
+++ b/autonoetic-gateway/src/sentinel/baseline/supply_chain.rs
@@ -5,7 +5,8 @@
 //! Frozen snapshot of `super::checks::supply_chain` (issue #153).
 //! See `super::baseline::credential` for the full editing-rules rationale.
 //!
-//! Last frozen: PR landing #153.
+//! Last frozen at `BASELINE_VERSION = 1.0.0` (issue #153, initial freeze).
+//! See `super::BASELINE_VERSION` for the version pin and bump policy.
 
 #![allow(dead_code)]
 

--- a/autonoetic-gateway/src/sentinel/dual_sweep.rs
+++ b/autonoetic-gateway/src/sentinel/dual_sweep.rs
@@ -79,9 +79,16 @@ impl DualSweepRunner {
     ) -> Result<DualSweepResult> {
         let sweep_at = chrono::Utc::now().to_rfc3339();
 
-        // Enforce Phase-1-only on the baseline regardless of caller config.
+        // Enforce Phase-1-only on the baseline regardless of caller config,
+        // and force the baseline pass to dispatch to the frozen
+        // `super::baseline` module (issue #153). The current pass continues
+        // to use `super::checks`. Together this means a regex regression in
+        // `checks/credential.rs` (or similar) shows up as a `baseline_only`
+        // disagreement here, rather than silently propagating to both passes
+        // as it did when both branches called the same code.
         let baseline_config_p1 = SweepConfig {
             phase1_only: true,
+            phase1_use_baseline: true,
             sentinel_revision_id: baseline_config.sentinel_revision_id.clone(),
             since_rfc3339: baseline_config.since_rfc3339.clone(),
             scan_limit: baseline_config.scan_limit,

--- a/autonoetic-gateway/src/sentinel/mod.rs
+++ b/autonoetic-gateway/src/sentinel/mod.rs
@@ -38,6 +38,7 @@
 //! The sentinel *reads* from state; it does not mutate anything except the
 //! append-only `security_findings` table.
 
+pub mod baseline;
 pub mod checks;
 pub mod dual_sweep;
 pub mod promotion_gate;

--- a/autonoetic-gateway/src/sentinel/runner.rs
+++ b/autonoetic-gateway/src/sentinel/runner.rs
@@ -28,6 +28,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::scheduler::gateway_store::GatewayStore;
+use super::baseline;
 use super::checks::{approval_bypass, capability_accretion, credential, prompt_injection, sandbox_escape, session_cluster, supply_chain};
 
 /// Configuration for a sentinel sweep (Phase 1 + Phase 2).
@@ -65,6 +66,12 @@ pub struct SweepConfig {
     /// pre-promotion gate so a critical finding from agent A does not block
     /// promotion of agent B (issue #155). `None` = full-store sweep.
     pub scope_agent_id: Option<String>,
+    /// When `true`, dispatch Phase-1 checks to `super::baseline::*` instead of
+    /// `super::checks::*`. The baseline module is a frozen snapshot that does
+    /// not change when `super::checks::*` is refined; the dual-sweep uses this
+    /// to detect regressions in the canonical sentinel by comparing the two
+    /// sets of findings (issue #153).
+    pub phase1_use_baseline: bool,
 }
 
 impl Default for SweepConfig {
@@ -81,6 +88,7 @@ impl Default for SweepConfig {
             exec_repeat_threshold: 10,
             phase1_only: false,
             scope_agent_id: None,
+            phase1_use_baseline: false,
         }
     }
 }
@@ -211,27 +219,60 @@ impl SentinelRunner {
         let scope = config.scope_agent_id.as_deref();
 
         // All DB checks in a single connection borrow.
+        let phase1_use_baseline = config.phase1_use_baseline;
         let db_results: Vec<Result<Vec<SecurityFinding>>> = self.store.with_conn(|conn| {
-            let mut checks = vec![
-                // Phase 1 — deterministic
-                credential::scan_credential_leaks(conn, rev_id, since, scan_limit, scope),
-                capability_accretion::scan_capability_accretion(
-                    conn, rev_id, window_days, accretion_threshold, scope,
-                ),
-                approval_bypass::scan_approval_denials(
-                    conn, rev_id, window_days, denial_threshold, scope,
-                ),
-                approval_bypass::scan_exec_without_grant(conn, rev_id, since, scan_limit, scope),
-                sandbox_escape::scan_escape_attempt_records(conn, rev_id, since, scan_limit, scope),
-                sandbox_escape::scan_escape_patterns_in_events(conn, rev_id, since, scan_limit, scope),
-                // Phase 1 — supply-chain auditing
-                supply_chain::scan_layer_scope_violations(conn, rev_id, since, scan_limit, scope),
-                supply_chain::scan_layer_provenance_gaps(conn, rev_id, since, scan_limit, scope),
-            ];
+            // Phase-1 checks dispatch to either the canonical `super::checks`
+            // module or the frozen `super::baseline` snapshot. The baseline is
+            // a hand-frozen copy (issue #153) so a regression in `super::checks`
+            // surfaces as a `baseline_only` disagreement in the dual-sweep.
+            let mut checks = if phase1_use_baseline {
+                vec![
+                    baseline::credential::scan_credential_leaks(conn, rev_id, since, scan_limit, scope),
+                    baseline::capability_accretion::scan_capability_accretion(
+                        conn, rev_id, window_days, accretion_threshold, scope,
+                    ),
+                    baseline::approval_bypass::scan_approval_denials(
+                        conn, rev_id, window_days, denial_threshold, scope,
+                    ),
+                    baseline::approval_bypass::scan_exec_without_grant(
+                        conn, rev_id, since, scan_limit, scope,
+                    ),
+                    baseline::sandbox_escape::scan_escape_attempt_records(
+                        conn, rev_id, since, scan_limit, scope,
+                    ),
+                    baseline::sandbox_escape::scan_escape_patterns_in_events(
+                        conn, rev_id, since, scan_limit, scope,
+                    ),
+                    baseline::supply_chain::scan_layer_scope_violations(
+                        conn, rev_id, since, scan_limit, scope,
+                    ),
+                    baseline::supply_chain::scan_layer_provenance_gaps(
+                        conn, rev_id, since, scan_limit, scope,
+                    ),
+                ]
+            } else {
+                vec![
+                    // Phase 1 — deterministic
+                    credential::scan_credential_leaks(conn, rev_id, since, scan_limit, scope),
+                    capability_accretion::scan_capability_accretion(
+                        conn, rev_id, window_days, accretion_threshold, scope,
+                    ),
+                    approval_bypass::scan_approval_denials(
+                        conn, rev_id, window_days, denial_threshold, scope,
+                    ),
+                    approval_bypass::scan_exec_without_grant(conn, rev_id, since, scan_limit, scope),
+                    sandbox_escape::scan_escape_attempt_records(conn, rev_id, since, scan_limit, scope),
+                    sandbox_escape::scan_escape_patterns_in_events(conn, rev_id, since, scan_limit, scope),
+                    // Phase 1 — supply-chain auditing
+                    supply_chain::scan_layer_scope_violations(conn, rev_id, since, scan_limit, scope),
+                    supply_chain::scan_layer_provenance_gaps(conn, rev_id, since, scan_limit, scope),
+                ]
+            };
             // Phase 2a — cluster heuristics (always rolling window, not `since`).
             // Skipped when phase1_only is set (e.g. frozen baseline runner).
             // Cluster heuristics are not scoped — they are diagnostic across
-            // sessions and the gate only consumes Phase-1 findings.
+            // sessions and the gate only consumes Phase-1 findings. The
+            // baseline never runs Phase-2 (the baseline contract is Phase-1 only).
             if !config.phase1_only {
                 checks.push(session_cluster::scan_failure_bursts(
                     conn, rev_id, cluster_window_minutes, failure_burst_threshold, scan_limit,
@@ -324,6 +365,7 @@ impl SentinelRunner {
                 accretion_threshold: config.accretion_threshold,
                 denial_threshold: config.denial_threshold,
                 scope_agent_id: config.scope_agent_id.clone(),
+                phase1_use_baseline: config.phase1_use_baseline,
                 ..SweepConfig::default()
             }
         })?;

--- a/autonoetic-gateway/src/sentinel/runner.rs
+++ b/autonoetic-gateway/src/sentinel/runner.rs
@@ -71,6 +71,13 @@ pub struct SweepConfig {
     /// not change when `super::checks::*` is refined; the dual-sweep uses this
     /// to detect regressions in the canonical sentinel by comparing the two
     /// sets of findings (issue #153).
+    ///
+    /// **Implies `phase1_only`.** The baseline never runs Phase-2 (the cluster
+    /// heuristics and prompt-injection scan have no baseline copy). Setting
+    /// `phase1_use_baseline = true` with `phase1_only = false` is a config
+    /// error; `collect_findings` enforces the implication and skips Phase-2
+    /// regardless of `phase1_only`'s value, with a debug assertion to catch
+    /// the misconfiguration in tests.
     pub phase1_use_baseline: bool,
 }
 
@@ -218,8 +225,18 @@ impl SentinelRunner {
         let exec_repeat_threshold = config.exec_repeat_threshold;
         let scope = config.scope_agent_id.as_deref();
 
-        // All DB checks in a single connection borrow.
+        // `phase1_use_baseline => phase1_only`. The baseline contract is
+        // Phase-1 only — the cluster heuristics and prompt-injection scan
+        // have no baseline copy. A debug assertion catches the
+        // misconfiguration in tests; release builds silently enforce it.
         let phase1_use_baseline = config.phase1_use_baseline;
+        debug_assert!(
+            !(phase1_use_baseline && !config.phase1_only),
+            "phase1_use_baseline=true requires phase1_only=true (baseline is Phase-1 only)"
+        );
+        let phase1_only_effective = config.phase1_only || phase1_use_baseline;
+
+        // All DB checks in a single connection borrow.
         let db_results: Vec<Result<Vec<SecurityFinding>>> = self.store.with_conn(|conn| {
             // Phase-1 checks dispatch to either the canonical `super::checks`
             // module or the frozen `super::baseline` snapshot. The baseline is
@@ -272,8 +289,9 @@ impl SentinelRunner {
             // Skipped when phase1_only is set (e.g. frozen baseline runner).
             // Cluster heuristics are not scoped — they are diagnostic across
             // sessions and the gate only consumes Phase-1 findings. The
-            // baseline never runs Phase-2 (the baseline contract is Phase-1 only).
-            if !config.phase1_only {
+            // `phase1_only_effective` value above bakes in
+            // `phase1_use_baseline => phase1_only`.
+            if !phase1_only_effective {
                 checks.push(session_cluster::scan_failure_bursts(
                     conn, rev_id, cluster_window_minutes, failure_burst_threshold, scan_limit,
                 ));
@@ -301,13 +319,13 @@ impl SentinelRunner {
         take_check!(sandbox_escape, "escape_patterns");
         take_check!(supply_chain, "supply_chain_scope");
         take_check!(supply_chain, "supply_chain_provenance");
-        if !config.phase1_only {
+        if !phase1_only_effective {
             take_check!(behavioral_anomaly, "failure_burst");
             take_check!(behavioral_anomaly, "exec_repeat");
         }
 
         // Phase 2b — prompt injection (filesystem, optional). Skipped for baseline.
-        if !config.phase1_only {
+        if !phase1_only_effective {
             if let Some(ref agents_dir) = self.agents_dir {
                 match prompt_injection::scan_prompt_injection(agents_dir, rev_id, scan_limit as usize) {
                     Ok(v) => raw.prompt_injection = v,

--- a/autonoetic-gateway/tests/security_sentinel_integration.rs
+++ b/autonoetic-gateway/tests/security_sentinel_integration.rs
@@ -1252,3 +1252,160 @@ fn list_security_findings_filtered_by_triage_state() {
     assert_eq!(tp.len(), 1);
     assert_eq!(tp[0].finding_id, f1.finding_id);
 }
+
+// ── Issue #153: Frozen-baseline module ──────────────────────────────────────
+//
+// The baseline lives in `autonoetic-gateway/src/sentinel/baseline/` as a
+// hand-frozen snapshot of `sentinel/checks/`. The dual-sweep dispatches the
+// baseline pass to `super::baseline::*` (via `phase1_use_baseline=true`),
+// while the current pass runs `super::checks::*`. A regression in the
+// canonical sentinel produces a `baseline_only` disagreement at the next
+// sweep instead of silently propagating to both branches.
+//
+// These tests pin two contracts:
+//
+// 1. **Dispatch wiring** — when `phase1_use_baseline=true`, the runner
+//    actually executes the baseline functions and returns findings (not just
+//    silently producing no output).
+// 2. **In-sync at this commit** — running both the baseline and the
+//    canonical checks against the same fixture produces equal findings, so
+//    a future PR that updates `super::checks` without `[baseline-update]`
+//    will fail this pin and force a deliberate decision.
+
+#[test]
+fn baseline_dispatch_runs_and_produces_findings() {
+    use autonoetic_gateway::sentinel::runner::{SentinelRunner, SweepConfig};
+
+    let (dir, store) = open_store();
+    insert_credential_leak_event(&dir, "coder.default", "evt_baseline_dispatch");
+
+    // Re-open so the runner sees the inserted row.
+    let store = std::sync::Arc::new(GatewayStore::open(dir.path()).unwrap());
+
+    // Run with phase1_use_baseline=true. If dispatch is broken (e.g. someone
+    // accidentally drops the baseline arm), we either get no findings or
+    // build errors. The baseline must produce at least the credential finding.
+    let runner = SentinelRunner::new(store);
+    let result = runner
+        .run_sweep(&SweepConfig {
+            sentinel_revision_id: "test.baseline".into(),
+            phase1_only: true,
+            phase1_use_baseline: true,
+            ..SweepConfig::default()
+        })
+        .expect("baseline sweep");
+
+    assert!(
+        !result.credential_findings.is_empty(),
+        "baseline dispatch must produce credential findings; got 0 \
+         (regression: SweepConfig::phase1_use_baseline may not be wired)"
+    );
+}
+
+#[test]
+fn baseline_and_checks_agree_on_credential_fixture_at_this_commit() {
+    // Pin: at the time this test was written, `sentinel/baseline/credential.rs`
+    // is a hand-frozen snapshot of `sentinel/checks/credential.rs`, so they
+    // must produce equal findings on the same fixture. A future PR that
+    // updates `checks` without also updating `baseline` (deliberate
+    // `[baseline-update]` action) will fail this test, forcing the author
+    // to decide: (a) propagate the change with `[baseline-update]`, or
+    // (b) accept the divergence as the disagreement-detection signal it's
+    // designed to be.
+    use autonoetic_gateway::sentinel::runner::{SentinelRunner, SweepConfig};
+
+    let (dir, _store) = open_store();
+    insert_credential_leak_event(&dir, "coder.default", "evt_pin_001");
+    let store = std::sync::Arc::new(GatewayStore::open(dir.path()).unwrap());
+
+    let baseline = SentinelRunner::new(std::sync::Arc::clone(&store))
+        .run_sweep(&SweepConfig {
+            sentinel_revision_id: "test.baseline".into(),
+            phase1_only: true,
+            phase1_use_baseline: true,
+            ..SweepConfig::default()
+        })
+        .expect("baseline sweep");
+    let current = SentinelRunner::new(store)
+        .run_sweep(&SweepConfig {
+            sentinel_revision_id: "test.current".into(),
+            phase1_only: true,
+            phase1_use_baseline: false,
+            ..SweepConfig::default()
+        })
+        .expect("current sweep");
+
+    // Same number of findings per category.
+    assert_eq!(
+        baseline.credential_findings.len(),
+        current.credential_findings.len(),
+        "baseline and checks must produce equal credential-finding counts at \
+         this commit — divergence means the canonical checks were updated \
+         without a [baseline-update] PR. Either propagate the change to \
+         baseline (deliberate) or accept it as a disagreement signal."
+    );
+
+    // Same anchors (compare by event_id, since finding_id is UUID-random).
+    let anchor_set =
+        |findings: &[autonoetic_types::security::SecurityFinding]| -> std::collections::BTreeSet<String> {
+            findings
+                .iter()
+                .flat_map(|f| f.evidence_anchors.iter())
+                .filter_map(|a| match a {
+                    autonoetic_types::security::EvidenceAnchor::CausalEvent { id } => {
+                        Some(id.clone())
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+    assert_eq!(
+        anchor_set(&baseline.credential_findings),
+        anchor_set(&current.credential_findings),
+        "evidence anchors must match between baseline and checks at this commit"
+    );
+}
+
+#[test]
+fn dual_sweep_at_creation_records_full_baseline_agreement() {
+    // End-to-end pin: with the baseline frozen as an exact copy of checks,
+    // every Phase-1 finding from the dual-sweep should have
+    // `baseline_agreed = true` and zero baseline_only / current_only
+    // disagreements. A future divergence will break this pin AND surface as
+    // a real disagreement record — the intended behaviour.
+    use autonoetic_gateway::scheduler::gateway_store::sentinel_disagreements::DisagreementDirection;
+    use autonoetic_gateway::sentinel::runner::SweepConfig;
+    use autonoetic_gateway::sentinel::DualSweepRunner;
+
+    let (dir, _store) = open_store();
+    insert_credential_leak_event(&dir, "coder.default", "evt_dual_pin_001");
+    let store = std::sync::Arc::new(GatewayStore::open(dir.path()).unwrap());
+
+    let runner = DualSweepRunner::new(std::sync::Arc::clone(&store));
+    let baseline_config = SweepConfig {
+        sentinel_revision_id: "sentinel.baseline".into(),
+        ..SweepConfig::default()
+    };
+    let current_config = SweepConfig {
+        sentinel_revision_id: "sentinel.current".into(),
+        ..SweepConfig::default()
+    };
+    let result = runner.run(&baseline_config, &current_config).expect("dual sweep");
+
+    assert!(
+        result.baseline_agreed_count > 0,
+        "baseline_agreed_count > 0 expected at this commit (baseline = checks)"
+    );
+    assert!(
+        result.disagreements.iter().all(|d| {
+            d.direction != DisagreementDirection::BaselineOnly
+                && d.direction != DisagreementDirection::CurrentOnly
+        }),
+        "no Phase-1 disagreements expected at this commit; got: {:?}",
+        result
+            .disagreements
+            .iter()
+            .map(|d| (&d.direction, &d.anchor_json))
+            .collect::<Vec<_>>()
+    );
+}

--- a/autonoetic-gateway/tests/security_sentinel_integration.rs
+++ b/autonoetic-gateway/tests/security_sentinel_integration.rs
@@ -1276,7 +1276,7 @@ fn list_security_findings_filtered_by_triage_state() {
 fn baseline_dispatch_runs_and_produces_findings() {
     use autonoetic_gateway::sentinel::runner::{SentinelRunner, SweepConfig};
 
-    let (dir, store) = open_store();
+    let (dir, _store) = open_store();
     insert_credential_leak_event(&dir, "coder.default", "evt_baseline_dispatch");
 
     // Re-open so the runner sees the inserted row.

--- a/docs/security-sentinel.md
+++ b/docs/security-sentinel.md
@@ -14,18 +14,13 @@ Status: **implemented (Phases 0–7 merged)**. Phase mapping below.
 
 Configuration knobs are documented in [`docs/config-reference.md`](config-reference.md) under "Security Sentinel".
 
-> **Caveat on the "frozen baseline" claim.** The dual-sweep runs the same in-process Rust check code on both passes — the baseline is forced to `phase1_only: true`, the current sentinel adds Phase-2 — rather than a separately-versioned baseline binary. What it actually provides today:
+> **Frozen-baseline contract** (issue #153, fixed): the dual-sweep dispatches the baseline pass to a hand-frozen `autonoetic-gateway/src/sentinel/baseline/` module — independent copies of the Phase-1 deterministic checks. A regression introduced into the canonical `sentinel/checks/` does **not** propagate to the baseline, so it surfaces as a `baseline_only` disagreement at the next sweep. What dual-sweep provides today:
 >
-> - **`baseline_agreed` annotation on Phase-1 findings** when both passes flag the same evidence anchor.
-> - **Phase-1 disagreement records** in `security_sentinel_disagreements` (`baseline_only` / `current_only`).
-> - **Independent Phase-2 findings** from the current pass — these are *not* compared against the baseline (the baseline never runs Phase-2).
+> - **`baseline_agreed` annotation on Phase-1 findings** when both the canonical checks and the frozen baseline flag the same evidence anchor.
+> - **Phase-1 disagreement records** in `security_sentinel_disagreements` (`baseline_only` when only the baseline flagged the anchor — i.e. a regression in canonical checks; `current_only` when only the canonical flagged it — i.e. a baseline that has aged out).
+> - **Independent Phase-2 findings** from the current pass. The baseline never runs Phase-2; it is `phase1_only` by contract.
 >
-> What it does **not** do:
->
-> - Detect deterministic-core regressions — a regex change in `checks/credential.rs` lands in both passes simultaneously.
-> - Detect Phase-2 regressions — the baseline has no Phase-2 layer to disagree with.
->
-> Restoring the design's stronger recursive-trust claim requires a separately-versioned baseline module; tracked as a follow-up.
+> Editing the baseline requires a deliberate `[baseline-update]` commit prefix and lands as a separate PR from any concurrent `sentinel/checks/` change. PRs that touch both for the same pattern defeat the purpose.
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Closes #153 — the last item from the post-merge security review backlog.

The "frozen baseline" claim in \`docs/security-sentinel.md\` was previously just a configuration label: both the baseline and current passes of the dual-sweep called the same \`super::checks::*\` code, with only \`phase1_only: true\` and a different \`sentinel_revision_id\` distinguishing them. A regression in \`checks/credential.rs\` (or any other Phase-1 check) silently propagated to both branches and the dual-sweep could not detect it — defeating the central recursive-trust mitigation PR #142 was supposed to provide. This PR makes the contract real.

## Approach

I went with **option (1)** from my earlier proposal: a separate \`sentinel/baseline/\` module with hand-copied (frozen) check code, dispatched by a flag in \`SweepConfig\`. Trade-offs versus the alternatives:

- **(1) chosen** — \`sentinel/baseline/\` directory, ~1000 LOC of frozen code, dispatched by \`phase1_use_baseline: bool\`. **Pros:** in-tree, no new build machinery, clear "DO NOT EDIT" headers, integration tests pin the contract. **Cons:** code duplication; the baseline is at the \`mod baseline { ... }\` layer rather than its own crate.
- **(2)** Separate crate or feature-gated module with version-pinned releases. **Pros:** strongest separation. **Cons:** workspace surgery; release machinery; out of proportion to the threat.
- **(3)** Build-time generation from a frozen JSON/TOML manifest. **Pros:** declarative. **Cons:** any bug in the generator propagates to the baseline — defeats the purpose. Not viable.

I'd be happy to revisit this for option (2) later if the threat model evolves; option (1) is the smallest viable fix that closes the design doc's claim.

## Changes

### \`autonoetic-gateway/src/sentinel/baseline/\` (new)

Hand-frozen copies of the five Phase-1 checks: \`credential\`, \`capability_accretion\`, \`approval_bypass\`, \`sandbox_escape\`, \`supply_chain\`. Unit tests stripped (canonical checks own those). Each file:

- \"DO NOT EDIT WITHOUT EXPLICIT OPERATOR ACTION\" header.
- \"Last frozen: PR landing #153\" pin.
- \`#![allow(dead_code)]\` (functions only reachable via dispatch).

\`mod.rs\` documents the editing rules: changes go to \`super::checks\`, not here; deliberate baseline updates require a \`[baseline-update]\` commit prefix and a separate PR.

### \`SweepConfig::phase1_use_baseline\`

Boolean flag, defaults to false. When set, \`collect_findings\` dispatches to \`sentinel::baseline::*\` instead of \`sentinel::checks::*\` for the Phase-1 batch. Phase-2 (cluster heuristics, prompt injection) is not duplicated — baseline is \`phase1_only\` by contract.

### \`DualSweepRunner\` wires the flag

Baseline pass forces \`phase1_use_baseline: true\` regardless of caller config. The current pass continues to use \`sentinel::checks::*\`. \`compare_phase1\` records disagreements as before, but those will now actually fire when \`super::checks\` regresses without a corresponding \`[baseline-update]\` to \`super::baseline\`.

### Three new integration tests

- \`baseline_dispatch_runs_and_produces_findings\` — pin that \`phase1_use_baseline=true\` executes baseline functions and returns findings.
- \`baseline_and_checks_agree_on_credential_fixture_at_this_commit\` — pin that baseline output equals checks output at this commit. A future PR updating \`checks/\` without \`[baseline-update]\` fails this test, forcing the author to either propagate or accept the disagreement.
- \`dual_sweep_at_creation_records_full_baseline_agreement\` — end-to-end pin: every Phase-1 finding has \`baseline_agreed: true\` and zero Phase-1 disagreements at this commit.

### Doc

\`docs/security-sentinel.md\` "Caveat on the frozen baseline claim" block (added in PR #151) is replaced with a "Frozen-baseline contract" block describing what dual-sweep catches now and the editing rules.

## Test plan

- [x] \`cargo build -p autonoetic-gateway\` clean.
- [x] \`cargo test --test security_sentinel_integration\` — 37/37 (was 34, +3 new).
- [x] \`cargo test --lib sentinel\` — 55/55.
- [ ] Reviewer sanity-check: the editing rules in \`baseline/mod.rs\` are clear enough that a future contributor will not casually edit baseline files alongside \`checks/\` changes. If not, consider a CI guard rejecting concurrent edits without a \`[baseline-update]\` label (deferrable follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)