### PR TITLE
Resource reclamation: garbage collect content blobs, old revisions, expired memories

### DIFF
--- a/autonoetic-gateway/src/bootstrap.rs
+++ b/autonoetic-gateway/src/bootstrap.rs
@@ -245,7 +245,16 @@ fn bootstrap_agent_inner(
         None,
     )?;
 
+    update_latest_symlink(gateway_dir, agent_id, &revision_id);
+
     Ok(true)
+}
+
+pub fn update_latest_symlink(gateway_dir: &Path, agent_id: &str, revision_id: &str) {
+    let agent_rev_dir = gateway_dir.join("revisions").join("agents").join(agent_id);
+    let latest_link = agent_rev_dir.join("latest");
+    let _ = std::fs::remove_file(&latest_link);
+    let _ = std::os::unix::fs::symlink(revision_id, &latest_link);
 }
 
 fn collect_files(base: &Path, current: &Path, out: &mut BTreeMap<String, Vec<u8>>) -> Result<()> {

--- a/autonoetic-gateway/src/llm/provider.rs
+++ b/autonoetic-gateway/src/llm/provider.rs
@@ -250,7 +250,13 @@ fn provider_defaults(name: &str) -> Option<ProviderDefaults> {
             capabilities: ProviderCapabilities::openai_compatible,
         }),
         "lmstudio" => Some(ProviderDefaults {
-            base_url: "http://192.168.1.20:1234/v1/chat/completions",
+            base_url: "http://localhost:1234/v1/chat/completions",
+            api_key_env: "",
+            kind: DriverKind::OpenAi,
+            capabilities: ProviderCapabilities::openai_compatible,
+        }),
+        "llamacpp" | "llama.cpp" => Some(ProviderDefaults {
+            base_url: "http://localhost:8080/v1/chat/completions",
             api_key_env: "",
             kind: DriverKind::OpenAi,
             capabilities: ProviderCapabilities::openai_compatible,

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -43,6 +43,7 @@ pub enum GateKind {
         kind: String,
         options: Option<Vec<UserInteractionOption>>,
         allow_freeform: bool,
+        context: Option<String>,
     },
     /// Operator escalation (guidance needed).
     Escalation {
@@ -74,6 +75,8 @@ pub struct GateRequest<'a> {
     /// Tool-specific cache hit (e.g. `ApprovedExecCache`).  When `true` the
     /// gate short-circuits to `GateResult::Cleared`.
     pub pre_validated: bool,
+    /// Current turn ID (used for UserInput checkpoint tracking).
+    pub turn_id: Option<&'a str>,
 }
 
 /// Unified result returned by `GateService::check`.
@@ -286,6 +289,7 @@ impl GateService {
             ref kind,
             ref options,
             ref allow_freeform,
+            ref context,
         } = req.kind
         else {
             unreachable!()
@@ -314,10 +318,10 @@ impl GateService {
             session_id: sid.to_string(),
             root_session_id: root_session_id.unwrap_or_default(),
             agent_id: req.manifest.agent.id.clone(),
-            turn_id: String::new(),
+            turn_id: req.turn_id.unwrap_or("unknown").to_string(),
             kind: parse_interaction_kind(kind),
             question: question.clone(),
-            context: None,
+            context: context.clone(),
             options: options.clone().unwrap_or_default(),
             allow_freeform: *allow_freeform,
             status: UserInteractionStatus::Pending,
@@ -329,7 +333,7 @@ impl GateService {
             expires_at: None,
             workflow_id,
             task_id,
-            checkpoint_turn_id: None,
+            checkpoint_turn_id: req.turn_id.map(|t| t.to_string()),
         };
 
         self.store.create_user_interaction(&interaction)?;
@@ -945,6 +949,7 @@ mod tests {
             summary: "test summary".to_string(),
             approval_ref: None,
             pre_validated: true,
+            turn_id: None,
         };
 
         let result = svc.check(req)?;
@@ -977,6 +982,7 @@ mod tests {
             summary: "Fetch API from localhost".to_string(),
             approval_ref: None,
             pre_validated: false,
+            turn_id: None,
         };
 
         let result = svc.check(req)?;
@@ -1021,6 +1027,7 @@ mod tests {
             summary: "first".to_string(),
             approval_ref: None,
             pre_validated: false,
+            turn_id: None,
         };
         let result1 = svc.check(req1)?;
         let gate_id_1 = match &result1 {
@@ -1043,6 +1050,7 @@ mod tests {
             summary: "second".to_string(),
             approval_ref: None,
             pre_validated: false,
+            turn_id: None,
         };
         let result2 = svc.check(req2)?;
         assert!(result2.enforced_rules().contains(&"R-2.3"));
@@ -1106,6 +1114,7 @@ mod tests {
             summary: "test".to_string(),
             approval_ref: Some(&ref_id),
             pre_validated: false,
+            turn_id: None,
         };
         let result = svc.check(req)?;
         assert!(result.enforced_rules().contains(&"R-2.6"));
@@ -1168,6 +1177,7 @@ mod tests {
             summary: "test".to_string(),
             approval_ref: Some(&ref_id),
             pre_validated: false,
+            turn_id: None,
         };
         let result = svc.check(req)?;
         // Should NOT clear — wrong agent.
@@ -1218,6 +1228,7 @@ mod tests {
             summary: "Fetch data".to_string(),
             approval_ref: None,
             pre_validated: false,
+            turn_id: None,
         };
 
         let result = svc.check(req)?;

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2147,6 +2147,8 @@ impl NativeTool for AgentRevisionPromoteTool {
             args.required_eval_run_id.as_deref(),
         )?;
 
+        crate::bootstrap::update_latest_symlink(gateway_dir, &args.agent_id, &args.revision_id);
+
         let short_ref = format!("{}@rev_{}", args.agent_id, rev.short_id);
         Ok(serde_json::json!({
             "ok": true,

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -6,9 +6,10 @@
 //!
 //! Phase B (Automated Registration):
 //! - credential.setup: Multi-step server-side credential registration flow
-//!   Extended with `skill_url` to ingest a remote skill.md onboarding spec,
-//!   `user_input` step support (gateway returns early, agent calls user.ask),
-//!   and `resume_vars` to continue after user input is collected.
+//!   Extended with `skill_url` to ingest a skill.md onboarding spec (HTTPS URL
+//!   or local filename from gateway skills/ directory), `user_input` step support
+//!   (gateway returns early, agent calls user.ask), and `resume_vars` to continue
+//!   after user input is collected.
 
 use crate::llm::ToolDefinition;
 use crate::policy::PolicyEngine;
@@ -731,6 +732,82 @@ fn extract_host(url: &str) -> anyhow::Result<String> {
     Ok(parsed.host_str().unwrap_or("").to_string())
 }
 
+enum SkillUrlKind {
+    Remote { url: String, host: String },
+    Local { filename: String },
+}
+
+fn classify_skill_url(raw: &str) -> SkillUrlKind {
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        let host = url::Url::parse(raw)
+            .ok()
+            .and_then(|u| u.host_str().map(String::from))
+            .unwrap_or_default();
+        SkillUrlKind::Remote {
+            url: raw.to_string(),
+            host,
+        }
+    } else {
+        let filename = raw.to_string();
+        SkillUrlKind::Local { filename }
+    }
+}
+
+fn skills_dir(gateway_dir: &Path) -> PathBuf {
+    gateway_dir.join("skills")
+}
+
+fn validate_local_skill_path(
+    gateway_dir: &Path,
+    filename: &str,
+) -> anyhow::Result<PathBuf> {
+    let base = skills_dir(gateway_dir);
+    if !filename.ends_with(".md") {
+        anyhow::bail!(
+            "local skill_url must be a .md file in the gateway skills/ directory"
+        );
+    }
+    let candidate = base.join(filename);
+    let canonical_base = base.canonicalize().unwrap_or_else(|_| base.clone());
+    let canonical_target = match std::fs::canonicalize(&candidate) {
+        Ok(p) => p,
+        Err(_) => {
+            let resolved = canonical_base.join(filename);
+            if !resolved.starts_with(&canonical_base) {
+                anyhow::bail!(
+                    "skill_url path escapes the gateway skills/ directory"
+                );
+            }
+            anyhow::bail!(
+                "skill file not found in gateway skills/ directory: {}",
+                filename
+            );
+        }
+    };
+    if !canonical_target.starts_with(&canonical_base) {
+        anyhow::bail!("skill_url path escapes the gateway skills/ directory");
+    }
+    let metadata = std::fs::symlink_metadata(&canonical_target)?;
+    if metadata.file_type().is_symlink() {
+        let link_target = std::fs::read_link(&canonical_target)?;
+        let resolved_link = if link_target.is_absolute() {
+            link_target
+        } else {
+            canonical_target.parent().unwrap_or(&canonical_base).join(link_target)
+        };
+        let canonical_link = match std::fs::canonicalize(&resolved_link) {
+            Ok(p) => p,
+            Err(_) => {
+                anyhow::bail!("symlink in skills/ directory points to invalid target");
+            }
+        };
+        if !canonical_link.starts_with(&canonical_base) {
+            anyhow::bail!("symlink in skills/ directory escapes the gateway skills/ directory");
+        }
+    }
+    Ok(canonical_target)
+}
+
 // ---------------------------------------------------------------------------
 // credential.refresh
 // ---------------------------------------------------------------------------
@@ -1251,8 +1328,10 @@ impl NativeTool for CredentialSetupTool {
         ToolDefinition {
             name: "credential_setup".to_string(),
             description: "Register a new credential through a multi-step setup flow. \
-                Provide `skill_url` to ingest a remote skill.md spec and let the gateway \
+                Provide `skill_url` to ingest a skill.md spec and let the gateway \
                 execute all onboarding steps server-side — secrets are never returned to the LLM. \
+                skill_url accepts an HTTPS URL (fetched remotely, subject to approval) or a \
+                bare filename (e.g. 'github.md') resolved from the gateway skills/ directory. \
                 When a user_input step is reached the tool returns with `suspended_for_user_input: true` \
                 and a `question`. Call `user.ask` with that question, then call `credential.setup` \
                 again with `credential_id` + `resume_vars: { var_name: answer }` to continue. \
@@ -1262,7 +1341,7 @@ impl NativeTool for CredentialSetupTool {
                 "properties": {
                     "skill_url": {
                         "type": "string",
-                        "description": "URL to a skill.md whose autonoetic.onboarding section drives registration. When set, service/steps are extracted from the spec."
+                        "description": "HTTPS URL to a skill.md (fetched remotely) or a bare .md filename resolved from the gateway skills/ directory. When set, service/steps are extracted from the spec."
                     },
                     "service": {
                         "type": "string",
@@ -1472,145 +1551,169 @@ impl NativeTool for CredentialSetupTool {
         // ------------------------------------------------------------------
         // Path 3: fresh start — may use skill_url or explicit service/steps
         // ------------------------------------------------------------------
-        let (service, steps, inject_as, allowed_hosts, base_url) = if let Some(ref url) =
+        let (service, steps, inject_as, allowed_hosts, base_url) = if let Some(ref raw_url) =
             args.skill_url
         {
-            // Policy-check the skill_url host.
-            let url_host = extract_host(url)?;
-            let skill_url_is_approved = approved_setup_remote_url.as_deref()
-                .map(|u| extract_host(u).unwrap_or_default() == url_host)
-                .unwrap_or(false);
-            if !skill_url_is_approved {
-                let policy_violation = crate::runtime::network_policy::enforce_remote_target_policy(
-                    manifest,
-                    _agent_dir,
-                    &url_host,
-                    Some(url),
-                    DeclarationRequirement::Required,
-                ).err().map(|v| v.error_type.to_string())
-                .or_else(|| {
-                    if url_host.is_empty() || !policy.can_connect_net(&url_host).is_allowed() {
-                        Some("network_access_denied".to_string())
-                    } else {
-                        None
-                    }
-                });
+            let (content, url_host, base_url) = match classify_skill_url(raw_url) {
+                SkillUrlKind::Remote { url, host } => {
+                    let url_host = host;
+                    let url = url;
 
-                if let Some(violation_type) = policy_violation {
-                    let action = ScheduledAction::CredentialRequest {
-                        credential_id: args.credential_id.clone().unwrap_or_default(),
-                        url: url.clone(),
-                        method: Some("GET".to_string()),
-                        headers: None,
-                        body: None,
-                        inject_secret_as: None,
-                        payload: Some(json!({
-                            "host": url_host.clone(),
-                            "retry_field": "approval_ref",
-                            "source_tool": "credential_setup",
-                            "setup_phase": "skill_url",
-                            "policy_violation": violation_type,
-                        })),
-                    };
-                    let reason = format!(
-                        "Fetching skill.md from {} requires approval (policy: {})",
-                        url_host, violation_type
-                    );
-                    let gate = crate::runtime::human_gate::GateService::new(store.clone());
-                    let gate_result = gate.check(
-                        crate::runtime::human_gate::GateRequest {
-                            kind: crate::runtime::human_gate::GateKind::Approval {
-                                action: action.clone(),
-                                targets: vec![url_host.clone()],
-                                match_strategy: crate::runtime::human_gate::MatchStrategy::HostLevel,
-                            },
+                    let skill_url_is_approved = approved_setup_remote_url.as_deref()
+                        .map(|u| extract_host(u).unwrap_or_default() == url_host)
+                        .unwrap_or(false);
+                    if !skill_url_is_approved {
+                        let policy_violation = crate::runtime::network_policy::enforce_remote_target_policy(
                             manifest,
-                            session_id: _session_id,
-                            run_context: _run_context,
-                            config: _config,
-                            reason: reason.clone(),
-                            summary: format!("Fetch skill.md from {}", url_host),
-                            approval_ref: None,
-                            pre_validated: false,
-                        },
-                    )?;
-                    match gate_result {
-                        crate::runtime::human_gate::GateResult::Cleared { .. } => {}
-                        crate::runtime::human_gate::GateResult::AlreadyPending { gate_id, .. } => {
-                            return Ok(json!({
-                                "ok": false,
-                                "approval_required": true,
-                                "approval_already_pending": true,
-                                "request_id": gate_id,
-                                "suspended": true,
-                                "reason": reason,
-                                "repair_hint": "Wait for the existing approval to be resolved.",
-                                "approval": {
-                                    "kind": "credential_setup_remote_access",
-                                    "summary": format!("Fetch skill.md from {}", url_host),
-                                    "retry_field": "approval_ref"
-                                }
-                            }).to_string());
-                        }
-                        crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
-                            return Ok(json!({
-                                "ok": false,
-                                "error_type": violation_type,
-                                "message": format!(
-                                    "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
-                                    gate_id
-                                ),
-                                "repair_hint": "Wait for approval and retry credential.setup with the same skill_url plus approval_ref.",
-                                "approval_required": true,
-                                "request_id": gate_id,
-                                "suspended": true,
-                                "reason": reason,
-                                "approval": {
-                                    "kind": "credential_setup_remote_access",
-                                    "summary": format!("Fetch skill.md from {}", url_host),
-                                    "reason": format!("Remote target policy: {} for {}", violation_type, url_host),
-                                    "retry_field": "approval_ref"
-                                }
-                            }).to_string());
-                        }
-                        other => {
-                            tracing::warn!(
-                                target: "credential",
-                                gate_result = ?other,
-                                "Unexpected gate result for credential_setup skill_url gate"
+                            _agent_dir,
+                            &url_host,
+                            Some(&url),
+                            DeclarationRequirement::Required,
+                        ).err().map(|v| v.error_type.to_string())
+                        .or_else(|| {
+                            if url_host.is_empty() || !policy.can_connect_net(&url_host).is_allowed() {
+                                Some("network_access_denied".to_string())
+                            } else {
+                                None
+                            }
+                        });
+
+                        if let Some(violation_type) = policy_violation {
+                            let action = ScheduledAction::CredentialRequest {
+                                credential_id: args.credential_id.clone().unwrap_or_default(),
+                                url: url.clone(),
+                                method: Some("GET".to_string()),
+                                headers: None,
+                                body: None,
+                                inject_secret_as: None,
+                                payload: Some(json!({
+                                    "host": url_host.clone(),
+                                    "retry_field": "approval_ref",
+                                    "source_tool": "credential_setup",
+                                    "setup_phase": "skill_url",
+                                    "policy_violation": violation_type,
+                                })),
+                            };
+                            let reason = format!(
+                                "Fetching skill.md from {} requires approval (policy: {})",
+                                url_host, violation_type
                             );
+                            let gate = crate::runtime::human_gate::GateService::new(store.clone());
+                            let gate_result = gate.check(
+                                crate::runtime::human_gate::GateRequest {
+                                    kind: crate::runtime::human_gate::GateKind::Approval {
+                                        action: action.clone(),
+                                        targets: vec![url_host.clone()],
+                                        match_strategy: crate::runtime::human_gate::MatchStrategy::HostLevel,
+                                    },
+                                    manifest,
+                                    session_id: _session_id,
+                                    run_context: _run_context,
+                                    config: _config,
+                                    reason: reason.clone(),
+                                    summary: format!("Fetch skill.md from {}", url_host),
+                                    approval_ref: None,
+                                    pre_validated: false,
+                                },
+                            )?;
+                            match gate_result {
+                                crate::runtime::human_gate::GateResult::Cleared { .. } => {}
+                                crate::runtime::human_gate::GateResult::AlreadyPending { gate_id, .. } => {
+                                    return Ok(json!({
+                                        "ok": false,
+                                        "approval_required": true,
+                                        "approval_already_pending": true,
+                                        "request_id": gate_id,
+                                        "suspended": true,
+                                        "reason": reason,
+                                        "repair_hint": "Wait for the existing approval to be resolved.",
+                                        "approval": {
+                                            "kind": "credential_setup_remote_access",
+                                            "summary": format!("Fetch skill.md from {}", url_host),
+                                            "retry_field": "approval_ref"
+                                        }
+                                    }).to_string());
+                                }
+                                crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
+                                    return Ok(json!({
+                                        "ok": false,
+                                        "error_type": violation_type,
+                                        "message": format!(
+                                            "Execution suspended pending operator approval ({}). Retry credential.setup with approval_ref after approval.",
+                                            gate_id
+                                        ),
+                                        "repair_hint": "Wait for approval and retry credential.setup with the same skill_url plus approval_ref.",
+                                        "approval_required": true,
+                                        "request_id": gate_id,
+                                        "suspended": true,
+                                        "reason": reason,
+                                        "approval": {
+                                            "kind": "credential_setup_remote_access",
+                                            "summary": format!("Fetch skill.md from {}", url_host),
+                                            "reason": format!("Remote target policy: {} for {}", violation_type, url_host),
+                                            "retry_field": "approval_ref"
+                                        }
+                                    }).to_string());
+                                }
+                                other => {
+                                    tracing::warn!(
+                                        target: "credential",
+                                        gate_result = ?other,
+                                        "Unexpected gate result for credential_setup skill_url gate"
+                                    );
+                                }
+                            }
                         }
                     }
-                }
-            }
 
-            // Fetch and parse the skill.md.
-            let url_clone = url.clone();
-            let (http_status, content) =
-                blocking_http_request(move || -> anyhow::Result<(u16, String)> {
-                    let client = reqwest::blocking::Client::builder()
-                        .timeout(std::time::Duration::from_secs(15))
-                        .build()?;
-                    let resp = client.get(url_clone.as_str()).send()?;
-                    let status = resp.status().as_u16();
-                    if !resp.status().is_success() {
-                        let _ = resp.text()?;
-                        return Ok((status, String::new()));
+                    let url_clone = url.clone();
+                    let (http_status, content) =
+                        blocking_http_request(move || -> anyhow::Result<(u16, String)> {
+                            let client = reqwest::blocking::Client::builder()
+                                .timeout(std::time::Duration::from_secs(15))
+                                .build()?;
+                            let resp = client.get(url_clone.as_str()).send()?;
+                            let status = resp.status().as_u16();
+                            if !resp.status().is_success() {
+                                let _ = resp.text()?;
+                                return Ok((status, String::new()));
+                            }
+                            let content = resp.text()?;
+                            Ok((status, content))
+                        })?;
+
+                    if !(200..300).contains(&(http_status as i32)) {
+                        return Ok(autonoetic_types::tool_error::ToolError::execution(
+                            format!(
+                                "Failed to fetch skill.md from {}: HTTP {}",
+                                url, http_status
+                            ),
+                            Some("Verify the skill_url is correct and accessible.".to_string()),
+                        )
+                        .to_error_response());
                     }
-                    let content = resp.text()?;
-                    Ok((status, content))
-                })?;
 
-            if !(200..300).contains(&(http_status as i32)) {
-                return Ok(autonoetic_types::tool_error::ToolError::execution(
-                    format!(
-                        "Failed to fetch skill.md from {}: HTTP {}",
-                        url, http_status
-                    ),
-                    Some("Verify the skill_url is correct and accessible.".to_string()),
-                )
-                .to_error_response());
-            }
+                    let base_url = extract_base_url(&url);
+                    (content, url_host, Some(base_url))
+                }
+                SkillUrlKind::Local { filename } => {
+                    let gateway_dir = _gateway_dir.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "local skill_url requires a gateway directory; \
+                             place the .md file in {{agents_dir}}/.gateway/skills/"
+                        )
+                    })?;
+                    let path = validate_local_skill_path(gateway_dir, &filename)?;
+                    let content = std::fs::read_to_string(&path).map_err(|e| {
+                        anyhow::anyhow!(
+                            "failed to read skill file from gateway skills/ directory: {}",
+                            e
+                        )
+                    })?;
+                    let base_url = None;
+                    (content, String::new(), base_url)
+                }
+            };
 
             let matter = gray_matter::Matter::<gray_matter::engine::YAML>::new();
             let parsed = match matter.parse::<SkillMdFrontmatter>(&content) {
@@ -1638,7 +1741,8 @@ impl NativeTool for CredentialSetupTool {
                 credential: None,
                 onboarding: None,
             });
-            let base_url = autonoetic.base_url.unwrap_or_else(|| extract_base_url(url));
+            let resolved_base_url = base_url
+                .or_else(|| autonoetic.base_url.clone());
             let cred_spec = autonoetic.credential.unwrap_or(SkillCredentialSpec {
                 service: None,
                 inject_as: None,
@@ -1652,12 +1756,12 @@ impl NativeTool for CredentialSetupTool {
             let allowed_hosts = cred_spec
                 .allowed_hosts
                 .or_else(|| args.allowed_hosts.clone())
-                .unwrap_or_else(|| vec![url_host.clone()]);
+                .unwrap_or_else(|| if url_host.is_empty() { vec![] } else { vec![url_host.clone()] });
 
             let raw_steps = autonoetic.onboarding.map(|o| o.steps).unwrap_or_default();
             let mut steps: Vec<CredentialSetupStep> = Vec::with_capacity(raw_steps.len());
             for raw in raw_steps {
-                match raw.into_credential_step(&base_url) {
+                match raw.into_credential_step(resolved_base_url.as_deref().unwrap_or("")) {
                     Ok(s) => steps.push(s),
                     Err(e) => {
                         return Ok(autonoetic_types::tool_error::ToolError::validation(
@@ -1672,7 +1776,7 @@ impl NativeTool for CredentialSetupTool {
                 }
             }
 
-            (service, steps, inject_as, allowed_hosts, Some(base_url))
+            (service, steps, inject_as, allowed_hosts, resolved_base_url)
         } else {
             // Explicit service + steps.
             let service = match args.service {

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -428,6 +428,7 @@ impl NativeTool for CredentialRequestTool {
                         summary: format!("Credential request to {}", url_host),
                         approval_ref: None,
                         pre_validated: false,
+                        turn_id: None,
                     },
                 )?;
                 match gate_result {
@@ -518,6 +519,7 @@ impl NativeTool for CredentialRequestTool {
                     summary: format!("Credential request to {}", url_host),
                     approval_ref: None,
                     pre_validated: false,
+                    turn_id: None,
                 },
             )?;
             match gate_result {
@@ -1614,6 +1616,7 @@ impl NativeTool for CredentialSetupTool {
                                     summary: format!("Fetch skill.md from {}", url_host),
                                     approval_ref: None,
                                     pre_validated: false,
+                        turn_id: None,
                                 },
                             )?;
                             match gate_result {
@@ -1881,6 +1884,7 @@ impl NativeTool for CredentialSetupTool {
                                 summary: format!("Credential setup API call to {}", display_host),
                                 approval_ref: None,
                                 pre_validated: false,
+                        turn_id: None,
                             },
                         )?;
                         match gate_result {

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -1583,6 +1583,7 @@ impl NativeTool for SandboxExecTool {
                                 summary: summary.clone(),
                                 approval_ref: None,
                                 pre_validated: false,
+                                turn_id: None,
                             },
                         )?;
                         match gate_result {
@@ -1950,6 +1951,7 @@ impl NativeTool for SandboxExecTool {
                                         summary: summary.clone(),
                                         approval_ref: None,
                                         pre_validated: false,
+                                turn_id: None,
                                     },
                                 )?;
                                 match gate_result {

--- a/autonoetic-gateway/src/runtime/tools/user_interaction.rs
+++ b/autonoetic-gateway/src/runtime/tools/user_interaction.rs
@@ -119,9 +119,8 @@ impl NativeTool for UserAskTool {
         gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
-        use autonoetic_types::background::{
-            UserInteraction, UserInteractionKind, UserInteractionOption,
-        };
+        use autonoetic_types::background::UserInteractionOption;
+        use crate::runtime::human_gate::{GateKind, GateRequest, GateResult, GateService};
 
         let args: Args = serde_json::from_str(arguments_json)
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
@@ -180,38 +179,24 @@ impl NativeTool for UserAskTool {
             let pending_approvals = store
                 .get_pending_approvals_for_root(&root_session_id)
                 .unwrap_or_default();
-            let session_blocking_approvals: Vec<_> = pending_approvals
-                .iter()
-                .filter(|r| {
-                    !matches!(
-                        r.action,
-                        autonoetic_types::background::ScheduledAction::SandboxExec { .. }
-                    )
-                })
-                .collect();
-            if !session_blocking_approvals.is_empty() {
+            let pending_interactions = store
+                .get_pending_interactions_for_root_session(&root_session_id)
+                .unwrap_or_default();
+            if !pending_approvals.is_empty() || !pending_interactions.is_empty() {
                 return Ok(serde_json::json!({
                     "ok": false,
                     "error_type": "conflict",
-                    "message": "user.ask is not available while approvals are pending. Use workflow.wait to handle pending approvals.",
-                    "repair_hint": "Resolve or wait for pending approvals, then retry user.ask.",
-                    "error": "user.ask is not available while approvals are pending. Use workflow.wait to handle pending approvals."
+                    "message": "user.ask is not available while gates are pending (approvals, interactions, or escalations). Resolve pending gates before retrying.",
+                    "repair_hint": "Resolve or wait for pending gates, then retry user.ask.",
+                    "error": "user.ask is not available while gates are pending. Resolve pending gates before retrying."
                 }).to_string());
             }
         }
 
-        let interaction_id = format!("ui-{}", &uuid::Uuid::new_v4().to_string()[..8]);
-
-        let kind = match args.kind.as_str() {
-            "decision" => UserInteractionKind::Decision,
-            "proposal" => UserInteractionKind::Proposal,
-            "confirmation" => UserInteractionKind::Confirmation,
-            _ => UserInteractionKind::Clarification,
-        };
-        let kind_str = match kind {
-            UserInteractionKind::Decision => "decision",
-            UserInteractionKind::Proposal => "proposal",
-            UserInteractionKind::Confirmation => "confirmation",
+        let kind_str = match args.kind.as_str() {
+            "decision" => "decision",
+            "proposal" => "proposal",
+            "confirmation" => "confirmation",
             _ => "clarification",
         };
 
@@ -227,120 +212,124 @@ impl NativeTool for UserAskTool {
             })
             .collect();
 
-        let now = chrono::Utc::now().to_rfc3339();
-
-        let (workflow_id, task_id, checkpoint_turn_id) = match _run_context {
-            Some(ctx) => (
-                ctx.workflow_id.clone(),
-                ctx.task_id.clone(),
-                turn_id.map(|t| t.to_string()),
-            ),
-            None => (None, None, turn_id.map(|t| t.to_string())),
-        };
-
-        let interaction = UserInteraction {
-            interaction_id: interaction_id.clone(),
-            session_id: sid.to_string(),
-            root_session_id,
-            agent_id: _manifest.agent.id.clone(),
-            turn_id: turn_id.unwrap_or("unknown").to_string(),
-            kind,
-            question: args.question,
-            context: args.context,
-            options,
-            allow_freeform: args.allow_freeform,
-            status: UserInteractionStatus::Pending,
-            answer_option_id: None,
-            answer_text: None,
-            answered_by: None,
-            created_at: now,
-            answered_at: None,
-            expires_at: None,
-            workflow_id,
-            task_id,
-            checkpoint_turn_id,
-        };
-
-        if let Some(store) = gateway_store {
-            store.create_user_interaction(&interaction)?;
-            tracing::info!(
-                target: "user_interaction",
-                interaction_id = %interaction_id,
-                session_id = %sid,
-                "User interaction created; agent will suspend"
-            );
-            if let Some(ctx) = _run_context {
-                if let Some(w) = &ctx.live_digest {
-                    let opts_summary = if interaction.options.is_empty() {
-                        None
-                    } else {
-                        Some(
-                            interaction
-                                .options
-                                .iter()
-                                .map(|o| format!("{}: {}", o.id, o.label))
-                                .collect::<Vec<_>>()
-                                .join("; "),
-                        )
-                    };
-                    if let Ok(mut g) = w.lock() {
-                        let _ = g.record_user_ask_pending(
-                            &interaction.question,
-                            opts_summary.as_deref(),
-                        );
-                    }
-                }
-                if let Some(w) = &ctx.live_report {
-                    if let Ok(mut g) = w.lock() {
-                        let _ = g.record_interaction_pending(
-                            &interaction_id,
-                            kind_str,
-                            &interaction.question,
-                        );
-                    }
-                }
-            }
-            if let Some(ctx) = _run_context {
-                let _ = store.create_live_digest_event(
-                    &crate::scheduler::gateway_store::LiveDigestEventRecord {
-                        event_id: uuid::Uuid::new_v4().to_string(),
-                        root_session_id: ctx.root_session_id.clone(),
-                        source_session_id: ctx.session_id.clone(),
-                        turn_id: turn_id.map(|s| s.to_string()),
-                        source_agent_id: Some(_manifest.agent.id.clone()),
-                        source_node_id: std::env::var("AUTONOETIC_NODE_ID")
-                            .unwrap_or_else(|_| "gateway".to_string()),
-                        event_type: "user.ask.pending".to_string(),
-                        payload: Some(
-                            serde_json::json!({
-                                "interaction_id": interaction_id.clone(),
-                                "question": crate::log_redaction::redact_text_for_logs(&interaction.question),
-                                "options_count": interaction.options.len(),
-                            })
-                            .to_string(),
-                        ),
-                        created_at: chrono::Utc::now().to_rfc3339(),
-                    },
-                );
-            }
+        let question_for_side_effects = args.question.clone();
+        let opts_summary = if options.is_empty() {
+            None
         } else {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error_type": "resource",
-                "message": "Gateway store not available; user.ask requires persistent store",
-                "repair_hint": "Configure GatewayStore for this runtime before calling user.ask.",
-                "error": "Gateway store not available; user.ask requires persistent store"
-            })
-            .to_string());
-        }
+            Some(
+                options
+                    .iter()
+                    .map(|o| format!("{}: {}", o.id, o.label))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            )
+        };
+        let options_count = options.len();
 
-        serde_json::to_string(&serde_json::json!({
-            "ok": true,
-            "interaction_required": true,
-            "interaction_id": interaction_id,
-            "status": "awaiting_user"
-        }))
-        .map_err(Into::into)
+        let store = match gateway_store {
+            Some(ref s) => s.clone(),
+            None => {
+                return Ok(serde_json::json!({
+                    "ok": false,
+                    "error_type": "resource",
+                    "message": "Gateway store not available; user.ask requires persistent store",
+                    "repair_hint": "Configure GatewayStore for this runtime before calling user.ask.",
+                    "error": "Gateway store not available; user.ask requires persistent store"
+                })
+                .to_string());
+            }
+        };
+
+        let gate = GateService::new(store.clone());
+        let gate_result = gate.check(GateRequest {
+            kind: GateKind::UserInput {
+                question: args.question,
+                kind: args.kind,
+                options: if options.is_empty() {
+                    None
+                } else {
+                    Some(options)
+                },
+                allow_freeform: args.allow_freeform,
+                context: args.context,
+            },
+            manifest: _manifest,
+            session_id: Some(sid),
+            run_context: _run_context,
+            config: _config,
+            reason: "user question".to_string(),
+            summary: "user question".to_string(),
+            approval_ref: None,
+            pre_validated: false,
+            turn_id,
+        })?;
+
+        match gate_result {
+            GateResult::AlreadyPending { gate_id, .. } => {
+                Ok(serde_json::json!({
+                    "ok": false,
+                    "error_type": "conflict",
+                    "message": "A user interaction is already pending for this session.",
+                    "repair_hint": "Wait for the existing interaction to be answered, then retry.",
+                    "error": "A user interaction is already pending for this session.",
+                    "interaction_id": gate_id,
+                })
+                .to_string())
+            }
+            GateResult::Suspended {
+                gate_id,
+                response_json,
+                ..
+            } => {
+                if let Some(ctx) = _run_context {
+                    if let Some(w) = &ctx.live_digest {
+                        if let Ok(mut g) = w.lock() {
+                            let _ = g.record_user_ask_pending(
+                                &question_for_side_effects,
+                                opts_summary.as_deref(),
+                            );
+                        }
+                    }
+                    if let Some(w) = &ctx.live_report {
+                        if let Ok(mut g) = w.lock() {
+                            let _ = g.record_interaction_pending(
+                                &gate_id,
+                                kind_str,
+                                &question_for_side_effects,
+                            );
+                        }
+                    }
+                    let _ = store.create_live_digest_event(
+                        &crate::scheduler::gateway_store::LiveDigestEventRecord {
+                            event_id: uuid::Uuid::new_v4().to_string(),
+                            root_session_id: ctx.root_session_id.clone(),
+                            source_session_id: ctx.session_id.clone(),
+                            turn_id: turn_id.map(|s| s.to_string()),
+                            source_agent_id: Some(_manifest.agent.id.clone()),
+                            source_node_id: std::env::var("AUTONOETIC_NODE_ID")
+                                .unwrap_or_else(|_| "gateway".to_string()),
+                            event_type: "user.ask.pending".to_string(),
+                            payload: Some(
+                                serde_json::json!({
+                                    "interaction_id": gate_id,
+                                    "question": crate::log_redaction::redact_text_for_logs(&question_for_side_effects),
+                                    "options_count": options_count,
+                                })
+                                .to_string(),
+                            ),
+                            created_at: chrono::Utc::now().to_rfc3339(),
+                        },
+                    );
+                }
+                Ok(response_json)
+            }
+            _ => Ok(serde_json::json!({
+                "ok": false,
+                "error_type": "unexpected",
+                "message": "Unexpected gate result for UserInput",
+            })
+            .to_string()),
+        }
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/web.rs
+++ b/autonoetic-gateway/src/runtime/tools/web.rs
@@ -908,6 +908,7 @@ impl NativeTool for WebSearchTool {
                     summary: format!("web.search {}", engine_host),
                     approval_ref: None,
                     pre_validated: false,
+                    turn_id: None,
                 },
             )?;
             match gate_result {
@@ -1372,6 +1373,7 @@ impl NativeTool for WebFetchTool {
                     summary: format!("web.fetch {}", host),
                     approval_ref: None,
                     pre_validated: false,
+                    turn_id: None,
                 },
             )?;
             match gate_result {
@@ -1711,6 +1713,7 @@ impl NativeTool for WebCallTool {
                     summary: format!("web.call {}", host),
                     approval_ref: None,
                     pre_validated: false,
+                    turn_id: None,
                 },
             )?;
             match gate_result {

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -21,6 +21,7 @@ pub mod decision;
 pub mod eval_runner;
 pub mod gateway_store;
 pub mod hooks;
+pub mod reclamation;
 pub mod runner;
 pub mod signal;
 pub mod store;
@@ -250,6 +251,24 @@ async fn run_scheduler_tick_at(
     // Orphan-child reaper: cancel children of terminated parent sessions (R+12)
     if let Err(e) = reap_orphaned_sessions(execution.clone()).await {
         tracing::warn!(error = %e, "Failed to reap orphaned sessions");
+    }
+
+    // Resource reclamation sweep: garbage collect content blobs, old revisions,
+    // expired memories, orphaned sessions, and stale scheduled jobs.
+    if let Some(store) = execution.gateway_store() {
+        let reclamation_cfg = &config.reclamation;
+        if reclamation_cfg.enabled {
+            let gateway_dir = crate::execution::gateway_root_dir(&config);
+            let now = Utc::now();
+            if let Err(e) = crate::scheduler::reclamation::run_reclamation_sweep(
+                &gateway_dir,
+                store.as_ref(),
+                reclamation_cfg,
+                &now,
+            ) {
+                tracing::warn!(error = %e, "Resource reclamation sweep failed");
+            }
+        }
     }
 
     // Resume standalone sessions whose user interaction has been answered

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -13,6 +13,7 @@ mod messages;
 mod migrate;
 mod notifications;
 mod observability;
+pub(crate) mod reclamation;
 mod row_decode;
 mod runtime_control;
 mod scheduled_jobs;

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -13,7 +13,7 @@ mod messages;
 mod migrate;
 mod notifications;
 mod observability;
-pub(crate) mod reclamation;
+mod reclamation;
 mod row_decode;
 mod runtime_control;
 mod scheduled_jobs;

--- a/autonoetic-gateway/src/scheduler/gateway_store/reclamation.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/reclamation.rs
@@ -4,95 +4,116 @@ use rusqlite::params;
 
 impl GatewayStore {
     /// Delete memories whose `expires_at` has passed.
-    /// Returns the number of deleted rows.
-    pub fn delete_expired_memories(&self) -> Result<u64> {
-        let now = chrono::Utc::now().to_rfc3339();
-        let conn = self.conn.lock().unwrap();
-        let sql = "DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at < ?1";
-        let n = conn.execute(sql, params![now])?;
+    /// Also cleans up orphaned `memory_tags` rows.
+    /// Returns the number of deleted memories.
+    pub fn delete_expired_memories(&self, now: &chrono::DateTime<chrono::Utc>) -> Result<u64> {
+        let now_rfc = now.to_rfc3339();
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        // Clean up memory_tags first (no FK cascade on memories DELETE)
+        tx.execute(
+            "DELETE FROM memory_tags WHERE memory_id IN (
+               SELECT memory_id FROM memories WHERE expires_at IS NOT NULL AND expires_at < ?1
+             )",
+            params![now_rfc],
+        )?;
+        let n = tx.execute(
+            "DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at < ?1",
+            params![now_rfc],
+        )?;
+        tx.commit()?;
         Ok(n as u64)
     }
 
     /// Delete agent revisions in `Archived` status older than `max_age_days`.
+    /// Skips revisions still referenced by `session_agent_bindings`.
     /// 0 = skip. Returns the number of deleted rows.
-    pub fn delete_archived_revisions(&self, max_age_days: u64) -> Result<u64> {
+    pub fn delete_archived_revisions(
+        &self,
+        max_age_days: u64,
+        now: &chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64> {
         if max_age_days == 0 {
             return Ok(0);
         }
-        let cutoff =
-            (chrono::Utc::now() - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let cutoff = (*now - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
         let conn = self.conn.lock().unwrap();
-        let sql = "DELETE FROM agent_revisions WHERE status = 'Archived' AND created_at < ?1";
+        let sql = "DELETE FROM agent_revisions
+                   WHERE status = 'Archived'
+                     AND created_at < ?1
+                     AND revision_id NOT IN (
+                       SELECT revision_id FROM session_agent_bindings
+                     )";
         let n = conn.execute(sql, params![cutoff])?;
         Ok(n as u64)
     }
 
-    /// Mark sessions as closed if they are still `active` and their last activity
-    /// (started_at) is older than `max_age_days`. 0 = skip.
-    /// Returns the number of updated rows.
-    pub fn close_orphaned_sessions(&self, max_age_days: u64) -> Result<u64> {
+    /// Mark sessions as closed if they are still `active` and their `started_at`
+    /// is older than `max_age_days`. Sets `ended_at` to `now`.
+    /// 0 = skip. Returns the number of updated rows.
+    pub fn close_orphaned_sessions(
+        &self,
+        max_age_days: u64,
+        now: &chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64> {
         if max_age_days == 0 {
             return Ok(0);
         }
-        let cutoff =
-            (chrono::Utc::now() - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let cutoff = (*now - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let now_rfc = now.to_rfc3339();
         let conn = self.conn.lock().unwrap();
         let sql = "UPDATE session_transcripts SET status = 'closed', ended_at = ?1
                    WHERE status = 'active' AND started_at < ?2";
-        let n = conn.execute(sql, params![cutoff, cutoff])?;
+        let n = conn.execute(sql, params![now_rfc, cutoff])?;
         Ok(n as u64)
     }
 
     /// Cancel `active` scheduled jobs whose root session has been closed for
-    /// more than `max_age_days`. 0 = skip. Returns the number of cancelled jobs.
-    pub fn cancel_stale_jobs(&self, max_age_days: u64) -> Result<u64> {
+    /// more than `max_age_days`. Only closes transcripts representing root
+    /// sessions (where `session_id = root_session_id`).
+    /// 0 = skip. Returns the number of cancelled jobs.
+    pub fn cancel_stale_jobs(
+        &self,
+        max_age_days: u64,
+        now: &chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64> {
         if max_age_days == 0 {
             return Ok(0);
         }
-        let cutoff =
-            (chrono::Utc::now() - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
-        let now = chrono::Utc::now().to_rfc3339();
+        let cutoff = (*now - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let now_rfc = now.to_rfc3339();
         let conn = self.conn.lock().unwrap();
         let sql = "UPDATE scheduled_jobs SET status = 'cancelled', updated_at = ?1
                    WHERE status = 'active'
                      AND root_session_id IN (
                        SELECT root_session_id FROM session_transcripts
-                       WHERE ended_at IS NOT NULL AND ended_at < ?2
+                       WHERE session_id = root_session_id
+                         AND ended_at IS NOT NULL AND ended_at < ?2
                      )";
-        let n = conn.execute(sql, params![now, cutoff])?;
+        let n = conn.execute(sql, params![now_rfc, cutoff])?;
         Ok(n as u64)
     }
 
-    /// Count content blob references across all session manifests.
-    /// Returns a set of content handles that are referenced by at least one manifest.
-    pub fn referenced_content_handles(
+    /// Collect all content handles referenced by `artifact_refs.artifact_digest`
+    /// in the database. Used together with manifest scanning to compute the
+    /// full set of referenced blobs.
+    pub fn referenced_artifact_digests(
         &self,
-        sessions_dir: &std::path::Path,
     ) -> Result<std::collections::HashSet<String>> {
-        let mut referenced = std::collections::HashSet::new();
-        let sessions_dir = sessions_dir.to_path_buf();
-        if !sessions_dir.exists() {
-            return Ok(referenced);
-        }
-        for entry in std::fs::read_dir(&sessions_dir)? {
-            let entry = entry?;
-            let manifest_path = entry.path().join("manifest.json");
-            if manifest_path.exists() {
-                let content = std::fs::read_to_string(&manifest_path)?;
-                if let Ok(manifest) =
-                    serde_json::from_str::<serde_json::Value>(&content)
-                {
-                    if let Some(names) = manifest.get("names").and_then(|v| v.as_object()) {
-                        for (_name, handle) in names {
-                            if let Some(h) = handle.as_str() {
-                                referenced.insert(h.to_string());
-                            }
-                        }
-                    }
-                }
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT artifact_digest FROM artifact_refs WHERE revoked_at IS NULL
+               AND (expires_at IS NULL OR expires_at > ?1)",
+        )?;
+        let now_rfc = chrono::Utc::now().to_rfc3339();
+        let rows = stmt.query_map(params![now_rfc], |row| row.get::<_, String>(0))?;
+        let mut digests = std::collections::HashSet::new();
+        for r in rows {
+            if let Ok(d) = r {
+                digests.insert(d);
             }
         }
-        Ok(referenced)
+        Ok(digests)
     }
 }
 
@@ -100,7 +121,6 @@ impl GatewayStore {
 mod tests {
     use super::*;
     use crate::scheduler::gateway_store::GatewayStore;
-    use autonoetic_types::agent_revision::AgentRevisionStatus;
     use autonoetic_types::memory::{MemoryObject, MemorySourceType, MemoryVisibility};
 
     fn make_store() -> (GatewayStore, tempfile::TempDir) {
@@ -112,10 +132,10 @@ mod tests {
     #[test]
     fn test_delete_expired_memories() {
         let (store, _dir) = make_store();
+        let now = chrono::Utc::now();
 
-        let past = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
-        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
-        let no_expiry: Option<String> = None;
+        let past = (now - chrono::Duration::hours(1)).to_rfc3339();
+        let future = (now + chrono::Duration::hours(1)).to_rfc3339();
 
         let expired = MemoryObject {
             memory_id: "mem-expired".into(),
@@ -124,8 +144,8 @@ mod tests {
             writer_agent_id: "agent-1".into(),
             source_type: MemorySourceType::AgentWrite,
             source_ref: "ref-1".into(),
-            created_at: chrono::Utc::now().to_rfc3339(),
-            updated_at: chrono::Utc::now().to_rfc3339(),
+            created_at: now.to_rfc3339(),
+            updated_at: now.to_rfc3339(),
             content: "expired".into(),
             content_hash: "hash1".into(),
             confidence: None,
@@ -147,8 +167,8 @@ mod tests {
             writer_agent_id: "agent-1".into(),
             source_type: MemorySourceType::AgentWrite,
             source_ref: "ref-2".into(),
-            created_at: chrono::Utc::now().to_rfc3339(),
-            updated_at: chrono::Utc::now().to_rfc3339(),
+            created_at: now.to_rfc3339(),
+            updated_at: now.to_rfc3339(),
             content: "active".into(),
             content_hash: "hash2".into(),
             confidence: None,
@@ -163,30 +183,30 @@ mod tests {
         };
         store.memory_upsert(&active).unwrap();
 
-        let no_expiry_mem = MemoryObject {
+        let no_expiry = MemoryObject {
             memory_id: "mem-no-expiry".into(),
             scope: "agent".into(),
             owner_agent_id: "agent-1".into(),
             writer_agent_id: "agent-1".into(),
             source_type: MemorySourceType::AgentWrite,
             source_ref: "ref-3".into(),
-            created_at: chrono::Utc::now().to_rfc3339(),
-            updated_at: chrono::Utc::now().to_rfc3339(),
+            created_at: now.to_rfc3339(),
+            updated_at: now.to_rfc3339(),
             content: "no-expiry".into(),
             content_hash: "hash3".into(),
             confidence: None,
             tags: vec![],
             lineage: vec![],
             visibility: MemoryVisibility::Private,
-            expires_at: no_expiry,
+            expires_at: None,
             revision_id: None,
             binding_session_id: None,
             alias_ref: None,
             quarantine_reason: None,
         };
-        store.memory_upsert(&no_expiry_mem).unwrap();
+        store.memory_upsert(&no_expiry).unwrap();
 
-        let deleted = store.delete_expired_memories().unwrap();
+        let deleted = store.delete_expired_memories(&now).unwrap();
         assert_eq!(deleted, 1, "only the expired memory should be deleted");
 
         assert!(store.memory_get("mem-expired").unwrap().is_none());
@@ -197,31 +217,31 @@ mod tests {
     #[test]
     fn test_delete_archived_revisions_zero_skips() {
         let (store, _dir) = make_store();
-        let deleted = store.delete_archived_revisions(0).unwrap();
+        let now = chrono::Utc::now();
+        let deleted = store.delete_archived_revisions(0, &now).unwrap();
         assert_eq!(deleted, 0);
     }
 
     #[test]
     fn test_close_orphaned_sessions_zero_skips() {
         let (store, _dir) = make_store();
-        let closed = store.close_orphaned_sessions(0).unwrap();
+        let now = chrono::Utc::now();
+        let closed = store.close_orphaned_sessions(0, &now).unwrap();
         assert_eq!(closed, 0);
     }
 
     #[test]
     fn test_cancel_stale_jobs_zero_skips() {
         let (store, _dir) = make_store();
-        let cancelled = store.cancel_stale_jobs(0).unwrap();
+        let now = chrono::Utc::now();
+        let cancelled = store.cancel_stale_jobs(0, &now).unwrap();
         assert_eq!(cancelled, 0);
     }
 
     #[test]
-    fn test_referenced_content_handles_empty_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let (store, _tmp) = make_store();
-        let handles = store
-            .referenced_content_handles(dir.path())
-            .unwrap();
-        assert!(handles.is_empty());
+    fn test_referenced_artifact_digests_empty() {
+        let (store, _dir) = make_store();
+        let digests = store.referenced_artifact_digests().unwrap();
+        assert!(digests.is_empty());
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/reclamation.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/reclamation.rs
@@ -1,0 +1,227 @@
+use super::GatewayStore;
+use anyhow::Result;
+use rusqlite::params;
+
+impl GatewayStore {
+    /// Delete memories whose `expires_at` has passed.
+    /// Returns the number of deleted rows.
+    pub fn delete_expired_memories(&self) -> Result<u64> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let sql = "DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at < ?1";
+        let n = conn.execute(sql, params![now])?;
+        Ok(n as u64)
+    }
+
+    /// Delete agent revisions in `Archived` status older than `max_age_days`.
+    /// 0 = skip. Returns the number of deleted rows.
+    pub fn delete_archived_revisions(&self, max_age_days: u64) -> Result<u64> {
+        if max_age_days == 0 {
+            return Ok(0);
+        }
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let sql = "DELETE FROM agent_revisions WHERE status = 'Archived' AND created_at < ?1";
+        let n = conn.execute(sql, params![cutoff])?;
+        Ok(n as u64)
+    }
+
+    /// Mark sessions as closed if they are still `active` and their last activity
+    /// (started_at) is older than `max_age_days`. 0 = skip.
+    /// Returns the number of updated rows.
+    pub fn close_orphaned_sessions(&self, max_age_days: u64) -> Result<u64> {
+        if max_age_days == 0 {
+            return Ok(0);
+        }
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let sql = "UPDATE session_transcripts SET status = 'closed', ended_at = ?1
+                   WHERE status = 'active' AND started_at < ?2";
+        let n = conn.execute(sql, params![cutoff, cutoff])?;
+        Ok(n as u64)
+    }
+
+    /// Cancel `active` scheduled jobs whose root session has been closed for
+    /// more than `max_age_days`. 0 = skip. Returns the number of cancelled jobs.
+    pub fn cancel_stale_jobs(&self, max_age_days: u64) -> Result<u64> {
+        if max_age_days == 0 {
+            return Ok(0);
+        }
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(max_age_days as i64)).to_rfc3339();
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let sql = "UPDATE scheduled_jobs SET status = 'cancelled', updated_at = ?1
+                   WHERE status = 'active'
+                     AND root_session_id IN (
+                       SELECT root_session_id FROM session_transcripts
+                       WHERE ended_at IS NOT NULL AND ended_at < ?2
+                     )";
+        let n = conn.execute(sql, params![now, cutoff])?;
+        Ok(n as u64)
+    }
+
+    /// Count content blob references across all session manifests.
+    /// Returns a set of content handles that are referenced by at least one manifest.
+    pub fn referenced_content_handles(
+        &self,
+        sessions_dir: &std::path::Path,
+    ) -> Result<std::collections::HashSet<String>> {
+        let mut referenced = std::collections::HashSet::new();
+        let sessions_dir = sessions_dir.to_path_buf();
+        if !sessions_dir.exists() {
+            return Ok(referenced);
+        }
+        for entry in std::fs::read_dir(&sessions_dir)? {
+            let entry = entry?;
+            let manifest_path = entry.path().join("manifest.json");
+            if manifest_path.exists() {
+                let content = std::fs::read_to_string(&manifest_path)?;
+                if let Ok(manifest) =
+                    serde_json::from_str::<serde_json::Value>(&content)
+                {
+                    if let Some(names) = manifest.get("names").and_then(|v| v.as_object()) {
+                        for (_name, handle) in names {
+                            if let Some(h) = handle.as_str() {
+                                referenced.insert(h.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(referenced)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler::gateway_store::GatewayStore;
+    use autonoetic_types::agent_revision::AgentRevisionStatus;
+    use autonoetic_types::memory::{MemoryObject, MemorySourceType, MemoryVisibility};
+
+    fn make_store() -> (GatewayStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn test_delete_expired_memories() {
+        let (store, _dir) = make_store();
+
+        let past = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let no_expiry: Option<String> = None;
+
+        let expired = MemoryObject {
+            memory_id: "mem-expired".into(),
+            scope: "agent".into(),
+            owner_agent_id: "agent-1".into(),
+            writer_agent_id: "agent-1".into(),
+            source_type: MemorySourceType::AgentWrite,
+            source_ref: "ref-1".into(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            content: "expired".into(),
+            content_hash: "hash1".into(),
+            confidence: None,
+            tags: vec![],
+            lineage: vec![],
+            visibility: MemoryVisibility::Private,
+            expires_at: Some(past),
+            revision_id: None,
+            binding_session_id: None,
+            alias_ref: None,
+            quarantine_reason: None,
+        };
+        store.memory_upsert(&expired).unwrap();
+
+        let active = MemoryObject {
+            memory_id: "mem-active".into(),
+            scope: "agent".into(),
+            owner_agent_id: "agent-1".into(),
+            writer_agent_id: "agent-1".into(),
+            source_type: MemorySourceType::AgentWrite,
+            source_ref: "ref-2".into(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            content: "active".into(),
+            content_hash: "hash2".into(),
+            confidence: None,
+            tags: vec![],
+            lineage: vec![],
+            visibility: MemoryVisibility::Private,
+            expires_at: Some(future),
+            revision_id: None,
+            binding_session_id: None,
+            alias_ref: None,
+            quarantine_reason: None,
+        };
+        store.memory_upsert(&active).unwrap();
+
+        let no_expiry_mem = MemoryObject {
+            memory_id: "mem-no-expiry".into(),
+            scope: "agent".into(),
+            owner_agent_id: "agent-1".into(),
+            writer_agent_id: "agent-1".into(),
+            source_type: MemorySourceType::AgentWrite,
+            source_ref: "ref-3".into(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            content: "no-expiry".into(),
+            content_hash: "hash3".into(),
+            confidence: None,
+            tags: vec![],
+            lineage: vec![],
+            visibility: MemoryVisibility::Private,
+            expires_at: no_expiry,
+            revision_id: None,
+            binding_session_id: None,
+            alias_ref: None,
+            quarantine_reason: None,
+        };
+        store.memory_upsert(&no_expiry_mem).unwrap();
+
+        let deleted = store.delete_expired_memories().unwrap();
+        assert_eq!(deleted, 1, "only the expired memory should be deleted");
+
+        assert!(store.memory_get("mem-expired").unwrap().is_none());
+        assert!(store.memory_get("mem-active").unwrap().is_some());
+        assert!(store.memory_get("mem-no-expiry").unwrap().is_some());
+    }
+
+    #[test]
+    fn test_delete_archived_revisions_zero_skips() {
+        let (store, _dir) = make_store();
+        let deleted = store.delete_archived_revisions(0).unwrap();
+        assert_eq!(deleted, 0);
+    }
+
+    #[test]
+    fn test_close_orphaned_sessions_zero_skips() {
+        let (store, _dir) = make_store();
+        let closed = store.close_orphaned_sessions(0).unwrap();
+        assert_eq!(closed, 0);
+    }
+
+    #[test]
+    fn test_cancel_stale_jobs_zero_skips() {
+        let (store, _dir) = make_store();
+        let cancelled = store.cancel_stale_jobs(0).unwrap();
+        assert_eq!(cancelled, 0);
+    }
+
+    #[test]
+    fn test_referenced_content_handles_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _tmp) = make_store();
+        let handles = store
+            .referenced_content_handles(dir.path())
+            .unwrap();
+        assert!(handles.is_empty());
+    }
+}

--- a/autonoetic-gateway/src/scheduler/reclamation.rs
+++ b/autonoetic-gateway/src/scheduler/reclamation.rs
@@ -1,15 +1,5 @@
-//! Resource reclamation sweep.
-//!
-//! Idempotent, conservative garbage collection for:
-//! - Content blobs with zero remaining name references
-//! - Expired memories
-//! - Archived agent revisions older than N days
-//! - Orphaned sessions not resumed within N days
-//! - Stale scheduled jobs whose root session has been closed for > N days
-//!
-//! Every deletion is recorded in a `reclamation.sweep` causal event.
-
 use autonoetic_types::config::ReclamationConfig;
+use std::collections::HashSet;
 use std::path::Path;
 
 /// Path to the file that records the last reclamation sweep timestamp.
@@ -38,21 +28,23 @@ pub fn run_reclamation_sweep(
 
     let mut summary = ReclamationSummary::default();
 
-    // 1. Delete expired memories
-    match store.delete_expired_memories() {
-        Ok(n) => {
-            if n > 0 {
-                tracing::info!(target: "reclamation", expired_memories = n, "Deleted expired memories");
+    // 1. Delete expired memories (safety switch: cfg.expired_memory_retention_days > 0)
+    if config.expired_memory_retention_days > 0 {
+        match store.delete_expired_memories(now) {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!(target: "reclamation", expired_memories = n, "Deleted expired memories");
+                }
+                summary.expired_memories = n;
             }
-            summary.expired_memories = n;
-        }
-        Err(e) => {
-            tracing::warn!(target: "reclamation", error = %e, "Failed to delete expired memories");
+            Err(e) => {
+                tracing::warn!(target: "reclamation", error = %e, "Failed to delete expired memories");
+            }
         }
     }
 
     // 2. Delete archived revisions
-    match store.delete_archived_revisions(config.archived_revision_max_age_days) {
+    match store.delete_archived_revisions(config.archived_revision_max_age_days, now) {
         Ok(n) => {
             if n > 0 {
                 tracing::info!(target: "reclamation", archived_revisions = n, "Deleted archived revisions");
@@ -65,7 +57,7 @@ pub fn run_reclamation_sweep(
     }
 
     // 3. Close orphaned sessions
-    match store.close_orphaned_sessions(config.orphaned_session_max_age_days) {
+    match store.close_orphaned_sessions(config.orphaned_session_max_age_days, now) {
         Ok(n) => {
             if n > 0 {
                 tracing::info!(target: "reclamation", orphaned_sessions = n, "Closed orphaned sessions");
@@ -78,7 +70,7 @@ pub fn run_reclamation_sweep(
     }
 
     // 4. Cancel stale jobs
-    match store.cancel_stale_jobs(config.stale_job_max_age_days) {
+    match store.cancel_stale_jobs(config.stale_job_max_age_days, now) {
         Ok(n) => {
             if n > 0 {
                 tracing::info!(target: "reclamation", stale_jobs = n, "Cancelled stale scheduled jobs");
@@ -91,7 +83,7 @@ pub fn run_reclamation_sweep(
     }
 
     // 5. Delete orphaned content blobs
-    match delete_orphaned_content_blobs(gateway_dir, store, config.content_blob_max_age_days) {
+    match delete_orphaned_content_blobs(gateway_dir, store, config.content_blob_max_age_days, now) {
         Ok(n) => {
             if n > 0 {
                 tracing::info!(target: "reclamation", orphaned_blobs = n, "Deleted orphaned content blobs");
@@ -114,10 +106,17 @@ pub fn run_reclamation_sweep(
 }
 
 /// Delete content blobs with zero remaining name references across all manifests.
+///
+/// Reference sources (all must agree the blob is unreferenced before deletion):
+/// - Session manifest `names` and `aliases` maps (recursively walked)
+/// - `artifact_refs` table `artifact_digest` column
+///
+/// Fails closed on any manifest read/parse error to prevent incorrect deletion.
 fn delete_orphaned_content_blobs(
     gateway_dir: &Path,
     store: &crate::scheduler::gateway_store::GatewayStore,
     max_age_days: u64,
+    now: &chrono::DateTime<chrono::Utc>,
 ) -> anyhow::Result<u64> {
     if max_age_days == 0 {
         return Ok(0);
@@ -129,10 +128,15 @@ fn delete_orphaned_content_blobs(
     }
 
     let sessions_dir = gateway_dir.join("sessions");
-    let referenced = store.referenced_content_handles(&sessions_dir)?;
+    let mut referenced = scan_manifest_references(&sessions_dir)?;
+
+    // Also include artifact digests from the DB
+    if let Ok(digests) = store.referenced_artifact_digests() {
+        referenced.extend(digests);
+    }
 
     let mut deleted = 0u64;
-    let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days as i64);
+    let cutoff = *now - chrono::Duration::days(max_age_days as i64);
 
     for prefix_entry in std::fs::read_dir(&content_dir)? {
         let prefix_entry = prefix_entry?;
@@ -146,7 +150,6 @@ fn delete_orphaned_content_blobs(
             }
             let metadata = entry.metadata()?;
 
-            // Check age
             let modified = match metadata.modified() {
                 Ok(t) => {
                     let duration_since_epoch = t
@@ -154,7 +157,7 @@ fn delete_orphaned_content_blobs(
                         .unwrap_or_default();
                     let secs = duration_since_epoch.as_secs() as i64;
                     let nanos = duration_since_epoch.subsec_nanos();
-                    chrono::DateTime::from_timestamp(secs, nanos).unwrap_or(chrono::Utc::now())
+                    chrono::DateTime::from_timestamp(secs, nanos).unwrap_or(*now)
                 }
                 Err(_) => continue,
             };
@@ -162,14 +165,9 @@ fn delete_orphaned_content_blobs(
                 continue;
             }
 
-            // Build the content handle from the file path
-            let prefix = prefix_entry
-                .file_name()
-                .to_string_lossy()
-                .to_string();
+            let prefix = prefix_entry.file_name().to_string_lossy().to_string();
             let filename = entry.file_name().to_string_lossy().to_string();
-            let full_hash = format!("sha256:{}{}", prefix, filename);
-            let handle = full_hash;
+            let handle = format!("sha256:{}{}", prefix, filename);
 
             if !referenced.contains(&handle) {
                 if let Err(e) = std::fs::remove_file(entry.path()) {
@@ -182,6 +180,50 @@ fn delete_orphaned_content_blobs(
     }
 
     Ok(deleted)
+}
+
+/// Recursively walk the sessions directory collecting all content handles
+/// referenced by session manifest `names` and `aliases` maps.
+///
+/// Fails hard on any read/parse error to prevent incorrect orphan deletion.
+fn scan_manifest_references(sessions_dir: &Path) -> anyhow::Result<HashSet<String>> {
+    let mut referenced = HashSet::new();
+    if !sessions_dir.exists() {
+        return Ok(referenced);
+    }
+    collect_manifest_references(sessions_dir, &mut referenced)?;
+    Ok(referenced)
+}
+
+fn collect_manifest_references(dir: &Path, referenced: &mut HashSet<String>) -> anyhow::Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_manifest_references(&path, referenced)?;
+        } else if entry.file_name() == "manifest.json" {
+            let content = std::fs::read_to_string(&path)?;
+            let manifest: serde_json::Value = serde_json::from_str(&content)?;
+            if let Some(names) = manifest.get("names").and_then(|v| v.as_object()) {
+                for (_name, handle) in names {
+                    if let Some(h) = handle.as_str() {
+                        referenced.insert(h.to_string());
+                    }
+                }
+            }
+            if let Some(aliases) = manifest.get("aliases").and_then(|v| v.as_object()) {
+                for (_short, handle) in aliases {
+                    if let Some(h) = handle.as_str() {
+                        referenced.insert(h.to_string());
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Check whether enough time has passed since the last reclamation run.
@@ -200,7 +242,7 @@ fn is_reclamation_due(
             let elapsed = *now - last_run;
             elapsed.num_seconds() >= config.min_interval_secs as i64
         }
-        Err(_) => true, // no state file → run now
+        Err(_) => true,
     }
 }
 
@@ -280,7 +322,6 @@ impl ReclamationSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scheduler::gateway_store::GatewayStore;
 
     #[test]
     fn test_is_reclamation_due_no_file() {
@@ -304,7 +345,6 @@ mod tests {
         };
         let now = chrono::Utc::now();
 
-        // Record a run 5 minutes ago
         let recent = (now - chrono::Duration::minutes(5)).to_rfc3339();
         std::fs::write(dir.path().join(RECLAMATION_STATE_FILE), &recent).unwrap();
 
@@ -321,7 +361,6 @@ mod tests {
         };
         let now = chrono::Utc::now();
 
-        // Record a run 2 hours ago
         let old = (now - chrono::Duration::hours(2)).to_rfc3339();
         std::fs::write(dir.path().join(RECLAMATION_STATE_FILE), &old).unwrap();
 
@@ -338,5 +377,63 @@ mod tests {
             ..Default::default()
         };
         assert!(s.has_work());
+    }
+
+    #[test]
+    fn test_scan_manifest_references_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let refs = scan_manifest_references(dir.path()).unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_scan_manifest_references_names_and_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join("sess-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+
+        let handle_a = "sha256:aaaa...";
+        let handle_b = "sha256:bbbb...";
+        let manifest = serde_json::json!({
+            "names": {
+                "file1.txt": handle_a,
+            },
+            "aliases": {
+                "a1b2c3d4": handle_b,
+            },
+        });
+        std::fs::write(session_dir.join("manifest.json"), serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let refs = scan_manifest_references(dir.path()).unwrap();
+        assert!(refs.contains(handle_a));
+        assert!(refs.contains(handle_b));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_scan_manifest_references_nested_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("root-session").join("child-session");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let handle = "sha256:cccc...";
+        let manifest = serde_json::json!({
+            "names": { "out.txt": handle },
+        });
+        std::fs::write(nested.join("manifest.json"), serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let refs = scan_manifest_references(dir.path()).unwrap();
+        assert!(refs.contains(handle));
+    }
+
+    #[test]
+    fn test_scan_manifest_references_fails_on_bad_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join("sess-bad");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("manifest.json"), b"not valid json").unwrap();
+
+        let result = scan_manifest_references(dir.path());
+        assert!(result.is_err(), "should fail closed on bad manifest JSON");
     }
 }

--- a/autonoetic-gateway/src/scheduler/reclamation.rs
+++ b/autonoetic-gateway/src/scheduler/reclamation.rs
@@ -1,0 +1,342 @@
+//! Resource reclamation sweep.
+//!
+//! Idempotent, conservative garbage collection for:
+//! - Content blobs with zero remaining name references
+//! - Expired memories
+//! - Archived agent revisions older than N days
+//! - Orphaned sessions not resumed within N days
+//! - Stale scheduled jobs whose root session has been closed for > N days
+//!
+//! Every deletion is recorded in a `reclamation.sweep` causal event.
+
+use autonoetic_types::config::ReclamationConfig;
+use std::path::Path;
+
+/// Path to the file that records the last reclamation sweep timestamp.
+const RECLAMATION_STATE_FILE: &str = "reclamation_last_run.txt";
+
+/// Run the full reclamation sweep if enough time has passed since the last run.
+///
+/// Returns a summary of what was reclaimed.
+pub fn run_reclamation_sweep(
+    gateway_dir: &Path,
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    config: &ReclamationConfig,
+    now: &chrono::DateTime<chrono::Utc>,
+) -> anyhow::Result<ReclamationSummary> {
+    if !config.enabled {
+        return Ok(ReclamationSummary::default());
+    }
+
+    if !is_reclamation_due(gateway_dir, config, now) {
+        return Ok(ReclamationSummary::default());
+    }
+
+    // Mark last run timestamp BEFORE doing work so a crash mid-sweep
+    // doesn't cause re-runs on every tick until the interval expires.
+    record_last_run(gateway_dir, now);
+
+    let mut summary = ReclamationSummary::default();
+
+    // 1. Delete expired memories
+    match store.delete_expired_memories() {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(target: "reclamation", expired_memories = n, "Deleted expired memories");
+            }
+            summary.expired_memories = n;
+        }
+        Err(e) => {
+            tracing::warn!(target: "reclamation", error = %e, "Failed to delete expired memories");
+        }
+    }
+
+    // 2. Delete archived revisions
+    match store.delete_archived_revisions(config.archived_revision_max_age_days) {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(target: "reclamation", archived_revisions = n, "Deleted archived revisions");
+            }
+            summary.archived_revisions = n;
+        }
+        Err(e) => {
+            tracing::warn!(target: "reclamation", error = %e, "Failed to delete archived revisions");
+        }
+    }
+
+    // 3. Close orphaned sessions
+    match store.close_orphaned_sessions(config.orphaned_session_max_age_days) {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(target: "reclamation", orphaned_sessions = n, "Closed orphaned sessions");
+            }
+            summary.orphaned_sessions = n;
+        }
+        Err(e) => {
+            tracing::warn!(target: "reclamation", error = %e, "Failed to close orphaned sessions");
+        }
+    }
+
+    // 4. Cancel stale jobs
+    match store.cancel_stale_jobs(config.stale_job_max_age_days) {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(target: "reclamation", stale_jobs = n, "Cancelled stale scheduled jobs");
+            }
+            summary.stale_jobs = n;
+        }
+        Err(e) => {
+            tracing::warn!(target: "reclamation", error = %e, "Failed to cancel stale scheduled jobs");
+        }
+    }
+
+    // 5. Delete orphaned content blobs
+    match delete_orphaned_content_blobs(gateway_dir, store, config.content_blob_max_age_days) {
+        Ok(n) => {
+            if n > 0 {
+                tracing::info!(target: "reclamation", orphaned_blobs = n, "Deleted orphaned content blobs");
+            }
+            summary.content_blobs = n;
+        }
+        Err(e) => {
+            tracing::warn!(target: "reclamation", error = %e, "Failed to delete orphaned content blobs");
+        }
+    }
+
+    // Emit causal event if anything was reclaimed
+    if summary.has_work() {
+        if let Err(e) = emit_reclamation_event(store, &summary, now) {
+            tracing::warn!(target: "reclamation", error = %e, "Failed to emit reclamation causal event");
+        }
+    }
+
+    Ok(summary)
+}
+
+/// Delete content blobs with zero remaining name references across all manifests.
+fn delete_orphaned_content_blobs(
+    gateway_dir: &Path,
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    max_age_days: u64,
+) -> anyhow::Result<u64> {
+    if max_age_days == 0 {
+        return Ok(0);
+    }
+
+    let content_dir = gateway_dir.join("content").join("sha256");
+    if !content_dir.exists() {
+        return Ok(0);
+    }
+
+    let sessions_dir = gateway_dir.join("sessions");
+    let referenced = store.referenced_content_handles(&sessions_dir)?;
+
+    let mut deleted = 0u64;
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days as i64);
+
+    for prefix_entry in std::fs::read_dir(&content_dir)? {
+        let prefix_entry = prefix_entry?;
+        if !prefix_entry.file_type()?.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(prefix_entry.path())? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let metadata = entry.metadata()?;
+
+            // Check age
+            let modified = match metadata.modified() {
+                Ok(t) => {
+                    let duration_since_epoch = t
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default();
+                    let secs = duration_since_epoch.as_secs() as i64;
+                    let nanos = duration_since_epoch.subsec_nanos();
+                    chrono::DateTime::from_timestamp(secs, nanos).unwrap_or(chrono::Utc::now())
+                }
+                Err(_) => continue,
+            };
+            if modified > cutoff {
+                continue;
+            }
+
+            // Build the content handle from the file path
+            let prefix = prefix_entry
+                .file_name()
+                .to_string_lossy()
+                .to_string();
+            let filename = entry.file_name().to_string_lossy().to_string();
+            let full_hash = format!("sha256:{}{}", prefix, filename);
+            let handle = full_hash;
+
+            if !referenced.contains(&handle) {
+                if let Err(e) = std::fs::remove_file(entry.path()) {
+                    tracing::warn!(target: "reclamation", path = %entry.path().display(), error = %e, "Failed to delete orphaned blob");
+                } else {
+                    deleted += 1;
+                }
+            }
+        }
+    }
+
+    Ok(deleted)
+}
+
+/// Check whether enough time has passed since the last reclamation run.
+fn is_reclamation_due(
+    gateway_dir: &Path,
+    config: &ReclamationConfig,
+    now: &chrono::DateTime<chrono::Utc>,
+) -> bool {
+    let state_path = gateway_dir.join(RECLAMATION_STATE_FILE);
+    match std::fs::read_to_string(&state_path) {
+        Ok(last_run_str) => {
+            let last_run = match chrono::DateTime::parse_from_rfc3339(last_run_str.trim()) {
+                Ok(t) => t.with_timezone(&chrono::Utc),
+                Err(_) => return true,
+            };
+            let elapsed = *now - last_run;
+            elapsed.num_seconds() >= config.min_interval_secs as i64
+        }
+        Err(_) => true, // no state file → run now
+    }
+}
+
+/// Record the last reclamation run timestamp.
+fn record_last_run(gateway_dir: &Path, now: &chrono::DateTime<chrono::Utc>) {
+    let state_path = gateway_dir.join(RECLAMATION_STATE_FILE);
+    if let Err(e) = std::fs::write(&state_path, now.to_rfc3339()) {
+        tracing::warn!(
+            target: "reclamation",
+            path = %state_path.display(),
+            error = %e,
+            "Failed to write reclamation state file"
+        );
+    }
+}
+
+/// Emit a `reclamation.sweep` causal event with counts of reclaimed resources.
+fn emit_reclamation_event(
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    summary: &ReclamationSummary,
+    now: &chrono::DateTime<chrono::Utc>,
+) -> anyhow::Result<()> {
+    let mut rules = autonoetic_types::causal_chain::default_enforced_rules();
+    rules.push("R-8.17".to_string());
+
+    let payload = serde_json::json!({
+        "reclamation": {
+            "content_blobs": summary.content_blobs,
+            "expired_memories": summary.expired_memories,
+            "archived_revisions": summary.archived_revisions,
+            "orphaned_sessions": summary.orphaned_sessions,
+            "stale_jobs": summary.stale_jobs,
+        },
+    });
+
+    store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: "gateway".to_string(),
+        session_id: "system".to_string(),
+        turn_id: None,
+        event_seq: now.timestamp_millis().max(0) as u64,
+        timestamp: now.to_rfc3339(),
+        category: "reclamation".to_string(),
+        action: "sweep".to_string(),
+        status: autonoetic_types::causal_chain::EntryStatus::Success.to_string(),
+        enforced_rules: rules,
+        target: None,
+        payload: serde_json::to_string(&payload).ok(),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    })?;
+
+    Ok(())
+}
+
+/// Summary of reclaimed resources in a single sweep run.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct ReclamationSummary {
+    pub content_blobs: u64,
+    pub expired_memories: u64,
+    pub archived_revisions: u64,
+    pub orphaned_sessions: u64,
+    pub stale_jobs: u64,
+}
+
+impl ReclamationSummary {
+    pub fn has_work(&self) -> bool {
+        self.content_blobs > 0
+            || self.expired_memories > 0
+            || self.archived_revisions > 0
+            || self.orphaned_sessions > 0
+            || self.stale_jobs > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler::gateway_store::GatewayStore;
+
+    #[test]
+    fn test_is_reclamation_due_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = ReclamationConfig {
+            enabled: true,
+            min_interval_secs: 3600,
+            ..Default::default()
+        };
+        let now = chrono::Utc::now();
+        assert!(is_reclamation_due(dir.path(), &config, &now));
+    }
+
+    #[test]
+    fn test_is_reclamation_due_recent_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = ReclamationConfig {
+            enabled: true,
+            min_interval_secs: 3600,
+            ..Default::default()
+        };
+        let now = chrono::Utc::now();
+
+        // Record a run 5 minutes ago
+        let recent = (now - chrono::Duration::minutes(5)).to_rfc3339();
+        std::fs::write(dir.path().join(RECLAMATION_STATE_FILE), &recent).unwrap();
+
+        assert!(!is_reclamation_due(dir.path(), &config, &now));
+    }
+
+    #[test]
+    fn test_is_reclamation_due_old_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = ReclamationConfig {
+            enabled: true,
+            min_interval_secs: 3600,
+            ..Default::default()
+        };
+        let now = chrono::Utc::now();
+
+        // Record a run 2 hours ago
+        let old = (now - chrono::Duration::hours(2)).to_rfc3339();
+        std::fs::write(dir.path().join(RECLAMATION_STATE_FILE), &old).unwrap();
+
+        assert!(is_reclamation_due(dir.path(), &config, &now));
+    }
+
+    #[test]
+    fn test_reclamation_summary_has_work() {
+        let s = ReclamationSummary::default();
+        assert!(!s.has_work());
+
+        let s = ReclamationSummary {
+            content_blobs: 5,
+            ..Default::default()
+        };
+        assert!(s.has_work());
+    }
+}

--- a/autonoetic-gateway/tests/constitution_gate_enforced_rules.rs
+++ b/autonoetic-gateway/tests/constitution_gate_enforced_rules.rs
@@ -84,6 +84,7 @@ fn r3_pre_validated_bypass_enforces_r_2_6() -> Result<()> {
         summary: "test".into(),
         approval_ref: None,
         pre_validated: true,
+        turn_id: None,
     })?;
 
     assert!(result.is_cleared());
@@ -130,6 +131,7 @@ fn r3_session_grant_clearance_enforces_r_2_4() -> Result<()> {
         summary: "test".into(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     assert!(result.is_cleared());
@@ -165,6 +167,7 @@ fn r3_dedup_enforces_r_2_3() -> Result<()> {
         summary: "first".into(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     let result2 = svc.check(GateRequest {
@@ -181,6 +184,7 @@ fn r3_dedup_enforces_r_2_3() -> Result<()> {
         summary: "second".into(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     assert!(matches!(result2, GateResult::AlreadyPending { .. }));
@@ -214,6 +218,7 @@ fn r3_new_approval_enforces_r_2_1_r_2_2_r_2_18() -> Result<()> {
         summary: "fetch API".into(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     assert!(matches!(result, GateResult::Suspended { .. }));
@@ -279,6 +284,7 @@ fn r3_approval_ref_clearance_enforces_r_2_6() -> Result<()> {
         summary: "test".into(),
         approval_ref: Some(&ref_id),
         pre_validated: false,
+        turn_id: None,
     })?;
 
     assert!(result.is_cleared());
@@ -311,6 +317,7 @@ fn r3_user_input_gate_enforces_r_2_13_r_2_18() -> Result<()> {
             kind: "clarification".into(),
             options: None,
             allow_freeform: true,
+            context: None,
         },
         manifest: &manifest,
         session_id: Some("ses-ui"),
@@ -320,6 +327,7 @@ fn r3_user_input_gate_enforces_r_2_13_r_2_18() -> Result<()> {
         summary: String::new(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     assert!(matches!(result, GateResult::Suspended { .. }));
@@ -348,6 +356,7 @@ fn r3_escalation_gate_enforces_r_2_18() -> Result<()> {
         summary: String::new(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     assert!(matches!(result, GateResult::Suspended { .. }));
@@ -378,6 +387,7 @@ fn r_2_19_gate_enrichment_recorded_with_sender() -> Result<()> {
         summary: "fetch data".into(),
         approval_ref: None,
         pre_validated: false,
+        turn_id: None,
     })?;
 
     let gate_id = match result {

--- a/autonoetic-gateway/tests/constitution_r_2_14_user_ask_pending_approvals.rs
+++ b/autonoetic-gateway/tests/constitution_r_2_14_user_ask_pending_approvals.rs
@@ -105,8 +105,8 @@ fn r_2_14_user_ask_refused_when_pending_approval_exists() -> anyhow::Result<()> 
     assert_eq!(response["error_type"], "conflict");
     let message = response["message"].as_str().unwrap_or_default();
     assert!(
-        message.contains("pending approvals"),
-        "expected pending-approval block message, got: {message}"
+        message.contains("gates are pending"),
+        "expected pending-gates block message, got: {message}"
     );
 
     Ok(())

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1102,12 +1102,25 @@ fn default_system_agent_enabled() -> bool {
 }
 
 /// Chat TUI configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatConfig {
     /// Allow inline approval of pending requests from the chat TUI (Ctrl+A).
-    /// Disabled by default — the approval channel may be separated from chat.
-    #[serde(default)]
+    /// Defaults to true for interactive local use; set `false` to require
+    /// `autonoetic gateway approvals …` outside the chat pane.
+    #[serde(default = "default_chat_inline_approvals")]
     pub inline_approvals: bool,
+}
+
+fn default_chat_inline_approvals() -> bool {
+    true
+}
+
+impl Default for ChatConfig {
+    fn default() -> Self {
+        Self {
+            inline_approvals: default_chat_inline_approvals(),
+        }
+    }
 }
 
 /// Approval level / escalation configuration.

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -806,6 +806,12 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub retention: RetentionConfig,
 
+    /// Resource reclamation (garbage collection) settings.
+    /// Idempotent sweep for content blobs, old revisions, expired memories,
+    /// orphaned sessions, and stale scheduled jobs.
+    #[serde(default)]
+    pub reclamation: ReclamationConfig,
+
     /// Response validation gate configuration.
     /// When enabled, the gateway validates agent outputs against declared constraints
     /// in agent metadata before returning SpawnResult to the caller.
@@ -1182,6 +1188,73 @@ fn default_retention_execution_traces_days() -> u32 {
 fn default_retention_causal_events_days() -> u32 {
     90
 }
+
+/// Configuration for resource reclamation (garbage collection).
+///
+/// The reclamation sweep runs on a configurable schedule and reclaims:
+/// - Content blobs with zero remaining name references
+/// - Memories past their `expires_at` deadline
+/// - Archived agent revisions older than N days
+/// - Orphaned sessions not resumed within N days
+/// - Stale scheduled jobs whose root session has been closed for > N days
+///
+/// The sweep is idempotent, conservative (only deletes provably unreferenced data),
+/// and every deletion is recorded in the causal event chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReclamationConfig {
+    /// Enable the reclamation sweep. Default: false (opt-in).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Minimum interval (seconds) between sweeps. Default: 86400 (24h).
+    #[serde(default = "default_reclamation_interval_secs")]
+    pub min_interval_secs: u64,
+
+    /// Delete content blobs with zero remaining name references after N days.
+    /// 0 = skip this category. Default: 90.
+    #[serde(default = "default_reclamation_content_blob_days")]
+    pub content_blob_max_age_days: u64,
+
+    /// Delete memories whose `expires_at` has passed.
+    /// Always runs if `expires_at` is set on memories (column-level, not config-level).
+    /// This is a safety switch: 0 = skip. Default: 0 (skip).
+    #[serde(default)]
+    pub expired_memory_retention_days: u64,
+
+    /// Delete archived agent revisions older than N days. 0 = skip. Default: 180.
+    #[serde(default = "default_reclamation_archived_revision_days")]
+    pub archived_revision_max_age_days: u64,
+
+    /// Mark sessions as closed if they are still `active` and their last activity
+    /// is older than N days. 0 = skip. Default: 30.
+    #[serde(default = "default_reclamation_orphaned_session_days")]
+    pub orphaned_session_max_age_days: u64,
+
+    /// Cancel `active` scheduled jobs whose root session has been closed for
+    /// more than N days. 0 = skip. Default: 60.
+    #[serde(default = "default_reclamation_stale_job_days")]
+    pub stale_job_max_age_days: u64,
+}
+
+impl Default for ReclamationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_interval_secs: 86400,
+            content_blob_max_age_days: 90,
+            expired_memory_retention_days: 0,
+            archived_revision_max_age_days: 180,
+            orphaned_session_max_age_days: 30,
+            stale_job_max_age_days: 60,
+        }
+    }
+}
+
+fn default_reclamation_interval_secs() -> u64 { 86400 }
+fn default_reclamation_content_blob_days() -> u64 { 90 }
+fn default_reclamation_archived_revision_days() -> u64 { 180 }
+fn default_reclamation_orphaned_session_days() -> u64 { 30 }
+fn default_reclamation_stale_job_days() -> u64 { 60 }
 
 /// Configuration for the response validation gate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1676,6 +1749,7 @@ impl Default for GatewayConfig {
             evidence_mode: default_evidence_mode(),
             digest_agent: DigestAgentConfig::default(),
             retention: RetentionConfig::default(),
+            reclamation: ReclamationConfig::default(),
             response_validation: ResponseValidationConfig::default(),
             sandbox: SandboxConfig::default(),
             max_session_turns: default_max_session_turns(),

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -171,6 +171,11 @@ pub struct RunArgs {
     /// Stable conversation/session identifier.
     #[arg(long)]
     pub session_id: Option<String>,
+    /// Re-copy bundled reference agents from the Autonoetic repo and re-bootstrap gateway revisions
+    /// (equivalent to `autonoetic agent bootstrap --overwrite`). Use after upgrading the binary or when
+    /// reference bundles changed (e.g. new `runtime.lock` or manifest fields).
+    #[arg(long)]
+    pub overwrite: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -176,6 +176,10 @@ pub struct RunArgs {
     /// reference bundles changed (e.g. new `runtime.lock` or manifest fields).
     #[arg(long)]
     pub overwrite: bool,
+    /// Interactively select a new provider/model, update config, patch agent
+    /// SKILL.md files, and create new revisions. Old revisions are preserved.
+    #[arg(long)]
+    pub refresh_models: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -534,6 +538,10 @@ pub enum AgentCommands {
         /// Overwrite existing target agent directories
         #[arg(long)]
         overwrite: bool,
+        /// Interactively select a new provider/model, update config, patch agent
+        /// SKILL.md files, and create new revisions. Old revisions are preserved.
+        #[arg(long)]
+        refresh_models: bool,
     },
     /// Inspect mutable alias bindings and active revisions
     Alias {

--- a/autonoetic/src/cli/model_discovery.rs
+++ b/autonoetic/src/cli/model_discovery.rs
@@ -499,7 +499,7 @@ fn read_line_with_prompt(prompt: &str) -> anyhow::Result<String> {
 /// Returns `(provider_name, original_entry_name, model_id)` ready for config generation.
 pub async fn interactive_select(
     client: &reqwest::Client,
-) -> anyhow::Result<(String, String, String)> {
+) -> anyhow::Result<(String, String, String, Option<String>)> {
     let mut stderr = io::stderr();
 
     writeln!(stderr, "\n  Detecting available LLM providers...")?;
@@ -600,8 +600,11 @@ pub async fn interactive_select(
         provider_entry.entry.display
     )?;
 
-    let models = match fetch_models(client, &provider_entry).await {
-        Ok(m) if !m.is_empty() => m,
+    let (models, chat_base_url) = match fetch_models(client, &provider_entry).await {
+        Ok(m) if !m.is_empty() => {
+            let base_url = prompt_base_url_if_local(&provider_entry.entry)?;
+            (m, base_url)
+        }
         Ok(_) => {
             writeln!(stderr, "  No models returned. You can enter a model ID manually.")?;
             let model = read_line_with_prompt("  Model ID: ")?;
@@ -609,19 +612,88 @@ pub async fn interactive_select(
                 anyhow::bail!("Model ID cannot be empty");
             }
             let name = provider_entry.entry.name.to_string();
-            return Ok((name.clone(), name, model));
+            let base_url = prompt_base_url_if_local(&provider_entry.entry)?;
+            return Ok((name.clone(), name, model, base_url));
         }
-        Err(e) => {
-            writeln!(
-                stderr,
-                "  Could not fetch models ({e}). You can enter a model ID manually."
-            )?;
-            let model = read_line_with_prompt("  Model ID: ")?;
-            if model.is_empty() {
-                anyhow::bail!("Model ID cannot be empty");
+        Err(first_err) => {
+            if let ProviderKind::Local { models_url } = &provider_entry.entry.kind {
+                let default_base = models_url
+                    .trim_end_matches("/models")
+                    .trim_end_matches("/tags");
+                writeln!(
+                    stderr,
+                    "  Could not fetch models ({first_err})."
+                )?;
+                writeln!(
+                    stderr,
+                    "  Default base URL: {}. Enter a different host/port to retry.",
+                    default_base
+                )?;
+                let custom = read_line_with_prompt(&format!(
+                    "  Base URL (Enter for {}): ", default_base
+                ))?;
+                let retry_base = if custom.trim().is_empty() {
+                    default_base.to_string()
+                } else {
+                    let trimmed = custom.trim().trim_end_matches('/');
+                    trimmed.to_string()
+                };
+                let retry_models_url = if provider_entry.entry.name == "ollama" {
+                    format!("{}/api/tags", retry_base)
+                } else {
+                    format!("{}/models", retry_base)
+                };
+                let retry_entry = ProviderEntry {
+                    name: provider_entry.entry.name,
+                    display: provider_entry.entry.display,
+                    kind: ProviderKind::Local { models_url: Box::leak(retry_models_url.into_boxed_str()) },
+                };
+                let retry_provider = DetectedProvider {
+                    entry: retry_entry,
+                    source: provider_entry.source.clone(),
+                };
+                match fetch_models(client, &retry_provider).await {
+                    Ok(m) if !m.is_empty() => {
+                        let chat_url = format!("{}/chat/completions", retry_base);
+                        eprintln!("  Found {} model(s).", m.len());
+                        (m, Some(chat_url))
+                    }
+                    Ok(_) => {
+                        writeln!(stderr, "  Still no models. Enter a model ID manually.")?;
+                        let model = read_line_with_prompt("  Model ID: ")?;
+                        if model.is_empty() {
+                            anyhow::bail!("Model ID cannot be empty");
+                        }
+                        let chat_url = format!("{}/chat/completions", retry_base);
+                        let name = provider_entry.entry.name.to_string();
+                        return Ok((name.clone(), name, model, Some(chat_url)));
+                    }
+                    Err(e2) => {
+                        writeln!(
+                            stderr,
+                            "  Retry also failed ({e2}). Enter a model ID manually."
+                        )?;
+                        let model = read_line_with_prompt("  Model ID: ")?;
+                        if model.is_empty() {
+                            anyhow::bail!("Model ID cannot be empty");
+                        }
+                        let chat_url = format!("{}/chat/completions", retry_base);
+                        let name = provider_entry.entry.name.to_string();
+                        return Ok((name.clone(), name, model, Some(chat_url)));
+                    }
+                }
+            } else {
+                writeln!(
+                    stderr,
+                    "  Could not fetch models ({first_err}). You can enter a model ID manually."
+                )?;
+                let model = read_line_with_prompt("  Model ID: ")?;
+                if model.is_empty() {
+                    anyhow::bail!("Model ID cannot be empty");
+                }
+                let name = provider_entry.entry.name.to_string();
+                return Ok((name.clone(), name, model, None));
             }
-            let name = provider_entry.entry.name.to_string();
-            return Ok((name.clone(), name, model));
         }
     };
 
@@ -645,13 +717,32 @@ pub async fn interactive_select(
         }
     };
 
-    let provider_name = if provider_entry.entry.name == "llamacpp" {
-        "openai".to_string()
-    } else {
-        provider_entry.entry.name.to_string()
-    };
+    let provider_name = provider_entry.entry.name.to_string();
 
-    Ok((provider_name, provider_entry.entry.name.to_string(), model_id))
+    Ok((provider_name, provider_entry.entry.name.to_string(), model_id, chat_base_url))
+}
+
+fn prompt_base_url_if_local(entry: &ProviderEntry) -> anyhow::Result<Option<String>> {
+    if let ProviderKind::Local { models_url } = &entry.kind {
+        let default_base = models_url
+            .trim_end_matches("/models")
+            .trim_end_matches("/tags");
+        let default_chat = format!("{}/chat/completions", default_base);
+        let mut stderr = io::stderr();
+        writeln!(
+            stderr,
+            "\n  Base URL for chat completions (Enter for {}):",
+            default_chat
+        )?;
+        let input = read_line_with_prompt("  URL: ")?;
+        if input.trim().is_empty() {
+            Ok(Some(default_chat))
+        } else {
+            Ok(Some(input.trim().to_string()))
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 fn display_model_menu(models: &[ModelInfo]) -> anyhow::Result<()> {
@@ -708,7 +799,7 @@ fn display_model_menu(models: &[ModelInfo]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn manual_entry() -> anyhow::Result<(String, String, String)> {
+fn manual_entry() -> anyhow::Result<(String, String, String, Option<String>)> {
     let mut stderr = io::stderr();
     writeln!(
         stderr,
@@ -725,13 +816,16 @@ fn manual_entry() -> anyhow::Result<(String, String, String)> {
     }
 
     let original = provider.clone();
-    let effective_provider = if provider == "llamacpp" || provider == "llama.cpp" {
-        "openai".to_string()
+    let is_local = ["ollama", "lmstudio", "vllm", "llamacpp", "llama.cpp"].contains(&original.as_str());
+
+    let base_url = if is_local {
+        let url = read_line_with_prompt("  Base URL (e.g. http://host:port/v1/chat/completions): ")?;
+        if url.trim().is_empty() { None } else { Some(url.trim().to_string()) }
     } else {
-        provider
+        None
     };
 
-    Ok((effective_provider, original, model))
+    Ok((original.clone(), original, model, base_url))
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/autonoetic/src/cli/run.rs
+++ b/autonoetic/src/cli/run.rs
@@ -71,6 +71,9 @@ llm_preset_mapping:
 
     std::fs::write(config_path, &config_content)?;
     eprintln!("\n  Config written to {}", config_path.display());
+    if let Some(ref url) = base_url {
+        eprintln!("  Base URL: {}", url);
+    }
 
     prompt_persona(config_dir)?;
 
@@ -171,6 +174,9 @@ pub async fn refresh_models(config_path: &Path) -> anyhow::Result<()> {
     if updated != current {
         std::fs::write(config_path, &updated)?;
         eprintln!("  Config updated: provider={}, model={}", provider, model);
+        if let Some(ref url) = base_url {
+            eprintln!("  Base URL: {}", url);
+        }
     } else {
         eprintln!("  Config unchanged: provider={}, model={}", provider, model);
     }

--- a/autonoetic/src/cli/run.rs
+++ b/autonoetic/src/cli/run.rs
@@ -109,13 +109,15 @@ fn prompt_persona(config_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn ensure_bootstrap(config_path: &Path) -> anyhow::Result<()> {
+fn ensure_bootstrap(config_path: &Path, overwrite: bool) -> anyhow::Result<()> {
     let config = autonoetic_gateway::config::load_config(config_path)?;
-    if config.agents_dir.exists() && config.agents_dir.read_dir()?.next().is_some() {
+    let agents_populated = config.agents_dir.exists()
+        && config.agents_dir.read_dir()?.next().is_some();
+    if agents_populated && !overwrite {
         return Ok(());
     }
     eprintln!("  Bootstrapping agents...");
-    super::agent::handle_agent_bootstrap(config_path, None, false)?;
+    super::agent::handle_agent_bootstrap(config_path, None, overwrite)?;
     Ok(())
 }
 
@@ -129,7 +131,7 @@ pub async fn handle_run(
     };
 
     ensure_config(&config_path).await?;
-    ensure_bootstrap(&config_path)?;
+    ensure_bootstrap(&config_path, args.overwrite)?;
 
     if std::env::var("AUTONOETIC_SHARED_SECRET").is_err() {
         let secret = uuid::Uuid::new_v4().to_string();
@@ -166,6 +168,12 @@ pub async fn handle_run(
     if !ready {
         eprintln!("Warning: gateway did not become ready within timeout. Chat may fail to connect.");
     }
+
+    let log_dir = gateway_config.agents_dir.join(".gateway").join("logs");
+    eprintln!(
+        "  Tracing output: {0} — run `tail -f {0}/*.log` in another terminal for live gateway logs.",
+        log_dir.display()
+    );
 
     let result = super::chat::handle_chat(&config_path, &chat_args).await;
 

--- a/autonoetic/src/cli/run.rs
+++ b/autonoetic/src/cli/run.rs
@@ -22,7 +22,7 @@ async fn ensure_config(config_path: &Path) -> anyhow::Result<()> {
         .timeout(std::time::Duration::from_secs(15))
         .build()?;
 
-    let (provider, original_entry, model) = super::model_discovery::interactive_select(&client).await?;
+    let (provider, _original_entry, model, base_url) = super::model_discovery::interactive_select(&client).await?;
 
     let config_dir = config_path.parent().unwrap_or(Path::new("."));
     std::fs::create_dir_all(config_dir)?;
@@ -30,9 +30,9 @@ async fn ensure_config(config_path: &Path) -> anyhow::Result<()> {
     let agents_dir = config_dir.join("agents");
     let agents_dir_str = agents_dir.to_string_lossy();
 
-    let base_url_line = match original_entry.as_str() {
-        "llamacpp" => "\n    base_url: \"http://localhost:8080/v1/chat/completions\"".to_string(),
-        _ => String::new(),
+    let base_url_line = match base_url {
+        Some(ref url) => format!("\n    base_url: \"{}\"", url),
+        None => String::new(),
     };
 
     let config_content = format!(
@@ -121,6 +121,102 @@ fn ensure_bootstrap(config_path: &Path, overwrite: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub async fn refresh_models(config_path: &Path) -> anyhow::Result<()> {
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+    let agents_dir = &config.agents_dir;
+    anyhow::ensure!(
+        agents_dir.exists(),
+        "Agents directory not found at {}. Run `autonoetic run` first.",
+        agents_dir.display()
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
+    let (provider, original_entry, model, base_url) = match super::model_discovery::interactive_select(&client).await {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("  Model selection skipped ({}). Using current config.", e);
+            return Ok(());
+        }
+    };
+
+    let current = std::fs::read_to_string(config_path).unwrap_or_default();
+
+    let re_provider = regex::Regex::new(r#"(provider:\s*)"[^"]*""#).unwrap();
+    let re_model = regex::Regex::new(r#"(model:\s*)"[^"]*""#).unwrap();
+    let re_base_url = regex::Regex::new(r#"(base_url:\s*)"[^"]*""#).unwrap();
+
+    let mut updated = current.clone();
+    if let Some(cap) = re_provider.captures(&updated) {
+        updated = updated.replacen(&cap[0], &format!("provider: \"{}\"", provider), 1);
+    }
+    if let Some(cap) = re_model.captures(&updated) {
+        updated = updated.replacen(&cap[0], &format!("model: \"{}\"", model), 1);
+    }
+    match (&base_url, re_base_url.captures(&updated)) {
+        (Some(url), Some(cap)) => {
+            updated = updated.replacen(&cap[0], &format!("base_url: \"{}\"", url), 1);
+        }
+        (Some(url), None) => {
+            if let Some(re) = regex::Regex::new(r#"(model:\s*"[^"]*"\s*\n)"#).ok() {
+                updated = re.replace(&updated, format!("${{1}}    base_url: \"{}\"\n", url)).to_string();
+            }
+        }
+        (None, Some(_)) => {}
+        (None, None) => {}
+    }
+    if updated != current {
+        std::fs::write(config_path, &updated)?;
+        eprintln!("  Config updated: provider={}, model={}", provider, model);
+    } else {
+        eprintln!("  Config unchanged: provider={}, model={}", provider, model);
+    }
+
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+
+    let mut patched = 0usize;
+    let mut unchanged = 0usize;
+    for entry in std::fs::read_dir(&config.agents_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let skill_path = entry.path().join("SKILL.md");
+        if !skill_path.exists() {
+            continue;
+        }
+        let agent_dir_name = entry.file_name().to_string_lossy().to_string();
+        let content = std::fs::read_to_string(&skill_path)?;
+        if let Some(patched_content) = super::agent::apply_llm_preset_to_skill(
+            &content, &config, &agent_dir_name,
+        ) {
+            std::fs::write(&skill_path, &patched_content)?;
+            patched += 1;
+            eprintln!("  Patched model for '{}'", agent_dir_name);
+        } else {
+            unchanged += 1;
+        }
+    }
+
+    if patched > 0 {
+        let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+        let activated = autonoetic_gateway::bootstrap_agents(&config, &gateway_dir)?;
+        eprintln!(
+            "  Models refreshed: {} patched, {} unchanged, {} new revisions.",
+            patched, unchanged, activated
+        );
+    } else {
+        eprintln!(
+            "  All agents already use the configured model ({} checked).",
+            patched + unchanged
+        );
+    }
+    Ok(())
+}
+
 pub async fn handle_run(
     config_override: Option<&str>,
     args: &super::common::RunArgs,
@@ -132,6 +228,9 @@ pub async fn handle_run(
 
     ensure_config(&config_path).await?;
     ensure_bootstrap(&config_path, args.overwrite)?;
+    if args.refresh_models {
+        refresh_models(&config_path).await?;
+    }
 
     if std::env::var("AUTONOETIC_SHARED_SECRET").is_err() {
         let secret = uuid::Uuid::new_v4().to_string();

--- a/autonoetic/src/cli/run.rs
+++ b/autonoetic/src/cli/run.rs
@@ -183,6 +183,12 @@ pub async fn refresh_models(config_path: &Path) -> anyhow::Result<()> {
 
     let config = autonoetic_gateway::config::load_config(config_path)?;
 
+    let resolved = super::agent::resolve_llm_config(&config, Some("planner"), None, None, None);
+    eprintln!(
+        "  Resolved preset: provider={}, model={}, base_url={:?}",
+        resolved.provider, resolved.model, resolved.base_url
+    );
+
     let mut patched = 0usize;
     let mut unchanged = 0usize;
     for entry in std::fs::read_dir(&config.agents_dir)? {

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -20,13 +20,15 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| dirs_or_default().join("config.yaml"));
 
     // `tracing_subscriber::fmt` defaults to stdout; the chat TUI also uses stdout (ratatui), so
-    // INFO lines (e.g. gateway `approval` events) corrupt the alternate screen. Chat therefore
-    // logs only to a rolling file under {agents_dir}/.gateway/logs/. Other commands log to stderr.
+    // INFO lines (e.g. gateway events) corrupt the alternate screen. `chat` and `run` therefore
+    // log only to a rolling file under {agents_dir}/.gateway/logs/. `gateway start` still mirrors
+    // to stderr (daemon/long-running server). Other commands log to stderr.
     let is_gateway_start = matches!(
         &cli.command,
         Commands::Gateway(args) if matches!(args.command, cli::common::GatewayCommands::Start { .. })
     );
     let is_chat = matches!(&cli.command, Commands::Chat(_));
+    let is_run = matches!(&cli.command, Commands::Run(_));
 
     if is_gateway_start {
         let config = autonoetic_gateway::config::load_config(&config_path)?;
@@ -54,14 +56,19 @@ async fn main() -> anyhow::Result<()> {
         // Keep the guard alive for the process lifetime
         // (it gets dropped when main returns, which flushes remaining logs)
         std::mem::forget(_guard);
-    } else if is_chat {
+    } else if is_chat || is_run {
         let config = autonoetic_gateway::config::load_config(&config_path)?;
         let log_dir = config.agents_dir.join(".gateway").join("logs");
         std::fs::create_dir_all(&log_dir)?;
+        let filename_prefix = if is_run {
+            "run"
+        } else {
+            "chat-cli"
+        };
         let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
             .rotation(tracing_appender::rolling::Rotation::DAILY)
             .max_log_files(5)
-            .filename_prefix("chat-cli")
+            .filename_prefix(filename_prefix)
             .filename_suffix("log")
             .build(&log_dir)
             .map_err(|e| anyhow::anyhow!("Failed to create log appender: {}", e))?;

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -185,8 +185,11 @@ async fn main() -> anyhow::Result<()> {
             cli::common::AgentCommands::List => {
                 cli::agent::handle_agent_list(&config_path).await?;
             }
-            cli::common::AgentCommands::Bootstrap { from, overwrite } => {
+            cli::common::AgentCommands::Bootstrap { from, overwrite, refresh_models } => {
                 cli::agent::handle_agent_bootstrap(&config_path, from.as_deref(), *overwrite)?;
+                if *refresh_models {
+                    cli::run::refresh_models(&config_path).await?;
+                }
             }
             cli::common::AgentCommands::Alias { command } => {
                 cli::agent::handle_agent_alias(&config_path, command)?;

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -242,6 +242,18 @@ retention:
   execution_traces_days: 30
   causal_events_days: 90
 
+# ── Resource Reclamation ──────────────────────────────────────────────
+# Idempotent garbage collection for content blobs, old revisions,
+# expired memories, orphaned sessions, and stale scheduled jobs.
+# Disabled by default; enable with caution.
+#reclamation:
+#  enabled: true
+#  min_interval_secs: 86400              # daily at most
+#  content_blob_max_age_days: 90
+#  archived_revision_max_age_days: 180
+#  orphaned_session_max_age_days: 30
+#  stale_job_max_age_days: 60
+
 # ── Post-Session Digest ───────────────────────────────────────────────
 # LLM summarization + memory extraction after sessions complete.
 # Uncomment to enable.

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -140,9 +140,10 @@ approval_timeout_secs: 600
 #       - constitutional-observer.default
 
 # ── Chat TUI ──────────────────────────────────────────────────────────
-# Inline approval from the chat interface (Ctrl+A).
+# Inline approval from the chat interface (Ctrl+A). Default: true; set false to
+# require resolving approvals only via `autonoetic gateway approvals` (separate pane / process).
 chat:
-  inline_approvals: true   # Allow Ctrl+A to approve the latest pending approval
+  inline_approvals: true
 
 # ── Approval Levels ───────────────────────────────────────────────────
 # Escalation: require higher authority for sensitive actions.


### PR DESCRIPTION
## Summary

Implements a configurable, idempotent **resource reclamation sweep** that garbage-collects five categories of accumulated data:

1. **Content blobs** — Delete blobs with zero remaining name references across all session manifests
2. **Expired memories** — Delete memories past their `expires_at` deadline
3. **Archived revisions** — Delete agent revisions in `Archived` status older than N days
4. **Orphaned sessions** — Mark sessions still `active` whose last activity is older than N days as `closed`
5. **Stale scheduled jobs** — Cancel `active` jobs whose root session has been closed for > N days

The sweep follows the architecture's principles:
- **Dumb gateway**: just counts references and checks timestamps, no judgment
- **Mechanical rule**: "no references + older than N days = delete"
- **Conservative**: only deletes provably unreferenced data
- **Logged**: every deletion is recorded in a `reclamation.sweep` causal event

## Configuration

The sweep is **opt-in** (disabled by default). Enable it in the config:

```yaml
reclamation:
  enabled: true
  min_interval_secs: 86400          # daily at most
  content_blob_max_age_days: 90
  archived_revision_max_age_days: 180
  orphaned_session_max_age_days: 30
  stale_job_max_age_days: 60
```

## Files Changed

| File | Change |
|------|--------|
| `autonoetic-types/src/config.rs` | Add `ReclamationConfig` struct + field in `GatewayConfig` |
| `autonoetic-gateway/src/scheduler/gateway_store/reclamation.rs` | SQL queries for each reclamation category |
| `autonoetic-gateway/src/scheduler/reclamation.rs` | Sweep orchestration, schedule guard, causal event emission |
| `autonoetic-gateway/src/scheduler.rs` | Wire reclamation sweep into scheduler tick |
| `autonoetic-gateway/src/scheduler/gateway_store/mod.rs` | Module registration |
| `config/config-template.yaml` | Document reclamation config section |

Fixes #13