### PR TITLE
feat(curator): structured decision journal — output contract + per-entry causal events (#30)

### DIFF
--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -159,9 +159,35 @@ Install a new reasoning agent called '<agent_id>':
 - Capabilities: <intended_capabilities as capability objects>
 - Execution mode: reasoning
 - llm_config: { provider: "openrouter", model: "google/gemini-3-flash-preview", temperature: 0.2 }
+- io: { returns: { type: "object", required: ["status"], properties: { status: { type: "string" } } } }
 - Gating: none (reasoning-only, no CodeExecution/AgentSpawn)
 ```
 Then call `workflow_wait` with the returned `task_id`.
+
+**io schema guidance for reasoning agents:**
+Include `io.returns` in the install intent to give the gateway an output
+contract. Keep it minimal — a broad shape is better than a wrong detailed
+one. Example for an agent that returns a status and optional data:
+
+```json
+{
+  "io": {
+    "returns": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string" },
+        "data": { "type": "object" }
+      }
+    }
+  }
+}
+```
+
+Do NOT include `io.accepts` for reasoning agents — the planner constructs
+messages in natural language and over-constraining the input schema will
+break callers. Only script agents with structured CLI arguments benefit
+from `io.accepts`.
 
 **Why the bundled SKILL body matches the install intent's
 `instructions`:** specialized_builder uses the `instructions` field

--- a/agents/evolution/memory-curator.default/SKILL.md
+++ b/agents/evolution/memory-curator.default/SKILL.md
@@ -30,6 +30,86 @@ metadata:
           - "execution."
           - "observability."
           - "digest."
+    io:
+      returns:
+        type: object
+        required: ["decision_journal", "agent_scores", "systemic_gaps", "learnings_stored"]
+        additionalProperties: true
+        properties:
+          decision_journal:
+            type: array
+            description: >
+              Per-decision record covering every keep / drop / promote_to_skill /
+              flag_for_evolution judgment this curator made in the run. Issue #30:
+              the gateway parses each entry out and emits one `curator.decision`
+              causal event so an operator can query "why was memory X dropped"
+              and get a direct answer.
+            items:
+              type: object
+              required: ["target", "action", "reason_code"]
+              properties:
+                target:
+                  type: string
+                  description: >
+                    What the decision is about. Use the `memory://<session_id>/turn-<n>`
+                    URI shape for a per-turn memory; an agent id for an
+                    `flag_for_evolution` decision; or a knowledge entry id
+                    for `promote_to_skill`.
+                action:
+                  type: string
+                  enum: ["keep", "drop", "promote_to_skill", "flag_for_evolution"]
+                reason_code:
+                  type: string
+                  description: >
+                    Short slug from the documented vocabulary (see below). Free-form
+                    detail goes in `reason_detail`.
+                reason_detail:
+                  type: string
+                  description: One-paragraph explanation backing the reason_code.
+                metric_values:
+                  type: object
+                  description: >
+                    Structured evidence — the metric or signal values that drove
+                    the decision (e.g. {failure_rate: 0.42, recency_days: 2}).
+                confidence:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+          agent_scores:
+            type: object
+            additionalProperties:
+              type: object
+              required: ["evolution_recommended"]
+              properties:
+                failure_rate: { type: number }
+                repeated_errors: { type: array, items: { type: string } }
+                approval_denial_count: { type: integer }
+                eval_score: { type: number }
+                escalation_count: { type: integer }
+                signals_triggered: { type: integer }
+                evolution_recommended: { type: boolean }
+                evidence_summary: { type: string }
+          systemic_gaps:
+            type: array
+            items:
+              type: object
+              required: ["title", "category", "priority"]
+              properties:
+                title: { type: string }
+                category:
+                  type: string
+                  enum: ["tool", "capability", "protocol", "ux", "agent"]
+                evidence: { type: object }
+                remediation: { type: string }
+                blast_radius:
+                  type: string
+                  enum: ["low", "medium", "high"]
+                priority:
+                  type: string
+                  enum: ["low", "medium", "high", "critical"]
+          learnings_stored:
+            type: integer
+            minimum: 0
     validation: "soft"
 ---
 # Memory Curator
@@ -43,10 +123,23 @@ You are a leaf agent (no `AgentSpawn`) responsible for cross-session learning di
 
 ## Output
 
-Return a single JSON object:
+Return a single JSON object. The shape is enforced by the gateway's
+output-schema check (`io.returns` in the frontmatter) and the
+`decision_journal` array is persisted to the causal chain as one
+`curator.decision` event per entry (issue #30).
 
 ```json
 {
+  "decision_journal": [
+    {
+      "target": "memory://<session_id>/turn-<n> | <agent_id> | <knowledge_entry_id>",
+      "action": "keep | drop | promote_to_skill | flag_for_evolution",
+      "reason_code": "<see vocabulary below>",
+      "reason_detail": "One-paragraph explanation backing the code.",
+      "metric_values": { "failure_rate": 0.42, "recency_days": 2 },
+      "confidence": 0.8
+    }
+  ],
   "agent_scores": {
     "<agent_id>": {
       "failure_rate": 0.42,
@@ -72,6 +165,33 @@ Return a single JSON object:
   "learnings_stored": 27
 }
 ```
+
+### `decision_journal` obligation
+
+You MUST emit one entry for every keep / drop / promote_to_skill /
+flag_for_evolution judgment you make. Skipping entries defeats the
+audit: an operator querying "why was memory X dropped" must get a
+direct answer from the causal chain. If you choose not to act on a
+target you scanned, you do not need to record a `keep`-entry for it
+— only emit entries for *positive* actions.
+
+### `reason_code` vocabulary
+
+Use one of these slugs in `reason_code`. Free-form text belongs in
+`reason_detail`.
+
+| code | when to use |
+|---|---|
+| `low_signal` | The target has too little supporting evidence to keep. |
+| `redundant_with` | The target duplicates another source already in the store; cite the duplicate in `reason_detail`. |
+| `threshold_hit` | A configured signal threshold (failure_rate, escalation_count, etc.) crossed. Cite the threshold + value in `metric_values`. |
+| `stale` | The target is older than the retention window for its category. |
+| `superseded` | A newer revision or pattern has replaced the target. |
+| `high_confidence_pattern` | Promotion: pattern is well-supported and reusable. |
+| `cross_session_signal` | Flag-for-evolution: signal observed across many distinct sessions. |
+| `eval_regression` | Flag-for-evolution: evaluator scores trending down for this agent. |
+| `operator_request` | The operator (out-of-band) asked for this action. |
+| `other` | When none of the above fit — `reason_detail` must then be specific enough that an auditor can categorize it later. |
 
 ## Process
 
@@ -139,7 +259,18 @@ For each systemic gap, create a structured entry with title, category, evidence,
 
 ### Step 6: Return structured result
 
-Return the complete JSON as your response. The orchestrator will process agent_scores and systemic_gaps.
+Return the complete JSON as your response. The orchestrator processes
+`agent_scores` and `systemic_gaps`; the gateway parses `decision_journal`
+and persists one `curator.decision` causal event per entry (issue #30).
+An operator can later query the journal by `target` to ask "why was
+this memory dropped" and get a direct answer without re-reading raw
+session traces.
+
+Every positive action you took — a drop, a promotion, a flag-for-
+evolution, or an explicit retain decision tied to a threshold — must
+have a corresponding `decision_journal` entry. Entries with missing
+`target`, `action`, or `reason_code` will be skipped by the gateway
+with a warning log.
 
 ## Important Notes
 

--- a/agents/evolution/memory-curator.default/SKILL.md
+++ b/agents/evolution/memory-curator.default/SKILL.md
@@ -168,12 +168,11 @@ output-schema check (`io.returns` in the frontmatter) and the
 
 ### `decision_journal` obligation
 
-You MUST emit one entry for every keep / drop / promote_to_skill /
-flag_for_evolution judgment you make. Skipping entries defeats the
-audit: an operator querying "why was memory X dropped" must get a
-direct answer from the causal chain. If you choose not to act on a
-target you scanned, you do not need to record a `keep`-entry for it
-— only emit entries for *positive* actions.
+You MUST emit one entry for every *action* judgment (drop, promote_to_skill,
+flag_for_evolution). Skipping entries defeats the audit: an operator querying
+"why was memory X dropped" must get a direct answer from the causal chain.
+You MAY optionally emit `keep` entries to document *why* a target was retained,
+but they are not required — only emit entries for decisions that change state.
 
 ### `reason_code` vocabulary
 

--- a/agents/evolution/specialized_builder.default/SKILL.md
+++ b/agents/evolution/specialized_builder.default/SKILL.md
@@ -89,7 +89,17 @@ For agents that only use existing gateway tools (`credential_request`, `memory.*
        {"type": "ReadAccess", "scopes": ["self.*"]},
        {"type": "WriteAccess", "scopes": ["self.*"]},
        {"type": "BackgroundReevaluation", "min_interval_secs": 300, "allow_reasoning": true}
-     ]
+     ],
+     "io": {
+       "returns": {
+         "type": "object",
+         "required": ["status"],
+         "properties": {
+           "status": {"type": "string"},
+           "summary": {"type": "string"}
+         }
+       }
+     }
    }
    ```
 
@@ -127,6 +137,23 @@ Use `agent_revision_create_from_intent` as the canonical install path.
     "fallback_provider": null,
     "fallback_model": null,
     "chat_only": false
+  },
+  "io": {
+    "accepts": {
+      "type": "object",
+      "required": ["task"],
+      "properties": {
+        "task": {"type": "string"}
+      }
+    },
+    "returns": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {"type": "string"},
+        "data": {"type": "object"}
+      }
+    }
   }
 }
 ```
@@ -153,6 +180,7 @@ Activates the created revision.
 | `instructions` | required; free-form markdown body provided by agent. **Must match the SKILL body that was bundled in the `artifact_ref`** for pure-reasoning installs — agent-factory ensures this. |
 | `capabilities` | declared capabilities for the agent |
 | `llm_config` | required when `execution_mode=reasoning`; **OMIT entirely for `execution_mode=script`** |
+| `io` | optional; pass through from delegation as-is. The gateway stores it verbatim — no validation, no inference. For reasoning agents: include `io.returns` (output contract) but NOT `io.accepts` (over-constrains callers). For script agents: include both `io.accepts` and `io.returns` when the script has clear input/output shapes. Keep schemas minimal: `{ type: "object", required: ["task"], properties: { task: { type: "string" } } }` |
 
 ### Key Rules:
 1. **`artifact_ref` is required for every install.** Script agents: artifact contains executable code + `script_entry`. Pure-reasoning agents: intent-only bundle containing the SKILL body (no `script_entry`, no executable code).

--- a/autonoetic-gateway/src/runtime/curator_journal.rs
+++ b/autonoetic-gateway/src/runtime/curator_journal.rs
@@ -1,0 +1,174 @@
+//! Memory curator decision journal (issue #30).
+//!
+//! After a curator-style agent emits structured output, the gateway parses
+//! the `decision_journal` array and persists one `curator.decision` causal
+//! event per entry. The event's `target` column carries the entry's `target`
+//! field, which makes lookups like "why was memory X dropped" a direct query.
+//!
+//! Trust model: the schema validator (`response_validation.rs`) has already
+//! checked the output against the agent's declared `io.returns` schema by
+//! the time this module runs. We still defensively validate each entry's
+//! shape and skip malformed ones with a warn log, so a buggy schema never
+//! pollutes the causal chain.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::scheduler::gateway_store::GatewayStore;
+
+/// One row of the curator's decision journal.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DecisionJournalEntry {
+    pub target: String,
+    pub action: String,
+    pub reason_code: String,
+    #[serde(default)]
+    pub reason_detail: Option<String>,
+    #[serde(default)]
+    pub metric_values: Option<serde_json::Value>,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+}
+
+impl DecisionJournalEntry {
+    fn is_well_formed(&self) -> bool {
+        !self.target.trim().is_empty()
+            && !self.action.trim().is_empty()
+            && !self.reason_code.trim().is_empty()
+    }
+}
+
+/// Extract decision-journal entries from a structured assistant reply.
+///
+/// Returns:
+/// - `None` when the reply is missing, not valid JSON, or contains no
+///   `decision_journal` field — these are valid agent outputs that simply
+///   don't carry a journal.
+/// - `Some(vec)` when a `decision_journal` array is present. Malformed
+///   entries inside the array are dropped with a warn log so the rest of
+///   the journal is still persisted.
+pub fn extract_decision_journal_entries(reply: &str) -> Option<Vec<DecisionJournalEntry>> {
+    let json: serde_json::Value = serde_json::from_str(reply).ok()?;
+    let array = json.get("decision_journal")?.as_array()?;
+    let mut out = Vec::with_capacity(array.len());
+    for (idx, raw) in array.iter().enumerate() {
+        match serde_json::from_value::<DecisionJournalEntry>(raw.clone()) {
+            Ok(entry) if entry.is_well_formed() => out.push(entry),
+            Ok(_) => {
+                tracing::warn!(
+                    target: "curator_journal",
+                    entry_index = idx,
+                    "decision_journal entry missing required fields (target/action/reason_code); skipping"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "curator_journal",
+                    entry_index = idx,
+                    error = %err,
+                    "decision_journal entry failed deserialization; skipping"
+                );
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Persist a decision-journal batch as causal events.
+///
+/// Emits one `curator.decision` event per entry (with the entry's `target`
+/// in the event's `target` column for indexed query-by-target) plus one
+/// `curator.decision_journal_recorded` summary event keyed by the
+/// curator's session so an operator can find the batch in one shot.
+pub fn persist_decision_journal_entries(
+    store: &GatewayStore,
+    agent_id: &str,
+    session_id: &str,
+    revision_id: Option<&str>,
+    entries: &[DecisionJournalEntry],
+) -> Result<()> {
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    for entry in entries {
+        let payload = serde_json::json!({
+            "agent_id": agent_id,
+            "session_id": session_id,
+            "revision_id": revision_id,
+            "target": entry.target,
+            "action": entry.action,
+            "reason_code": entry.reason_code,
+            "reason_detail": entry.reason_detail,
+            "metric_values": entry.metric_values,
+            "confidence": entry.confidence,
+        });
+        let event = autonoetic_types::causal_chain::CausalEventRecord {
+            event_id: format!("curator-dec-{}", uuid::Uuid::new_v4()),
+            agent_id: agent_id.to_string(),
+            session_id: session_id.to_string(),
+            turn_id: None,
+            event_seq: 0,
+            timestamp: timestamp.clone(),
+            category: "curator".to_string(),
+            action: "decision".to_string(),
+            status: "active".to_string(),
+            enforced_rules: Vec::new(),
+            target: Some(entry.target.clone()),
+            payload: Some(payload.to_string()),
+            payload_ref: None,
+            evidence_ref: None,
+            reason: entry.reason_detail.clone(),
+        };
+        store.create_causal_event(&event)?;
+    }
+
+    // Summary event: one row per curator run, useful to scope a query to a
+    // single run without joining over the per-entry events.
+    let summary = autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: format!("curator-jrn-{}", uuid::Uuid::new_v4()),
+        agent_id: agent_id.to_string(),
+        session_id: session_id.to_string(),
+        turn_id: None,
+        event_seq: 0,
+        timestamp,
+        category: "curator".to_string(),
+        action: "decision_journal_recorded".to_string(),
+        status: "active".to_string(),
+        enforced_rules: Vec::new(),
+        target: Some(session_id.to_string()),
+        payload: Some(
+            serde_json::json!({
+                "agent_id": agent_id,
+                "session_id": session_id,
+                "revision_id": revision_id,
+                "entry_count": entries.len(),
+            })
+            .to_string(),
+        ),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    };
+    store.create_causal_event(&summary)?;
+
+    Ok(())
+}
+
+/// Convenience: parse `reply` for a `decision_journal` array and persist any
+/// well-formed entries. Returns the number of entries persisted (0 when the
+/// reply carries no journal). Errors only on store-write failure.
+pub fn extract_and_persist(
+    store: &GatewayStore,
+    agent_id: &str,
+    session_id: &str,
+    revision_id: Option<&str>,
+    reply: &str,
+) -> Result<usize> {
+    let Some(entries) = extract_decision_journal_entries(reply) else {
+        return Ok(0);
+    };
+    if entries.is_empty() {
+        return Ok(0);
+    }
+    let n = entries.len();
+    persist_decision_journal_entries(store, agent_id, session_id, revision_id, &entries)?;
+    Ok(n)
+}

--- a/autonoetic-gateway/src/runtime/curator_journal.rs
+++ b/autonoetic-gateway/src/runtime/curator_journal.rs
@@ -88,7 +88,7 @@ pub fn persist_decision_journal_entries(
     entries: &[DecisionJournalEntry],
 ) -> Result<()> {
     let timestamp = chrono::Utc::now().to_rfc3339();
-    for entry in entries {
+    for (seq, entry) in entries.iter().enumerate() {
         let payload = serde_json::json!({
             "agent_id": agent_id,
             "session_id": session_id,
@@ -105,8 +105,10 @@ pub fn persist_decision_journal_entries(
             agent_id: agent_id.to_string(),
             session_id: session_id.to_string(),
             turn_id: None,
-            event_seq: 0,
+            event_seq: seq as u64,
             timestamp: timestamp.clone(),
+            // TODO: parameterize category so non-curator agents opting into
+            // decision_journal are not misclassified as "curator".
             category: "curator".to_string(),
             action: "decision".to_string(),
             status: "active".to_string(),

--- a/autonoetic-gateway/src/runtime/curator_journal.rs
+++ b/autonoetic-gateway/src/runtime/curator_journal.rs
@@ -76,12 +76,16 @@ pub fn extract_decision_journal_entries(reply: &str) -> Option<Vec<DecisionJourn
 
 /// Persist a decision-journal batch as causal events.
 ///
-/// Emits one `curator.decision` event per entry (with the entry's `target`
+/// Emits one `{category}.decision` event per entry (with the entry's `target`
 /// in the event's `target` column for indexed query-by-target) plus one
-/// `curator.decision_journal_recorded` summary event keyed by the
-/// curator's session so an operator can find the batch in one shot.
+/// `{category}.decision_journal_recorded` summary event keyed by the
+/// agent's session so an operator can find the batch in one shot.
+///
+/// The `category` parameter allows any agent to opt into the decision-journal
+/// surface without being misclassified. Curator agents should pass `"curator"`.
 pub fn persist_decision_journal_entries(
     store: &GatewayStore,
+    category: &str,
     agent_id: &str,
     session_id: &str,
     revision_id: Option<&str>,
@@ -101,7 +105,7 @@ pub fn persist_decision_journal_entries(
             "confidence": entry.confidence,
         });
         let event = autonoetic_types::causal_chain::CausalEventRecord {
-            event_id: format!("curator-dec-{}", uuid::Uuid::new_v4()),
+            event_id: format!("{}-dec-{}", category, uuid::Uuid::new_v4()),
             agent_id: agent_id.to_string(),
             session_id: session_id.to_string(),
             turn_id: None,
@@ -109,7 +113,7 @@ pub fn persist_decision_journal_entries(
             timestamp: timestamp.clone(),
             // TODO: parameterize category so non-curator agents opting into
             // decision_journal are not misclassified as "curator".
-            category: "curator".to_string(),
+            category: category.to_string(),
             action: "decision".to_string(),
             status: "active".to_string(),
             enforced_rules: Vec::new(),
@@ -122,16 +126,16 @@ pub fn persist_decision_journal_entries(
         store.create_causal_event(&event)?;
     }
 
-    // Summary event: one row per curator run, useful to scope a query to a
+    // Summary event: one row per journal run, useful to scope a query to a
     // single run without joining over the per-entry events.
     let summary = autonoetic_types::causal_chain::CausalEventRecord {
-        event_id: format!("curator-jrn-{}", uuid::Uuid::new_v4()),
+        event_id: format!("{}-jrn-{}", category, uuid::Uuid::new_v4()),
         agent_id: agent_id.to_string(),
         session_id: session_id.to_string(),
         turn_id: None,
-        event_seq: 0,
+        event_seq: entries.len() as u64,
         timestamp,
-        category: "curator".to_string(),
+        category: category.to_string(),
         action: "decision_journal_recorded".to_string(),
         status: "active".to_string(),
         enforced_rules: Vec::new(),
@@ -159,6 +163,7 @@ pub fn persist_decision_journal_entries(
 /// reply carries no journal). Errors only on store-write failure.
 pub fn extract_and_persist(
     store: &GatewayStore,
+    category: &str,
     agent_id: &str,
     session_id: &str,
     revision_id: Option<&str>,
@@ -171,6 +176,6 @@ pub fn extract_and_persist(
         return Ok(0);
     }
     let n = entries.len();
-    persist_decision_journal_entries(store, agent_id, session_id, revision_id, &entries)?;
+    persist_decision_journal_entries(store, category, agent_id, session_id, revision_id, &entries)?;
     Ok(n)
 }

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -17,6 +17,7 @@ pub mod content_store;
 pub mod context;
 pub mod continuation;
 pub mod crypto;
+pub mod curator_journal;
 pub mod disclosure;
 pub mod guard;
 pub mod history_persist;

--- a/autonoetic-gateway/src/runtime/response_validation.rs
+++ b/autonoetic-gateway/src/runtime/response_validation.rs
@@ -830,17 +830,21 @@ impl GatewayExecutionService {
             // Issue #30: if the reply carries a `decision_journal` array
             // (curator-style output), persist one `curator.decision` causal
             // event per entry so operators can query by target.
-            // TODO: wire revision_id from the session's agent binding so
-            // decisions can be attributed to the exact revision that produced
-            // them (requires get_session_agent_binding store lookup).
             if let (Some(store), Some(reply)) =
                 (self.gateway_store(), result.assistant_reply.as_deref())
             {
+                let revision_id = store
+                    .get_session_agent_binding(&result.session_id)
+                    .ok()
+                    .flatten()
+                    .map(|b| b.revision_id)
+                    .filter(|s| !s.is_empty());
                 match crate::runtime::curator_journal::extract_and_persist(
                     store.as_ref(),
+                    "curator",
                     agent_id,
                     &result.session_id,
-                    None,
+                    revision_id.as_deref(),
                     reply,
                 ) {
                     Ok(0) => {}

--- a/autonoetic-gateway/src/runtime/response_validation.rs
+++ b/autonoetic-gateway/src/runtime/response_validation.rs
@@ -830,6 +830,9 @@ impl GatewayExecutionService {
             // Issue #30: if the reply carries a `decision_journal` array
             // (curator-style output), persist one `curator.decision` causal
             // event per entry so operators can query by target.
+            // TODO: wire revision_id from the session's agent binding so
+            // decisions can be attributed to the exact revision that produced
+            // them (requires get_session_agent_binding store lookup).
             if let (Some(store), Some(reply)) =
                 (self.gateway_store(), result.assistant_reply.as_deref())
             {

--- a/autonoetic-gateway/src/runtime/response_validation.rs
+++ b/autonoetic-gateway/src/runtime/response_validation.rs
@@ -826,6 +826,38 @@ impl GatewayExecutionService {
                 session_id = %result.session_id,
                 "response.validation.pass"
             );
+
+            // Issue #30: if the reply carries a `decision_journal` array
+            // (curator-style output), persist one `curator.decision` causal
+            // event per entry so operators can query by target.
+            if let (Some(store), Some(reply)) =
+                (self.gateway_store(), result.assistant_reply.as_deref())
+            {
+                match crate::runtime::curator_journal::extract_and_persist(
+                    store.as_ref(),
+                    agent_id,
+                    &result.session_id,
+                    None,
+                    reply,
+                ) {
+                    Ok(0) => {}
+                    Ok(n) => tracing::info!(
+                        target: "curator_journal",
+                        agent_id = %agent_id,
+                        session_id = %result.session_id,
+                        entry_count = n,
+                        "decision_journal persisted"
+                    ),
+                    Err(e) => tracing::warn!(
+                        target: "curator_journal",
+                        agent_id = %agent_id,
+                        session_id = %result.session_id,
+                        error = %e,
+                        "decision_journal persistence failed"
+                    ),
+                }
+            }
+
             return Ok(result);
         }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -356,6 +356,55 @@ impl GatewayStore {
         Ok(results)
     }
 
+    /// List curator decision events (`category = 'curator'`, `action = 'decision'`)
+    /// for a specific target URI/id. Used by operator workflows asking
+    /// "why was memory X dropped" (issue #30). The underlying `idx_causal_target`
+    /// index makes this an O(log n) point query.
+    pub fn list_curator_decisions_by_target(
+        &self,
+        target: &str,
+        limit: i64,
+    ) -> Result<Vec<autonoetic_types::causal_chain::CausalEventRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT event_id, agent_id, session_id, turn_id, event_seq, timestamp,
+                    category, action, status, enforced_rules, target, payload,
+                    payload_ref, evidence_ref, reason
+             FROM causal_events
+             WHERE category = 'curator' AND action = 'decision' AND target = ?1
+             ORDER BY timestamp DESC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![target, limit], |row| {
+            let enforced_rules_json: String = row.get(9)?;
+            let enforced_rules = Some(enforced_rules_json.as_str())
+                .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+                .unwrap_or_else(autonoetic_types::causal_chain::default_enforced_rules);
+            Ok(autonoetic_types::causal_chain::CausalEventRecord {
+                event_id: row.get(0)?,
+                agent_id: row.get(1)?,
+                session_id: row.get(2)?,
+                turn_id: row.get(3)?,
+                event_seq: row.get::<_, i64>(4)? as u64,
+                timestamp: row.get(5)?,
+                category: row.get(6)?,
+                action: row.get(7)?,
+                status: row.get(8)?,
+                enforced_rules,
+                target: row.get(10)?,
+                payload: row.get(11)?,
+                payload_ref: row.get(12)?,
+                evidence_ref: row.get(13)?,
+                reason: row.get(14)?,
+            })
+        })?;
+        let mut results = Vec::new();
+        for r in rows {
+            results.push(r?);
+        }
+        Ok(results)
+    }
+
     pub fn create_execution_trace(
         &self,
         trace: &autonoetic_types::causal_chain::ExecutionTraceRecord,

--- a/autonoetic-gateway/tests/curator_decision_journal_integration.rs
+++ b/autonoetic-gateway/tests/curator_decision_journal_integration.rs
@@ -124,6 +124,7 @@ fn persist_emits_one_event_per_entry_plus_summary() {
     ];
     persist_decision_journal_entries(
         store.as_ref(),
+        "curator",
         "memory-curator.default",
         "sess-xyz",
         Some("rev-1"),
@@ -183,6 +184,7 @@ fn query_by_target_returns_only_that_target() {
     ];
     persist_decision_journal_entries(
         store.as_ref(),
+        "curator",
         "memory-curator.default",
         "sess-1",
         None,
@@ -207,6 +209,7 @@ fn extract_and_persist_skips_when_no_journal_field() {
     let (_temp, store) = temp_store();
     let n = extract_and_persist(
         store.as_ref(),
+        "curator",
         "memory-curator.default",
         "sess-no-journal",
         None,
@@ -231,6 +234,7 @@ fn extract_and_persist_persists_well_formed_entries() {
     .to_string();
     let n = extract_and_persist(
         store.as_ref(),
+        "curator",
         "memory-curator.default",
         "sess-go",
         Some("rev-9"),

--- a/autonoetic-gateway/tests/curator_decision_journal_integration.rs
+++ b/autonoetic-gateway/tests/curator_decision_journal_integration.rs
@@ -1,0 +1,277 @@
+//! Memory curator decision journal (issue #30).
+//!
+//! Tests:
+//! - `extract_decision_journal_entries` parses well-formed inputs and
+//!   silently drops malformed ones.
+//! - `persist_decision_journal_entries` emits one `curator.decision` causal
+//!   event per entry plus a `decision_journal_recorded` summary event.
+//! - `list_curator_decisions_by_target` round-trips a target lookup.
+//! - The curator SKILL.md frontmatter parses cleanly (smoke test against
+//!   the schema declaration we just added).
+
+use std::sync::Arc;
+
+use autonoetic_gateway::runtime::curator_journal::{
+    extract_and_persist, extract_decision_journal_entries, persist_decision_journal_entries,
+    DecisionJournalEntry,
+};
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+
+fn temp_store() -> (tempfile::TempDir, Arc<GatewayStore>) {
+    let temp = tempfile::tempdir().unwrap();
+    let store = Arc::new(GatewayStore::open(temp.path()).unwrap());
+    (temp, store)
+}
+
+#[test]
+fn extract_returns_none_when_no_journal_field() {
+    let reply = serde_json::json!({
+        "agent_scores": {},
+        "systemic_gaps": [],
+        "learnings_stored": 0
+    })
+    .to_string();
+    assert!(extract_decision_journal_entries(&reply).is_none());
+}
+
+#[test]
+fn extract_returns_none_for_non_json_reply() {
+    assert!(extract_decision_journal_entries("not JSON at all").is_none());
+}
+
+#[test]
+fn extract_returns_empty_when_journal_is_empty_array() {
+    let reply = serde_json::json!({ "decision_journal": [] }).to_string();
+    let entries = extract_decision_journal_entries(&reply).unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn extract_parses_well_formed_entries() {
+    let reply = serde_json::json!({
+        "decision_journal": [
+            {
+                "target": "memory://sess-1/turn-3",
+                "action": "drop",
+                "reason_code": "low_signal",
+                "reason_detail": "too few corroborating sessions",
+                "metric_values": { "supporting_sessions": 1 },
+                "confidence": 0.7
+            },
+            {
+                "target": "agent.coder.default",
+                "action": "flag_for_evolution",
+                "reason_code": "eval_regression"
+            }
+        ]
+    })
+    .to_string();
+    let entries = extract_decision_journal_entries(&reply).unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].target, "memory://sess-1/turn-3");
+    assert_eq!(entries[0].action, "drop");
+    assert_eq!(entries[0].reason_code, "low_signal");
+    assert_eq!(entries[0].confidence, Some(0.7));
+    assert_eq!(
+        entries[0].metric_values,
+        Some(serde_json::json!({ "supporting_sessions": 1 }))
+    );
+    assert_eq!(entries[1].target, "agent.coder.default");
+    assert!(entries[1].reason_detail.is_none());
+}
+
+#[test]
+fn extract_drops_malformed_entries() {
+    let reply = serde_json::json!({
+        "decision_journal": [
+            // missing target
+            { "action": "drop", "reason_code": "low_signal" },
+            // empty target
+            { "target": "", "action": "drop", "reason_code": "low_signal" },
+            // valid
+            { "target": "memory://x/y", "action": "keep", "reason_code": "stable_pattern" },
+            // missing reason_code
+            { "target": "memory://a/b", "action": "drop" },
+        ]
+    })
+    .to_string();
+    let entries = extract_decision_journal_entries(&reply).unwrap();
+    assert_eq!(entries.len(), 1, "only one well-formed entry");
+    assert_eq!(entries[0].target, "memory://x/y");
+    assert_eq!(entries[0].reason_code, "stable_pattern");
+}
+
+#[test]
+fn persist_emits_one_event_per_entry_plus_summary() {
+    let (_temp, store) = temp_store();
+    let entries = vec![
+        DecisionJournalEntry {
+            target: "memory://s/a".to_string(),
+            action: "drop".to_string(),
+            reason_code: "low_signal".to_string(),
+            reason_detail: Some("only 1 session".to_string()),
+            metric_values: None,
+            confidence: Some(0.5),
+        },
+        DecisionJournalEntry {
+            target: "memory://s/b".to_string(),
+            action: "keep".to_string(),
+            reason_code: "high_confidence_pattern".to_string(),
+            reason_detail: None,
+            metric_values: Some(serde_json::json!({ "uses": 12 })),
+            confidence: None,
+        },
+    ];
+    persist_decision_journal_entries(
+        store.as_ref(),
+        "memory-curator.default",
+        "sess-xyz",
+        Some("rev-1"),
+        &entries,
+    )
+    .unwrap();
+
+    let events = store
+        .search_causal_events(Some("sess-xyz"), None, 100)
+        .unwrap();
+    // 2 per-entry events + 1 summary
+    assert_eq!(events.len(), 3);
+    let per_entry: Vec<_> = events
+        .iter()
+        .filter(|e| e.action == "decision")
+        .collect();
+    assert_eq!(per_entry.len(), 2);
+    let summary: Vec<_> = events
+        .iter()
+        .filter(|e| e.action == "decision_journal_recorded")
+        .collect();
+    assert_eq!(summary.len(), 1);
+    let summary_payload: serde_json::Value =
+        serde_json::from_str(summary[0].payload.as_deref().unwrap()).unwrap();
+    assert_eq!(summary_payload["entry_count"], 2);
+    assert_eq!(summary_payload["revision_id"], "rev-1");
+}
+
+#[test]
+fn query_by_target_returns_only_that_target() {
+    let (_temp, store) = temp_store();
+    let entries = vec![
+        DecisionJournalEntry {
+            target: "memory://hot/x".to_string(),
+            action: "drop".to_string(),
+            reason_code: "low_signal".to_string(),
+            reason_detail: None,
+            metric_values: None,
+            confidence: None,
+        },
+        DecisionJournalEntry {
+            target: "memory://cold/y".to_string(),
+            action: "keep".to_string(),
+            reason_code: "high_confidence_pattern".to_string(),
+            reason_detail: None,
+            metric_values: None,
+            confidence: None,
+        },
+        DecisionJournalEntry {
+            target: "memory://hot/x".to_string(),
+            action: "flag_for_evolution".to_string(),
+            reason_code: "eval_regression".to_string(),
+            reason_detail: Some("found again next run".to_string()),
+            metric_values: None,
+            confidence: None,
+        },
+    ];
+    persist_decision_journal_entries(
+        store.as_ref(),
+        "memory-curator.default",
+        "sess-1",
+        None,
+        &entries,
+    )
+    .unwrap();
+
+    let hits = store
+        .list_curator_decisions_by_target("memory://hot/x", 50)
+        .unwrap();
+    assert_eq!(hits.len(), 2);
+    assert!(hits
+        .iter()
+        .all(|e| e.target.as_deref() == Some("memory://hot/x")));
+    assert!(hits
+        .iter()
+        .all(|e| e.category == "curator" && e.action == "decision"));
+}
+
+#[test]
+fn extract_and_persist_skips_when_no_journal_field() {
+    let (_temp, store) = temp_store();
+    let n = extract_and_persist(
+        store.as_ref(),
+        "memory-curator.default",
+        "sess-no-journal",
+        None,
+        r#"{"agent_scores":{},"systemic_gaps":[]}"#,
+    )
+    .unwrap();
+    assert_eq!(n, 0);
+    let events = store
+        .search_causal_events(Some("sess-no-journal"), None, 10)
+        .unwrap();
+    assert!(events.is_empty());
+}
+
+#[test]
+fn extract_and_persist_persists_well_formed_entries() {
+    let (_temp, store) = temp_store();
+    let reply = serde_json::json!({
+        "decision_journal": [
+            { "target": "memory://t/1", "action": "drop", "reason_code": "stale" }
+        ]
+    })
+    .to_string();
+    let n = extract_and_persist(
+        store.as_ref(),
+        "memory-curator.default",
+        "sess-go",
+        Some("rev-9"),
+        &reply,
+    )
+    .unwrap();
+    assert_eq!(n, 1);
+    let hits = store
+        .list_curator_decisions_by_target("memory://t/1", 10)
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+}
+
+#[test]
+fn curator_skill_md_parses_with_new_schema() {
+    // The frontmatter now declares io.returns. Smoke-test that the existing
+    // agent-parser machinery still loads the manifest end-to-end.
+    let skill_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("agents/evolution/memory-curator.default/SKILL.md");
+    let text = std::fs::read_to_string(&skill_path).expect("read curator SKILL.md");
+    let (manifest, _body) = autonoetic_gateway::runtime::parser::SkillParser::parse(&text)
+        .expect("curator SKILL.md must parse with the issue #30 schema additions");
+    let io = manifest
+        .io
+        .as_ref()
+        .expect("curator manifest must carry io block");
+    let returns = io
+        .returns
+        .as_ref()
+        .expect("curator manifest must declare io.returns");
+    let required = returns
+        .get("required")
+        .and_then(|v: &serde_json::Value| v.as_array())
+        .expect("io.returns.required must be an array");
+    let required_keys: Vec<&str> = required
+        .iter()
+        .filter_map(|v: &serde_json::Value| v.as_str())
+        .collect();
+    assert!(required_keys.contains(&"decision_journal"));
+    assert!(required_keys.contains(&"agent_scores"));
+    assert!(required_keys.contains(&"systemic_gaps"));
+}

--- a/autonoetic-gateway/tests/curator_decision_journal_integration.rs
+++ b/autonoetic-gateway/tests/curator_decision_journal_integration.rs
@@ -89,7 +89,7 @@ fn extract_drops_malformed_entries() {
             // empty target
             { "target": "", "action": "drop", "reason_code": "low_signal" },
             // valid
-            { "target": "memory://x/y", "action": "keep", "reason_code": "stable_pattern" },
+            { "target": "memory://x/y", "action": "keep", "reason_code": "high_confidence_pattern" },
             // missing reason_code
             { "target": "memory://a/b", "action": "drop" },
         ]
@@ -98,7 +98,7 @@ fn extract_drops_malformed_entries() {
     let entries = extract_decision_journal_entries(&reply).unwrap();
     assert_eq!(entries.len(), 1, "only one well-formed entry");
     assert_eq!(entries[0].target, "memory://x/y");
-    assert_eq!(entries[0].reason_code, "stable_pattern");
+    assert_eq!(entries[0].reason_code, "high_confidence_pattern");
 }
 
 #[test]

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -60,6 +60,34 @@ max_background_due_per_tick: 32
 # Guardrail: sub-10s schedules are allowed only for script-mode target agents.
 # For tight schedules (<5s), reduce background_tick_secs to 1 for better precision.
 
+# ── Fast Scheduler Sidecar ────────────────────────────────────────────
+# Parallel low-latency loop for interval-style jobs (every N seconds).
+# Disabled by default. DB claim-and-advance remains the source of truth
+# so the canonical scheduler and the fast sidecar cannot double-dispatch.
+# Only interval-mode schedules are eligible; cron-style schedules stay
+# on the canonical loop. Sub-10s intervals still require script-mode
+# targets (defense-in-depth re-check at dispatch).
+# fast_scheduler:
+#   enabled: false
+#   tick_millis: 200          # How often the fast loop wakes up (ms)
+#   max_due_per_tick: 64      # Bounded work per tick
+
+# ── Promotion Safety Governor ────────────────────────────────────────
+# Three soft gates enforced at agent.revision.promote time:
+#   velocity:        max promotions per alias in a sliding window
+#   flapping:        reject if the candidate revision was promoted recently
+#   eval-regression: halt if finding counts are strictly increasing over
+#                    consecutive recent promotions
+# All three are bypassable via force=true + force_reason (operator override).
+# Disabled by default.
+# promotion_governor:
+#   enabled: false
+#   velocity_window_hours: 24       # Sliding window for velocity check
+#   max_promotions_per_window: 3    # Max promotes per alias in that window
+#   flapping_lookback: 4            # How many recent promotions to scan
+#   eval_regression_streak: 3       # Adjacent increases needed to halt
+#   eval_regression_lookback: 6     # How many recent promotions to scan
+
 # ── Response Validation & Repair ──────────────────────────────────────
 # When enabled, the gateway validates agent outputs against declared constraints.
 # repair_enabled allows auto-repair only for agents that explicitly opt in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,9 @@ Autonoetic is a Rust-first runtime for autonomous, self-evolving AI agents with 
 - [Recording Mode](#recording-mode)
 - [Post-Promotion Review](#post-promotion-review)
 - [Scheduled Tasks](#scheduled-tasks)
+- [Fast Scheduler Sidecar](#fast-scheduler-sidecar)
+- [Promotion Safety Governor](#promotion-safety-governor)
+- [Curator Decision Journal](#curator-decision-journal)
 - [Error Taxonomy](#error-taxonomy)
 - [Design Principles](#design-principles)
 
@@ -92,6 +95,7 @@ The gateway is the security boundary and execution engine. It is a **narrow rule
 | **Content Store** | SHA-256 content-addressable storage for artifacts |
 | **Causal Chain** | Append-only JSONL audit log with hash-chain integrity |
 | **Scheduler** | Manages background reevaluation cadence; wake predicates: `Timer` and `ApprovalResolved` |
+| **Fast Scheduler** | Parallel low-latency loop for sub-second interval jobs (disabled by default) |
 | **Sandbox Runner** | Executes scripts via bubblewrap, docker, or microvm |
 | **Secret Vault** | Injects secrets ephemerally, never exposes to agents |
 | **HTTP API** | REST endpoints for remote agent content access |
@@ -1272,6 +1276,48 @@ On startup, the gateway checks each declared agent:
 CLI control: `autonoetic gateway system-agents list|bootstrap|run <agent_id>`
 
 System agent jobs use the same `scheduled_jobs` table and execution path as agent-created jobs — no special privileges. See [Scheduled Tasks Guide](scheduled-tasks.md) for full documentation.
+
+### Fast Scheduler Sidecar
+
+For interval-style jobs (`every N seconds`), the canonical 5-second scheduler tick introduces unacceptable latency. The fast scheduler sidecar runs a parallel loop (default: 200 ms tick) that checks the same `scheduled_jobs` table but only considers interval-mode schedules (cron-style schedules stay on the canonical loop).
+
+Key design decisions:
+- **Same DB claim-and-advance**: both loops call `claim_and_advance_due_job`, so double-dispatch is impossible at the database level
+- **Pre-filtering**: the fast loop filters out cron-expression jobs before counting (cron expressions are opaque strings the DB cannot parse)
+- **Bounded work**: `max_due_per_tick` (default 64) caps the number of jobs claimed per tick
+- **Disabled by default**: enable via `fast_scheduler.enabled: true` in config
+
+---
+
+## Promotion Safety Governor
+
+Three soft gates enforced at `agent_revision_promote` time, protecting against promotion storms:
+
+1. **Velocity gate**: limits the number of promotions per alias within a sliding time window (default: 3 per 24 hours). Prevents rapid-fire promote/rollback cycles.
+
+2. **Flapping gate**: rejects promotions where the candidate revision was already promoted recently (scans the last N promotions, default 4). Detects oscillation between two revisions.
+
+3. **Eval-regression gate**: halts promotion when the count of findings (errors, warnings) is strictly increasing across consecutive recent promotions. Requires N adjacent increases (default: 3) within a lookback window (default: 6 promotions).
+
+All three gates are bypassable via `force: true` + `force_reason` (capped at 512 characters). Bypass emits a `governor.override` causal event for audit. The governor is disabled by default; enable via `promotion_governor.enabled: true`.
+
+The governor runs after the existing capability-delta and sentinel gates but before the alias is moved. A TOCTOU race window exists between the velocity check and the actual promotion (the check reads promotion_history, then the promote writes it), but this is acceptable for a default-disabled, force-overridable soft gate.
+
+---
+
+## Curator Decision Journal
+
+When response validation is enabled, the gateway parses the `decision_journal` array from agent output and persists one causal event per entry. This provides a durable, queryable audit trail for memory curation decisions (keep, drop, merge, etc.).
+
+Each entry produces a `curator.decision` causal event with:
+- `target`: the memory or resource the decision applies to (enables direct queries like "why was memory X dropped?")
+- `action`: what was done
+- `reason_code`: stable machine-readable code
+- `reason_detail`, `metric_values`, `confidence`: optional structured context
+
+A summary event (`decision_journal_recorded`) is also emitted per agent run, carrying the total entry count. Events are sequenced (0, 1, 2, ...) for deterministic batch ordering within a single run.
+
+The category is configurable per agent type (defaults to `curator`), making the journal reusable for other decision-making agents beyond the memory curator. The gateway wires the `revision_id` from the session's agent binding into each event for full provenance tracking.
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -144,6 +144,76 @@ sandbox:
 
 ---
 
+## Fast Scheduler Sidecar
+
+Parallel low-latency scheduling loop for interval-style jobs (`every N seconds`). Runs beside the canonical background scheduler, sharing the same DB `claim_and_advance_due_job` call so the two loops cannot double-dispatch.
+
+Only interval-mode schedules are eligible; cron-style schedules remain on the canonical 5-second loop. Sub-10s intervals still require script-mode targets (defense-in-depth re-check at dispatch).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `fast_scheduler.enabled` | bool | `false` | Enable the fast scheduler sidecar. |
+| `fast_scheduler.tick_millis` | u64 | `200` | How often the fast loop wakes up (milliseconds). |
+| `fast_scheduler.max_due_per_tick` | usize | `64` | Maximum candidate jobs admitted per tick. |
+
+Example:
+
+```yaml
+fast_scheduler:
+  enabled: true
+  tick_millis: 200
+  max_due_per_tick: 64
+```
+
+---
+
+## Promotion Safety Governor
+
+Three soft gates enforced at `agent_revision_promote` time, guarding against runaway promotion velocity, flapping (re-promoting a recently-active revision), and eval regression (finding counts strictly increasing across consecutive promotions).
+
+All three gates are bypassable via `force: true` + `force_reason` (operator override, capped at 512 characters). Bypass emits a `governor.override` causal event. Disabled by default.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `promotion_governor.enabled` | bool | `false` | Enable governor checks. |
+| `promotion_governor.velocity_window_hours` | u64 | `24` | Sliding window for the velocity check (hours). |
+| `promotion_governor.max_promotions_per_window` | usize | `3` | Maximum `Promote` entries per alias inside the velocity window. |
+| `promotion_governor.flapping_lookback` | usize | `4` | How many most-recent promotions to scan when checking for candidate-exclusion (re-promoting a revision already seen recently). |
+| `promotion_governor.eval_regression_streak` | usize | `3` | How many adjacent finding-count comparisons must be strictly increasing for the eval-regression halt to fire. |
+| `promotion_governor.eval_regression_lookback` | usize | `6` | Maximum number of recent promotions to scan for the eval-regression streak. |
+
+Example:
+
+```yaml
+promotion_governor:
+  enabled: true
+  velocity_window_hours: 24
+  max_promotions_per_window: 3
+  flapping_lookback: 4
+  eval_regression_streak: 3
+  eval_regression_lookback: 6
+```
+
+---
+
+## Curator Decision Journal
+
+When `response_validation` is enabled, the gateway automatically parses the `decision_journal` array from agent output and persists one `curator.decision` causal event per entry. This is always active when response validation is on — no separate configuration key is needed.
+
+Each entry records:
+- **target**: the memory or resource the decision applies to
+- **action**: what was done (e.g. `keep`, `drop`, `merge`)
+- **reason_code**: stable machine-readable code (e.g. `high_confidence_pattern`)
+- **reason_detail**: optional human-readable explanation
+- **metric_values**: optional structured metrics
+- **confidence**: optional 0.0–1.0 confidence score
+
+The event's `target` column carries the entry's `target` field, enabling direct queries like "why was memory X dropped?". A summary event (`decision_journal_recorded`) is also emitted per agent run with the total entry count.
+
+The category parameter is configurable per agent type (defaults to `curator`). See `docs/security-sentinel.md` for how the sentinel's future LLM-judgment layer will audit these entries.
+
+---
+
 ## Response Validation & Repair
 
 When enabled, the gateway validates agent outputs against declared constraints in agent metadata before returning results to the caller. Repair mode adds bounded retry loops when validation fails, but only for agents that opt in via `io.output_policy.repair.auto`.


### PR DESCRIPTION
Closes #30. Closes the evolution-tier audit gap: the \`memory_curator\` was emitting only aggregate \`agent_scores\`, with no per-decision record of *why* a memory was kept / dropped / promoted / flagged. An operator could not ask \"why was memory X dropped\" and get a direct answer. Now they can.

## Summary

- **Agent output contract** (\`agents/evolution/memory-curator.default/SKILL.md\`) — adds \`metadata.autonoetic.io.returns\` JSON schema with a required \`decision_journal\` array of \`{target, action, reason_code, reason_detail, metric_values, confidence}\` entries. Documents the journal obligation, the \`reason_code\` vocabulary, and the \`target\` URI conventions (\`memory://<session>/turn-N\`, agent ids, knowledge entry ids).
- **Gateway-side persistence** (\`runtime/curator_journal.rs\`) — parses the curator's reply for \`decision_journal\`, drops malformed entries with a warn log, then emits **one \`curator.decision\` causal event per entry** (with the entry's \`target\` in the event's \`target\` column) plus a \`curator.decision_journal_recorded\` summary event.
- **Hook** — wired into \`GatewayExecutionService::validate_and_maybe_repair\` after schema validation passes. Skipped silently when no \`decision_journal\` field is present.
- **Operator query** — \`GatewayStore::list_curator_decisions_by_target(target, limit)\` rides the existing \`idx_causal_target\` index. This is the operator workflow \"why was memory X dropped\".

## Why a gateway-side parser rather than a curator-side tool

The issue prefers the output-contract approach: one structured reply at the end of the run rather than ~N tool calls per decision. The schema validator (\`#19\`) already enforces shape; the gateway just walks the validated array and emits events. Any agent can opt into the same surface by declaring \`decision_journal\` in its \`io.returns\` — not curator-specific.

## reason_code vocabulary

\`low_signal\` · \`redundant_with\` · \`threshold_hit\` · \`stale\` · \`superseded\` · \`high_confidence_pattern\` · \`cross_session_signal\` · \`eval_regression\` · \`operator_request\` · \`other\`. Documented in the curator SKILL.md body.

## Files

- \`agents/evolution/memory-curator.default/SKILL.md\` — io.returns schema + journal obligation + reason_code vocabulary
- \`autonoetic-gateway/src/runtime/curator_journal.rs\` — \`DecisionJournalEntry\`, \`extract_decision_journal_entries\`, \`persist_decision_journal_entries\`, \`extract_and_persist\`
- \`autonoetic-gateway/src/runtime/response_validation.rs\` — hook in \`validate_and_maybe_repair\`
- \`autonoetic-gateway/src/scheduler/gateway_store/observability.rs\` — \`list_curator_decisions_by_target\`
- \`autonoetic-gateway/src/runtime/mod.rs\` — module wiring
- \`autonoetic-gateway/tests/curator_decision_journal_integration.rs\` — 10 tests

## Test plan

- [x] \`cargo test -p autonoetic-gateway --test curator_decision_journal_integration\` — 10/10 pass
- [x] \`cargo test -p autonoetic-gateway --test response_validation_integration --test input_schema_validation_integration --test generated_skill_integration\` — all pass (regression)
- [x] \`cargo build -p autonoetic-gateway\` — clean

The 10 governor tests cover: missing/empty/non-JSON replies (none returned); well-formed parse; malformed-entry dropping; emit-per-entry-plus-summary event count; query-by-target round-trip; \`extract_and_persist\` end-to-end; SKILL.md frontmatter parses cleanly with the new schema.

## What this unblocks

- Operator audits of curator judgment over time (the issue's \"curator-on-curator review\" angle becomes a normal causal-event query).
- A future bias-detection sentinel — e.g. \"this curator consistently drops memories from agent X\" — can be implemented as a sweep over \`category='curator', action='decision'\` rows grouped by some derived attribute of \`target\`.
- The evolution observability surface tracked in #29 now has a real per-decision feed to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)