### PR TITLE
feat(gate): surface enrichment messages in TUI and CLI (Phase 6, #167)

### DIFF
--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -242,7 +242,9 @@ impl GateService {
                 format!(" (targets: {})", targets.join(", "))
             };
             let seed = format!("{}{}", req.reason, targets_str);
-            let _ = self.add_gate_message(&gate_id, "system", &seed);
+            if !seed.trim().is_empty() {
+                let _ = self.add_gate_message(&gate_id, "system", &seed);
+            }
         }
 
         // 6. Build suspension JSON.

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -234,6 +234,17 @@ impl GateService {
         // 5. Create new approval row.
         let gate_id = self.create_approval_row(req, action)?;
 
+        // 5b. Seed enrichment thread with reason + targets.
+        {
+            let targets_str = if targets.is_empty() {
+                String::new()
+            } else {
+                format!(" (targets: {})", targets.join(", "))
+            };
+            let seed = format!("{}{}", req.reason, targets_str);
+            let _ = self.add_gate_message(&gate_id, "system", &seed);
+        }
+
         // 6. Build suspension JSON.
         let response_json = self.build_approval_suspension_json(&gate_id, req, action)?;
 
@@ -293,6 +304,8 @@ impl GateService {
 
         self.store.create_user_interaction(&interaction)?;
 
+        let _ = self.add_gate_message(&interaction_id, "system", &format!("Agent asks: {}", question));
+
         let response_json = serde_json::json!({
             "ok": true,
             "interaction_required": true,
@@ -334,6 +347,8 @@ impl GateService {
         };
 
         let gate_id = self.create_approval_row(req, &action)?;
+
+        let _ = self.add_gate_message(&gate_id, "system", &format!("Escalation: {}", reason));
 
         let response_json = serde_json::json!({
             "ok": false,
@@ -1099,6 +1114,51 @@ mod tests {
         // Empty for a different gate.
         let empty = svc.get_gate_messages("apr-nonexistent")?;
         assert!(empty.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn approval_auto_seeds_enrichment_message() -> Result<()> {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(GatewayStore::open(tmp.path()).unwrap());
+        let svc = GateService::new(store.clone());
+        let manifest = test_manifest();
+
+        let req = GateRequest {
+            kind: GateKind::Approval {
+                action: make_credential_request_action("http://api.example.com/data"),
+                targets: vec!["api.example.com".to_string()],
+                match_strategy: MatchStrategy::HostLevel,
+            },
+            manifest: &manifest,
+            session_id: Some("ses-seed-123"),
+            run_context: None,
+            config: None,
+            reason: "API access required".to_string(),
+            summary: "Fetch data".to_string(),
+            approval_ref: None,
+            pre_validated: false,
+        };
+
+        let result = svc.check(req)?;
+        let gate_id = match result {
+            GateResult::Suspended { gate_id, .. } => gate_id,
+            other => panic!("expected Suspended, got {:?}", other),
+        };
+
+        let msgs = svc.get_gate_messages(&gate_id)?;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].sender, "system");
+        assert!(
+            msgs[0].content.contains("API access required"),
+            "seed message should contain the reason: {:?}",
+            msgs[0].content
+        );
+        assert!(
+            msgs[0].content.contains("api.example.com"),
+            "seed message should contain the target: {:?}",
+            msgs[0].content
+        );
         Ok(())
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/approval.rs
+++ b/autonoetic-gateway/src/runtime/tools/approval.rs
@@ -74,11 +74,18 @@ impl NativeTool for ApprovalListTool {
         if let Some(rid) = &args.request_id {
             let req = store.get_approval(rid)?;
             return match req {
-                Some(r) => Ok(serde_json::json!({
-                    "ok": true,
-                    "approval": approval_summary(&r),
-                })
-                .to_string()),
+                Some(r) => {
+                    let mut summary = serde_json::json!({
+                        "ok": true,
+                        "approval": approval_summary(&r),
+                    });
+                    if let Ok(msgs) = store.get_gate_messages(rid) {
+                        if !msgs.is_empty() {
+                            summary["enrichment_messages"] = serde_json::json!(msgs);
+                        }
+                    }
+                    Ok(summary.to_string())
+                }
                 None => Ok(autonoetic_types::tool_error::ToolError::not_found(
                     format!("approval '{}'", rid),
                     Some(

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -3760,7 +3760,11 @@ fn indent_block(prefix: &str, text: &str) -> String {
 }
 
 /// Multi-line card for a persisted [`ApprovalRequest`] (gateway store sync).
-fn format_store_approval_card(req: &ApprovalRequest, approval_instructions: &str) -> String {
+fn format_store_approval_card(
+    req: &ApprovalRequest,
+    approval_instructions: &str,
+    enrichment: &[autonoetic_gateway::runtime::human_gate::GateMessage],
+) -> String {
     let mut lines: Vec<String> = Vec::new();
     lines.push(format!("⏸ Pending approval — {}", req.request_id));
     lines.push(format!(
@@ -3782,6 +3786,13 @@ fn format_store_approval_card(req: &ApprovalRequest, approval_instructions: &str
     if let Some(ev) = req.evidence_ref.as_deref().filter(|s| !s.is_empty()) {
         lines.push(String::new());
         lines.push(format!("Evidence ref: {}", clamp_chat_field(ev)));
+    }
+    if !enrichment.is_empty() {
+        lines.push(String::new());
+        lines.push("Context:".to_string());
+        for msg in enrichment {
+            lines.push(format!("  [{}] {}", msg.sender, msg.content));
+        }
     }
     lines.push(String::new());
     lines.push(approval_instructions.to_string());
@@ -3832,7 +3843,8 @@ fn merge_gateway_store_pending_approvals(
                     req.request_id
                 )
             };
-            let card = format_store_approval_card(&req, &detail);
+            let enrichment = store.get_gate_messages(&req.request_id).unwrap_or_default();
+            let card = format_store_approval_card(&req, &detail, &enrichment);
             app.add_message(MessageRole::Signal, card);
             announced = true;
         }

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -3791,7 +3791,13 @@ fn format_store_approval_card(
         lines.push(String::new());
         lines.push("Context:".to_string());
         for msg in enrichment {
-            lines.push(format!("  [{}] {}", msg.sender, msg.content));
+            for (i, ln) in msg.content.lines().enumerate() {
+                if i == 0 {
+                    lines.push(format!("  [{}] {}", msg.sender, clamp_chat_field(ln)));
+                } else {
+                    lines.push(format!("  {}", clamp_chat_field(ln)));
+                }
+            }
         }
     }
     lines.push(String::new());
@@ -3843,7 +3849,13 @@ fn merge_gateway_store_pending_approvals(
                     req.request_id
                 )
             };
-            let enrichment = store.get_gate_messages(&req.request_id).unwrap_or_default();
+            let enrichment = match store.get_gate_messages(&req.request_id) {
+                Ok(msgs) => msgs,
+                Err(e) => {
+                    tracing::debug!(target: "chat", error = %e, request_id = %req.request_id, "Failed to load gate enrichment");
+                    Vec::new()
+                }
+            };
             let card = format_store_approval_card(&req, &detail, &enrichment);
             app.add_message(MessageRole::Signal, card);
             announced = true;

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -440,12 +440,14 @@ pub async fn handle_gateway_approvals(
                         if !msgs.is_empty() {
                             println!("\nEnrichment:");
                             for msg in &msgs {
-                                println!(
-                                    "  [{}] {}: {}",
-                                    msg.created_at.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.' || c == 'Z' || c == '+' || c == '-').trim_end_matches(|c: char| c == ':' || c == 'T'),
-                                    msg.sender,
-                                    msg.content
-                                );
+                                let ts: String = msg.created_at.chars().take(19).collect();
+                                for (i, ln) in msg.content.lines().enumerate() {
+                                    if i == 0 {
+                                        println!("  [{}] {}: {}", ts, msg.sender, ln);
+                                    } else {
+                                        println!("  {}{}", " ".repeat(22 + msg.sender.len()), ln);
+                                    }
+                                }
                             }
                         }
                     }
@@ -653,6 +655,10 @@ async fn run_interactive_approvals(
     let mut tui_mode = TuiMode::Navigate;
     let mut question_input = String::new();
     let mut question_answer = String::new();
+
+    let mut enrichment_cache: std::collections::HashMap<String, Vec<autonoetic_gateway::runtime::human_gate::GateMessage>> =
+        std::collections::HashMap::new();
+    let mut last_selected: Option<usize> = None;
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -1078,7 +1084,14 @@ async fn run_interactive_approvals(
                     }
                 }
 
-                if let Ok(msgs) = gateway_store.get_gate_messages(&items[idx].request_id) {
+                let selected_id = items[idx].request_id.clone();
+                if last_selected != Some(idx) {
+                    if let Ok(msgs) = gateway_store.get_gate_messages(&selected_id) {
+                        enrichment_cache.insert(selected_id.clone(), msgs);
+                    }
+                    last_selected = Some(idx);
+                }
+                if let Some(msgs) = enrichment_cache.get(&selected_id) {
                     if !msgs.is_empty() {
                         lines.push(Line::from(""));
                         lines.push(Line::from(Span::styled(
@@ -1087,11 +1100,22 @@ async fn run_interactive_approvals(
                         )));
                         for msg in msgs {
                             let sender = format!("[{}] ", msg.sender);
-                            let content = msg.content;
-                            lines.push(Line::from(vec![
-                                Span::styled(sender, Style::default().fg(Color::DarkGray)),
-                                Span::styled(content, Style::default().fg(Color::Cyan)),
-                            ]));
+                            for (i, ln) in msg.content.lines().enumerate() {
+                                if i == 0 {
+                                    lines.push(Line::from(vec![
+                                        Span::styled(sender.clone(), Style::default().fg(Color::DarkGray)),
+                                        Span::styled(ln.to_string(), Style::default().fg(Color::Cyan)),
+                                    ]));
+                                } else {
+                                    lines.push(Line::from(vec![
+                                        Span::styled(
+                                            format!("{:width$}", "", width = sender.len()),
+                                            Style::default().fg(Color::DarkGray),
+                                        ),
+                                        Span::styled(ln.to_string(), Style::default().fg(Color::Cyan)),
+                                    ]));
+                                }
+                            }
                         }
                     }
                 }
@@ -1335,6 +1359,8 @@ async fn run_interactive_approvals(
                         ) {
                             Ok(refreshed) => {
                                 items = refreshed;
+                                enrichment_cache.clear();
+                                last_selected = None;
                                 if items.is_empty() {
                                     done = true;
                                     status_msg = "No more pending approvals.".to_string();

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -435,6 +435,20 @@ pub async fn handle_gateway_approvals(
                     if let Some(ref phrase) = a.confirm_phrase {
                         println!("R++4 confirm:   --confirm-phrase '{}'", phrase);
                     }
+
+                    if let Ok(msgs) = gateway_store.get_gate_messages(request_id) {
+                        if !msgs.is_empty() {
+                            println!("\nEnrichment:");
+                            for msg in &msgs {
+                                println!(
+                                    "  [{}] {}: {}",
+                                    msg.created_at.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.' || c == 'Z' || c == '+' || c == '-').trim_end_matches(|c: char| c == ':' || c == 'T'),
+                                    msg.sender,
+                                    msg.content
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1063,6 +1077,25 @@ async fn run_interactive_approvals(
                         ]));
                     }
                 }
+
+                if let Ok(msgs) = gateway_store.get_gate_messages(&items[idx].request_id) {
+                    if !msgs.is_empty() {
+                        lines.push(Line::from(""));
+                        lines.push(Line::from(Span::styled(
+                            "Enrichment:",
+                            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                        )));
+                        for msg in msgs {
+                            let sender = format!("[{}] ", msg.sender);
+                            let content = msg.content;
+                            lines.push(Line::from(vec![
+                                Span::styled(sender, Style::default().fg(Color::DarkGray)),
+                                Span::styled(content, Style::default().fg(Color::Cyan)),
+                            ]));
+                        }
+                    }
+                }
+
                 lines
             } else {
                 vec![Line::from(Span::styled(


### PR DESCRIPTION
## Summary
- Phase 6 of the HumanGate unification plan (#167): surfaces auto-seeded gate enrichment messages to operators in three display surfaces
- **`gateway approvals show <id>`**: prints an "Enrichment:" section with `[sender] content` for each gate message after existing approval fields
- **Interactive approvals TUI** (`gateway approvals interactive`): adds a cyan "Enrichment:" section in the detail panel for the selected approval
- **Chat TUI approval cards**: adds a "Context:" section in `format_store_approval_card` with enrichment messages (sender + content)

## Test plan
- `cargo build -p autonoetic` — confirms all three surfaces compile
- `cargo test -p autonoetic-gateway --lib human_gate` — 12 tests pass (enrichment infrastructure unchanged)
- Manual: `gateway approvals show <id>` on an approval with auto-seeded messages should display the enrichment section

Depends on #177 (Phase 5) being merged first.