### PR TITLE
feat(promotion): safety governor — velocity, flapping, eval-regression gates (#25)

### DIFF
--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -33,6 +33,7 @@ pub mod network_policy;
 pub mod openrouter_catalog;
 pub mod parser;
 pub mod post_session_digest;
+pub mod promotion_governor;
 pub mod promotion_store;
 pub mod prompt_budget;
 pub mod quality_signal;

--- a/autonoetic-gateway/src/runtime/promotion_governor.rs
+++ b/autonoetic-gateway/src/runtime/promotion_governor.rs
@@ -1,0 +1,383 @@
+//! Promotion safety governor (issue #25).
+//!
+//! Gate-level checks applied at `agent.revision.promote` *before* the actual
+//! `atomic_promote` write. Three independent signals:
+//!
+//! 1. **Velocity** — too many promotions per alias inside a window.
+//! 2. **Flapping** — re-promoting a revision that was already promoted recently
+//!    on this alias (A→B→A or A→B→A→B pattern).
+//! 3. **Eval-regression** — the per-revision count of non-info findings is
+//!    monotonically increasing across recent promotions.
+//!
+//! All three are gated on the same `PromotionGovernorConfig.enabled` flag and
+//! all three are bypassable via an explicit operator force (`force: true` +
+//! required `force_reason`). Bypass emits a `governor.override` causal event.
+//!
+//! Operator-side throughput safeguards on the federation escalation channel
+//! (also discussed in issue #25) are a separate concern handled outside this
+//! module — see `promotion-federation-followup-review.md` §5.
+
+use std::path::Path;
+
+use anyhow::Result;
+use autonoetic_types::config::PromotionGovernorConfig;
+use autonoetic_types::promotion::{Finding, FindingSeverity};
+
+use crate::scheduler::gateway_store::GatewayStore;
+
+/// Structured rejection returned by the governor. Convert to the tool's
+/// JSON error response via [`GovernorRejection::to_tool_error`].
+#[derive(Debug, Clone)]
+pub struct GovernorRejection {
+    /// Stable machine-readable error code (e.g. `promotion_velocity_exceeded`).
+    pub error: &'static str,
+    /// Human-readable message included in the tool response.
+    pub message: String,
+    /// Hint shown to the caller.
+    pub repair_hint: String,
+    /// Extra fields merged into the JSON response (e.g. `recent_promotions`,
+    /// `next_allowed_at`, `recent_revisions`).
+    pub payload: serde_json::Value,
+}
+
+impl GovernorRejection {
+    /// Render the rejection as the `{ok: false, error_type: "governor", ...}`
+    /// shape the promote tool returns to the caller.
+    pub fn to_tool_error(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert("ok".to_string(), serde_json::Value::Bool(false));
+        obj.insert(
+            "error_type".to_string(),
+            serde_json::Value::String("governor".to_string()),
+        );
+        obj.insert(
+            "error".to_string(),
+            serde_json::Value::String(self.error.to_string()),
+        );
+        obj.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.message.clone()),
+        );
+        obj.insert(
+            "repair_hint".to_string(),
+            serde_json::Value::String(self.repair_hint.clone()),
+        );
+        if let serde_json::Value::Object(extra) = &self.payload {
+            for (k, v) in extra {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+        serde_json::Value::Object(obj)
+    }
+}
+
+/// Run all enabled governor checks. Returns the first rejection found, or
+/// `Ok(None)` when promotion may proceed (also `None` when the governor is
+/// disabled or the caller passed `force=true`).
+pub fn run_governor_checks(
+    config: &PromotionGovernorConfig,
+    store: &GatewayStore,
+    gateway_dir: &Path,
+    agent_id: &str,
+    revision_id: &str,
+) -> Result<Option<GovernorRejection>> {
+    if !config.enabled {
+        return Ok(None);
+    }
+    if let Some(r) = check_velocity(config, store, agent_id)? {
+        return Ok(Some(r));
+    }
+    if let Some(r) = check_flapping(config, store, agent_id, revision_id)? {
+        return Ok(Some(r));
+    }
+    if let Some(r) = check_eval_regression(config, store, gateway_dir, agent_id)? {
+        return Ok(Some(r));
+    }
+    Ok(None)
+}
+
+/// Velocity check: count `Promote` rows for the alias in the configured
+/// window; reject when the count >= the configured cap.
+pub fn check_velocity(
+    config: &PromotionGovernorConfig,
+    store: &GatewayStore,
+    agent_id: &str,
+) -> Result<Option<GovernorRejection>> {
+    if config.max_promotions_per_window == 0 || config.velocity_window_hours == 0 {
+        return Ok(None);
+    }
+    let window = chrono::Duration::hours(config.velocity_window_hours as i64);
+    let since = chrono::Utc::now() - window;
+    let since_rfc = since.to_rfc3339();
+    let count = store.count_promotions_since(agent_id, &since_rfc)?;
+    if count < config.max_promotions_per_window {
+        return Ok(None);
+    }
+    let next_allowed_at = compute_next_allowed_at(store, agent_id, config)?;
+    Ok(Some(GovernorRejection {
+        error: "promotion_velocity_exceeded",
+        message: format!(
+            "Promotion velocity exceeded for alias '{}': {} promotions in the last {}h \
+             (cap = {}). Wait until the oldest in-window promotion ages out, or retry \
+             with `force: true` and `force_reason`.",
+            agent_id, count, config.velocity_window_hours, config.max_promotions_per_window
+        ),
+        repair_hint: "Reduce promotion cadence, or pass `force: true` + `force_reason` to override."
+            .to_string(),
+        payload: serde_json::json!({
+            "alias": agent_id,
+            "window_hours": config.velocity_window_hours,
+            "recent_promotions": count,
+            "max_promotions_per_window": config.max_promotions_per_window,
+            "next_allowed_at": next_allowed_at,
+        }),
+    }))
+}
+
+/// Flapping check: scan the most recent `flapping_lookback` promotion rows.
+/// If the candidate `revision_id` appears among them, it means the alias is
+/// being moved *back* to a revision already promoted in the recent past —
+/// the canonical A→B→A oscillation signal.
+pub fn check_flapping(
+    config: &PromotionGovernorConfig,
+    store: &GatewayStore,
+    agent_id: &str,
+    candidate_revision_id: &str,
+) -> Result<Option<GovernorRejection>> {
+    if config.flapping_lookback == 0 {
+        return Ok(None);
+    }
+    let history = store.list_promotion_history(agent_id)?;
+    let recent: Vec<_> = history
+        .into_iter()
+        .filter(|r| matches!(r.kind, autonoetic_types::agent_revision::PromotionKind::Promote))
+        .take(config.flapping_lookback)
+        .collect();
+
+    if !recent
+        .iter()
+        .any(|r| r.new_revision_id == candidate_revision_id)
+    {
+        return Ok(None);
+    }
+
+    let recent_revs: Vec<String> = recent.iter().map(|r| r.new_revision_id.clone()).collect();
+    Ok(Some(GovernorRejection {
+        error: "promotion_flapping_detected",
+        message: format!(
+            "Promotion flapping detected: revision '{}' was already promoted to alias '{}' \
+             within the last {} promotions. Repeated A→B→A oscillation is a runaway-evolution \
+             signal; halt and investigate.",
+            candidate_revision_id, agent_id, config.flapping_lookback
+        ),
+        repair_hint:
+            "Investigate why this revision is being re-promoted. If the move is intentional \
+             (e.g. validated rollback-then-redo), retry with `force: true` + `force_reason`."
+                .to_string(),
+        payload: serde_json::json!({
+            "alias": agent_id,
+            "candidate_revision_id": candidate_revision_id,
+            "lookback": config.flapping_lookback,
+            "recent_revisions": recent_revs,
+        }),
+    }))
+}
+
+/// Eval-regression check: walk the most recent promotions, look up each
+/// revision's verdict findings, and count `eval_regression_streak`
+/// consecutive monotonic increases in the non-info finding count. The
+/// signal: even when the boolean `evaluator_pass` is `true`, a steady
+/// rise in warning/error findings means quality is drifting downward.
+pub fn check_eval_regression(
+    config: &PromotionGovernorConfig,
+    store: &GatewayStore,
+    gateway_dir: &Path,
+    agent_id: &str,
+) -> Result<Option<GovernorRejection>> {
+    if config.eval_regression_streak == 0 || config.eval_regression_lookback == 0 {
+        return Ok(None);
+    }
+    let history = store.list_promotion_history(agent_id)?;
+    let recent: Vec<_> = history
+        .into_iter()
+        .filter(|r| matches!(r.kind, autonoetic_types::agent_revision::PromotionKind::Promote))
+        .take(config.eval_regression_lookback)
+        .collect();
+
+    // promotion_store opens the on-disk JSON each call; cheap enough for
+    // the bounded lookback (≤ a few rows).
+    let promo_store = crate::runtime::promotion_store::PromotionStore::new(gateway_dir)?;
+
+    // Order recent[] is newest-first; reverse to oldest-first for monotonic
+    // comparison.
+    let mut counts: Vec<usize> = Vec::with_capacity(recent.len());
+    for entry in recent.iter().rev() {
+        let rev = match store.get_agent_revision(&entry.new_revision_id)? {
+            Some(r) => r,
+            None => continue,
+        };
+        let artifact_id = match rev.artifact_id.as_deref() {
+            Some(a) => a,
+            None => continue,
+        };
+        let record = match promo_store.get_promotion(artifact_id) {
+            Some(r) => r,
+            None => continue,
+        };
+        counts.push(non_info_finding_count(&record));
+    }
+
+    if counts.len() < config.eval_regression_streak + 1 {
+        return Ok(None);
+    }
+
+    let need = config.eval_regression_streak;
+    // Look at the last `need + 1` counts and check strict monotonic increase
+    // across the trailing window: c[k-need-1] < c[k-need] < ... < c[k-1].
+    let tail = &counts[counts.len() - (need + 1)..];
+    let monotonic = tail.windows(2).all(|w| w[0] < w[1]);
+    if !monotonic {
+        return Ok(None);
+    }
+
+    Ok(Some(GovernorRejection {
+        error: "promotion_eval_regression",
+        message: format!(
+            "Promotion eval-regression halt for alias '{}': non-info finding counts \
+             have strictly increased {} times in a row ({:?}). Even with `evaluator_pass=true`, \
+             this is degrading quality across revisions.",
+            agent_id, need, tail
+        ),
+        repair_hint:
+            "Inspect the last promotions' findings, address the worsening signals, then retry. \
+             Use `force: true` + `force_reason` to override after operator review."
+                .to_string(),
+        payload: serde_json::json!({
+            "alias": agent_id,
+            "streak_threshold": need,
+            "recent_finding_counts": tail,
+        }),
+    }))
+}
+
+/// Emit a `governor.rejected` causal event so the audit trail records the
+/// rejection (the tool response is also returned to the caller, but the
+/// event makes the rejection queryable later).
+pub fn emit_rejected_event(
+    store: &GatewayStore,
+    caller_agent_id: &str,
+    session_id: Option<&str>,
+    target_agent_id: &str,
+    revision_id: &str,
+    rejection: &GovernorRejection,
+) {
+    let event = autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: format!("gov-rej-{}", uuid::Uuid::new_v4()),
+        agent_id: caller_agent_id.to_string(),
+        session_id: session_id.unwrap_or("").to_string(),
+        turn_id: None,
+        event_seq: 0,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        category: "revision".to_string(),
+        action: "governor.rejected".to_string(),
+        status: "blocked".to_string(),
+        enforced_rules: Vec::new(),
+        target: Some(target_agent_id.to_string()),
+        payload: Some(
+            serde_json::json!({
+                "alias": target_agent_id,
+                "revision_id": revision_id,
+                "error": rejection.error,
+                "payload": rejection.payload,
+            })
+            .to_string(),
+        ),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: Some(rejection.message.clone()),
+    };
+    let _ = store.create_causal_event(&event);
+}
+
+/// Emit a `governor.override` causal event whenever the governor is bypassed
+/// via `force: true`. Records the operator-supplied reason so the bypass is
+/// always traceable.
+pub fn emit_override_event(
+    store: &GatewayStore,
+    caller_agent_id: &str,
+    session_id: Option<&str>,
+    target_agent_id: &str,
+    revision_id: &str,
+    force_reason: &str,
+) {
+    let event = autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: format!("gov-ovr-{}", uuid::Uuid::new_v4()),
+        agent_id: caller_agent_id.to_string(),
+        session_id: session_id.unwrap_or("").to_string(),
+        turn_id: None,
+        event_seq: 0,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        category: "revision".to_string(),
+        action: "governor.override".to_string(),
+        status: "active".to_string(),
+        enforced_rules: Vec::new(),
+        target: Some(target_agent_id.to_string()),
+        payload: Some(
+            serde_json::json!({
+                "alias": target_agent_id,
+                "revision_id": revision_id,
+                "force_reason": force_reason,
+            })
+            .to_string(),
+        ),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: Some(format!("operator override: {}", force_reason)),
+    };
+    let _ = store.create_causal_event(&event);
+}
+
+fn non_info_finding_count(record: &autonoetic_types::promotion::PromotionRecord) -> usize {
+    let buckets: [&Vec<Finding>; 5] = [
+        &record.evaluator_findings,
+        &record.auditor_findings,
+        &record.static_evaluator_findings,
+        &record.unit_test_runner_findings,
+        &record.sealed_evaluator_findings,
+    ];
+    buckets
+        .iter()
+        .flat_map(|v| v.iter())
+        .filter(|f| !matches!(f.severity, FindingSeverity::Info))
+        .count()
+}
+
+/// Best-effort `next_allowed_at`: the timestamp at which the oldest
+/// in-window promotion will age out, freeing one slot.
+fn compute_next_allowed_at(
+    store: &GatewayStore,
+    agent_id: &str,
+    config: &PromotionGovernorConfig,
+) -> Result<Option<String>> {
+    let history = store.list_promotion_history(agent_id)?;
+    let window = chrono::Duration::hours(config.velocity_window_hours as i64);
+    let since = chrono::Utc::now() - window;
+    let mut in_window: Vec<_> = history
+        .into_iter()
+        .filter(|r| matches!(r.kind, autonoetic_types::agent_revision::PromotionKind::Promote))
+        .filter_map(|r| {
+            chrono::DateTime::parse_from_rfc3339(&r.created_at)
+                .ok()
+                .map(|t| t.with_timezone(&chrono::Utc))
+                .filter(|t| *t >= since)
+        })
+        .collect();
+    in_window.sort();
+    if in_window.len() < config.max_promotions_per_window {
+        return Ok(None);
+    }
+    // Once the oldest in-window promotion is older than `window`, it no
+    // longer counts. So the next allowed slot is at `oldest + window`.
+    let oldest = in_window.first().copied();
+    Ok(oldest.map(|t| (t + window).to_rfc3339()))
+}

--- a/autonoetic-gateway/src/runtime/promotion_governor.rs
+++ b/autonoetic-gateway/src/runtime/promotion_governor.rs
@@ -98,6 +98,14 @@ pub fn run_governor_checks(
 
 /// Velocity check: count `Promote` rows for the alias in the configured
 /// window; reject when the count >= the configured cap.
+///
+/// **TOCTOU note**: this check runs *outside* `atomic_promote`'s SQLite
+/// transaction. Concurrent promote calls for the same alias can all observe
+/// the same pre-promotion count and pass this gate before any of them inserts
+/// into `promotion_history`. For a default-disabled, force-overridable safety
+/// gate this is acceptable; the cap is a soft limit, not a hard invariant.
+/// TODO: move the count check into the `atomic_promote` transaction to close
+/// the window entirely.
 pub fn check_velocity(
     config: &PromotionGovernorConfig,
     store: &GatewayStore,
@@ -147,11 +155,10 @@ pub fn check_flapping(
     if config.flapping_lookback == 0 {
         return Ok(None);
     }
-    let history = store.list_promotion_history(agent_id)?;
+    let history = store.list_recent_promotion_history(agent_id, config.flapping_lookback)?;
     let recent: Vec<_> = history
         .into_iter()
         .filter(|r| matches!(r.kind, autonoetic_types::agent_revision::PromotionKind::Promote))
-        .take(config.flapping_lookback)
         .collect();
 
     if !recent
@@ -188,6 +195,13 @@ pub fn check_flapping(
 /// consecutive monotonic increases in the non-info finding count. The
 /// signal: even when the boolean `evaluator_pass` is `true`, a steady
 /// rise in warning/error findings means quality is drifting downward.
+///
+/// **Design note**: this check inspects only *already-promoted* history,
+/// not the candidate revision. The signal is a trailing indicator on
+/// completed promotions — "is the recent trend degrading?" The promotion
+/// that crosses the threshold is allowed through; the *next* one gets
+/// blocked. Including the candidate would require the promotion record to
+/// exist before the check runs, inverting the check-before-write model.
 pub fn check_eval_regression(
     config: &PromotionGovernorConfig,
     store: &GatewayStore,
@@ -197,11 +211,10 @@ pub fn check_eval_regression(
     if config.eval_regression_streak == 0 || config.eval_regression_lookback == 0 {
         return Ok(None);
     }
-    let history = store.list_promotion_history(agent_id)?;
+    let history = store.list_recent_promotion_history(agent_id, config.eval_regression_lookback)?;
     let recent: Vec<_> = history
         .into_iter()
         .filter(|r| matches!(r.kind, autonoetic_types::agent_revision::PromotionKind::Promote))
-        .take(config.eval_regression_lookback)
         .collect();
 
     // promotion_store opens the on-disk JSON each call; cheap enough for
@@ -359,7 +372,7 @@ fn compute_next_allowed_at(
     agent_id: &str,
     config: &PromotionGovernorConfig,
 ) -> Result<Option<String>> {
-    let history = store.list_promotion_history(agent_id)?;
+    let history = store.list_recent_promotion_history(agent_id, config.max_promotions_per_window)?;
     let window = chrono::Duration::hours(config.velocity_window_hours as i64);
     let since = chrono::Utc::now() - window;
     let mut in_window: Vec<_> = history

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2284,6 +2284,16 @@ impl NativeTool for AgentRevisionPromoteTool {
                     })
                     .to_string());
                 }
+                if reason.len() > 512 {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "error_type": "validation",
+                        "error": "governor_force_reason_too_long",
+                        "message": format!("`force_reason` must be at most 512 characters (got {}).", reason.len()),
+                        "repair_hint": "Shorten the override justification.",
+                    })
+                    .to_string());
+                }
                 if cfg.promotion_governor.enabled {
                     crate::runtime::promotion_governor::emit_override_event(
                         gateway_store.as_ref(),

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -1681,6 +1681,14 @@ struct RevisionPromoteArgs {
     /// bypassed for this exact (agent_id, revision_id) pair.
     #[serde(default)]
     approval_ref: Option<String>,
+    /// Bypass the promotion safety governor (issue #25). Requires
+    /// `force_reason` and emits a `governor.override` causal event.
+    #[serde(default)]
+    force: Option<bool>,
+    /// Operator-supplied justification recorded with the override event.
+    /// Required when `force = true`.
+    #[serde(default)]
+    force_reason: Option<String>,
 }
 
 pub struct AgentRevisionPromoteTool;
@@ -1708,7 +1716,9 @@ impl NativeTool for AgentRevisionPromoteTool {
                     "revision_id": { "type": "string", "description": "Revision ID to promote (must be in candidate or ready status)" },
                     "reason": { "type": "string", "description": "Optional: human-readable reason for promotion" },
                     "required_eval_run_id": { "type": "string", "description": "Optional: if provided, promotion requires this eval run to have passed for the target revision" },
-                    "approval_ref": { "type": "string", "description": "Optional: approval ID returned by an earlier promote call that hit the capability-delta gate (R++2). Pass it on retry to bypass the gate." }
+                    "approval_ref": { "type": "string", "description": "Optional: approval ID returned by an earlier promote call that hit the capability-delta gate (R++2). Pass it on retry to bypass the gate." },
+                    "force": { "type": "boolean", "description": "Optional: bypass the promotion safety governor (issue #25). Requires `force_reason`; emits a `governor.override` causal event." },
+                    "force_reason": { "type": "string", "description": "Required when `force = true`. Operator-supplied justification recorded with the override event." }
                 },
                 "required": ["agent_id", "revision_id"],
                 "additionalProperties": false
@@ -2251,6 +2261,56 @@ impl NativeTool for AgentRevisionPromoteTool {
                         "repair_hint": "Run an eval suite against this revision, then retry promotion with `required_eval_run_id` pointing to the passed run.",
                     })
                     .to_string());
+                }
+            }
+        }
+
+        // Promotion safety governor (issue #25): velocity / flapping /
+        // eval-regression gates. Bypassed when `force = true` (and a
+        // `force_reason` is recorded for the audit trail). Sits between the
+        // protected-agent gate and the sentinel sweep so a rejection here
+        // avoids the cost of a sentinel pre-promotion run.
+        if let Some(cfg) = config {
+            let force_requested = args.force.unwrap_or(false);
+            if force_requested {
+                let reason = args.force_reason.as_deref().unwrap_or("").trim();
+                if reason.is_empty() {
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "error_type": "validation",
+                        "error": "governor_force_requires_reason",
+                        "message": "Passing `force: true` to bypass the promotion safety governor requires a non-empty `force_reason`.",
+                        "repair_hint": "Supply `force_reason` describing why the governor is being overridden (e.g. 'planned rollback re-run after operator review').",
+                    })
+                    .to_string());
+                }
+                if cfg.promotion_governor.enabled {
+                    crate::runtime::promotion_governor::emit_override_event(
+                        gateway_store.as_ref(),
+                        &manifest.agent.id,
+                        session_id,
+                        &args.agent_id,
+                        &args.revision_id,
+                        reason,
+                    );
+                }
+            } else if cfg.promotion_governor.enabled {
+                if let Some(rejection) = crate::runtime::promotion_governor::run_governor_checks(
+                    &cfg.promotion_governor,
+                    gateway_store.as_ref(),
+                    gateway_dir,
+                    &args.agent_id,
+                    &args.revision_id,
+                )? {
+                    crate::runtime::promotion_governor::emit_rejected_event(
+                        gateway_store.as_ref(),
+                        &manifest.agent.id,
+                        session_id,
+                        &args.agent_id,
+                        &args.revision_id,
+                        &rejection,
+                    );
+                    return Ok(rejection.to_tool_error().to_string());
                 }
             }
         }

--- a/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
@@ -636,6 +636,51 @@ impl GatewayStore {
         Ok(count.max(0) as usize)
     }
 
+    /// Bounded variant of [`list_promotion_history`](Self::list_promotion_history).
+    /// Returns at most `limit` newest rows for the alias. Used by the promotion
+    /// safety governor to avoid loading unbounded history for long-lived agents.
+    pub fn list_recent_promotion_history(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<PromotionRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT promotion_id, kind, alias_id, agent_id, previous_revision_id,
+                    new_revision_id, source_eval_run_id, reason, created_at,
+                    created_by_type, created_by_id, origin_node_id
+             FROM promotion_history WHERE agent_id = ?1 ORDER BY created_at DESC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![agent_id, limit as i64], |row| {
+            let kind_str: String = row.get(1)?;
+            let kind = match kind_str.as_str() {
+                "Promote" => PromotionKind::Promote,
+                "Rollback" => PromotionKind::Rollback,
+                _ => PromotionKind::Promote,
+            };
+            Ok(PromotionRecord {
+                promotion_id: row.get(0)?,
+                kind,
+                alias_id: row.get(2)?,
+                agent_id: row.get(3)?,
+                previous_revision_id: row.get(4)?,
+                new_revision_id: row.get(5)?,
+                source_eval_run_id: row.get(6)?,
+                reason: row.get(7)?,
+                created_at: row.get(8)?,
+                created_by_type: row.get(9)?,
+                created_by_id: row.get(10)?,
+                origin_node_id: row.get(11)?,
+            })
+        })?;
+        let mut results = Vec::new();
+        for r in rows {
+            results.push(r?);
+        }
+        Ok(results)
+    }
+
     pub fn list_promotion_history(&self, agent_id: &str) -> Result<Vec<PromotionRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(

--- a/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
@@ -618,6 +618,24 @@ impl GatewayStore {
         Ok(current_revision_id)
     }
 
+    /// Count `Promote` (not `Rollback`) entries for an alias whose
+    /// `created_at >= since_rfc3339`. Used by the promotion safety governor
+    /// (issue #25) for the per-alias velocity check.
+    pub fn count_promotions_since(
+        &self,
+        agent_id: &str,
+        since_rfc3339: &str,
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM promotion_history
+             WHERE agent_id = ?1 AND kind = 'Promote' AND created_at >= ?2",
+            params![agent_id, since_rfc3339],
+            |row| row.get(0),
+        )?;
+        Ok(count.max(0) as usize)
+    }
+
     pub fn list_promotion_history(&self, agent_id: &str) -> Result<Vec<PromotionRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(

--- a/autonoetic-gateway/tests/promotion_governor_integration.rs
+++ b/autonoetic-gateway/tests/promotion_governor_integration.rs
@@ -1,0 +1,402 @@
+//! Promotion safety governor (issue #25) — gate-level velocity, flapping,
+//! and eval-regression checks. Tests target the governor module directly
+//! against a temp `GatewayStore` + on-disk `PromotionStore`. The integration
+//! through `agent.revision.promote` is exercised by existing promote tests;
+//! adding governor checks to that surface is a pure additive concern.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use autonoetic_gateway::runtime::promotion_governor::{
+    check_eval_regression, check_flapping, check_velocity, run_governor_checks,
+};
+use autonoetic_gateway::runtime::promotion_store::PromotionStore;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent_revision::{
+    AgentRevisionRecord, AgentRevisionStatus, PromotionKind, PromotionRecord as HistoryRecord,
+};
+use autonoetic_types::config::PromotionGovernorConfig;
+use autonoetic_types::promotion::{Finding, FindingSeverity, PromotionRole};
+use chrono::{Duration, Utc};
+
+fn temp_setup() -> (tempfile::TempDir, Arc<GatewayStore>, PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let gateway_dir = temp.path().to_path_buf();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    (temp, store, gateway_dir)
+}
+
+fn enabled_config() -> PromotionGovernorConfig {
+    PromotionGovernorConfig {
+        enabled: true,
+        velocity_window_hours: 24,
+        max_promotions_per_window: 3,
+        flapping_lookback: 4,
+        eval_regression_streak: 3,
+        eval_regression_lookback: 6,
+    }
+}
+
+fn seed_promotion(
+    store: &GatewayStore,
+    agent_id: &str,
+    new_revision_id: &str,
+    previous_revision_id: Option<&str>,
+    created_at: chrono::DateTime<Utc>,
+) {
+    let rec = HistoryRecord {
+        promotion_id: format!("prom-{}-{}", agent_id, new_revision_id),
+        kind: PromotionKind::Promote,
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        previous_revision_id: previous_revision_id.map(|s| s.to_string()),
+        new_revision_id: new_revision_id.to_string(),
+        source_eval_run_id: None,
+        reason: None,
+        created_at: created_at.to_rfc3339(),
+        created_by_type: "test".to_string(),
+        created_by_id: "promotion_governor_integration".to_string(),
+        origin_node_id: "gateway".to_string(),
+    };
+    store.insert_promotion_record(&rec).unwrap();
+}
+
+fn seed_revision_with_artifact(store: &GatewayStore, agent_id: &str, revision_id: &str, artifact_id: &str) {
+    let rec = AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: agent_id.to_string(),
+        base_revision_id: None,
+        artifact_id: Some(artifact_id.to_string()),
+        content_digest: format!("sha256:{}", revision_id),
+        runtime_lock_hash: format!("sha256:lock-{}", revision_id),
+        manifest_hash: format!("sha256:manifest-{}", revision_id),
+        created_at: Utc::now().to_rfc3339(),
+        created_by_type: "test".to_string(),
+        created_by_id: "promotion_governor_integration".to_string(),
+        source_kind: "test".to_string(),
+        source_ref: None,
+        origin_node_id: "gateway".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Ready,
+        metadata_json: serde_json::json!({}),
+        short_id: String::new(),
+        signature: None,
+        signer_id: None,
+    };
+    store.insert_agent_revision(&rec).unwrap();
+}
+
+fn seed_verdict_with_findings(
+    promo_store: &PromotionStore,
+    artifact_id: &str,
+    warning_count: usize,
+) {
+    let findings: Vec<Finding> = (0..warning_count)
+        .map(|i| Finding {
+            severity: FindingSeverity::Warning,
+            description: format!("seeded warning {}", i),
+            evidence: Some("test".to_string()),
+        })
+        .collect();
+    promo_store
+        .record_promotion(
+            artifact_id.to_string(),
+            None,
+            None,
+            PromotionRole::Evaluator,
+            "evaluator.default",
+            true,
+            findings,
+            None,
+        )
+        .unwrap();
+}
+
+#[test]
+fn governor_disabled_passes_unconditionally() {
+    let (_temp, store, gateway_dir) = temp_setup();
+    let agent_id = "agent.disabled";
+    // Seed way more than the cap. With governor disabled, none of this matters.
+    for i in 0..10 {
+        seed_promotion(
+            &store,
+            agent_id,
+            &format!("rev-{}", i),
+            None,
+            Utc::now() - Duration::hours(1),
+        );
+    }
+    let cfg = PromotionGovernorConfig {
+        enabled: false,
+        ..enabled_config()
+    };
+    let rejection = run_governor_checks(&cfg, &store, &gateway_dir, agent_id, "rev-new").unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn velocity_under_cap_passes() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.under-cap";
+    let cfg = enabled_config();
+    // cap = 3; seed 2 in window
+    for i in 0..2 {
+        seed_promotion(
+            &store,
+            agent_id,
+            &format!("rev-{}", i),
+            None,
+            Utc::now() - Duration::hours(1),
+        );
+    }
+    let rejection = check_velocity(&cfg, &store, agent_id).unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn velocity_at_cap_rejects() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.at-cap";
+    let cfg = enabled_config();
+    for i in 0..3 {
+        seed_promotion(
+            &store,
+            agent_id,
+            &format!("rev-{}", i),
+            None,
+            Utc::now() - Duration::hours(1),
+        );
+    }
+    let rejection = check_velocity(&cfg, &store, agent_id).unwrap().unwrap();
+    assert_eq!(rejection.error, "promotion_velocity_exceeded");
+    let p = &rejection.payload;
+    assert_eq!(p["alias"], agent_id);
+    assert_eq!(p["recent_promotions"], 3);
+    assert_eq!(p["max_promotions_per_window"], 3);
+    assert!(p["next_allowed_at"].is_string());
+}
+
+#[test]
+fn velocity_only_counts_in_window() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.window";
+    let cfg = enabled_config(); // 24h window
+    // 4 promotions 30h ago — outside window
+    for i in 0..4 {
+        seed_promotion(
+            &store,
+            agent_id,
+            &format!("rev-old-{}", i),
+            None,
+            Utc::now() - Duration::hours(30),
+        );
+    }
+    // 1 promotion 1h ago — inside window
+    seed_promotion(
+        &store,
+        agent_id,
+        "rev-recent",
+        None,
+        Utc::now() - Duration::hours(1),
+    );
+    let rejection = check_velocity(&cfg, &store, agent_id).unwrap();
+    assert!(
+        rejection.is_none(),
+        "old promotions outside window must not count toward the cap"
+    );
+}
+
+#[test]
+fn flapping_re_promote_rejected() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.flap";
+    let cfg = enabled_config();
+    // alias history: rev-A, rev-B, rev-C
+    seed_promotion(&store, agent_id, "rev-A", None, Utc::now() - Duration::hours(3));
+    seed_promotion(
+        &store,
+        agent_id,
+        "rev-B",
+        Some("rev-A"),
+        Utc::now() - Duration::hours(2),
+    );
+    seed_promotion(
+        &store,
+        agent_id,
+        "rev-C",
+        Some("rev-B"),
+        Utc::now() - Duration::hours(1),
+    );
+    // candidate = rev-A — already promoted recently → flapping
+    let rejection = check_flapping(&cfg, &store, agent_id, "rev-A").unwrap().unwrap();
+    assert_eq!(rejection.error, "promotion_flapping_detected");
+    let recent = rejection.payload["recent_revisions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    // newest first
+    assert_eq!(recent, vec!["rev-C", "rev-B", "rev-A"]);
+}
+
+#[test]
+fn flapping_new_revision_allowed() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.no-flap";
+    let cfg = enabled_config();
+    seed_promotion(&store, agent_id, "rev-A", None, Utc::now() - Duration::hours(2));
+    seed_promotion(
+        &store,
+        agent_id,
+        "rev-B",
+        Some("rev-A"),
+        Utc::now() - Duration::hours(1),
+    );
+    // candidate = brand-new revision → no flap
+    let rejection = check_flapping(&cfg, &store, agent_id, "rev-NEW").unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn flapping_disabled_with_zero_lookback() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.flap-disabled";
+    let cfg = PromotionGovernorConfig {
+        flapping_lookback: 0,
+        ..enabled_config()
+    };
+    seed_promotion(&store, agent_id, "rev-A", None, Utc::now() - Duration::hours(1));
+    let rejection = check_flapping(&cfg, &store, agent_id, "rev-A").unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn eval_regression_monotonic_rejects() {
+    let (_temp, store, gateway_dir) = temp_setup();
+    let agent_id = "agent.regress";
+    let cfg = enabled_config(); // streak = 3, lookback = 6
+    let promo_store = PromotionStore::new(&gateway_dir).unwrap();
+
+    // Seed 4 promotions, oldest → newest with finding counts 1, 2, 3, 4
+    // (4 counts → 3 strict increases → triggers streak = 3).
+    let plan = [("rev-0", "art-0", 1), ("rev-1", "art-1", 2), ("rev-2", "art-2", 3), ("rev-3", "art-3", 4)];
+    for (i, (rev, art, n)) in plan.iter().enumerate() {
+        seed_revision_with_artifact(&store, agent_id, rev, art);
+        seed_verdict_with_findings(&promo_store, art, *n);
+        // hours_ago: index 0 = oldest, plan length = 4
+        let hours_ago = (plan.len() - i) as i64;
+        seed_promotion(&store, agent_id, rev, None, Utc::now() - Duration::hours(hours_ago));
+    }
+    let rejection = check_eval_regression(&cfg, &store, &gateway_dir, agent_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(rejection.error, "promotion_eval_regression");
+    let counts: Vec<u64> = rejection.payload["recent_finding_counts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_u64().unwrap())
+        .collect();
+    assert_eq!(counts, vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn eval_regression_non_monotonic_allows() {
+    let (_temp, store, gateway_dir) = temp_setup();
+    let agent_id = "agent.no-regress";
+    let cfg = enabled_config();
+    let promo_store = PromotionStore::new(&gateway_dir).unwrap();
+
+    let plan = [
+        ("rev-0", "art-0", 3),
+        ("rev-1", "art-1", 2), // dip — kills the streak
+        ("rev-2", "art-2", 3),
+        ("rev-3", "art-3", 4),
+    ];
+    for (i, (rev, art, n)) in plan.iter().enumerate() {
+        seed_revision_with_artifact(&store, agent_id, rev, art);
+        seed_verdict_with_findings(&promo_store, art, *n);
+        let hours_ago = (plan.len() - i) as i64;
+        seed_promotion(&store, agent_id, rev, None, Utc::now() - Duration::hours(hours_ago));
+    }
+    let rejection = check_eval_regression(&cfg, &store, &gateway_dir, agent_id).unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn eval_regression_too_few_records_allows() {
+    let (_temp, store, gateway_dir) = temp_setup();
+    let agent_id = "agent.short-history";
+    let cfg = enabled_config(); // streak = 3 (need streak+1 = 4 records)
+    let promo_store = PromotionStore::new(&gateway_dir).unwrap();
+
+    // Only 2 records — well under streak+1
+    let plan = [("rev-0", "art-0", 1), ("rev-1", "art-1", 2)];
+    for (i, (rev, art, n)) in plan.iter().enumerate() {
+        seed_revision_with_artifact(&store, agent_id, rev, art);
+        seed_verdict_with_findings(&promo_store, art, *n);
+        let hours_ago = (plan.len() - i) as i64;
+        seed_promotion(&store, agent_id, rev, None, Utc::now() - Duration::hours(hours_ago));
+    }
+    let rejection = check_eval_regression(&cfg, &store, &gateway_dir, agent_id).unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn run_governor_returns_velocity_before_flapping() {
+    // When both signals would fire, the velocity check (cheapest) should
+    // win. This pins ordering so the most informative rejection surfaces
+    // first.
+    let (_temp, store, gateway_dir) = temp_setup();
+    let agent_id = "agent.both";
+    let cfg = enabled_config();
+    // 3 promotions in window: velocity at cap
+    for i in 0..3 {
+        seed_promotion(
+            &store,
+            agent_id,
+            &format!("rev-{}", i),
+            None,
+            Utc::now() - Duration::hours(1),
+        );
+    }
+    // candidate matches one of them → flapping would also fire
+    let rejection = run_governor_checks(&cfg, &store, &gateway_dir, agent_id, "rev-1")
+        .unwrap()
+        .unwrap();
+    assert_eq!(rejection.error, "promotion_velocity_exceeded");
+}
+
+#[test]
+fn run_governor_returns_none_when_clear() {
+    let (_temp, store, gateway_dir) = temp_setup();
+    let cfg = enabled_config();
+    let rejection =
+        run_governor_checks(&cfg, &store, &gateway_dir, "agent.clean", "rev-fresh").unwrap();
+    assert!(rejection.is_none());
+}
+
+#[test]
+fn rejection_to_tool_error_shape() {
+    let (_temp, store, _gateway_dir) = temp_setup();
+    let agent_id = "agent.shape";
+    let cfg = enabled_config();
+    for i in 0..3 {
+        seed_promotion(
+            &store,
+            agent_id,
+            &format!("rev-{}", i),
+            None,
+            Utc::now() - Duration::hours(1),
+        );
+    }
+    let rejection = check_velocity(&cfg, &store, agent_id).unwrap().unwrap();
+    let err = rejection.to_tool_error();
+    assert_eq!(err["ok"], serde_json::Value::Bool(false));
+    assert_eq!(err["error_type"], "governor");
+    assert_eq!(err["error"], "promotion_velocity_exceeded");
+    assert!(err["message"].as_str().unwrap().contains("velocity exceeded"));
+    assert_eq!(err["recent_promotions"], 3);
+    assert_eq!(err["max_promotions_per_window"], 3);
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -879,6 +879,11 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub scheduled_jobs: ScheduledJobsConfig,
 
+    /// Promotion safety governor (issue #25). Per-alias velocity, flapping,
+    /// and eval-regression checks enforced at `agent.revision.promote`.
+    #[serde(default)]
+    pub promotion_governor: PromotionGovernorConfig,
+
     /// System agents: declared background agents that the gateway reconciles on startup.
     #[serde(default)]
     pub system_agents: Vec<SystemAgentEntry>,
@@ -981,6 +986,88 @@ fn default_scheduled_jobs_max_per_root() -> usize {
 
 fn default_scheduled_jobs_max_due_per_tick() -> usize {
     16
+}
+
+/// Promotion safety governor (issue #25).
+///
+/// Three gate-level checks applied at `agent.revision.promote` *before*
+/// `atomic_promote`:
+/// - **velocity**: max promotions per alias per window
+/// - **flapping**: re-promoting a recently-promoted revision_id
+/// - **eval-regression**: consecutive monotonic increases in non-info finding
+///   counts across recent verdicts
+///
+/// All three are bypassable via `force: true` + `force_reason` on the promote
+/// call (emits a `governor.override` causal event for the audit trail).
+/// Disabled by default for backwards compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromotionGovernorConfig {
+    /// Enable governor checks. Default: false (opt-in).
+    #[serde(default = "default_promotion_governor_enabled")]
+    pub enabled: bool,
+
+    /// Velocity-check window in hours. Default: 24.
+    #[serde(default = "default_promotion_governor_velocity_window_hours")]
+    pub velocity_window_hours: u64,
+
+    /// Maximum number of `Promote` entries per alias inside the velocity
+    /// window. Default: 3.
+    #[serde(default = "default_promotion_governor_max_promotions_per_window")]
+    pub max_promotions_per_window: usize,
+
+    /// How many most-recent promotions to scan when looking for the candidate
+    /// revision_id (flapping signal: re-promoting a revision already seen
+    /// recently). Default: 4.
+    #[serde(default = "default_promotion_governor_flapping_lookback")]
+    pub flapping_lookback: usize,
+
+    /// How many adjacent finding-count comparisons must be strictly increasing
+    /// for the eval-regression halt to fire. Default: 3 (i.e. counts c0 < c1
+    /// < c2 < c3 → 3 increases → halt).
+    #[serde(default = "default_promotion_governor_eval_regression_streak")]
+    pub eval_regression_streak: usize,
+
+    /// Maximum number of recent promotions to scan for the eval-regression
+    /// streak. Default: 6.
+    #[serde(default = "default_promotion_governor_eval_regression_lookback")]
+    pub eval_regression_lookback: usize,
+}
+
+impl Default for PromotionGovernorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_promotion_governor_enabled(),
+            velocity_window_hours: default_promotion_governor_velocity_window_hours(),
+            max_promotions_per_window: default_promotion_governor_max_promotions_per_window(),
+            flapping_lookback: default_promotion_governor_flapping_lookback(),
+            eval_regression_streak: default_promotion_governor_eval_regression_streak(),
+            eval_regression_lookback: default_promotion_governor_eval_regression_lookback(),
+        }
+    }
+}
+
+fn default_promotion_governor_enabled() -> bool {
+    false
+}
+
+fn default_promotion_governor_velocity_window_hours() -> u64 {
+    24
+}
+
+fn default_promotion_governor_max_promotions_per_window() -> usize {
+    3
+}
+
+fn default_promotion_governor_flapping_lookback() -> usize {
+    4
+}
+
+fn default_promotion_governor_eval_regression_streak() -> usize {
+    3
+}
+
+fn default_promotion_governor_eval_regression_lookback() -> usize {
+    6
 }
 
 /// Security sentinel configuration.
@@ -1789,6 +1876,7 @@ impl Default for GatewayConfig {
             signal_delivery_timeout_secs: default_signal_delivery_timeout_secs(),
             hooks: Vec::new(),
             scheduled_jobs: ScheduledJobsConfig::default(),
+            promotion_governor: PromotionGovernorConfig::default(),
             system_agents: Vec::new(),
             interaction_answer_orchestration: default_interaction_answer_orchestration(),
             allow_runtime_lock_drift: false,


### PR DESCRIPTION
Addresses the **gate-level half** of #25. The operator-throughput half (federation escalation rate limit / batching / dedup across artifact_content_digests, flagged in \`promotion-federation-followup-review.md\` §5) is a separate workstream — it touches a different subsystem (federation.escalate, admin routes) and warrants its own PR. The remaining bullet list on #25 is now fully isolated to that channel.

## Summary

Three independent gate-level checks inside \`agent.revision.promote\`, running before \`atomic_promote\`. All gated by one config flag, all bypassable via \`force: true\` + required \`force_reason\` (emits a \`governor.override\` causal event).

- **Velocity** — too many promotions per alias inside a configurable window. Reject with \`promotion_velocity_exceeded\` + \`{recent_promotions, max_promotions_per_window, next_allowed_at}\`.
- **Flapping** — re-promoting a revision_id that was already promoted within the last K rows. Catches the canonical A→B→A oscillation. Reject with \`promotion_flapping_detected\` + \`{recent_revisions}\`.
- **Eval-regression** — walks recent verdicts and rejects when the non-info finding count is strictly monotonically increasing across the last \`streak+1\` revisions. This fires even when boolean \`evaluator_pass=true\`, because the signal is *degrading quality* over time.

Disabled by default (\`fast_scheduler\`-style opt-in). Sits between the protected-agent gate (#21) and the sentinel pre-promotion gate (#155), so a rejection here saves the cost of a sentinel sweep.

## Files

- \`autonoetic-types/src/config.rs\` — \`PromotionGovernorConfig\` (enabled / velocity_window_hours / max_promotions_per_window / flapping_lookback / eval_regression_streak / eval_regression_lookback)
- \`autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs\` — \`count_promotions_since\` (indexed on the existing \`(agent_id)\` + \`created_at\`)
- \`autonoetic-gateway/src/runtime/promotion_governor.rs\` — three checks + \`run_governor_checks\` orchestrator + \`GovernorRejection::to_tool_error\` + \`emit_rejected_event\` / \`emit_override_event\` causal-event helpers
- \`autonoetic-gateway/src/runtime/tools/agent_revision.rs\` — wired between protected-agent gate and sentinel sweep; \`force\` / \`force_reason\` added to \`RevisionPromoteArgs\` and the input schema; validation rejects empty \`force_reason\` when \`force = true\`
- \`autonoetic-gateway/tests/promotion_governor_integration.rs\` — 13 tests

## Causal events

- \`governor.rejected\` (status \`blocked\`) — recorded alongside the tool error response so rejections are queryable later (feeds the evolution observability surface tracked in #29)
- \`governor.override\` (status \`active\`) — recorded whenever \`force=true\` bypasses the gates, carrying the operator \`force_reason\`

## Test plan

- [x] \`cargo test -p autonoetic-gateway --test promotion_governor_integration\` — 13/13 pass
- [x] \`cargo test -p autonoetic-gateway --test promotion_record_e2e --test promotion_record_evaluator_fail --test promotion_required_record_integration --test promotion_gate_hardening_integration --test constitution_promotion_capability_delta --test constitution_promotion_distinct_identity\` — all pass (regression for the existing promote surface)
- [x] \`cargo build -p autonoetic-gateway\` — clean

Two pre-existing failures on \`main\` (verified by running the same tests against \`main\`):
- \`tests/recording_integration.rs\` — compile mismatch with \`start_sealed_proxy\` (test file behind current API)
- \`tests/promotion_record_findings_validation::test_promotion_record_rejects_empty_finding_description\` — unwrap_err on Ok shape, return-type drift

Neither is related to this PR.

## Out of scope (deferred to a follow-up issue)

- Operator-side throughput safeguards on \`federation.escalate\` (rate limit, batching API, dedup across content_digests). See \`docs/design/promotion-federation-followup-review.md\` §5 — flagged as the single biggest operational risk for the federation model at scale.
- \`evolution status\` CLI consuming the new causal events (#29 residual scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)