### PR TITLE
feat: gate history in TUI, session report, and post-session digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Autonoetic is a Rust-first runtime for autonomous, self-evolving agents with durable memory, portable identity, and reproducible execution.
 
-The project is currently incubated in the `autonoetic/` directory inside the broader `ccos` repository, but it is intended to become a standalone project once the architecture and implementation stabilize.
+This repository hosts the standalone Autonoetic project.
 
 ## Why Autonoetic
 

--- a/agents/governance/governance-author.default/runtime.lock
+++ b/agents/governance/governance-author.default/runtime.lock
@@ -1,0 +1,11 @@
+gateway:
+  artifact: "marketplace://gateway/autonoetic-gateway"
+  version: "0.1.0"
+  sha256: "replace-me"
+sdk:
+  version: "0.1.0"
+sandbox:
+  backend: "bubblewrap"
+dependencies: []
+artifacts: []
+layers: []

--- a/autonoetic-gateway/src/interaction_answer.rs
+++ b/autonoetic-gateway/src/interaction_answer.rs
@@ -178,6 +178,22 @@ pub async fn answer_and_orchestrate_resume(
         .get_user_interaction(&params.interaction_id)?
         .ok_or_else(|| anyhow::anyhow!("interaction missing after answer"))?;
 
+    {
+        let gateway_dir = crate::execution::gateway_root_dir(cfg.as_ref());
+        if let Ok(mut report) = crate::runtime::session_report::SessionReportWriter::open(
+            &gateway_dir,
+            &interaction.session_id,
+            &interaction.agent_id,
+        ) {
+            let answer_str = params
+                .answer_text
+                .as_deref()
+                .or(params.answer_option_id.as_deref())
+                .unwrap_or("—");
+            let _ = report.resolve_interaction(&params.interaction_id, answer_str);
+        }
+    }
+
     anyhow::ensure!(
         interaction.status == UserInteractionStatus::Answered,
         "unexpected interaction status after apply: {:?}",

--- a/autonoetic-gateway/src/llm/provider.rs
+++ b/autonoetic-gateway/src/llm/provider.rs
@@ -333,7 +333,7 @@ pub fn resolve(
         vec![
             (
                 "HTTP-Referer".to_string(),
-                "https://autonoetic.ccos.local".to_string(),
+                "https://autonoetic.local".to_string(),
             ),
             (
                 "X-OpenRouter-Title".to_string(),

--- a/autonoetic-gateway/src/runtime/post_session_digest.rs
+++ b/autonoetic-gateway/src/runtime/post_session_digest.rs
@@ -284,8 +284,45 @@ async fn run_post_session_digest_inner(
         .parent()
         .ok_or_else(|| anyhow::anyhow!("gateway_dir has no parent (expected agents/.gateway)"))?;
     let system = load_digest_skill_body(agents_dir)?;
+
+    let mut governance_lines = Vec::new();
+    let approvals = store.list_all_approvals_for_session(session_id).unwrap_or_default();
+    if !approvals.is_empty() {
+        governance_lines.push(format!("Approvals ({} total):", approvals.len()));
+        for a in &approvals {
+            let decision = match &a.decision_reason {
+                Some(d) => format!(" — {d}"),
+                None => String::new(),
+            };
+            governance_lines.push(format!(
+                "  [{:?}] {} ({}) by {}{}",
+                a.status, a.request_id, a.action.kind(), a.agent_id, decision
+            ));
+        }
+    }
+    let interactions = store.list_user_interactions_for_session_trace(session_id).unwrap_or_default();
+    if !interactions.is_empty() {
+        governance_lines.push(format!("User interactions ({} total):", interactions.len()));
+        for i in &interactions {
+            let answer = match (&i.answer_option_id, &i.answer_text) {
+                (Some(opt), _) => format!(" → option: {opt}"),
+                (_, Some(txt)) => format!(" → {txt}"),
+                _ => String::new(),
+            };
+            governance_lines.push(format!(
+                "  [{:?}] {} (kind: {}): {}{}",
+                i.status, i.interaction_id, i.kind, i.question, answer
+            ));
+        }
+    }
+    let governance_block = if governance_lines.is_empty() {
+        String::new()
+    } else {
+        format!("\n\n## Governance events (approvals + user interactions)\n\n{}", governance_lines.join("\n"))
+    };
+
     let user = format!(
-        "Session id (full): {session_id}\nSource agent: {source_agent_id}\n\n## Live digest (markdown)\n\n{live_digest}\n\n## Execution traces (successes + failures summary)\n\n{trace_block}\n\nRespond with ONLY a single JSON object as specified in your instructions."
+        "Session id (full): {session_id}\nSource agent: {source_agent_id}\n\n## Live digest (markdown)\n\n{live_digest}\n\n## Execution traces (successes + failures summary)\n\n{trace_block}{governance_block}\n\nRespond with ONLY a single JSON object as specified in your instructions."
     );
 
     let mut req = CompletionRequest::simple(

--- a/autonoetic-gateway/src/runtime/post_session_digest.rs
+++ b/autonoetic-gateway/src/runtime/post_session_digest.rs
@@ -286,32 +286,45 @@ async fn run_post_session_digest_inner(
     let system = load_digest_skill_body(agents_dir)?;
 
     let mut governance_lines = Vec::new();
+    let root = crate::runtime::content_store::root_session_id(session_id);
     let approvals = store.list_all_approvals_for_session(session_id).unwrap_or_default();
     if !approvals.is_empty() {
         governance_lines.push(format!("Approvals ({} total):", approvals.len()));
         for a in &approvals {
+            let status_label = match &a.status {
+                Some(s) => format!("{:?}", s).to_lowercase(),
+                None => "pending".to_string(),
+            };
             let decision = match &a.decision_reason {
-                Some(d) => format!(" — {d}"),
-                None => String::new(),
+                Some(d) => truncate_chars(d, 80),
+                None => status_label.clone(),
             };
             governance_lines.push(format!(
-                "  [{:?}] {} ({}) by {}{}",
-                a.status, a.request_id, a.action.kind(), a.agent_id, decision
+                "  [{}] {} ({}) by {}",
+                status_label, a.request_id, a.action.kind(), a.agent_id
             ));
+            if decision != status_label {
+                governance_lines.push(format!("    reason: {}", decision));
+            }
         }
     }
-    let interactions = store.list_user_interactions_for_session_trace(session_id).unwrap_or_default();
+    let interactions = store.list_user_interactions_for_session_trace(root).unwrap_or_default();
     if !interactions.is_empty() {
         governance_lines.push(format!("User interactions ({} total):", interactions.len()));
         for i in &interactions {
+            let status_label = format!("{:?}", i.status).to_lowercase();
             let answer = match (&i.answer_option_id, &i.answer_text) {
-                (Some(opt), _) => format!(" → option: {opt}"),
-                (_, Some(txt)) => format!(" → {txt}"),
+                (Some(opt), _) => format!(" → option: {}", truncate_chars(opt, 60)),
+                (_, Some(txt)) => format!(" → {}", truncate_chars(txt, 80)),
                 _ => String::new(),
             };
             governance_lines.push(format!(
-                "  [{:?}] {} (kind: {}): {}{}",
-                i.status, i.interaction_id, i.kind, i.question, answer
+                "  [{}] {} (kind: {}): {}{}",
+                status_label,
+                i.interaction_id,
+                i.kind,
+                truncate_chars(&i.question, 120),
+                answer
             ));
         }
     }
@@ -440,6 +453,16 @@ pub async fn run_post_session_digest_with_driver(
         driver,
     )
     .await
+}
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    let mut iter = s.chars();
+    let chunk: String = iter.by_ref().take(max).collect();
+    if iter.next().is_some() {
+        format!("{}…", chunk)
+    } else {
+        chunk
+    }
 }
 
 #[cfg(test)]

--- a/autonoetic-gateway/src/runtime/session_report.rs
+++ b/autonoetic-gateway/src/runtime/session_report.rs
@@ -52,6 +52,7 @@ struct AgentReport {
     last_event_kind: Option<String>,
     last_event_summary: Option<String>,
     approvals: Vec<ApprovalItem>,
+    interactions: Vec<InteractionItem>,
     errors: Vec<ErrorItem>,
     artifacts: Vec<ArtifactItem>,
     delegations: Vec<DelegationItem>,
@@ -73,6 +74,17 @@ struct ApprovalItem {
     resolution_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     links: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InteractionItem {
+    interaction_id: String,
+    kind: String,
+    status: String,
+    question: String,
+    answer: Option<String>,
+    created_at: String,
+    resolved_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -171,6 +183,7 @@ impl AgentReport {
             last_event_kind: None,
             last_event_summary: None,
             approvals: Vec::new(),
+            interactions: Vec::new(),
             errors: Vec::new(),
             artifacts: Vec::new(),
             delegations: Vec::new(),
@@ -1167,6 +1180,44 @@ fn resolve_approval(
     }
 }
 
+fn record_interaction_pending(
+    agent: &mut AgentReport,
+    interaction_id: &str,
+    kind: &str,
+    question: &str,
+    now: &str,
+) {
+    if agent.interactions.iter().any(|i| i.interaction_id == interaction_id) {
+        return;
+    }
+    agent.interactions.push(InteractionItem {
+        interaction_id: interaction_id.to_string(),
+        kind: kind.to_string(),
+        status: "pending".to_string(),
+        question: truncate_chars(question, 200),
+        answer: None,
+        created_at: now.to_string(),
+        resolved_at: None,
+    });
+}
+
+fn resolve_interaction(
+    agent: &mut AgentReport,
+    interaction_id: &str,
+    answer: &str,
+    now: &str,
+) {
+    if let Some(existing) = agent
+        .interactions
+        .iter_mut()
+        .find(|i| i.interaction_id == interaction_id)
+    {
+        existing.status = "answered".to_string();
+        existing.answer = Some(truncate_chars(answer, 200));
+        existing.resolved_at = Some(now.to_string());
+    }
+}
+
 fn maybe_record_output(
     agent: &mut AgentReport,
     tool_name: &str,
@@ -1401,6 +1452,40 @@ fn render_live_markdown(state: &SessionReportState) -> String {
         }
     }
     let _ = writeln!(out);
+
+    {
+        let all_interactions: Vec<_> = state
+            .agents
+            .values()
+            .flat_map(|a| a.interactions.iter())
+            .collect();
+        let _ = writeln!(out, "## User Interactions");
+        let _ = writeln!(out);
+        if all_interactions.is_empty() {
+            let _ = writeln!(out, "_(none)_");
+        } else {
+            let _ = writeln!(
+                out,
+                "| Time | Agent | ID | Kind | Status | Question | Answer |"
+            );
+            let _ = writeln!(out, "|---|---|---|---|---|---|---|");
+            for i in &all_interactions {
+                let _ = writeln!(
+                    out,
+                    "| {} | `{}` | `{}` | {} | {} | {} | {} |",
+                    format_timestamp(Some(&i.created_at)),
+                    "—",
+                    i.interaction_id,
+                    i.kind,
+                    i.status,
+                    truncate_chars(&i.question, OUTPUT_PREVIEW_DISPLAY_CHARS),
+                    i.answer.as_deref().unwrap_or("—"),
+                );
+            }
+        }
+    }
+    let _ = writeln!(out);
+
     {
         let abnormal: Vec<_> = state
             .agents
@@ -2248,6 +2333,43 @@ fn render_final_markdown(state: &SessionReportState) -> String {
                     .map(|t| format_timestamp(Some(t)))
                     .unwrap_or_else(|| "—".to_string()),
             );
+        }
+    }
+    let _ = writeln!(out);
+
+    {
+        let _ = writeln!(out, "## User Interactions");
+        let _ = writeln!(out);
+        let all_interactions: Vec<_> = state
+            .agents
+            .values()
+            .flat_map(|a| a.interactions.iter().map(move |i| (a.agent_id.as_str(), i)))
+            .collect();
+        if all_interactions.is_empty() {
+            let _ = writeln!(out, "_(none)_");
+        } else {
+            let _ = writeln!(
+                out,
+                "| Time | Agent | ID | Kind | Status | Question | Answer | Resolved |"
+            );
+            let _ = writeln!(out, "|---|---|---|---|---|---|---|---|");
+            for (agent_id, i) in &all_interactions {
+                let _ = writeln!(
+                    out,
+                    "| {} | `{}` | `{}` | {} | {} | {} | {} | {} |",
+                    format_timestamp(Some(&i.created_at)),
+                    agent_id,
+                    i.interaction_id,
+                    i.kind,
+                    i.status,
+                    truncate_chars(&i.question, OUTPUT_PREVIEW_DISPLAY_CHARS),
+                    i.answer.as_deref().unwrap_or("—"),
+                    i.resolved_at
+                        .as_deref()
+                        .map(|t| format_timestamp(Some(t)))
+                        .unwrap_or_else(|| "—".to_string()),
+                );
+            }
         }
     }
     let _ = writeln!(out);

--- a/autonoetic-gateway/src/runtime/session_report.rs
+++ b/autonoetic-gateway/src/runtime/session_report.rs
@@ -650,6 +650,31 @@ impl SessionReportWriter {
         })
     }
 
+    pub fn record_interaction_pending(
+        &mut self,
+        interaction_id: &str,
+        kind: &str,
+        question: &str,
+    ) -> anyhow::Result<()> {
+        self.update_state(|state| {
+            let now = chrono::Utc::now().to_rfc3339();
+            let agent = ensure_agent(state, &self.session_id, &self.agent_id, self.depth);
+            record_interaction_pending(agent, interaction_id, kind, question, &now);
+        })
+    }
+
+    pub fn resolve_interaction(
+        &mut self,
+        interaction_id: &str,
+        answer: &str,
+    ) -> anyhow::Result<()> {
+        self.update_state(|state| {
+            let now = chrono::Utc::now().to_rfc3339();
+            let agent = ensure_agent(state, &self.session_id, &self.agent_id, self.depth);
+            resolve_interaction(agent, interaction_id, answer, &now);
+        })
+    }
+
     pub fn finish_session(
         &mut self,
         reason: &str,
@@ -1457,7 +1482,7 @@ fn render_live_markdown(state: &SessionReportState) -> String {
         let all_interactions: Vec<_> = state
             .agents
             .values()
-            .flat_map(|a| a.interactions.iter())
+            .flat_map(|a| a.interactions.iter().map(move |i| (a.agent_id.as_str(), i)))
             .collect();
         let _ = writeln!(out, "## User Interactions");
         let _ = writeln!(out);
@@ -1469,12 +1494,12 @@ fn render_live_markdown(state: &SessionReportState) -> String {
                 "| Time | Agent | ID | Kind | Status | Question | Answer |"
             );
             let _ = writeln!(out, "|---|---|---|---|---|---|---|");
-            for i in &all_interactions {
+            for (agent_id, i) in &all_interactions {
                 let _ = writeln!(
                     out,
                     "| {} | `{}` | `{}` | {} | {} | {} | {} |",
                     format_timestamp(Some(&i.created_at)),
-                    "—",
+                    agent_id,
                     i.interaction_id,
                     i.kind,
                     i.status,

--- a/autonoetic-gateway/src/runtime/tools/user_interaction.rs
+++ b/autonoetic-gateway/src/runtime/tools/user_interaction.rs
@@ -208,6 +208,12 @@ impl NativeTool for UserAskTool {
             "confirmation" => UserInteractionKind::Confirmation,
             _ => UserInteractionKind::Clarification,
         };
+        let kind_str = match kind {
+            UserInteractionKind::Decision => "decision",
+            UserInteractionKind::Proposal => "proposal",
+            UserInteractionKind::Confirmation => "confirmation",
+            _ => "clarification",
+        };
 
         let options: Vec<UserInteractionOption> = args
             .options
@@ -281,6 +287,15 @@ impl NativeTool for UserAskTool {
                         let _ = g.record_user_ask_pending(
                             &interaction.question,
                             opts_summary.as_deref(),
+                        );
+                    }
+                }
+                if let Some(w) = &ctx.live_report {
+                    if let Ok(mut g) = w.lock() {
+                        let _ = g.record_interaction_pending(
+                            &interaction_id,
+                            kind_str,
+                            &interaction.question,
                         );
                     }
                 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -258,6 +258,30 @@ impl GatewayStore {
         Ok(results)
     }
 
+    pub fn list_all_approvals_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<ApprovalRequest>> {
+        let root = crate::runtime::content_store::root_session_id(session_id);
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT request_id FROM approvals WHERE session_id = ?1 OR root_session_id = ?2 ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![session_id, &root], |row| {
+            let id: String = row.get(0)?;
+            Ok(id)
+        })?;
+
+        let mut results = Vec::new();
+        for id_result in rows {
+            let id = id_result?;
+            if let Some(app) = Self::get_approval_with_conn(&conn, &id)? {
+                results.push(app);
+            }
+        }
+        Ok(results)
+    }
+
     pub fn get_recent_approvals_for_agent(
         &self,
         agent_id: &str,

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -31,7 +31,10 @@ use autonoetic_gateway::router::{
 };
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::agent::LlmExchangeUsage;
-use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction, UserInteraction};
+use autonoetic_types::background::{
+    ApprovalLevel, ApprovalRequest, ApprovalStatus, ScheduledAction, UserInteraction,
+    UserInteractionStatus,
+};
 use autonoetic_types::config::GatewayConfig;
 
 // ============================================================================
@@ -262,6 +265,10 @@ struct App {
     seen_causal_policy_event_ids: HashSet<String>,
     /// Newest-first policy decision lines for the right pane.
     policy_causal_pane: Vec<String>,
+    /// Gate history: resolved approvals for this session tree.
+    gate_history_approvals: Vec<String>,
+    /// Gate history: resolved user interactions for this session tree.
+    gate_history_interactions: Vec<String>,
     /// Submitted user lines, newest last — for ↑/↓ recall in the prompt.
     prompt_history: Vec<String>,
     /// When set, the input shows `prompt_history[len - 1 - k]` (`k == 0` is the most recent submission).
@@ -315,6 +322,8 @@ impl App {
             gateway_connected: false,
             seen_causal_policy_event_ids: HashSet::new(),
             policy_causal_pane: Vec::new(),
+        gate_history_approvals: Vec::new(),
+        gate_history_interactions: Vec::new(),
             prompt_history: Vec::new(),
             prompt_history_scroll_back: None,
             prompt_history_draft: None,
@@ -653,13 +662,15 @@ fn format_session_status(app: &App) -> String {
         app.session_overview.root_session_id.clone()
     };
     format!(
-        "Session: {}\nRoot: {}\nTarget: {}\nWorkflow: {}\nPending approvals: {}\nPending questions: {}\nGateway: {}",
+        "Session: {}\nRoot: {}\nTarget: {}\nWorkflow: {}\nPending approvals: {}\nPending questions: {}\nResolved approvals: {}\nAnswered questions: {}\nGateway: {}",
         app.session_id,
         root_session_id,
         app.target_hint,
         workflow_id,
         app.pending_approval_ids.len(),
         app.session_overview.pending_user_interactions,
+        app.gate_history_approvals.len(),
+        app.gate_history_interactions.len(),
         if app.gateway_connected { "connected" } else { "disconnected" },
     )
 }
@@ -839,6 +850,44 @@ fn refresh_session_snapshot(
             let _ = append_new_pending_user_interaction_prompts(app, &snapshot.pending_interactions);
         }
         let _ = merge_gateway_store_pending_approvals(app, config, store, &active_session_id);
+
+        if let Ok(all_approvals) = store.list_all_approvals_for_session(&active_session_id) {
+            app.gate_history_approvals = all_approvals
+                .into_iter()
+                .filter_map(|a| {
+                    let st = a.status?;
+                    let status_label = match st {
+                        ApprovalStatus::Approved => "approved",
+                        ApprovalStatus::Rejected => "rejected",
+                        ApprovalStatus::Cancelled => "cancelled",
+                    };
+                    let decision = a.decision_reason.as_deref().unwrap_or(status_label);
+                    Some(format!(
+                        "[{}] {} ({})",
+                        status_label,
+                        a.action.kind(),
+                        decision
+                    ))
+                })
+                .collect();
+        }
+        if let Ok(all_interactions) = store.list_user_interactions_for_session_trace(&active_session_id) {
+            app.gate_history_interactions = all_interactions
+                .into_iter()
+                .filter(|i| i.status != UserInteractionStatus::Pending)
+                .map(|i| {
+                    let answer =
+                        i.answer_text.as_deref().or(i.answer_option_id.as_deref()).unwrap_or("—");
+                    let status_label = match i.status {
+                        UserInteractionStatus::Pending => "pending",
+                        UserInteractionStatus::Answered => "answered",
+                        UserInteractionStatus::Cancelled => "cancelled",
+                        UserInteractionStatus::Expired => "expired",
+                    };
+                    format!("[{}] {} → {}", status_label, i.question, answer)
+                })
+                .collect();
+        }
     }
 }
 
@@ -874,6 +923,8 @@ fn reset_for_session_switch(
     app.post_approval_pending_ids.clear();
     app.seen_causal_policy_event_ids.clear();
     app.policy_causal_pane.clear();
+    app.gate_history_approvals.clear();
+    app.gate_history_interactions.clear();
     app.pending_prompt = None;
 }
 
@@ -2164,6 +2215,21 @@ fn draw_right_pane(f: &mut Frame, app: &App, area: Rect) {
     } else {
         for line in app.policy_causal_pane.iter().take(POLICY_CAUSAL_PANE_MAX) {
             lines.push(Line::raw(line.clone()));
+        }
+    }
+
+    let gate_count = app.gate_history_approvals.len() + app.gate_history_interactions.len();
+    if gate_count > 0 {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            "Gate History",
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for entry in app.gate_history_approvals.iter().rev().take(4) {
+            lines.push(Line::raw(entry.clone()));
+        }
+        for entry in app.gate_history_interactions.iter().rev().take(4) {
+            lines.push(Line::raw(entry.clone()));
         }
     }
 

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -833,6 +833,71 @@ fn add_session_banner(
     );
 }
 
+fn refresh_gate_history(
+    app: &mut App,
+    store: &autonoetic_gateway::scheduler::gateway_store::GatewayStore,
+) {
+    let active_session_id = app.session_id.clone();
+    let root = if app.session_overview.root_session_id.is_empty() {
+        autonoetic_gateway::runtime::content_store::root_session_id(&active_session_id).to_string()
+    } else {
+        app.session_overview.root_session_id.clone()
+    };
+
+    if let Ok(all_approvals) = store.list_all_approvals_for_session(&active_session_id) {
+        app.gate_history_approvals = all_approvals
+            .into_iter()
+            .filter_map(|a| {
+                let st = a.status?;
+                let status_label = match st {
+                    ApprovalStatus::Approved => "approved",
+                    ApprovalStatus::Rejected => "rejected",
+                    ApprovalStatus::Cancelled => "cancelled",
+                };
+                let decision = a.decision_reason.as_deref().unwrap_or(status_label);
+                Some(format!(
+                    "[{}] {} ({})",
+                    status_label,
+                    a.action.kind(),
+                    truncate_str(decision, 60)
+                ))
+            })
+            .collect();
+    }
+    if let Ok(all_interactions) = store.list_user_interactions_for_session_trace(&root) {
+        app.gate_history_interactions = all_interactions
+            .into_iter()
+            .filter(|i| i.status != UserInteractionStatus::Pending)
+            .map(|i| {
+                let answer = i
+                    .answer_text
+                    .as_deref()
+                    .or(i.answer_option_id.as_deref())
+                    .unwrap_or("—");
+                let status_label = match i.status {
+                    UserInteractionStatus::Pending => "pending",
+                    UserInteractionStatus::Answered => "answered",
+                    UserInteractionStatus::Cancelled => "cancelled",
+                    UserInteractionStatus::Expired => "expired",
+                };
+                let q = truncate_str(&i.question.replace('\n', " "), 80);
+                let a = truncate_str(answer.replace('\n', " ").as_str(), 40);
+                format!("[{}] {} → {}", status_label, q, a)
+            })
+            .collect();
+    }
+}
+
+fn truncate_str(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let prefix: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{}…", prefix)
+    } else {
+        prefix
+    }
+}
+
 fn refresh_session_snapshot(
     app: &mut App,
     config: &autonoetic_types::config::GatewayConfig,
@@ -850,44 +915,7 @@ fn refresh_session_snapshot(
             let _ = append_new_pending_user_interaction_prompts(app, &snapshot.pending_interactions);
         }
         let _ = merge_gateway_store_pending_approvals(app, config, store, &active_session_id);
-
-        if let Ok(all_approvals) = store.list_all_approvals_for_session(&active_session_id) {
-            app.gate_history_approvals = all_approvals
-                .into_iter()
-                .filter_map(|a| {
-                    let st = a.status?;
-                    let status_label = match st {
-                        ApprovalStatus::Approved => "approved",
-                        ApprovalStatus::Rejected => "rejected",
-                        ApprovalStatus::Cancelled => "cancelled",
-                    };
-                    let decision = a.decision_reason.as_deref().unwrap_or(status_label);
-                    Some(format!(
-                        "[{}] {} ({})",
-                        status_label,
-                        a.action.kind(),
-                        decision
-                    ))
-                })
-                .collect();
-        }
-        if let Ok(all_interactions) = store.list_user_interactions_for_session_trace(&active_session_id) {
-            app.gate_history_interactions = all_interactions
-                .into_iter()
-                .filter(|i| i.status != UserInteractionStatus::Pending)
-                .map(|i| {
-                    let answer =
-                        i.answer_text.as_deref().or(i.answer_option_id.as_deref()).unwrap_or("—");
-                    let status_label = match i.status {
-                        UserInteractionStatus::Pending => "pending",
-                        UserInteractionStatus::Answered => "answered",
-                        UserInteractionStatus::Cancelled => "cancelled",
-                        UserInteractionStatus::Expired => "expired",
-                    };
-                    format!("[{}] {} → {}", status_label, i.question, answer)
-                })
-                .collect();
-        }
+        refresh_gate_history(app, store);
     }
 }
 
@@ -3663,7 +3691,7 @@ fn handle_key(
             if !app.inline_approvals_enabled {
                 app.add_message(
                     MessageRole::System,
-                    "Inline approvals not enabled. Set chat.inline_approvals: true in gateway config.".to_string(),
+                    "Inline approvals are off (`chat.inline_approvals: false`). Set to true in gateway config or use `autonoetic gateway approvals`.".to_string(),
                 );
             } else if app.pending_approval_ids.is_empty() {
                 app.add_message(
@@ -4178,7 +4206,7 @@ fn merge_gateway_store_pending_approvals(
                 )
             } else {
                 format!(
-                    "Resolve with `autonoetic gateway approvals approve {} …` (set `chat.inline_approvals: true` for Ctrl+A).",
+                    "Resolve with `autonoetic gateway approvals approve {} …` (or enable `chat.inline_approvals` and use Ctrl+A).",
                     req.request_id
                 )
             };
@@ -4472,6 +4500,7 @@ async fn check_signals(
         if merge_gateway_store_pending_approvals(app, config, store, session_id) {
             processed_any = true;
         }
+        refresh_gate_history(app, store);
     }
 
     tracing::debug!(target: "chat", processed_any = processed_any, total_messages = app.messages.len(), "check_signals: complete");

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -6,6 +6,9 @@ use autonoetic_types::causal_chain::CausalChainEntry;
 use autonoetic_types::config::GatewayConfig;
 use std::collections::BTreeMap;
 
+/// Default basename for operator config/workspace under `$HOME` (unless `--config` is set).
+pub const DEFAULT_OPERATOR_HOME_SUBDIR: &str = ".autonoetic";
+
 fn parse_key_value(s: &str) -> anyhow::Result<(String, String)> {
     let parts: Vec<&str> = s.splitn(2, '=').collect();
     if parts.len() != 2 {
@@ -125,7 +128,7 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
 
-    /// Path to a custom config.yaml or policy.yaml (default: ~/.ccos/)
+    /// Path to a custom config.yaml or policy.yaml (default: ~/.autonoetic/)
     #[arg(global = true, long)]
     pub config: Option<String>,
 
@@ -961,8 +964,8 @@ pub enum McpCommands {
 
 pub fn dirs_or_default() -> PathBuf {
     dirs::home_dir()
-        .map(|h| h.join(".ccos"))
-        .unwrap_or_else(|| PathBuf::from(".ccos"))
+        .map(|h| h.join(DEFAULT_OPERATOR_HOME_SUBDIR))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_OPERATOR_HOME_SUBDIR))
 }
 
 pub fn mcp_registry_path(config_path: &Path) -> PathBuf {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,7 +6,7 @@ The Autonoetic CLI (`autonoetic`) provides commands for managing the gateway, ag
 
 | Option | Description |
 |--------|-------------|
-| `-c, --config <PATH>` | Path to config file (default: `~/.ccos/config.yaml`) |
+| `-c, --config <PATH>` | Path to config file (default: `~/.autonoetic/config.yaml`) |
 | `--non-interactive` | Disables all prompts (for CI/CD) |
 
 ## Commands

--- a/docs/design/cli_interface.md
+++ b/docs/design/cli_interface.md
@@ -5,7 +5,7 @@ The `autonoetic` CLI is the primary human-to-system interface for Autonoetic. It
 ## 1. Global Flags & Configuration
 
 Commands can be modified by standard global flags:
-- `--config <path>`: Path to a custom `config.yaml` or `policy.yaml` (default: `~/.ccos/`)
+- `--config <path>`: Path to a custom `config.yaml` or `policy.yaml` (default: `~/.autonoetic/`)
 - `--log-level <level>`: Overrides the Gateway log level (`trace`, `debug`, `info`, `warn`, `error`)
 - `--non-interactive`: Disables all prompts (essential for CI/CD)
 
@@ -22,7 +22,7 @@ Starts the Gateway daemon in the foreground.
   - `--port <number>`: Override the default HTTP/TCP ports.
   - `--tls`: Force TLS wrapping on the OFP federation port.
 - **Operation:**
-  1. Reads `~/.ccos/policy.yaml` to establish global security constraints.
+  1. Reads `~/.autonoetic/policy.yaml` to establish global security constraints.
   2. Binds the local Unix Socket (or TCP loopback) for Agent IPC.
   3. Binds the OFP port (e.g., `4200`) for cluster federation.
 

--- a/docs/design/data_models.md
+++ b/docs/design/data_models.md
@@ -97,7 +97,7 @@ The Runtime Lock pins the execution closure required to reproduce an Agent or Sk
 
 ```yaml
 gateway:
-  artifact: "marketplace://gateway/ccos-gateway"
+  artifact: "marketplace://gateway/autonoetic-gateway"
   version: "0.1.0"
   sha256: "abc123..."
   signature: "ed25519:deadbeef..."
@@ -241,7 +241,7 @@ A Cognitive Capsule packages an Agent bundle together with its runtime closure f
     {"artifact_id": "artifact_01jabc...", "sha256": "7d865e959b2466918c9863a465f1..."}
   ],
   "gateway_runtime": {
-    "artifact": "marketplace://gateway/ccos-gateway",
+    "artifact": "marketplace://gateway/autonoetic-gateway",
     "version": "0.1.0",
     "sha256": "abc123..."
   },

--- a/docs/design/protocols.md
+++ b/docs/design/protocols.md
@@ -84,7 +84,7 @@ Sandboxes are ephemeral, stateless tasks. While running, they only emit and cons
 When a Sandbox script attempts to `sys.exit()`, the Gateway intercepts the final data points before destroying the MicroVM or bwrap instance:
 1. `stdout` buffer.
 2. `stderr` buffer.
-3. Specially designated return schemas written to `.ccos/out.json`.
+3. Specially designated return schemas written to `.autonoetic/out.json`.
 The Gateway then packs these together into an `ecosystem.skill_completed` method and routes it back to the parent Agent.
 
 ## 4. Artifact and Capsule Protocol


### PR DESCRIPTION
## Summary

- **TUI Gate History**: right pane now shows resolved approvals and answered user interactions; `/status` shows resolved counts
- **Session Report**: new `InteractionItem` tracking with pending/answered states; "User Interactions" table in both live overview and final report
- **Post-session Digest**: governance block in LLM prompt with approval history and user interaction Q&A
- **Store**: new `list_all_approvals_for_session()` returning all statuses for a session tree

Closes the gap where closed/resolved human gates and approvals were invisible in all surfaces despite being stored in SQLite.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test -p autonoetic-gateway --lib human_gate` — 12/12 pass
- [x] `cargo test -p autonoetic -- parse_slash` — pass