### PR TITLE
feat(gate): unify approval/clarification into HumanGate abstraction (Phase 1 & 2, #167)

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -54,15 +54,9 @@ fn inject_approval_ref_into_history(history: &mut Vec<Message>, approval_ref: &s
                             .unwrap_or_else(|_| tc.arguments.clone());
                     }
                     Err(_) => {
-                        // Arguments are not valid JSON; fall back to appending.
-                        if !tc.arguments.contains("approval_ref") {
-                            let suffix = if tc.arguments.ends_with('}') {
-                                format!(",\"approval_ref\":\"{}\"}}", approval_ref)
-                            } else {
-                                format!("{{\"approval_ref\":\"{}\"}}", approval_ref)
-                            };
-                            tc.arguments = suffix;
-                        }
+                        // Arguments are not valid JSON — leave them untouched.
+                        // The appended user message (below) carries the approval_ref
+                        // as a belt-and-suspenders hint.
                     }
                 }
             }

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -32,6 +32,51 @@ use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
 
+/// Inject `approval_ref` into the last tool_call's arguments in the history,
+/// then append a user message confirming the approval.  This fixes the
+/// LLM-dependent relay bug where the model ignores the text-only hint and
+/// retries without `approval_ref`, causing redundant approval requests.
+fn inject_approval_ref_into_history(history: &mut Vec<Message>, approval_ref: &str) {
+    // Walk history backwards to find the last assistant message with tool_calls.
+    for msg in history.iter_mut().rev() {
+        if matches!(msg.role, crate::llm::Role::Assistant) && !msg.tool_calls.is_empty() {
+            // Inject approval_ref into the last tool call's arguments.
+            if let Some(tc) = msg.tool_calls.last_mut() {
+                match serde_json::from_str::<serde_json::Value>(&tc.arguments) {
+                    Ok(mut args_val) => {
+                        if let Some(obj) = args_val.as_object_mut() {
+                            obj.insert(
+                                "approval_ref".to_string(),
+                                serde_json::Value::String(approval_ref.to_string()),
+                            );
+                        }
+                        tc.arguments = serde_json::to_string(&args_val)
+                            .unwrap_or_else(|_| tc.arguments.clone());
+                    }
+                    Err(_) => {
+                        // Arguments are not valid JSON; fall back to appending.
+                        if !tc.arguments.contains("approval_ref") {
+                            let suffix = if tc.arguments.ends_with('}') {
+                                format!(",\"approval_ref\":\"{}\"}}", approval_ref)
+                            } else {
+                                format!("{{\"approval_ref\":\"{}\"}}", approval_ref)
+                            };
+                            tc.arguments = suffix;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+    }
+    // Also inject the text hint as a user message (belt-and-suspenders).
+    history.push(crate::llm::Message::user(format!(
+        "[gateway] Approval `{}` has been granted by the operator. \
+         The tool call has been updated with approval_ref=\"{}\".",
+        approval_ref, approval_ref
+    )));
+}
+
 /// Ensures `close_session` runs when `execute_with_history` fails so session report / digest finalize.
 pub(crate) async fn execute_with_history_close_on_error(
     runtime: &mut AgentExecutor,
@@ -1855,15 +1900,7 @@ impl GatewayExecutionService {
                                     runtime.turn_counter = checkpoint.turn_counter;
                                     runtime.runtime_lock_hash = checkpoint.runtime_lock_hash.clone();
                                     let mut history = checkpoint.history.clone();
-                                    // Inject approval-granted notice so the LLM knows to pass
-                                    // approval_ref on retry instead of re-triggering the gate.
-                                    history.push(crate::llm::Message::user(format!(
-                                        "[gateway] Approval `{}` has been granted by the operator. \
-                                         When retrying the tool call that required approval, include \
-                                         `\"approval_ref\": \"{}\"` in the arguments to skip the \
-                                         approval gate.",
-                                        rid, rid
-                                    )));
+                                    inject_approval_ref_into_history(&mut history, rid);
                                     let initial_msg = checkpoint
                                         .history
                                         .iter()
@@ -2139,15 +2176,7 @@ impl GatewayExecutionService {
                                 runtime.turn_counter = checkpoint.turn_counter;
                                 runtime.runtime_lock_hash = checkpoint.runtime_lock_hash.clone();
                                 let mut history = checkpoint.history.clone();
-                                // Inject approval-granted notice so the LLM knows to pass
-                                // approval_ref on retry instead of re-triggering the gate.
-                                history.push(crate::llm::Message::user(format!(
-                                    "[gateway] Approval `{}` has been granted by the operator. \
-                                     When retrying the tool call that required approval, include \
-                                     `\"approval_ref\": \"{}\"` in the arguments to skip the \
-                                     approval gate.",
-                                    rid, rid
-                                )));
+                                inject_approval_ref_into_history(&mut history, rid);
                                 let initial_msg = checkpoint
                                     .history
                                     .iter()
@@ -3385,5 +3414,67 @@ mod tests {
             SessionCloseReason::for_checkpoint_respawn(false, false, false).as_str(),
             "checkpoint_respawn_complete_empty"
         );
+    }
+
+    #[test]
+    fn inject_approval_ref_into_history_adds_ref_to_last_tool_call() {
+        use crate::llm::ToolCall;
+
+        let mut history = vec![
+            Message::user("Set up credentials"),
+            Message {
+                role: crate::llm::Role::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "credential.setup".to_string(),
+                    arguments: r#"{"skill_url":"http://localhost:8080/skill.md"}"#.to_string(),
+                }],
+                tool_call_id: None,
+                reasoning_content: None,
+            },
+        ];
+
+        inject_approval_ref_into_history(&mut history, "apr-abc123");
+
+        // The assistant message's tool call should now have approval_ref.
+        let assistant_msg = &history[1];
+        assert_eq!(assistant_msg.role, crate::llm::Role::Assistant);
+        let tc = &assistant_msg.tool_calls[0];
+        let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap();
+        assert_eq!(args["approval_ref"], "apr-abc123");
+        assert_eq!(args["skill_url"], "http://localhost:8080/skill.md");
+
+        // A user message should be appended with the approval notice.
+        let user_msg = history.last().unwrap();
+        assert_eq!(user_msg.role, crate::llm::Role::User);
+        assert!(user_msg.content.contains("apr-abc123"));
+    }
+
+    #[test]
+    fn inject_approval_ref_preserves_existing_fields() {
+        use crate::llm::ToolCall;
+
+        let mut history = vec![
+            Message {
+                role: crate::llm::Role::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    id: "call_2".to_string(),
+                    name: "sandbox.exec".to_string(),
+                    arguments: r#"{"command":"curl http://api.example.com","approval_ref":"apr-old"}"#.to_string(),
+                }],
+                tool_call_id: None,
+                reasoning_content: None,
+            },
+        ];
+
+        inject_approval_ref_into_history(&mut history, "apr-new");
+
+        let tc = &history[0].tool_calls[0];
+        let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap();
+        // Should be overwritten with the new ref.
+        assert_eq!(args["approval_ref"], "apr-new");
+        assert_eq!(args["command"], "curl http://api.example.com");
     }
 }

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -1,0 +1,1104 @@
+//! Unified HumanGate abstraction.
+//!
+//! Provides a single `GateService` entry point for all tool suspension needs:
+//! approvals (`GateKind::Approval`), user clarifications (`GateKind::UserInput`),
+//! and escalations (`GateKind::Escalation`).  The pipeline centralises the
+//! "check → dedup → gate → suspend" pattern that was previously reimplemented
+//! independently in 15+ tool files.
+//!
+//! See <docs/design/human-gate-unification-plan.md> for the full design.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::background::{
+    ApprovalLevel, ApprovalRequest, ApprovalStatus, ScheduledAction,
+    UserInteraction, UserInteractionKind, UserInteractionOption, UserInteractionStatus,
+};
+
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::content_store;
+use crate::runtime::tools::{build_approval_details, extract_host};
+use crate::scheduler::gateway_store::GatewayStore;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// What kind of gate a tool is requesting.
+#[derive(Debug, Clone)]
+pub enum GateKind {
+    /// Operator must approve/reject a gated action.
+    Approval {
+        action: ScheduledAction,
+        targets: Vec<String>,
+        match_strategy: MatchStrategy,
+    },
+    /// Agent explicitly asks the user a question.
+    UserInput {
+        question: String,
+        kind: String,
+        options: Option<Vec<UserInteractionOption>>,
+        allow_freeform: bool,
+    },
+    /// Operator escalation (guidance needed).
+    Escalation {
+        reason: String,
+    },
+}
+
+/// How strictly an `approval_ref` must match the current request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchStrategy {
+    /// Host extracted from URL must match (credential, web).
+    HostLevel,
+    /// Exact `ScheduledAction` field equality (current web behaviour).
+    ExactPayload,
+    /// Command string from approved action replaces current (sandbox).
+    SubstituteCommand,
+}
+
+/// What a tool provides to the gate.
+pub struct GateRequest<'a> {
+    pub kind: GateKind,
+    pub manifest: &'a AgentManifest,
+    pub session_id: Option<&'a str>,
+    pub run_context: Option<&'a NativeToolRunContext>,
+    pub config: Option<&'a autonoetic_types::config::GatewayConfig>,
+    pub reason: String,
+    pub summary: String,
+    pub approval_ref: Option<&'a str>,
+    /// Tool-specific cache hit (e.g. `ApprovedExecCache`).  When `true` the
+    /// gate short-circuits to `GateResult::Cleared`.
+    pub pre_validated: bool,
+}
+
+/// Unified result returned by `GateService::check`.
+#[derive(Debug)]
+pub enum GateResult {
+    /// Proceed — already approved / answered / granted.
+    Cleared {
+        source: ClearanceSource,
+    },
+    /// A matching gate is already pending — reuse the existing gate ID.
+    AlreadyPending {
+        gate_id: String,
+    },
+    /// New gate created; session should suspend.
+    Suspended {
+        gate_id: String,
+        response_json: String,
+    },
+    /// Policy allows without gating (no action required).
+    PolicyAllowed,
+}
+
+/// Why the gate was cleared.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClearanceSource {
+    ApprovalRef(String),
+    SessionGrant,
+    PreapprovedPolicy,
+    CachedApproval,
+    AnsweredInteraction(String),
+}
+
+impl GateResult {
+    pub fn is_cleared(&self) -> bool {
+        matches!(self, GateResult::Cleared { .. } | GateResult::PolicyAllowed)
+    }
+
+    /// Build the JSON string that the tool should return to the agent.
+    /// Returns `None` for `Cleared` / `PolicyAllowed` — the tool should proceed
+    /// normally in those cases.
+    pub fn suspension_response(&self) -> Option<&str> {
+        match self {
+            GateResult::Suspended { response_json, .. } => Some(response_json),
+            GateResult::AlreadyPending { .. } => {
+                // The tool should return an approval_already_pending-style
+                // response.  Consumers match on the variant directly.
+                None
+            }
+            GateResult::Cleared { .. } | GateResult::PolicyAllowed => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Enrichment message (gate_messages)
+// ---------------------------------------------------------------------------
+
+/// A single message in a gate's enrichment thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GateMessage {
+    pub id: i64,
+    pub gate_id: String,
+    pub sender: String,
+    pub content: String,
+    pub created_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// GateService
+// ---------------------------------------------------------------------------
+
+/// Decider-agnostic gate service.  Today the decider is always a human
+/// operator, but the interface is designed to support future deciders
+/// (autonomous agents, policy engines, webhooks).
+pub struct GateService {
+    store: Arc<GatewayStore>,
+}
+
+impl GateService {
+    pub fn new(store: Arc<GatewayStore>) -> Self {
+        Self { store }
+    }
+
+    // -----------------------------------------------------------------------
+    // Main entry point
+    // -----------------------------------------------------------------------
+
+    /// Run the unified gate pipeline.
+    ///
+    /// Returns `GateResult::Cleared` when the tool may proceed,
+    /// `GateResult::AlreadyPending` when a matching gate already exists,
+    /// or `GateResult::Suspended` when a new gate was created and the tool
+    /// must suspend execution.
+    pub fn check(&self, req: GateRequest<'_>) -> Result<GateResult> {
+        match &req.kind {
+            GateKind::Approval {
+                action,
+                targets,
+                match_strategy,
+            } => self.check_approval(&req, action, targets, *match_strategy),
+            GateKind::UserInput { .. } => self.check_user_input(&req),
+            GateKind::Escalation { .. } => self.check_escalation(&req),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Approval pipeline
+    // -----------------------------------------------------------------------
+
+    fn check_approval(
+        &self,
+        req: &GateRequest<'_>,
+        action: &ScheduledAction,
+        targets: &[String],
+        match_strategy: MatchStrategy,
+    ) -> Result<GateResult> {
+        // 1. Pre-validated bypass (e.g. ApprovedExecCache hit).
+        if req.pre_validated {
+            return Ok(GateResult::Cleared {
+                source: ClearanceSource::CachedApproval,
+            });
+        }
+
+        // 2. approval_ref validation.
+        if let Some(ref_id) = req.approval_ref {
+            match self.validate_approval_ref(ref_id, req, action, targets, match_strategy)? {
+                Some(result) => return Ok(result),
+                None => {}
+            }
+        }
+
+        // 3. Session grant coverage.
+        if !targets.is_empty() {
+            if let Some(sid) = req.session_id {
+                if !sid.is_empty() {
+                    let root_sid = content_store::root_session_id(sid);
+                    if self.store.session_grants_cover_targets(root_sid, targets) {
+                        return Ok(GateResult::Cleared {
+                            source: ClearanceSource::SessionGrant,
+                        });
+                    }
+                }
+            }
+        }
+
+        // 4. Pending dedup — avoid minting duplicate approval rows for the
+        //    same session + action kind + targets.
+        if let Some(sid) = req.session_id {
+            if !sid.is_empty() {
+                if let Some(pending_id) = self.find_pending_for_targets(sid, action, targets)? {
+                    return Ok(GateResult::AlreadyPending {
+                        gate_id: pending_id,
+                    });
+                }
+            }
+        }
+
+        // 5. Create new approval row.
+        let gate_id = self.create_approval_row(req, action)?;
+
+        // 6. Build suspension JSON.
+        let response_json = self.build_approval_suspension_json(&gate_id, req, action)?;
+
+        Ok(GateResult::Suspended {
+            gate_id,
+            response_json,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // UserInput pipeline
+    // -----------------------------------------------------------------------
+
+    fn check_user_input(&self, req: &GateRequest<'_>) -> Result<GateResult> {
+        let GateKind::UserInput {
+            ref question,
+            ref kind,
+            ref options,
+            ref allow_freeform,
+        } = req.kind
+        else {
+            unreachable!()
+        };
+
+        let interaction_id = format!("ui-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let sid = req.session_id.unwrap_or("");
+        let root_sid = if sid.is_empty() {
+            String::new()
+        } else {
+            content_store::root_session_id(sid).to_string()
+        };
+
+        let (root_session_id, workflow_id, task_id) = resolve_execution_context(req);
+
+        let interaction = UserInteraction {
+            interaction_id: interaction_id.clone(),
+            session_id: sid.to_string(),
+            root_session_id: root_session_id.unwrap_or_default(),
+            agent_id: req.manifest.agent.id.clone(),
+            turn_id: String::new(),
+            kind: parse_interaction_kind(kind),
+            question: question.clone(),
+            context: None,
+            options: options.clone().unwrap_or_default(),
+            allow_freeform: *allow_freeform,
+            status: UserInteractionStatus::Pending,
+            answer_option_id: None,
+            answer_text: None,
+            answered_by: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            answered_at: None,
+            expires_at: None,
+            workflow_id,
+            task_id,
+            checkpoint_turn_id: None,
+        };
+
+        self.store.create_user_interaction(&interaction)?;
+
+        let response_json = serde_json::json!({
+            "ok": true,
+            "interaction_required": true,
+            "interaction_id": interaction_id,
+            "status": "awaiting_user"
+        })
+        .to_string();
+
+        Ok(GateResult::Suspended {
+            gate_id: interaction_id,
+            response_json,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Escalation pipeline
+    // -----------------------------------------------------------------------
+
+    fn check_escalation(&self, req: &GateRequest<'_>) -> Result<GateResult> {
+        let GateKind::Escalation { ref reason } = req.kind else {
+            unreachable!()
+        };
+
+        let sid = req.session_id.unwrap_or("");
+        let root_sid = if sid.is_empty() {
+            String::new()
+        } else {
+            content_store::root_session_id(sid).to_string()
+        };
+        let action = ScheduledAction::SessionEscalate {
+            session_id: sid.to_string(),
+            root_session_id: root_sid,
+            requested_by_agent_id: req.manifest.agent.id.clone(),
+            reason: reason.clone(),
+            context: String::new(),
+            urgency: "normal".to_string(),
+            suggested_actions: Vec::new(),
+            payload: None,
+        };
+
+        let gate_id = self.create_approval_row(req, &action)?;
+
+        let response_json = serde_json::json!({
+            "ok": false,
+            "escalation_required": true,
+            "suspended": true,
+            "request_id": gate_id,
+            "reason": reason
+        })
+        .to_string();
+
+        Ok(GateResult::Suspended {
+            gate_id,
+            response_json,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — approval_ref validation
+    // -----------------------------------------------------------------------
+
+    fn validate_approval_ref(
+        &self,
+        ref_id: &str,
+        req: &GateRequest<'_>,
+        action: &ScheduledAction,
+        targets: &[String],
+        match_strategy: MatchStrategy,
+    ) -> Result<Option<GateResult>> {
+        let approval = match self.store.get_approval(ref_id)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+
+        // Must be approved.
+        match approval.status {
+            Some(ApprovalStatus::Approved) => {}
+            _ => return Ok(None),
+        }
+
+        // Agent must match.
+        if approval.agent_id != req.manifest.agent.id {
+            return Ok(None);
+        }
+
+        // Root session must match.
+        let sid = match req.session_id {
+            Some(s) if !s.is_empty() => s,
+            _ => return Ok(None),
+        };
+        let current_root = content_store::root_session_id(sid).to_string();
+        let approved_root = approval
+            .root_session_id
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
+        if current_root != approved_root {
+            return Ok(None);
+        }
+
+        // Match strategy determines whether the approval covers this request.
+        let covered = match match_strategy {
+            MatchStrategy::HostLevel => self.host_level_covers(&approval, targets),
+            MatchStrategy::ExactPayload => self.exact_payload_covers(&approval, action),
+            MatchStrategy::SubstituteCommand => {
+                // Sandbox-specific: approved action's detected hosts must cover
+                // the current targets.
+                self.substitute_command_covers(&approval, targets)
+            }
+        };
+
+        if covered {
+            Ok(Some(GateResult::Cleared {
+                source: ClearanceSource::ApprovalRef(ref_id.to_string()),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Check if the approved action's hosts cover the requested targets.
+    fn host_level_covers(&self, approval: &ApprovalRequest, targets: &[String]) -> bool {
+        let approved_hosts = approval.action.detected_hosts().unwrap_or_default();
+        if approved_hosts.is_empty() || targets.is_empty() {
+            return false;
+        }
+        targets.iter().all(|t| {
+            let t_host = extract_host_from_target(t);
+            approved_hosts.iter().any(|h| {
+                let a_host = extract_host_from_target(h);
+                a_host == t_host
+            })
+        })
+    }
+
+    /// Check if the approved action exactly matches the current action.
+    fn exact_payload_covers(&self, approval: &ApprovalRequest, action: &ScheduledAction) -> bool {
+        // Same action kind + same serialised payload.
+        approval.action.kind() == action.kind()
+            && serde_json::to_string(&approval.action).unwrap_or_default()
+                == serde_json::to_string(action).unwrap_or_default()
+    }
+
+    /// Check if the approved action's detected hosts cover the targets
+    /// (sandbox SubstituteCommand strategy).
+    fn substitute_command_covers(
+        &self,
+        approval: &ApprovalRequest,
+        targets: &[String],
+    ) -> bool {
+        let approved_hosts = approval.action.detected_hosts().unwrap_or_default();
+        if approved_hosts.is_empty() || targets.is_empty() {
+            return false;
+        }
+        use std::collections::BTreeSet;
+        let required: BTreeSet<String> = targets.iter().cloned().collect();
+        let granted: BTreeSet<String> = approved_hosts.into_iter().collect();
+        required.is_subset(&granted)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — pending dedup
+    // -----------------------------------------------------------------------
+
+    /// Find an existing pending approval for the same session + action kind
+    /// whose detected hosts overlap with the requested targets.
+    fn find_pending_for_targets(
+        &self,
+        session_id: &str,
+        action: &ScheduledAction,
+        targets: &[String],
+    ) -> Result<Option<String>> {
+        let pending = crate::scheduler::approval::pending_approval_requests_for_session(
+            &autonoetic_types::config::GatewayConfig::default(),
+            Some(&self.store),
+            session_id,
+        )?;
+
+        for req in &pending {
+            if req.action.kind() != action.kind() {
+                continue;
+            }
+            // If no targets specified, any pending of the same kind counts.
+            if targets.is_empty() {
+                return Ok(Some(req.request_id.clone()));
+            }
+            // Check host overlap.
+            let req_hosts = req.action.detected_hosts().unwrap_or_default();
+            if !req_hosts.is_empty() {
+                let overlap = targets.iter().any(|t| {
+                    let t_host = extract_host_from_target(t);
+                    req_hosts.iter().any(|h| extract_host_from_target(h) == t_host)
+                });
+                if overlap {
+                    return Ok(Some(req.request_id.clone()));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — approval row creation
+    // -----------------------------------------------------------------------
+
+    fn create_approval_row(
+        &self,
+        req: &GateRequest<'_>,
+        action: &ScheduledAction,
+    ) -> Result<String> {
+        let sid = req.session_id.unwrap_or("");
+        let (root_session_id, workflow_id, task_id) = resolve_execution_context(req);
+
+        let request_id = format!("apr-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let mut approval_req = ApprovalRequest {
+            request_id: request_id.clone(),
+            agent_id: req.manifest.agent.id.clone(),
+            session_id: sid.to_string(),
+            root_session_id,
+            workflow_id,
+            task_id,
+            action: action.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            reason: if req.reason.is_empty() {
+                None
+            } else {
+                Some(req.reason.clone())
+            },
+            evidence_ref: None,
+            decision_reason: None,
+            approval_level: req
+                .config
+                .map(|cfg| {
+                    crate::scheduler::approval::resolve_approval_level(cfg, action)
+                })
+                .unwrap_or(ApprovalLevel::Operator),
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+        };
+
+        self.store.create_approval(&mut approval_req)?;
+        Ok(request_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — suspension JSON
+    // -----------------------------------------------------------------------
+
+    fn build_approval_suspension_json(
+        &self,
+        gate_id: &str,
+        req: &GateRequest<'_>,
+        action: &ScheduledAction,
+    ) -> Result<String> {
+        let kind_label = action.kind();
+        let subject = serde_json::json!({
+            "action": kind_label,
+            "targets": match action.detected_hosts() {
+                Some(hosts) => hosts,
+                None => Vec::<String>::new(),
+            },
+        });
+
+        let approval_details = build_approval_details(
+            &ApprovalRequest {
+                request_id: gate_id.to_string(),
+                agent_id: req.manifest.agent.id.clone(),
+                session_id: req.session_id.unwrap_or("").to_string(),
+                root_session_id: None,
+                workflow_id: None,
+                task_id: None,
+                action: action.clone(),
+                created_at: String::new(),
+                status: None,
+                decided_at: None,
+                decided_by: None,
+                reason: if req.reason.is_empty() {
+                    None
+                } else {
+                    Some(req.reason.clone())
+                },
+                evidence_ref: None,
+                decision_reason: None,
+                approval_level: ApprovalLevel::Operator,
+                similar_to_request_id: None,
+                similarity_score: None,
+                min_dwell_ms: None,
+                confirm_phrase: None,
+            },
+            kind_label,
+            req.summary.clone(),
+            "approval_ref",
+            subject,
+        );
+
+        Ok(serde_json::json!({
+            "ok": false,
+            "approval_required": true,
+            "suspended": true,
+            "request_id": gate_id,
+            "approval": approval_details
+        })
+        .to_string())
+    }
+
+    // -----------------------------------------------------------------------
+    // Gate messages (enrichment thread)
+    // -----------------------------------------------------------------------
+
+    /// Add a message to a gate's enrichment thread.
+    pub fn add_gate_message(
+        &self,
+        gate_id: &str,
+        sender: &str,
+        content: &str,
+    ) -> Result<i64> {
+        self.store.add_gate_message(gate_id, sender, content)
+    }
+
+    /// Retrieve all messages for a gate's enrichment thread.
+    pub fn get_gate_messages(&self, gate_id: &str) -> Result<Vec<GateMessage>> {
+        self.store.get_gate_messages(gate_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve (root_session_id, workflow_id, task_id) from a GateRequest.
+fn resolve_execution_context(req: &GateRequest<'_>) -> (Option<String>, Option<String>, Option<String>) {
+    let sid = req.session_id.unwrap_or("");
+    if let Some(rc) = req.run_context {
+        let root_session_id = if rc.root_session_id.is_empty() {
+            None
+        } else {
+            Some(rc.root_session_id.clone())
+        };
+        (root_session_id, rc.workflow_id.clone(), rc.task_id.clone())
+    } else if !sid.is_empty() {
+        let root_sid = content_store::root_session_id(sid).to_string();
+        (Some(root_sid), None, None)
+    } else {
+        (None, None, None)
+    }
+}
+
+/// Parse an interaction kind string into the enum, defaulting to `Clarification`.
+fn parse_interaction_kind(kind: &str) -> UserInteractionKind {
+    match kind.to_lowercase().as_str() {
+        "clarification" => UserInteractionKind::Clarification,
+        "decision" => UserInteractionKind::Decision,
+        "proposal" => UserInteractionKind::Proposal,
+        "confirmation" => UserInteractionKind::Confirmation,
+        _ => UserInteractionKind::Clarification,
+    }
+}
+
+/// Extract the host portion from a target string (URL or bare hostname).
+/// Returns the input trimmed if no URL structure is detected.
+fn extract_host_from_target(target: &str) -> String {
+    if target.contains("://") {
+        extract_host(target).unwrap_or_else(|_| target.to_string())
+    } else {
+        target.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::agent::{
+        AgentIdentity, AgentManifest, RuntimeDeclaration,
+    };
+    use autonoetic_types::capability::Capability;
+
+    fn test_manifest() -> AgentManifest {
+        AgentManifest {
+            version: "1.0".to_string(),
+            runtime: RuntimeDeclaration {
+                engine: "autonoetic".to_string(),
+                gateway_version: "0.1.0".to_string(),
+                sdk_version: "0.1.0".to_string(),
+                runtime_type: "stateful".to_string(),
+                sandbox: "bubblewrap".to_string(),
+                runtime_lock: "runtime.lock".to_string(),
+            },
+            agent: AgentIdentity {
+                id: "test-agent".to_string(),
+                name: "test-agent".to_string(),
+                description: "test agent".to_string(),
+            },
+            capabilities: vec![],
+            llm_config: None,
+            limits: None,
+            background: None,
+            disclosure: None,
+            io: None,
+            middleware: None,
+            execution_mode: Default::default(),
+            script_entry: None,
+            script_input_mode: Default::default(),
+            gateway_url: None,
+            gateway_token: None,
+            allowed_tool_tiers: vec![],
+            agentskills_import: None,
+            compression: None,
+        }
+    }
+
+    fn make_credential_request_action(url: &str) -> ScheduledAction {
+        ScheduledAction::CredentialRequest {
+            credential_id: format!("cred_{}", url::Url::parse(url).map(|u| u.host_str().unwrap_or("x").to_string()).unwrap_or_else(|_| "test".to_string())),
+            url: url.to_string(),
+            method: Some("GET".to_string()),
+            headers: None,
+            body: None,
+            inject_secret_as: None,
+            payload: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Basic type tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn gate_result_is_cleared() {
+        assert!(GateResult::Cleared {
+            source: ClearanceSource::SessionGrant
+        }
+        .is_cleared());
+        assert!(GateResult::PolicyAllowed.is_cleared());
+        assert!(!GateResult::AlreadyPending {
+            gate_id: "apr-test".to_string()
+        }
+        .is_cleared());
+        assert!(!GateResult::Suspended {
+            gate_id: "apr-test".to_string(),
+            response_json: "{}".to_string()
+        }
+        .is_cleared());
+    }
+
+    #[test]
+    fn extract_host_from_target_bare_host() {
+        assert_eq!(extract_host_from_target("localhost"), "localhost");
+        assert_eq!(extract_host_from_target("api.example.com"), "api.example.com");
+    }
+
+    #[test]
+    fn extract_host_from_target_url() {
+        assert_eq!(
+            extract_host_from_target("http://localhost:8080/path"),
+            "localhost"
+        );
+        assert_eq!(
+            extract_host_from_target("https://api.example.com/v1/endpoint"),
+            "api.example.com"
+        );
+    }
+
+    #[test]
+    fn match_strategy_host_level_covers_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = GateService::new(Arc::new(GatewayStore::open(tmp.path()).unwrap()));
+
+        let approval = ApprovalRequest {
+            request_id: "apr-test".to_string(),
+            agent_id: "test-agent".to_string(),
+            session_id: "ses-123".to_string(),
+            root_session_id: Some("root-123".to_string()),
+            workflow_id: None,
+            task_id: None,
+            action: ScheduledAction::WebFetch {
+                url: "http://localhost:8080/api".to_string(),
+                timeout_secs: None,
+                max_chars: None,
+                detected_hosts: Some(vec!["localhost".to_string()]),
+                payload: None,
+            },
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: Some(ApprovalStatus::Approved),
+            decided_at: None,
+            decided_by: None,
+            reason: None,
+            evidence_ref: None,
+            decision_reason: None,
+            approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+        };
+
+        assert!(svc.host_level_covers(&approval, &["localhost".to_string()]));
+        assert!(!svc.host_level_covers(&approval, &["remote.example.com".to_string()]));
+    }
+
+    #[test]
+    fn exact_payload_covers_same_action() {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = GateService::new(Arc::new(GatewayStore::open(tmp.path()).unwrap()));
+
+        let action = make_credential_request_action("http://localhost:8080/api");
+        let approval = ApprovalRequest {
+            request_id: "apr-test".to_string(),
+            agent_id: "test-agent".to_string(),
+            session_id: "ses-123".to_string(),
+            root_session_id: Some("root-123".to_string()),
+            workflow_id: None,
+            task_id: None,
+            action: action.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: Some(ApprovalStatus::Approved),
+            decided_at: None,
+            decided_by: None,
+            reason: None,
+            evidence_ref: None,
+            decision_reason: None,
+            approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+        };
+
+        assert!(svc.exact_payload_covers(&approval, &action));
+    }
+
+    // -----------------------------------------------------------------------
+    // Full pipeline tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn approval_pre_validated_bypass() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = GateService::new(Arc::new(GatewayStore::open(tmp.path()).unwrap()));
+        let manifest = test_manifest();
+
+        let req = GateRequest {
+            kind: GateKind::Approval {
+                action: make_credential_request_action("http://localhost:8080/api"),
+                targets: vec!["localhost".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some("ses-123"),
+            run_context: None,
+            config: None,
+            reason: "test".to_string(),
+            summary: "test summary".to_string(),
+            approval_ref: None,
+            pre_validated: true,
+        };
+
+        let result = svc.check(req)?;
+        assert!(result.is_cleared());
+        match result {
+            GateResult::Cleared { source: ClearanceSource::CachedApproval } => {}
+            other => panic!("expected CachedApproval, got {:?}", other),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn approval_suspends_when_no_bypass() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = GateService::new(Arc::new(GatewayStore::open(tmp.path()).unwrap()));
+        let manifest = test_manifest();
+
+        let req = GateRequest {
+            kind: GateKind::Approval {
+                action: make_credential_request_action("http://localhost:8080/api"),
+                targets: vec!["localhost".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some("ses-123"),
+            run_context: None,
+            config: None,
+            reason: "network access required".to_string(),
+            summary: "Fetch API from localhost".to_string(),
+            approval_ref: None,
+            pre_validated: false,
+        };
+
+        let result = svc.check(req)?;
+        match result {
+            GateResult::Suspended { gate_id, response_json } => {
+                assert!(gate_id.starts_with("apr-"));
+                let json: serde_json::Value = serde_json::from_str(&response_json)?;
+                assert_eq!(json["ok"], false);
+                assert_eq!(json["approval_required"], true);
+                assert_eq!(json["suspended"], true);
+                assert_eq!(json["request_id"], gate_id);
+            }
+            other => panic!("expected Suspended, got {:?}", other),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn approval_dedup_returns_already_pending() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = GateService::new(Arc::new(GatewayStore::open(tmp.path()).unwrap()));
+        let manifest = test_manifest();
+        let sid = "ses-dedup-123";
+
+        let action = make_credential_request_action("http://localhost:8080/api");
+
+        // First request -> Suspended
+        let req1 = GateRequest {
+            kind: GateKind::Approval {
+                action: action.clone(),
+                targets: vec!["localhost".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some(sid),
+            run_context: None,
+            config: None,
+            reason: "first".to_string(),
+            summary: "first".to_string(),
+            approval_ref: None,
+            pre_validated: false,
+        };
+        let result1 = svc.check(req1)?;
+        let gate_id_1 = match &result1 {
+            GateResult::Suspended { gate_id, .. } => gate_id.clone(),
+            other => panic!("expected Suspended, got {:?}", other),
+        };
+
+        // Second request for same session/targets -> AlreadyPending
+        let req2 = GateRequest {
+            kind: GateKind::Approval {
+                action: action.clone(),
+                targets: vec!["localhost".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some(sid),
+            run_context: None,
+            config: None,
+            reason: "second".to_string(),
+            summary: "second".to_string(),
+            approval_ref: None,
+            pre_validated: false,
+        };
+        let result2 = svc.check(req2)?;
+        match result2 {
+            GateResult::AlreadyPending { gate_id } => {
+                assert_eq!(gate_id, gate_id_1);
+            }
+            other => panic!("expected AlreadyPending, got {:?}", other),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn approval_ref_validates_and_clears() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(GatewayStore::open(tmp.path()).unwrap());
+        let svc = GateService::new(store.clone());
+        let manifest = test_manifest();
+        let sid = "ses-ref-123";
+
+        let action = make_credential_request_action("http://localhost:8080/api");
+
+        // Create approval manually and approve it.
+        let ref_id = format!("apr-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let mut approval = ApprovalRequest {
+            request_id: ref_id.clone(),
+            agent_id: manifest.agent.id.clone(),
+            session_id: sid.to_string(),
+            root_session_id: Some(sid.to_string()),
+            workflow_id: None,
+            task_id: None,
+            action: action.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            reason: Some("test".to_string()),
+            evidence_ref: None,
+            decision_reason: None,
+            approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+        };
+        store.create_approval(&mut approval)?;
+        store.record_decision(&ref_id, "approved", "operator", &chrono::Utc::now().to_rfc3339(), None)?;
+
+        // Now check with approval_ref -> should clear.
+        let req = GateRequest {
+            kind: GateKind::Approval {
+                action: action.clone(),
+                targets: vec!["localhost".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some(sid),
+            run_context: None,
+            config: None,
+            reason: "test".to_string(),
+            summary: "test".to_string(),
+            approval_ref: Some(&ref_id),
+            pre_validated: false,
+        };
+        let result = svc.check(req)?;
+        match result {
+            GateResult::Cleared { source: ClearanceSource::ApprovalRef(id) } => {
+                assert_eq!(id, ref_id);
+            }
+            other => panic!("expected Cleared(ApprovalRef), got {:?}", other),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn approval_ref_wrong_agent_does_not_clear() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(GatewayStore::open(tmp.path()).unwrap());
+        let svc = GateService::new(store.clone());
+        let manifest = test_manifest();
+        let sid = "ses-wrong-123";
+
+        let action = make_credential_request_action("http://localhost:8080/api");
+
+        // Create approval for a different agent.
+        let ref_id = format!("apr-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let mut approval = ApprovalRequest {
+            request_id: ref_id.clone(),
+            agent_id: "other-agent".to_string(),
+            session_id: sid.to_string(),
+            root_session_id: Some(sid.to_string()),
+            workflow_id: None,
+            task_id: None,
+            action: action.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            reason: Some("test".to_string()),
+            evidence_ref: None,
+            decision_reason: None,
+            approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+        };
+        store.create_approval(&mut approval)?;
+        store.record_decision(&ref_id, "approved", "operator", &chrono::Utc::now().to_rfc3339(), None)?;
+
+        let req = GateRequest {
+            kind: GateKind::Approval {
+                action,
+                targets: vec!["localhost".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some(sid),
+            run_context: None,
+            config: None,
+            reason: "test".to_string(),
+            summary: "test".to_string(),
+            approval_ref: Some(&ref_id),
+            pre_validated: false,
+        };
+        let result = svc.check(req)?;
+        // Should NOT clear — wrong agent.
+        assert!(matches!(result, GateResult::Suspended { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn gate_messages_store_and_retrieve() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(GatewayStore::open(tmp.path()).unwrap());
+        let svc = GateService::new(store.clone());
+
+        let id1 = svc.add_gate_message("apr-test123", "operator", "Why does the agent need localhost?")?;
+        let id2 = svc.add_gate_message("apr-test123", "system", "Agent says: API runs on localhost:9876")?;
+
+        let msgs = svc.get_gate_messages("apr-test123")?;
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].sender, "operator");
+        assert_eq!(msgs[0].content, "Why does the agent need localhost?");
+        assert_eq!(msgs[1].sender, "system");
+        assert_eq!(msgs[1].id, id2);
+
+        // Empty for a different gate.
+        let empty = svc.get_gate_messages("apr-nonexistent")?;
+        assert!(empty.is_empty());
+        Ok(())
+    }
+}

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -258,13 +258,13 @@ impl GateService {
             unreachable!()
         };
 
-        let interaction_id = format!("ui-{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let sid = req.session_id.unwrap_or("");
-        let root_sid = if sid.is_empty() {
-            String::new()
-        } else {
-            content_store::root_session_id(sid).to_string()
-        };
+        anyhow::ensure!(
+            !sid.is_empty(),
+            "GateKind::UserInput requires a session_id"
+        );
+
+        let interaction_id = format!("ui-{}", &uuid::Uuid::new_v4().to_string()[..8]);
 
         let (root_session_id, workflow_id, task_id) = resolve_execution_context(req);
 

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -19,6 +19,7 @@ pub mod crypto;
 pub mod disclosure;
 pub mod guard;
 pub mod history_persist;
+pub mod human_gate;
 pub mod install_contract;
 pub mod lifecycle;
 pub mod live_digest;

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -492,39 +492,76 @@ impl NativeTool for CredentialRequestTool {
                     "Credential request to {} requires approval (policy: {})",
                     url_host, violation.error_type
                 );
-                let request_id = create_credential_request_approval(
-                    &store,
-                    manifest,
-                    _config,
-                    _run_context,
-                    _session_id,
-                    action,
-                    reason.clone(),
+
+                let gate = crate::runtime::human_gate::GateService::new(store.clone());
+                let gate_result = gate.check(
+                    crate::runtime::human_gate::GateRequest {
+                        kind: crate::runtime::human_gate::GateKind::Approval {
+                            action: action.clone(),
+                            targets: vec![url_host.clone()],
+                            match_strategy: crate::runtime::human_gate::MatchStrategy::ExactPayload,
+                        },
+                        manifest,
+                        session_id: _session_id,
+                        run_context: _run_context,
+                        config: _config,
+                        reason: reason.clone(),
+                        summary: format!("Credential request to {}", url_host),
+                        approval_ref: None,
+                        pre_validated: false,
+                    },
                 )?;
-                return Ok(json!({
-                    "ok": false,
-                    "error_type": violation.error_type,
-                    "message": format!(
-                        "Execution suspended pending operator approval ({}). Retry credential.request with approval_ref after approval.",
-                        request_id
-                    ),
-                    "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                    "error": violation.message,
-                    "approval_required": true,
-                    "request_id": request_id,
-                    "suspended": true,
-                    "reason": reason,
-                    "approval": {
-                        "kind": "credential_request",
-                        "summary": format!("Credential request to {}", url_host),
-                        "reason": format!(
-                            "Credential request to {} requires approval because remote target policy is not declared for this host.",
-                            url_host
-                        ),
-                        "retry_field": "approval_ref"
+                match gate_result {
+                    crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                    crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                        return Ok(json!({
+                            "ok": false,
+                            "approval_required": true,
+                            "approval_already_pending": true,
+                            "request_id": gate_id,
+                            "suspended": true,
+                            "reason": reason,
+                            "repair_hint": "Wait for the existing approval to be resolved.",
+                            "approval": {
+                                "kind": "credential_request",
+                                "summary": format!("Credential request to {}", url_host),
+                                "retry_field": "approval_ref"
+                            }
+                        }).to_string());
                     }
-                })
-                .to_string());
+                    crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                        return Ok(json!({
+                            "ok": false,
+                            "error_type": violation.error_type,
+                            "message": format!(
+                                "Execution suspended pending operator approval ({}). Retry credential.request with approval_ref after approval.",
+                                gate_id
+                            ),
+                            "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
+                            "error": violation.message,
+                            "approval_required": true,
+                            "request_id": gate_id,
+                            "suspended": true,
+                            "reason": reason,
+                            "approval": {
+                                "kind": "credential_request",
+                                "summary": format!("Credential request to {}", url_host),
+                                "reason": format!(
+                                    "Credential request to {} requires approval because remote target policy is not declared for this host.",
+                                    url_host
+                                ),
+                                "retry_field": "approval_ref"
+                            }
+                        }).to_string());
+                    }
+                    other => {
+                        tracing::warn!(
+                            target: "credential_request",
+                            gate_result = ?other,
+                            "Unexpected gate result for credential.request remote target gate"
+                        );
+                    }
+                }
             }
         }
 
@@ -545,37 +582,73 @@ impl NativeTool for CredentialRequestTool {
                 })),
             };
             let reason = format!("HTTP request to {} requires approval", url_host);
-            let request_id = create_credential_request_approval(
-                &store,
-                manifest,
-                _config,
-                _run_context,
-                _session_id,
-                action,
-                reason.clone(),
+
+            let gate = crate::runtime::human_gate::GateService::new(store.clone());
+            let gate_result = gate.check(
+                crate::runtime::human_gate::GateRequest {
+                    kind: crate::runtime::human_gate::GateKind::Approval {
+                        action: action.clone(),
+                        targets: vec![url_host.clone()],
+                        match_strategy: crate::runtime::human_gate::MatchStrategy::ExactPayload,
+                    },
+                    manifest,
+                    session_id: _session_id,
+                    run_context: _run_context,
+                    config: _config,
+                    reason: reason.clone(),
+                    summary: format!("Credential request to {}", url_host),
+                    approval_ref: None,
+                    pre_validated: false,
+                },
             )?;
-            let message = format!(
-                "Execution suspended pending operator approval ({}). Retry credential.request with approval_ref after approval.",
-                request_id
-            );
-            return Ok(json!({
-                "ok": false,
-                "error_type": "permission",
-                "message": message,
-                "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                "error": format!("Network access denied for host: {}", url_host),
-                "approval_required": true,
-                "request_id": request_id,
-                "suspended": true,
-                "reason": reason,
-                "approval": {
-                    "kind": "credential_request",
-                    "summary": format!("Credential request to {}", url_host),
-                    "reason": format!("HTTP request to {} requires approval", url_host),
-                    "retry_field": "approval_ref"
+            match gate_result {
+                crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                    return Ok(json!({
+                        "ok": false,
+                        "approval_required": true,
+                        "approval_already_pending": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "repair_hint": "Wait for the existing approval to be resolved.",
+                        "approval": {
+                            "kind": "credential_request",
+                            "summary": format!("Credential request to {}", url_host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string());
                 }
-            })
-            .to_string());
+                crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                    return Ok(json!({
+                        "ok": false,
+                        "error_type": "permission",
+                        "message": format!(
+                            "Execution suspended pending operator approval ({}). Retry credential.request with approval_ref after approval.",
+                            gate_id
+                        ),
+                        "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
+                        "error": format!("Network access denied for host: {}", url_host),
+                        "approval_required": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "approval": {
+                            "kind": "credential_request",
+                            "summary": format!("Credential request to {}", url_host),
+                            "reason": format!("HTTP request to {} requires approval", url_host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string());
+                }
+                other => {
+                    tracing::warn!(
+                        target: "credential_request",
+                        gate_result = ?other,
+                        "Unexpected gate result for credential.request network gate"
+                    );
+                }
+            }
         }
 
         // Bind credential to destination host: the URL host must match

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -1486,15 +1486,26 @@ impl NativeTool for CredentialSetupTool {
         {
             // Policy-check the skill_url host.
             let url_host = extract_host(url)?;
-            let skill_url_is_approved = approved_setup_remote_url.as_deref() == Some(url.as_str());
+            let skill_url_is_approved = approved_setup_remote_url.as_deref()
+                .map(|u| extract_host(u).unwrap_or_default() == url_host)
+                .unwrap_or(false);
             if !skill_url_is_approved {
-                if let Err(violation) = crate::runtime::network_policy::enforce_remote_target_policy(
+                let policy_violation = crate::runtime::network_policy::enforce_remote_target_policy(
                     manifest,
                     _agent_dir,
                     &url_host,
                     Some(url),
                     DeclarationRequirement::Required,
-                ) {
+                ).err().map(|v| v.error_type.to_string())
+                .or_else(|| {
+                    if url_host.is_empty() || !policy.can_connect_net(&url_host).is_allowed() {
+                        Some("network_access_denied".to_string())
+                    } else {
+                        None
+                    }
+                });
+
+                if let Some(violation_type) = policy_violation {
                     let action = ScheduledAction::CredentialRequest {
                         credential_id: args.credential_id.clone().unwrap_or_default(),
                         url: url.clone(),
@@ -1507,92 +1518,78 @@ impl NativeTool for CredentialSetupTool {
                             "retry_field": "approval_ref",
                             "source_tool": "credential_setup",
                             "setup_phase": "skill_url",
-                            "policy_violation": violation.error_type,
+                            "policy_violation": violation_type,
                         })),
                     };
                     let reason = format!(
                         "Fetching skill.md from {} requires approval (policy: {})",
-                        url_host, violation.error_type
+                        url_host, violation_type
                     );
-                    let request_id = create_credential_request_approval(
-                        &store,
-                        manifest,
-                        _config,
-                        _run_context,
-                        _session_id,
-                        action,
-                        reason.clone(),
+                    let gate = crate::runtime::human_gate::GateService::new(store.clone());
+                    let gate_result = gate.check(
+                        crate::runtime::human_gate::GateRequest {
+                            kind: crate::runtime::human_gate::GateKind::Approval {
+                                action: action.clone(),
+                                targets: vec![url_host.clone()],
+                                match_strategy: crate::runtime::human_gate::MatchStrategy::HostLevel,
+                            },
+                            manifest,
+                            session_id: _session_id,
+                            run_context: _run_context,
+                            config: _config,
+                            reason: reason.clone(),
+                            summary: format!("Fetch skill.md from {}", url_host),
+                            approval_ref: None,
+                            pre_validated: false,
+                        },
                     )?;
-                    return Ok(json!({
-                            "ok": false,
-                            "error_type": violation.error_type,
-                            "message": format!(
-                                "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
-                                request_id
-                            ),
-                            "repair_hint": "Wait for approval and retry credential.setup with the same skill_url plus approval_ref.",
-                            "error": violation.message,
-                            "approval_required": true,
-                            "request_id": request_id,
-                            "suspended": true,
-                            "reason": reason,
-                            "approval": {
-                                "kind": "credential_setup_remote_access",
-                                "summary": format!("Fetch skill.md from {}", url_host),
-                                "reason": format!("Remote target policy is undeclared for {}", url_host),
-                                "retry_field": "approval_ref"
-                            }
-                        })
-                        .to_string());
-                }
-                if url_host.is_empty() || !policy.can_connect_net(&url_host).is_allowed() {
-                    let reason = format!("Fetching skill.md from {} requires approval", url_host);
-                    let action = ScheduledAction::CredentialRequest {
-                        credential_id: args.credential_id.clone().unwrap_or_default(),
-                        url: url.clone(),
-                        method: Some("GET".to_string()),
-                        headers: None,
-                        body: None,
-                        inject_secret_as: None,
-                        payload: Some(json!({
-                            "host": url_host.clone(),
-                            "retry_field": "approval_ref",
-                            "source_tool": "credential_setup",
-                            "setup_phase": "skill_url",
-                            "policy_violation": "network_access_denied",
-                        })),
-                    };
-                    let request_id = create_credential_request_approval(
-                        &store,
-                        manifest,
-                        _config,
-                        _run_context,
-                        _session_id,
-                        action,
-                        reason.clone(),
-                    )?;
-                    let message = format!("Network access denied for skill_url host: {}", url_host);
-                    return Ok(json!({
-                            "ok": false,
-                            "error_type": "permission",
-                            "message": format!(
-                                "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
-                                request_id
-                            ),
-                            "repair_hint": "Wait for approval and retry credential.setup with the same skill_url plus approval_ref.",
-                            "error": message,
-                            "approval_required": true,
-                            "request_id": request_id,
-                            "suspended": true,
-                            "reason": reason,
-                            "approval": {
-                                "kind": "credential_setup_remote_access",
-                                "summary": format!("Fetch skill.md from {}", url_host),
-                                "reason": format!("Fetching skill.md from {} requires approval", url_host),
-                                "retry_field": "approval_ref"
-                            }
-                        })
-                        .to_string());
+                    match gate_result {
+                        crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                        crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                            return Ok(json!({
+                                "ok": false,
+                                "approval_required": true,
+                                "approval_already_pending": true,
+                                "request_id": gate_id,
+                                "suspended": true,
+                                "reason": reason,
+                                "repair_hint": "Wait for the existing approval to be resolved.",
+                                "approval": {
+                                    "kind": "credential_setup_remote_access",
+                                    "summary": format!("Fetch skill.md from {}", url_host),
+                                    "retry_field": "approval_ref"
+                                }
+                            }).to_string());
+                        }
+                        crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                            return Ok(json!({
+                                "ok": false,
+                                "error_type": violation_type,
+                                "message": format!(
+                                    "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
+                                    gate_id
+                                ),
+                                "repair_hint": "Wait for approval and retry credential.setup with the same skill_url plus approval_ref.",
+                                "approval_required": true,
+                                "request_id": gate_id,
+                                "suspended": true,
+                                "reason": reason,
+                                "approval": {
+                                    "kind": "credential_setup_remote_access",
+                                    "summary": format!("Fetch skill.md from {}", url_host),
+                                    "reason": format!("Remote target policy: {} for {}", violation_type, url_host),
+                                    "retry_field": "approval_ref"
+                                }
+                            }).to_string());
+                        }
+                        other => {
+                            tracing::warn!(
+                                target: "credential",
+                                gate_result = ?other,
+                                "Unexpected gate result for credential_setup skill_url gate"
+                            );
+                        }
+                    }
                 }
             }
 
@@ -1730,10 +1727,11 @@ impl NativeTool for CredentialSetupTool {
             } = step
             {
                 let host = extract_host(url)?;
-                let step_url_is_approved =
-                    approved_setup_remote_url.as_deref() == Some(url.as_str());
+                let step_url_is_approved = approved_setup_remote_url.as_deref()
+                    .map(|u| extract_host(u).unwrap_or_default() == host)
+                    .unwrap_or(false);
                 if !step_url_is_approved {
-                    if let Err(violation) =
+                    let policy_violation =
                         crate::runtime::network_policy::enforce_remote_target_policy(
                             manifest,
                             _agent_dir,
@@ -1741,7 +1739,18 @@ impl NativeTool for CredentialSetupTool {
                             Some(url),
                             DeclarationRequirement::Required,
                         )
-                    {
+                        .err()
+                        .map(|v| v.error_type.to_string())
+                        .or_else(|| {
+                            if host.is_empty() || !policy.can_connect_net(&host).is_allowed() {
+                                Some("network_access_denied".to_string())
+                            } else {
+                                None
+                            }
+                        });
+
+                    if let Some(violation_type) = policy_violation {
+                        let display_host = if host.is_empty() { "<empty host>" } else { &host };
                         let action = ScheduledAction::CredentialRequest {
                             credential_id: args.credential_id.clone().unwrap_or_default(),
                             url: url.clone(),
@@ -1754,110 +1763,78 @@ impl NativeTool for CredentialSetupTool {
                                 "retry_field": "approval_ref",
                                 "source_tool": "credential_setup",
                                 "setup_phase": "api_call_precheck",
-                                "policy_violation": violation.error_type,
+                                "policy_violation": violation_type,
                             })),
                         };
                         let reason = format!(
                             "API call to {} requires approval (policy: {})",
-                            if host.is_empty() {
-                                "<empty host>"
-                            } else {
-                                &host
+                            display_host, violation_type
+                        );
+                        let gate = crate::runtime::human_gate::GateService::new(store.clone());
+                        let gate_result = gate.check(
+                            crate::runtime::human_gate::GateRequest {
+                                kind: crate::runtime::human_gate::GateKind::Approval {
+                                    action: action.clone(),
+                                    targets: vec![host.clone()],
+                                    match_strategy: crate::runtime::human_gate::MatchStrategy::HostLevel,
+                                },
+                                manifest,
+                                session_id: _session_id,
+                                run_context: _run_context,
+                                config: _config,
+                                reason: reason.clone(),
+                                summary: format!("Credential setup API call to {}", display_host),
+                                approval_ref: None,
+                                pre_validated: false,
                             },
-                            violation.error_type
-                        );
-                        let request_id = create_credential_request_approval(
-                            &store,
-                            manifest,
-                            _config,
-                            _run_context,
-                            _session_id,
-                            action,
-                            reason.clone(),
                         )?;
-                        return Ok(json!({
-                            "ok": false,
-                            "error_type": violation.error_type,
-                            "message": format!(
-                                "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
-                                request_id
-                            ),
-                            "repair_hint": "Wait for approval and retry credential.setup with approval_ref.",
-                            "error": violation.message,
-                            "approval_required": true,
-                            "request_id": request_id,
-                            "suspended": true,
-                            "reason": reason,
-                            "approval": {
-                                "kind": "credential_setup_remote_access",
-                                "summary": format!(
-                                    "Credential setup API call to {}",
-                                    if host.is_empty() { "<empty host>" } else { &host }
-                                ),
-                                "reason": format!(
-                                    "Remote target policy is undeclared for {}",
-                                    if host.is_empty() { "<empty host>" } else { &host }
-                                ),
-                                "retry_field": "approval_ref"
+                        match gate_result {
+                            crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                            crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                                return Ok(json!({
+                                    "ok": false,
+                                    "approval_required": true,
+                                    "approval_already_pending": true,
+                                    "request_id": gate_id,
+                                    "suspended": true,
+                                    "reason": reason,
+                                    "repair_hint": "Wait for the existing approval to be resolved.",
+                                    "approval": {
+                                        "kind": "credential_setup_remote_access",
+                                        "summary": format!("Credential setup API call to {}", display_host),
+                                        "retry_field": "approval_ref"
+                                    }
+                                }).to_string());
                             }
-                        })
-                        .to_string());
-                    }
-                    if host.is_empty() || !policy.can_connect_net(&host).is_allowed() {
-                        let denied_host = if host.is_empty() { "<empty>" } else { &host };
-                        let reason = format!(
-                            "API call to {} requires approval",
-                            if host.is_empty() {
-                                "<empty host>"
-                            } else {
-                                &host
+                            crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                                return Ok(json!({
+                                    "ok": false,
+                                    "error_type": violation_type,
+                                    "message": format!(
+                                        "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
+                                        gate_id
+                                    ),
+                                    "repair_hint": "Wait for approval and retry credential.setup with approval_ref.",
+                                    "approval_required": true,
+                                    "request_id": gate_id,
+                                    "suspended": true,
+                                    "reason": reason,
+                                    "approval": {
+                                        "kind": "credential_setup_remote_access",
+                                        "summary": format!("Credential setup API call to {}", display_host),
+                                        "reason": format!("Remote target policy: {} for {}", violation_type, display_host),
+                                        "retry_field": "approval_ref"
+                                    }
+                                }).to_string());
                             }
-                        );
-                        let action = ScheduledAction::CredentialRequest {
-                            credential_id: args.credential_id.clone().unwrap_or_default(),
-                            url: url.clone(),
-                            method: method.clone(),
-                            headers: Some(headers.clone()),
-                            body: body.clone(),
-                            inject_secret_as: None,
-                            payload: Some(json!({
-                                "host": host.clone(),
-                                "retry_field": "approval_ref",
-                                "source_tool": "credential_setup",
-                                "setup_phase": "api_call_precheck",
-                                "policy_violation": "network_access_denied",
-                            })),
-                        };
-                        let request_id = create_credential_request_approval(
-                            &store,
-                            manifest,
-                            _config,
-                            _run_context,
-                            _session_id,
-                            action,
-                            reason.clone(),
-                        )?;
-                        return Ok(json!({
-                            "ok": false,
-                            "error_type": "permission",
-                            "message": format!(
-                                "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
-                                request_id
-                            ),
-                            "repair_hint": "Wait for approval and retry credential.setup with approval_ref.",
-                            "error": format!("Network access denied for host: {}", denied_host),
-                            "approval_required": true,
-                            "request_id": request_id,
-                            "suspended": true,
-                            "reason": reason,
-                            "approval": {
-                                "kind": "credential_setup_remote_access",
-                                "summary": format!("Credential setup API call to {}", denied_host),
-                                "reason": format!("API call to {} requires approval", denied_host),
-                                "retry_field": "approval_ref"
+                            other => {
+                                tracing::warn!(
+                                    target: "credential",
+                                    gate_result = ?other,
+                                    "Unexpected gate result for credential_setup api_call gate"
+                                );
                             }
-                        })
-                        .to_string());
+                        }
                     }
                 }
             }

--- a/autonoetic-gateway/src/runtime/tools/web.rs
+++ b/autonoetic-gateway/src/runtime/tools/web.rs
@@ -972,38 +972,74 @@ impl NativeTool for WebSearchTool {
                 })),
             };
             let reason = format!("web.search to {} requires approval", engine_host);
-            let request_id = create_network_approval(
-                store.as_ref(),
-                manifest,
-                Some(cfg),
-                _run_context,
-                _session_id,
-                action,
-                reason.clone(),
+
+            let gate = crate::runtime::human_gate::GateService::new(store.clone());
+            let gate_result = gate.check(
+                crate::runtime::human_gate::GateRequest {
+                    kind: crate::runtime::human_gate::GateKind::Approval {
+                        action: action.clone(),
+                        targets: vec![engine_host.clone()],
+                        match_strategy: crate::runtime::human_gate::MatchStrategy::ExactPayload,
+                    },
+                    manifest,
+                    session_id: _session_id,
+                    run_context: _run_context,
+                    config: Some(cfg),
+                    reason: reason.clone(),
+                    summary: format!("web.search {}", engine_host),
+                    approval_ref: None,
+                    pre_validated: false,
+                },
             )?;
-            Ok(Some(
-                serde_json::json!({
-                    "ok": false,
-                    "error_type": "permission",
-                    "message": format!(
-                        "Execution suspended pending operator approval ({}). Retry web.search with approval_ref after approval.",
-                        request_id
-                    ),
-                    "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                    "error": format!("Network access denied for host: {}", engine_host),
-                    "approval_required": true,
-                    "request_id": request_id,
-                    "suspended": true,
-                    "reason": reason,
-                    "approval": {
-                        "kind": "web_search",
-                        "summary": format!("web.search {}", engine_host),
-                        "reason": format!("web.search to {} requires approval", engine_host),
-                        "retry_field": "approval_ref"
-                    }
-                })
-                .to_string(),
-            ))
+            match gate_result {
+                crate::runtime::human_gate::GateResult::Cleared { .. } => Ok(None),
+                crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                    Ok(Some(serde_json::json!({
+                        "ok": false,
+                        "approval_required": true,
+                        "approval_already_pending": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "repair_hint": "Wait for the existing approval to be resolved.",
+                        "approval": {
+                            "kind": "web_search",
+                            "summary": format!("web.search {}", engine_host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string()))
+                }
+                crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                    Ok(Some(serde_json::json!({
+                        "ok": false,
+                        "error_type": "permission",
+                        "message": format!(
+                            "Execution suspended pending operator approval ({}). Retry web.search with approval_ref after approval.",
+                            gate_id
+                        ),
+                        "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
+                        "error": format!("Network access denied for host: {}", engine_host),
+                        "approval_required": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "approval": {
+                            "kind": "web_search",
+                            "summary": format!("web.search {}", engine_host),
+                            "reason": format!("web.search to {} requires approval", engine_host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string()))
+                }
+                other => {
+                    tracing::warn!(
+                        target: "web",
+                        gate_result = ?other,
+                        "Unexpected gate result for web.search gate"
+                    );
+                    Ok(None)
+                }
+            }
         };
 
         let mut attempted_providers = Vec::new();
@@ -1400,36 +1436,73 @@ impl NativeTool for WebFetchTool {
                 })),
             };
             let reason = format!("web.fetch to {} requires approval", host);
-            let request_id = create_network_approval(
-                store.as_ref(),
-                manifest,
-                Some(cfg),
-                _run_context,
-                _session_id,
-                action,
-                reason.clone(),
+
+            let gate = crate::runtime::human_gate::GateService::new(store);
+            let gate_result = gate.check(
+                crate::runtime::human_gate::GateRequest {
+                    kind: crate::runtime::human_gate::GateKind::Approval {
+                        action: action.clone(),
+                        targets: vec![host.clone()],
+                        match_strategy: crate::runtime::human_gate::MatchStrategy::ExactPayload,
+                    },
+                    manifest,
+                    session_id: _session_id,
+                    run_context: _run_context,
+                    config: Some(cfg),
+                    reason: reason.clone(),
+                    summary: format!("web.fetch {}", host),
+                    approval_ref: None,
+                    pre_validated: false,
+                },
             )?;
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error_type": "permission",
-                "message": format!(
-                    "Execution suspended pending operator approval ({}). Retry web.fetch with approval_ref after approval.",
-                    request_id
-                ),
-                "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                "error": format!("Network access denied for host: {}", host),
-                "approval_required": true,
-                "request_id": request_id,
-                "suspended": true,
-                "reason": reason,
-                "approval": {
-                    "kind": "web_fetch",
-                    "summary": format!("web.fetch {}", host),
-                    "reason": format!("web.fetch to {} requires approval", host),
-                    "retry_field": "approval_ref"
+            match gate_result {
+                crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "approval_required": true,
+                        "approval_already_pending": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "repair_hint": "Wait for the existing approval to be resolved.",
+                        "approval": {
+                            "kind": "web_fetch",
+                            "summary": format!("web.fetch {}", host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string());
                 }
-            })
-            .to_string());
+                crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "error_type": "permission",
+                        "message": format!(
+                            "Execution suspended pending operator approval ({}). Retry web.fetch with approval_ref after approval.",
+                            gate_id
+                        ),
+                        "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
+                        "error": format!("Network access denied for host: {}", host),
+                        "approval_required": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "approval": {
+                            "kind": "web_fetch",
+                            "summary": format!("web.fetch {}", host),
+                            "reason": format!("web.fetch to {} requires approval", host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string());
+                }
+                other => {
+                    tracing::warn!(
+                        target: "web",
+                        gate_result = ?other,
+                        "Unexpected gate result for web.fetch gate"
+                    );
+                }
+            }
         }
 
         let timeout_secs = args.timeout_secs.unwrap_or(20).clamp(5, 120);
@@ -1702,36 +1775,73 @@ impl NativeTool for WebCallTool {
                 })),
             };
             let reason = format!("web.call to {} requires approval", host);
-            let request_id = create_network_approval(
-                store.as_ref(),
-                manifest,
-                Some(cfg),
-                _run_context,
-                _session_id,
-                action,
-                reason.clone(),
+
+            let gate = crate::runtime::human_gate::GateService::new(store);
+            let gate_result = gate.check(
+                crate::runtime::human_gate::GateRequest {
+                    kind: crate::runtime::human_gate::GateKind::Approval {
+                        action: action.clone(),
+                        targets: vec![host.clone()],
+                        match_strategy: crate::runtime::human_gate::MatchStrategy::ExactPayload,
+                    },
+                    manifest,
+                    session_id: _session_id,
+                    run_context: _run_context,
+                    config: Some(cfg),
+                    reason: reason.clone(),
+                    summary: format!("web.call {}", host),
+                    approval_ref: None,
+                    pre_validated: false,
+                },
             )?;
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error_type": "permission",
-                "message": format!(
-                    "Execution suspended pending operator approval ({}). Retry web.call with approval_ref after approval.",
-                    request_id
-                ),
-                "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                "error": format!("Network access denied for host: {}", host),
-                "approval_required": true,
-                "request_id": request_id,
-                "suspended": true,
-                "reason": reason,
-                "approval": {
-                    "kind": "web_call",
-                    "summary": format!("web.call {}", host),
-                    "reason": format!("web.call to {} requires approval", host),
-                    "retry_field": "approval_ref"
+            match gate_result {
+                crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                crate::runtime::human_gate::GateResult::AlreadyPending { gate_id } => {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "approval_required": true,
+                        "approval_already_pending": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "repair_hint": "Wait for the existing approval to be resolved.",
+                        "approval": {
+                            "kind": "web_call",
+                            "summary": format!("web.call {}", host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string());
                 }
-            })
-            .to_string());
+                crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "error_type": "permission",
+                        "message": format!(
+                            "Execution suspended pending operator approval ({}). Retry web.call with approval_ref after approval.",
+                            gate_id
+                        ),
+                        "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
+                        "error": format!("Network access denied for host: {}", host),
+                        "approval_required": true,
+                        "request_id": gate_id,
+                        "suspended": true,
+                        "reason": reason,
+                        "approval": {
+                            "kind": "web_call",
+                            "summary": format!("web.call {}", host),
+                            "reason": format!("web.call to {} requires approval", host),
+                            "retry_field": "approval_ref"
+                        }
+                    }).to_string());
+                }
+                other => {
+                    tracing::warn!(
+                        target: "web",
+                        gate_result = ?other,
+                        "Unexpected gate result for web.call gate"
+                    );
+                }
+            }
         }
 
         let method = args

--- a/autonoetic-gateway/src/scheduler/gateway_store/gate_messages.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/gate_messages.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use rusqlite::{params};
+
+use crate::runtime::human_gate::GateMessage;
+
+use super::GatewayStore;
+
+impl GatewayStore {
+    pub fn add_gate_message(
+        &self,
+        gate_id: &str,
+        sender: &str,
+        content: &str,
+    ) -> Result<i64> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO gate_messages (gate_id, sender, content, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                gate_id,
+                sender,
+                content,
+                chrono::Utc::now().to_rfc3339(),
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub fn get_gate_messages(&self, gate_id: &str) -> Result<Vec<GateMessage>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, gate_id, sender, content, created_at
+             FROM gate_messages
+             WHERE gate_id = ?1
+             ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(params![gate_id], |row| {
+            Ok(GateMessage {
+                id: row.get(0)?,
+                gate_id: row.get(1)?,
+                sender: row.get(2)?,
+                content: row.get(3)?,
+                created_at: row.get(4)?,
+            })
+        })?;
+        let mut messages = Vec::new();
+        for msg in rows {
+            messages.push(msg?);
+        }
+        Ok(messages)
+    }
+}

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 30;
+const SCHEMA_VERSION_LATEST: i64 = 31;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -514,6 +514,8 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_eval_suite_ownership_v28(conn)?;
     apply_attack_patterns_v29(conn)?;
     apply_user_interaction_resume_claim_v30(conn)?;
+
+    apply_gate_messages_v31(conn)?;
 
     Ok(())
 }
@@ -1718,6 +1720,39 @@ fn apply_user_interaction_resume_claim_v30(conn: &mut Connection) -> Result<()> 
         params![
             30_i64,
             "user_interaction_resume_claim",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_gate_messages_v31(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 31 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS gate_messages (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            gate_id    TEXT NOT NULL,
+            sender     TEXT NOT NULL,
+            content    TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_gate_messages_gate_id
+            ON gate_messages(gate_id);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            31_i64,
+            "gate_messages",
             chrono::Utc::now().to_rfc3339()
         ],
     )?;

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -6,6 +6,7 @@ pub mod attack_patterns;
 pub mod constitutional_proposals;
 mod credentials;
 mod evaluations;
+mod gate_messages;
 mod hook_deliveries;
 mod memory;
 mod messages;


### PR DESCRIPTION
## Summary

- **Phase 1 (#168):** Introduce `GateService` with a unified pipeline for approvals (`GateKind::Approval`), user input (`GateKind::UserInput`), and escalation (`GateKind::Escalation`). New `human_gate.rs` module with core types (`GateKind`, `MatchStrategy`, `GateRequest`, `GateResult`, `ClearanceSource`), `gate_messages` table for enrichment threads, and 11 unit tests.

- **Phase 2 (#169):** Wire `credential_setup` through `GateService.check()` to fix four bugs that caused 7 redundant approval requests in a demo session:
  1. **Session grant bypass** — `credential_setup` now checks session grants via the gate pipeline
  2. **Host-level matching** — replaces exact URL byte-comparison with `extract_host()` comparison
  3. **Pending dedup** — returns `AlreadyPending` instead of minting duplicate `apr-*` IDs
  4. **Auto-inject `approval_ref`** — `inject_approval_ref_into_history()` mutates the last tool call's JSON arguments on checkpoint resume, eliminating LLM-dependent relay

## Files changed

| File | Change |
|------|--------|
| `runtime/human_gate.rs` | **New**: GateService + types + 11 tests |
| `scheduler/gateway_store/gate_messages.rs` | **New**: enrichment message store |
| `scheduler/gateway_store/migrate.rs` | Migration v31 for `gate_messages` table |
| `runtime/tools/credential.rs` | Wire both approval gates through GateService |
| `execution.rs` | Auto-inject approval_ref into tool call arguments |

## Remaining phases (follow-up PRs)

- Phase 3 (#170): Migrate sandbox, web, user_interaction tools to GateService
- Phase 4 (#171): Unify checkpoint resume paths
- Phase 5 (#172): Approval enrichment conversation thread
- Phase 6 (#173): TUI surfacing improvements

Closes #168, Closes #169
Parent: #167