### PR TITLE
feat: pluggable context governor + safe defaults (Phases 0 & 1)

### DIFF
--- a/autonoetic-gateway/src/llm/anthropic.rs
+++ b/autonoetic-gateway/src/llm/anthropic.rs
@@ -145,6 +145,11 @@ impl LlmDriver for AnthropicDriver {
                 .unwrap_or(false)
             {
                 let text = response.text().await.unwrap_or_default();
+                if crate::llm::is_context_overflow_error(status, &text) {
+                    anyhow::bail!(
+                        "context_overflow: provider=anthropic status={} detail={}", status, text
+                    );
+                }
                 anyhow::bail!("Anthropic API error {}: {}", status, text);
             }
 

--- a/autonoetic-gateway/src/llm/gemini.rs
+++ b/autonoetic-gateway/src/llm/gemini.rs
@@ -180,21 +180,27 @@ impl LlmDriver for GeminiDriver {
             let response = builder.send().await?;
             let status = response.status().as_u16();
 
-            if status == 429 {
-                if attempt < MAX_RETRIES {
-                    let wait_ms = (attempt + 1) as u64 * 2000;
-                    tracing::warn!(status, attempt, wait_ms, "Gemini rate limited, retrying");
-                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-                    continue;
-                }
-                anyhow::bail!("Gemini rate limited after {} retries", MAX_RETRIES);
-            }
-
+            // Check context overflow *before* rate-limit retry, because
+            // Gemini sometimes overflows as HTTP 429 with RESOURCE_EXHAUSTED.
             if !reqwest::StatusCode::from_u16(status)
                 .map(|s| s.is_success())
                 .unwrap_or(false)
             {
                 let text = response.text().await.unwrap_or_default();
+                if crate::llm::is_context_overflow_error(status, &text) {
+                    anyhow::bail!(
+                        "context_overflow: provider=gemini status={} detail={}", status, text
+                    );
+                }
+                if status == 429 {
+                    if attempt < MAX_RETRIES {
+                        let wait_ms = (attempt + 1) as u64 * 2000;
+                        tracing::warn!(status, attempt, wait_ms, "Gemini rate limited, retrying");
+                        tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                        continue;
+                    }
+                    anyhow::bail!("Gemini rate limited after {} retries", MAX_RETRIES);
+                }
                 anyhow::bail!("Gemini API error {}: {}", status, text);
             }
 

--- a/autonoetic-gateway/src/llm/mod.rs
+++ b/autonoetic-gateway/src/llm/mod.rs
@@ -16,6 +16,48 @@ pub mod gemini;
 pub mod openai;
 pub mod provider;
 
+/// Check whether a non-success status / body indicates a context-overflow error
+/// for any of the supported providers.  Returns `true` when the governor should
+/// trigger reduction strategies rather than propagate a fatal error.
+///
+/// Pattern matching order:
+///  1. `\"code\":\"context_length_exceeded\"` — OpenAI minified JSON in error body
+///  2. `max_context_window_reached` — Anthropic
+///  3. `RESOURCE_EXHAUSTED` + `context` — Gemini
+///  4. `SAFETY` — content-filter rejections (not overflow but surfaced the same way)
+pub fn is_context_overflow_error(status: u16, body: &str) -> bool {
+    if status == 0 {
+        return false;
+    }
+
+    // OpenRouter / OpenAI — pass through the JSON error body to check
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
+        // OpenAI returns error.code == "context_length_exceeded"
+        if let Some(code) = val.get("error").and_then(|e| e.get("code")).and_then(|c| c.as_str()) {
+            if code == "context_length_exceeded" {
+                return true;
+            }
+        }
+    }
+
+    // Anthropic — full text search (Anthropic doesn't always JSON-encode)
+    if body.contains("max_context_window_reached") {
+        return true;
+    }
+
+    // Gemini RESOURCE_EXHAUSTED context overflow
+    if body.contains("RESOURCE_EXHAUSTED") && body.contains("context") {
+        return true;
+    }
+
+    // Safety filter — treat as overflow-like so the governor handles it
+    if body.contains("SAFETY") {
+        return true;
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests;
 

--- a/autonoetic-gateway/src/llm/openai.rs
+++ b/autonoetic-gateway/src/llm/openai.rs
@@ -204,6 +204,11 @@ impl LlmDriver for OpenAiDriver {
 
             if !status.is_success() {
                 let text = response.text().await.unwrap_or_default();
+                if crate::llm::is_context_overflow_error(status.as_u16(), &text) {
+                    anyhow::bail!(
+                        "context_overflow: provider=openai status={} detail={}", status, text
+                    );
+                }
                 tracing::warn!(
                     target: "llm::openai",
                     status = %status,

--- a/autonoetic-gateway/src/runtime/context_governor/budget.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/budget.rs
@@ -1,0 +1,8 @@
+//! Budget computation.
+//!
+//! Re-exports from `prompt_budget` for use by the governor pipeline.
+//! Long-term, this module will own the budget types directly.
+
+pub use crate::runtime::prompt_budget::{
+    compress_tool_definitions, estimate_tokens, filter_tools_by_tier, PromptBudgetBreakdown,
+};

--- a/autonoetic-gateway/src/runtime/context_governor/compression.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/compression.rs
@@ -1,0 +1,116 @@
+use crate::runtime::compression::{self};
+use crate::runtime::context_governor::strategies::{
+    GovernorContext, ReductionOutcome,
+};
+use autonoetic_types::config::LlmPreset;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// LLM-based summarization strategy. Wraps existing `compress_context()`.
+pub struct CompressionStrategy {
+    http_client: reqwest::Client,
+    presets: HashMap<String, LlmPreset>,
+    gateway_dir: Option<PathBuf>,
+}
+
+impl CompressionStrategy {
+    pub fn new(
+        http_client: reqwest::Client,
+        presets: HashMap<String, LlmPreset>,
+    ) -> Self {
+        Self {
+            http_client,
+            presets,
+            gateway_dir: None,
+        }
+    }
+
+    pub fn with_gateway_dir(mut self, dir: PathBuf) -> Self {
+        self.gateway_dir = Some(dir);
+        self
+    }
+}
+
+#[async_trait]
+impl super::ReductionStrategy for CompressionStrategy {
+    fn name(&self) -> &'static str {
+        "compression"
+    }
+
+    async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+        let Some(ref cfg) = ctx.compression_config else {
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: ctx.breakdown.total_tokens,
+            });
+        };
+        if !cfg.enabled {
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: ctx.breakdown.total_tokens,
+            });
+        }
+
+        let result = compression::compress_context(
+            ctx.history.clone(),
+            ctx.breakdown.context_window,
+            cfg,
+            ctx.agent_compression.as_ref(),
+            &self.presets,
+            &self.http_client,
+            &ctx.session_id,
+            ctx.turn_number,
+            ctx.compression_metadata.as_ref(),
+        )
+        .await?;
+
+        if !result.compressed {
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: ctx.breakdown.total_tokens,
+            });
+        }
+
+        let mut new_meta = result.metadata;
+
+        // Persist original history to content store for audit
+        if let Some(ref dir) = self.gateway_dir {
+            if let Ok(Some(handle)) = compression::persist_compressed_context(
+                dir,
+                &ctx.session_id,
+                &result.original_history,
+                &new_meta,
+            ) {
+                new_meta.compressed_context_handle = Some(handle);
+            }
+        }
+
+        let conv_text: String = result
+            .history
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let tokens_after = crate::runtime::prompt_budget::estimate_tokens(&conv_text);
+        let new_total = ctx
+            .breakdown
+            .total_tokens
+            .saturating_sub(ctx.breakdown.conversation_tokens)
+            .saturating_add(tokens_after);
+
+        ctx.history = result.history;
+        ctx.compression_metadata = Some(new_meta);
+        // Update breakdown total to reflect compressed history
+        ctx.breakdown.conversation_tokens = tokens_after;
+        ctx.breakdown.total_tokens = new_total;
+
+        let still_over = ctx.breakdown.total_tokens > ctx.effective_limit;
+        if still_over {
+            Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: ctx.breakdown.total_tokens,
+            })
+        } else {
+            Ok(ReductionOutcome::Resolved {
+                tokens_after: ctx.breakdown.total_tokens,
+            })
+        }
+    }
+}

--- a/autonoetic-gateway/src/runtime/context_governor/demotion.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/demotion.rs
@@ -1,0 +1,49 @@
+use crate::llm::{Message, ToolDefinition};
+use crate::runtime::context_governor::strategies::{GovernorContext, ReductionOutcome};
+use crate::runtime::prompt_budget::{estimate_tokens, estimate_tool_definition, BudgetEnforcementStrategy};
+use async_trait::async_trait;
+
+fn recompute_total(system_tokens: usize, history: &[Message], tools: &[ToolDefinition]) -> usize {
+    let conv: usize = history.iter()
+        .filter(|m| !matches!(m.role, crate::llm::Role::System))
+        .map(|m| estimate_tokens(&m.content))
+        .sum();
+    let tool_tokens: usize = tools.iter().map(estimate_tool_definition).sum();
+    system_tokens + conv + tool_tokens
+}
+
+/// Remove specialized-tier tool definitions to reduce token usage.
+pub struct ToolDemotionStrategy;
+
+#[async_trait]
+impl super::ReductionStrategy for ToolDemotionStrategy {
+    fn name(&self) -> &'static str {
+        "demote_tools"
+    }
+
+    async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+        let system_prompt_tokens = ctx.breakdown.system_prompt_tokens;
+        let strategy = crate::runtime::prompt_budget::DemoteToolsStrategy;
+        let result = strategy.enforce(
+            ctx.tools.clone(),
+            ctx.history.clone(),
+            &ctx.breakdown,
+            ctx.effective_limit,
+            &ctx.budget_config,
+        )?;
+
+        let new_total = recompute_total(system_prompt_tokens, &result.history, &result.tools);
+        if new_total > ctx.effective_limit {
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: new_total,
+            });
+        }
+
+        ctx.tools = result.tools;
+        ctx.history = result.history;
+        ctx.breakdown.total_tokens = new_total;
+        Ok(ReductionOutcome::Resolved {
+            tokens_after: new_total,
+        })
+    }
+}

--- a/autonoetic-gateway/src/runtime/context_governor/error.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/error.rs
@@ -1,0 +1,54 @@
+use serde::Serialize;
+use std::fmt;
+
+/// Typed error for context overflow situations.
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextOverflowError {
+    pub diagnostic: ContextOverflowDiagnostic,
+}
+
+impl fmt::Display for ContextOverflowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "context overflow after {} actions: {} tokens vs limit {}",
+            self.diagnostic.actions_attempted.len(),
+            self.diagnostic.budget_snapshot.estimated_input,
+            self.diagnostic.budget_snapshot.window.unwrap_or(0),
+        )
+    }
+}
+
+impl std::error::Error for ContextOverflowError {}
+
+/// Structured diagnostic emitted when the governor fails to reduce context.
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextOverflowDiagnostic {
+    pub budget_snapshot: BudgetSnapshot,
+    pub actions_attempted: Vec<GovernorAction>,
+    pub recovery_action: RecoveryAction,
+}
+
+/// Snapshot of budget state at the time of overflow.
+#[derive(Debug, Clone, Serialize)]
+pub struct BudgetSnapshot {
+    pub estimated_input: usize,
+    pub margin: usize,
+    pub window: Option<usize>,
+    pub threshold_pct: f64,
+}
+
+/// What the governor did (or didn't) do to recover.
+#[derive(Debug, Clone, Serialize)]
+pub enum RecoveryAction {
+    Compressed,
+    Trimmed,
+    Failed,
+}
+
+/// Record of a single strategy firing in the pipeline.
+#[derive(Debug, Clone, Serialize)]
+pub struct GovernorAction {
+    pub strategy: String,
+    pub tokens_after: usize,
+}

--- a/autonoetic-gateway/src/runtime/context_governor/mod.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/mod.rs
@@ -1,0 +1,125 @@
+//! Pluggable Context Governor.
+//!
+//! Owns the full context budget lifecycle as a configurable pipeline of
+//! reduction strategies. The lifecycle loop calls a single `govern()` method.
+//!
+//! Adding a new reduction approach: implement `ReductionStrategy`, register
+//! it in the pipeline. Zero changes to lifecycle or the pipeline orchestrator.
+
+use crate::runtime::context_governor::error::{BudgetSnapshot, GovernorAction, RecoveryAction};
+use crate::runtime::context_governor::strategies::{
+    GovernorContext, GovernorResult, ReductionOutcome, ReductionStrategy,
+};
+use autonoetic_types::config::LlmPreset;
+use std::collections::HashMap;
+
+pub mod budget;
+pub mod compression;
+pub mod demotion;
+pub mod error;
+pub mod resolver;
+pub mod schema_compress;
+pub mod strategies;
+pub mod trimming;
+
+const STRICT_GOVERNOR_ENV: &str = "AUTONOETIC_STRICT_CONTEXT_GOVERNOR";
+
+/// Whether the strict context governor is enabled.
+pub fn strict_governor_enabled() -> bool {
+    std::env::var(STRICT_GOVERNOR_ENV).as_deref() == Ok("1")
+}
+
+/// Configuration for the context governor pipeline.
+pub struct GovernorConfig {
+    pub http_client: reqwest::Client,
+    pub presets: HashMap<String, LlmPreset>,
+}
+
+/// The context governor — runs a pluggable strategy pipeline.
+pub struct ContextGovernor {
+    strategies: Vec<Box<dyn ReductionStrategy>>,
+}
+
+impl ContextGovernor {
+    /// Build the default pipeline.
+    pub fn new(config: &GovernorConfig) -> Self {
+        let strategies: Vec<Box<dyn ReductionStrategy>> = vec![
+            Box::new(schema_compress::ToolSchemaCompressionStrategy),
+            Box::new(compression::CompressionStrategy::new(
+                config.http_client.clone(),
+                config.presets.clone(),
+            )),
+            Box::new(trimming::TrimHistoryStrategy),
+            Box::new(demotion::ToolDemotionStrategy),
+        ];
+        Self { strategies }
+    }
+
+    /// Build a custom pipeline (for testing or per-profile overrides).
+    pub fn with_strategies(strategies: Vec<Box<dyn ReductionStrategy>>) -> Self {
+        Self { strategies }
+    }
+
+    /// Run the full pipeline.
+    ///
+    /// Returns `WithinBudget` if no action needed, `Recovered` if the pipeline
+    /// resolved the issue, or `Overflow` with diagnostics if all strategies
+    /// were exhausted.
+    pub async fn govern(&self, ctx: &mut GovernorContext) -> anyhow::Result<GovernorResult> {
+        let within_budget = ctx.breakdown.total_tokens <= ctx.effective_limit;
+        if within_budget {
+            return Ok(GovernorResult::WithinBudget);
+        }
+
+        let mut actions_taken: Vec<GovernorAction> = Vec::new();
+
+        for strategy in &self.strategies {
+            let outcome = strategy.reduce(ctx).await?;
+            match outcome {
+                ReductionOutcome::Resolved { tokens_after } => {
+                    actions_taken.push(GovernorAction {
+                        strategy: strategy.name().to_string(),
+                        tokens_after,
+                    });
+                    return Ok(GovernorResult::Recovered { actions_taken });
+                }
+                ReductionOutcome::Insufficient { tokens_remaining } => {
+                    actions_taken.push(GovernorAction {
+                        strategy: strategy.name().to_string(),
+                        tokens_after: tokens_remaining,
+                    });
+                }
+            }
+        }
+
+        Ok(GovernorResult::Overflow(
+            crate::runtime::context_governor::error::ContextOverflowDiagnostic {
+                budget_snapshot: BudgetSnapshot::from(ctx),
+                actions_attempted: actions_taken,
+                recovery_action: RecoveryAction::Failed,
+            },
+        ))
+    }
+}
+
+impl From<&GovernorContext> for BudgetSnapshot {
+    fn from(ctx: &GovernorContext) -> Self {
+        BudgetSnapshot {
+            estimated_input: ctx.breakdown.total_tokens,
+            margin: ctx.budget_config.margin_tokens,
+            window: ctx.breakdown.context_window,
+            threshold_pct: ctx.budget_config.warn_at_pct,
+        }
+    }
+}
+
+impl From<&mut GovernorContext> for BudgetSnapshot {
+    fn from(ctx: &mut GovernorContext) -> Self {
+        BudgetSnapshot {
+            estimated_input: ctx.breakdown.total_tokens,
+            margin: ctx.budget_config.margin_tokens,
+            window: ctx.breakdown.context_window,
+            threshold_pct: ctx.budget_config.warn_at_pct,
+        }
+    }
+}

--- a/autonoetic-gateway/src/runtime/context_governor/resolver.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/resolver.rs
@@ -1,0 +1,104 @@
+//! Context window resolution.
+//!
+//! Resolves the effective context window from manifest, env vars, or
+//! provider catalog. Also includes static lookup for common models.
+
+use crate::runtime::openrouter_catalog::OpenRouterCatalog;
+use autonoetic_types::agent::AgentManifest;
+use std::sync::Arc;
+
+/// Resolve from manifest or env var.
+pub fn resolve_context_window_tokens(manifest: &AgentManifest) -> Option<u32> {
+    if let Some(cfg) = &manifest.llm_config {
+        if let Some(w) = cfg.context_window_tokens {
+            return Some(w);
+        }
+    }
+    std::env::var("AUTONOETIC_LLM_CONTEXT_WINDOW")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Manifest/env first; if still unknown and provider is OpenRouter, use the
+/// public models API cache. For other providers, falls back to static table.
+pub async fn resolve_context_window_for_run(
+    manifest: &AgentManifest,
+    model: &str,
+    catalog: Option<&Arc<OpenRouterCatalog>>,
+) -> Option<u32> {
+    if let Some(w) = resolve_context_window_tokens(manifest) {
+        return Some(w);
+    }
+    if let Some(w) = static_context_window(model) {
+        return Some(w);
+    }
+    let use_openrouter = manifest
+        .llm_config
+        .as_ref()
+        .map(|c| c.provider.eq_ignore_ascii_case("openrouter"))
+        .unwrap_or(false);
+    if !use_openrouter {
+        return None;
+    }
+    match catalog {
+        Some(cat) => cat.context_length_for_model(model).await.map(|v| v as u32),
+        None => None,
+    }
+}
+
+/// Static lookup table for common models that don't go through OpenRouter catalog.
+pub fn static_context_window(model: &str) -> Option<u32> {
+    let model_lower = model.to_lowercase();
+    // OpenAI models
+    if model_lower.starts_with("gpt-4o") {
+        return Some(128_000);
+    }
+    if model_lower.starts_with("gpt-4-turbo") {
+        return Some(128_000);
+    }
+    if model_lower.starts_with("gpt-4-") && model_lower.contains("1106") {
+        return Some(128_000);
+    }
+    if model_lower.starts_with("gpt-4") && !model_lower.contains("turbo") {
+        return Some(8_192);
+    }
+    if model_lower.starts_with("gpt-3.5-turbo") {
+        return Some(16_385);
+    }
+    if model_lower.starts_with("o1") || model_lower.starts_with("o3") || model_lower.starts_with("o4") {
+        return Some(200_000);
+    }
+    // Anthropic models
+    if model_lower.contains("claude") {
+        if model_lower.contains("sonnet-4") || model_lower.contains("opus-4") || model_lower.contains("haiku-4") {
+            return Some(200_000);
+        }
+        if model_lower.contains("sonnet") || model_lower.contains("opus") {
+            return Some(200_000);
+        }
+        if model_lower.contains("haiku") {
+            return Some(200_000);
+        }
+    }
+    // Gemini models
+    if model_lower.starts_with("gemini") {
+        if model_lower.contains("2.0") || model_lower.contains("2.5") || model_lower.contains("2.0-flash") {
+            return Some(1_048_576);
+        }
+        if model_lower.contains("1.5") {
+            return Some(1_048_576);
+        }
+        return Some(128_000);
+    }
+    None
+}
+
+/// Maps provider prompt (`input`) token count to % of a declared context window.
+pub fn input_tokens_as_context_pct(input_tokens: u64, context_window: Option<u32>) -> Option<f32> {
+    let w = f64::from(context_window?);
+    if w <= 0.0 {
+        return None;
+    }
+    let pct = (input_tokens as f64 / w) * 100.0;
+    Some(pct.min(9999.0) as f32)
+}

--- a/autonoetic-gateway/src/runtime/context_governor/schema_compress.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/schema_compress.rs
@@ -1,0 +1,49 @@
+use crate::llm::ToolDefinition;
+use crate::runtime::context_governor::strategies::{GovernorContext, ReductionOutcome};
+use crate::runtime::prompt_budget::{compress_tool_definitions, estimate_tool_definition};
+use async_trait::async_trait;
+
+fn tool_token_total(tools: &[ToolDefinition]) -> usize {
+    tools.iter().map(estimate_tool_definition).sum()
+}
+
+/// Strip tool JSON schemas to `{}` after turn 0.
+pub struct ToolSchemaCompressionStrategy;
+
+#[async_trait]
+impl super::ReductionStrategy for ToolSchemaCompressionStrategy {
+    fn name(&self) -> &'static str {
+        "tool_schema_compression"
+    }
+
+    async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+        if ctx.turn_number == 0 {
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: ctx.breakdown.total_tokens,
+            });
+        }
+
+        let before_tool_tokens = tool_token_total(&ctx.tools);
+        let compressed = compress_tool_definitions(
+            ctx.tools.clone(),
+            ctx.turn_number as usize,
+        );
+        let after_tool_tokens = tool_token_total(&compressed);
+        let saved = before_tool_tokens.saturating_sub(after_tool_tokens);
+        let new_total = ctx.breakdown.total_tokens.saturating_sub(saved);
+
+        if new_total > ctx.effective_limit {
+            ctx.tools = compressed;
+            ctx.breakdown.total_tokens = new_total;
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: new_total,
+            });
+        }
+
+        ctx.tools = compressed;
+        ctx.breakdown.total_tokens = new_total;
+        Ok(ReductionOutcome::Resolved {
+            tokens_after: new_total,
+        })
+    }
+}

--- a/autonoetic-gateway/src/runtime/context_governor/strategies.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/strategies.rs
@@ -1,0 +1,191 @@
+use crate::llm::{Message, ToolDefinition};
+use crate::runtime::context_governor::error::GovernorAction;
+use crate::runtime::prompt_budget::PromptBudgetBreakdown;
+use autonoetic_types::config::{ContextCompressionConfig, PromptBudgetConfig};
+use autonoetic_types::agent::CompressionConfig;
+use crate::runtime::compression::CompressionMetadata;
+
+/// Shared mutable state passed through the reduction pipeline.
+pub struct GovernorContext {
+    pub history: Vec<Message>,
+    pub tools: Vec<ToolDefinition>,
+    pub breakdown: PromptBudgetBreakdown,
+    pub effective_limit: usize,
+    pub turn_number: u64,
+    pub session_id: String,
+    pub compression_metadata: Option<CompressionMetadata>,
+    pub budget_config: PromptBudgetConfig,
+    pub compression_config: Option<ContextCompressionConfig>,
+    pub agent_compression: Option<CompressionConfig>,
+}
+
+impl GovernorContext {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        history: Vec<Message>,
+        tools: Vec<ToolDefinition>,
+        breakdown: PromptBudgetBreakdown,
+        effective_limit: usize,
+        turn_number: u64,
+        session_id: String,
+        compression_metadata: Option<CompressionMetadata>,
+        budget_config: PromptBudgetConfig,
+        compression_config: Option<ContextCompressionConfig>,
+        agent_compression: Option<CompressionConfig>,
+    ) -> Self {
+        Self {
+            history,
+            tools,
+            breakdown,
+            effective_limit,
+            turn_number,
+            session_id,
+            compression_metadata,
+            budget_config,
+            compression_config,
+            agent_compression,
+        }
+    }
+}
+
+/// Outcome of a single reduction attempt.
+pub enum ReductionOutcome {
+    /// Strategy resolved the budget issue.
+    Resolved {
+        tokens_after: usize,
+    },
+    /// Strategy was insufficient; remaining tokens still exceed limit.
+    Insufficient {
+        tokens_remaining: usize,
+    },
+}
+
+/// Result of the full governor pipeline.
+pub enum GovernorResult {
+    /// Context is within budget without any action.
+    WithinBudget,
+    /// One or more strategies brought it within budget.
+    Recovered {
+        actions_taken: Vec<GovernorAction>,
+    },
+    /// All strategies exhausted; overflow is terminal.
+    Overflow(crate::runtime::context_governor::error::ContextOverflowDiagnostic),
+}
+
+/// A pluggable context reduction strategy.
+#[async_trait::async_trait]
+pub trait ReductionStrategy: Send + Sync + 'static {
+    fn name(&self) -> &'static str;
+
+    /// Attempt to reduce context usage.
+    async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{Message, Role, ToolDefinition};
+    use crate::runtime::prompt_budget::PromptBudgetBreakdown;
+    use autonoetic_types::config::PromptBudgetConfig;
+
+    /// A strategy that always resolves (for testing pipeline short-circuit).
+    pub struct AlwaysResolveStrategy;
+
+    #[async_trait::async_trait]
+    impl ReductionStrategy for AlwaysResolveStrategy {
+        fn name(&self) -> &'static str {
+            "always_resolve"
+        }
+        async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+            ctx.history.push(Message::user("always_resolve"));
+            Ok(ReductionOutcome::Resolved { tokens_after: 1 })
+        }
+    }
+
+    /// A strategy that always returns insufficient (for testing pipeline fallthrough).
+    pub struct AlwaysInsufficientStrategy;
+
+    #[async_trait::async_trait]
+    impl ReductionStrategy for AlwaysInsufficientStrategy {
+        fn name(&self) -> &'static str {
+            "always_insufficient"
+        }
+        async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+            Ok(ReductionOutcome::Insufficient { tokens_remaining: ctx.breakdown.total_tokens })
+        }
+    }
+
+    fn make_context(total: usize, limit: usize) -> GovernorContext {
+        let breakdown = PromptBudgetBreakdown {
+            system_prompt_tokens: 10,
+            conversation_tokens: total.saturating_sub(10),
+            tool_count: 0,
+            tool_definition_tokens: 0,
+            total_tokens: total,
+            context_window: Some(limit),
+            utilization_pct: Some((total as f64 / limit as f64) * 100.0),
+        };
+        GovernorContext {
+            history: vec![],
+            tools: vec![],
+            breakdown,
+            effective_limit: limit,
+            turn_number: 1,
+            session_id: "test".to_string(),
+            compression_metadata: None,
+            budget_config: PromptBudgetConfig::default(),
+            compression_config: None,
+            agent_compression: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_within_budget_returns_immediately() {
+        let ctx = make_context(50, 100);
+        let strategies: Vec<Box<dyn ReductionStrategy>> = vec![
+            Box::new(AlwaysResolveStrategy),
+        ];
+        let governor = crate::runtime::context_governor::ContextGovernor::with_strategies(strategies);
+        let mut ctx = ctx;
+        let result = governor.govern(&mut ctx).await.unwrap();
+        assert!(matches!(result, GovernorResult::WithinBudget));
+    }
+
+    #[tokio::test]
+    async fn test_first_resolve_skips_later_strategies() {
+        let ctx = make_context(150, 100);
+        let strategies: Vec<Box<dyn ReductionStrategy>> = vec![
+            Box::new(AlwaysResolveStrategy),
+            Box::new(AlwaysInsufficientStrategy), // should NOT be reached
+        ];
+        let governor = crate::runtime::context_governor::ContextGovernor::with_strategies(strategies);
+        let mut ctx = ctx;
+        let result = governor.govern(&mut ctx).await.unwrap();
+        match result {
+            GovernorResult::Recovered { actions_taken } => {
+                assert_eq!(actions_taken.len(), 1);
+                assert_eq!(actions_taken[0].strategy, "always_resolve");
+            }
+            other => panic!("Expected Recovered, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_all_exhausted_yields_overflow() {
+        let ctx = make_context(200, 100);
+        let strategies: Vec<Box<dyn ReductionStrategy>> = vec![
+            Box::new(AlwaysInsufficientStrategy),
+            Box::new(AlwaysInsufficientStrategy),
+        ];
+        let governor = crate::runtime::context_governor::ContextGovernor::with_strategies(strategies);
+        let mut ctx = ctx;
+        let result = governor.govern(&mut ctx).await.unwrap();
+        match result {
+            GovernorResult::Overflow(diag) => {
+                assert_eq!(diag.actions_attempted.len(), 2);
+                assert!(diag.budget_snapshot.estimated_input > 0);
+            }
+            other => panic!("Expected Overflow, got {:?}", std::mem::discriminant(&other)),
+        }
+    }
+}

--- a/autonoetic-gateway/src/runtime/context_governor/trimming.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/trimming.rs
@@ -1,0 +1,49 @@
+use crate::llm::{Message, ToolDefinition};
+use crate::runtime::context_governor::strategies::{GovernorContext, ReductionOutcome};
+use crate::runtime::prompt_budget::{estimate_tokens, estimate_tool_definition, BudgetEnforcementStrategy};
+use async_trait::async_trait;
+
+fn recompute_total(system_tokens: usize, history: &[Message], tools: &[ToolDefinition]) -> usize {
+    let conv: usize = history.iter()
+        .filter(|m| !matches!(m.role, crate::llm::Role::System))
+        .map(|m| estimate_tokens(&m.content))
+        .sum();
+    let tool_tokens: usize = tools.iter().map(estimate_tool_definition).sum();
+    system_tokens + conv + tool_tokens
+}
+
+/// Drop oldest message groups to fit within budget.
+pub struct TrimHistoryStrategy;
+
+#[async_trait]
+impl super::ReductionStrategy for TrimHistoryStrategy {
+    fn name(&self) -> &'static str {
+        "trim_history"
+    }
+
+    async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+        let system_prompt_tokens = ctx.breakdown.system_prompt_tokens;
+        let strategy = crate::runtime::prompt_budget::TrimHistoryStrategy;
+        let result = strategy.enforce(
+            ctx.tools.clone(),
+            ctx.history.clone(),
+            &ctx.breakdown,
+            ctx.effective_limit,
+            &ctx.budget_config,
+        )?;
+
+        let new_total = recompute_total(system_prompt_tokens, &result.history, &result.tools);
+        if new_total > ctx.effective_limit {
+            return Ok(ReductionOutcome::Insufficient {
+                tokens_remaining: new_total,
+            });
+        }
+
+        ctx.tools = result.tools;
+        ctx.history = result.history;
+        ctx.breakdown.total_tokens = new_total;
+        Ok(ReductionOutcome::Resolved {
+            tokens_after: new_total,
+        })
+    }
+}

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -33,8 +33,9 @@ use std::sync::Arc;
 
 use crate::runtime::budget_tracker::{
     apply_prompt_budget, input_tokens_as_context_pct, is_retryable_empty_other_response,
-    max_other_empty_retries, resolve_context_window_for_run,
+    max_other_empty_retries,
 };
+use crate::runtime::context_governor::resolver::resolve_context_window_for_run;
 
 // ---------------------------------------------------------------------------
 // TurnOutcome
@@ -1198,7 +1199,7 @@ impl AgentExecutor {
             // Insert fresh system message at the front
             history.insert(0, Message::system(&system_instructions));
 
-            let tools: Vec<ToolDefinition> = {
+            let mut tools: Vec<ToolDefinition> = {
                 let pending_approvals = self.has_pending_approvals();
                 let tier_filter = determine_tool_tier_filter(
                     &self.manifest,
@@ -1263,90 +1264,152 @@ impl AgentExecutor {
                 })),
             );
 
-            // --- Budget Enforcement ---
-            let (tools, trimmed_history) = apply_prompt_budget(
-                tools,
-                history.clone(),
-                &budget_breakdown,
-                self.config.as_ref().map(|c| &**c),
-                &session_id,
-                &turn_id,
-                &mut tracer,
-            )?;
-            *history = trimmed_history;
-
-            // --- Context Compression ---
-            // Note: Budget enforcement (above) trims old turns when the prompt budget
-            // is exceeded. Context compression (below) summarizes old turns instead of
-            // discarding them. Both operate on the same token threshold independently.
-            // If `prompt_budget.warn_at_pct` and `context_compression.threshold_pct`
-            // are set to similar values, they may compete for the same boundary.
-            // Recommended: set compression threshold slightly below the budget trim
-            // threshold so compression fires first, preserving information.
-            let compression_cfg = self.config.as_ref().map(|c| &c.context_compression);
-            let agent_compression = self.manifest.compression.as_ref();
-            let should_compress = compression_cfg.map(|c| c.enabled).unwrap_or(false);
-            if should_compress {
-                let empty_presets = std::collections::HashMap::new();
-                let presets = match self.config.as_ref() {
-                    Some(c) => &c.llm_presets,
-                    None => &empty_presets,
+            // --- Budget Enforcement + Context Compression ---
+            // Feature-gated: the pluggable ContextGovernor pipeline replaces the
+            // legacy budget enforcement and compression block when the env var
+            // AUTONOETIC_STRICT_CONTEXT_GOVERNOR=1 is set.
+            if crate::runtime::context_governor::strict_governor_enabled() {
+                use crate::runtime::context_governor::{
+                    ContextGovernor, GovernorConfig,
+                    strategies::GovernorResult,
                 };
-                match crate::runtime::compression::compress_context(
+                let margin = self.config.as_ref()
+                    .map(|c| c.prompt_budget.margin_tokens as usize)
+                    .unwrap_or(4096);
+                let effective_limit = budget_breakdown
+                    .context_window
+                    .map(|w| w.saturating_sub(margin))
+                    .unwrap_or(budget_breakdown.total_tokens + 1);
+                let compression_cfg = self.config.as_ref().map(|c| &c.context_compression);
+                let mut ctx = crate::runtime::context_governor::strategies::GovernorContext::new(
                     history.clone(),
-                    context_window_resolved.map(|w| w as usize),
-                    compression_cfg.unwrap(),
-                    agent_compression,
-                    presets,
-                    &self.http_client,
-                    &session_id,
-                    self.turn_counter,
-                    Some(&self.compression_metadata),
-                )
-                .await
-                {
-                    Ok(result) => {
-                        if result.compressed {
-                            let mut metadata = result.metadata;
-                            if let Some(gateway_dir) = self.gateway_dir.as_ref() {
-                                match crate::runtime::compression::persist_compressed_context(
-                                    gateway_dir,
-                                    &session_id,
-                                    &result.original_history,
-                                    &metadata,
-                                ) {
-                                    Ok(handle) => {
-                                        metadata.compressed_context_handle = handle;
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            target: "autonoetic::compression",
-                                            error = %e,
-                                            "Failed to persist compressed context"
-                                        );
-                                    }
-                                }
+                    tools.clone(),
+                    budget_breakdown.clone(),
+                    effective_limit,
+                    self.turn_counter.saturating_sub(1),
+                    session_id.clone(),
+                    Some(self.compression_metadata.clone()),
+                    self.config.as_ref().map(|c| c.prompt_budget.clone())
+                        .unwrap_or_default(),
+                    compression_cfg.cloned(),
+                    self.manifest.compression.clone(),
+                );
+                let governor = ContextGovernor::new(&GovernorConfig {
+                    http_client: self.http_client.clone(),
+                    presets: self.config.as_ref().map(|c| c.llm_presets.clone())
+                        .unwrap_or_default(),
+                });
+                match governor.govern(&mut ctx).await {
+                    Ok(GovernorResult::Recovered { actions_taken }) => {
+                        tracing::info!(
+                            target: "autonoetic::context_governor",
+                            actions = ?actions_taken,
+                            "ContextGovernor recovered within budget"
+                        );
+                        // Update compression metadata if compression strategy ran
+                        if ctx.compression_metadata.as_ref().map(|m| m.compression_count > self.compression_metadata.compression_count).unwrap_or(false) {
+                            if let Some(meta) = ctx.compression_metadata.clone() {
+                                self.compression_metadata = meta;
                             }
-                            let _ = tracer.log_event(
-                                "agent.process",
-                                "context_compression",
-                                autonoetic_types::causal_chain::EntryStatus::Success,
-                                Some(serde_json::json!({
-                                    "messages_summarized": metadata.messages_summarized,
-                                    "compression_count": metadata.compression_count,
-                                    "compressed_context_handle": metadata.compressed_context_handle,
-                                })),
-                            );
-                            *history = result.history;
-                            self.compression_metadata = metadata;
                         }
                     }
+                    Ok(GovernorResult::Overflow(diag)) => {
+                        tracing::warn!(
+                            target: "autonoetic::context_governor",
+                            diagnostic = ?diag,
+                            "ContextGovernor exhausted — all strategies failed"
+                        );
+                    }
+                    Ok(GovernorResult::WithinBudget) => {}
                     Err(e) => {
                         tracing::warn!(
-                            target: "autonoetic::compression",
+                            target: "autonoetic::context_governor",
                             error = %e,
-                            "Context compression failed, proceeding without compression"
+                            "ContextGovernor error, falling through without reduction"
                         );
+                    }
+                }
+                *history = ctx.history;
+                tools = ctx.tools;
+            } else {
+                let (t, trimmed_history) = apply_prompt_budget(
+                    tools,
+                    history.clone(),
+                    &budget_breakdown,
+                    self.config.as_ref().map(|c| &**c),
+                    &session_id,
+                    &turn_id,
+                    &mut tracer,
+                )?;
+                tools = t;
+                *history = trimmed_history;
+
+                // --- Context Compression (legacy path) ---
+                let compression_cfg = self.config.as_ref().map(|c| &c.context_compression);
+                let agent_compression = self.manifest.compression.as_ref();
+                let should_compress = compression_cfg.map(|c| c.enabled).unwrap_or(false);
+                if should_compress {
+                    let empty_presets = std::collections::HashMap::new();
+                    let presets = match self.config.as_ref() {
+                        Some(c) => &c.llm_presets,
+                        None => &empty_presets,
+                    };
+                    match crate::runtime::compression::compress_context(
+                        history.clone(),
+                        context_window_resolved.map(|w| w as usize),
+                        compression_cfg.unwrap(),
+                        agent_compression,
+                        presets,
+                        &self.http_client,
+                        &session_id,
+                        self.turn_counter,
+                        Some(&self.compression_metadata),
+                    )
+                    .await
+                    {
+                        Ok(result) => {
+                            if result.compressed {
+                                let mut metadata = result.metadata;
+                                if let Some(gateway_dir) = self.gateway_dir.as_ref() {
+                                    match crate::runtime::compression::persist_compressed_context(
+                                        gateway_dir,
+                                        &session_id,
+                                        &result.original_history,
+                                        &metadata,
+                                    ) {
+                                        Ok(handle) => {
+                                            metadata.compressed_context_handle = handle;
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                target: "autonoetic::compression",
+                                                error = %e,
+                                                "Failed to persist compressed context"
+                                            );
+                                        }
+                                    }
+                                }
+                                let _ = tracer.log_event(
+                                    "agent.process",
+                                    "context_compression",
+                                    autonoetic_types::causal_chain::EntryStatus::Success,
+                                    Some(serde_json::json!({
+                                        "messages_summarized": metadata.messages_summarized,
+                                        "compression_count": metadata.compression_count,
+                                        "compressed_context_handle": metadata.compressed_context_handle,
+                                    })),
+                                );
+                                *history = result.history;
+                                self.compression_metadata = metadata;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "autonoetic::compression",
+                                error = %e,
+                                "Context compression failed, proceeding without compression"
+                            );
+                        }
                     }
                 }
             }

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -13,6 +13,7 @@ pub mod checkpoint;
 pub mod code_excerpts;
 pub mod compression;
 pub mod compression_quality;
+pub mod context_governor;
 pub mod content_store;
 pub mod context;
 pub mod continuation;

--- a/autonoetic-gateway/src/server/mod.rs
+++ b/autonoetic-gateway/src/server/mod.rs
@@ -183,6 +183,37 @@ impl GatewayServer {
             }
         }
 
+        // Warn at startup if any LLM preset has no context_window_tokens and
+        // the provider cannot resolve one from env, static table, or catalog.
+        let env_override = std::env::var("AUTONOETIC_LLM_CONTEXT_WINDOW").ok();
+        for (name, preset) in &self.config.llm_presets {
+            if preset.routing.is_some() {
+                continue;
+            }
+            if preset.context_window_tokens.is_some() {
+                continue;
+            }
+            if env_override.is_some() {
+                continue;
+            }
+            if let Some(ref model) = preset.model {
+                if crate::runtime::context_governor::resolver::static_context_window(model).is_some() {
+                    continue;
+                }
+            }
+            if preset.provider.as_deref().map(|p| p.eq_ignore_ascii_case("openrouter")).unwrap_or(false) {
+                continue;
+            }
+            tracing::warn!(
+                target: "gateway",
+                preset = %name,
+                provider = ?preset.provider,
+                model = ?preset.model,
+                "LLM preset has no context_window_tokens — context governor cannot enforce budget for this preset. \
+                 Set context_window_tokens in the preset, or set AUTONOETIC_LLM_CONTEXT_WINDOW env var."
+            );
+        }
+
         let jsonrpc_router = Arc::new(crate::router::JsonRpcRouter::new(
             self.config.as_ref().clone(),
             Some(gateway_store.clone()),

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -304,16 +304,16 @@ max_session_turns: 12
 #  max_tool_failures: 5
 #  max_consecutive_same_progress: 1
 
-# ── Prompt Budget ─────────────────────────────────────────────────────
+# ── Prompt Budget (Safe Defaults) ──────────────────────────────────────
 # Transparency and enforcement for context window usage.
-# Uncomment to customize (defaults: warn_at 80%, 4096 margin tokens).
-# prompt_budget:
-#   system_prompt_max_tokens: 0
-#   tool_definitions_max_tokens: 0
-#   warn_at_pct: 80.0
-#   margin_tokens: 4096
-#   on_exceeded: warn           # warn | trim_history | demote_tools | fail
-#   compress_tool_schemas_after_turn_0: false
+# Uncomment to customize.
+prompt_budget:
+  system_prompt_max_tokens: 0
+  tool_definitions_max_tokens: 0
+  warn_at_pct: 75.0
+  margin_tokens: 4096
+  on_exceeded: trim_history
+  compress_tool_schemas_after_turn_0: true
 #
 # ── Tool Tier Registry (Constitution 4.7) ──────────────────────────────
 # Tier assignments are declarative in config/tools.yaml and loaded at gateway start.
@@ -482,15 +482,15 @@ llm_preset_mapping:
 #   discovery: research          # semantic reasoning over agent descriptions
 #   default: fallback
 
-# ── Context Compression ──────────────────────────────────────────────
+# ── Context Compression (Safe Defaults) ──────────────────────────────
 # Summarizes old conversation turns when approaching context limits.
-# context_compression:
-#   enabled: false
-#   llm_preset: haiku
-#   threshold_pct: 60.0
-#   recent_turns_to_keep: 3
-#   max_summary_tokens: 500
-#   min_turns_between_compression: 3
+context_compression:
+  enabled: true
+  llm_preset: haiku
+  threshold_pct: 60.0
+  recent_turns_to_keep: 3
+  max_summary_tokens: 500
+  min_turns_between_compression: 3
 
 # ── System Agents ─────────────────────────────────────────────────────
 # Declared background agents that the gateway reconciles on startup.

--- a/docs/design/llm-context-overflow-mitigation-plan.md
+++ b/docs/design/llm-context-overflow-mitigation-plan.md
@@ -1,0 +1,497 @@
+# LLM Context Overflow Mitigation Plan
+
+## Status
+
+Proposed
+
+## Incident Summary
+
+A workflow run failed in the promotion/install path with:
+
+- `Context size has been exceeded` (OpenAI-compatible 500)
+- Followed by JSON-RPC client disconnect (`Broken pipe`)
+
+The observed token trajectory in the same run reached very high input sizes (roughly 42k to 50k+), and failure occurred during an async child task retry path, which reduced operator visibility and made progress appear stalled.
+
+## Goals
+
+1. Prevent hard context-overflow failures in long-running workflows.
+2. Keep workflow progress visible and understandable when compression/retry is happening.
+3. Avoid redundant child respawns after a successful stage when later turns overflow.
+4. Preserve auditability and correctness while compressing context.
+
+## Non-Goals
+
+1. Rewriting agent instruction architecture end-to-end in this iteration.
+2. Changing constitutional policy semantics.
+3. Optimizing model quality/cost beyond context safety requirements.
+
+## Existing Building Blocks (Already in Repo)
+
+These are implemented and tested. The plan consolidates them behind a pluggable interface.
+
+| Building Block | Location | Notes |
+|---|---|---|
+| Token estimation (`estimate_tokens`, heuristic 4 chars/token) | `prompt_budget.rs:79-86` | Per-tool overhead at L14 |
+| Budget breakdown computation (`PromptBudgetBreakdown`) | `prompt_budget.rs:20-77` | Sums system + conversation + tool tokens |
+| Enforcement strategies: Warn, TrimHistory, DemoteTools, Fail | `prompt_budget.rs:160-440` | Strategy trait at L146; factory at L429 |
+| Per-section caps (system_prompt_max_tokens, tool_definitions_max_tokens) | `budget_tracker.rs:191-220` | `check_section_caps()` |
+| Context compression with LLM summarization | `compression.rs:239-422` | Tool-call group preservation at L134-205 |
+| Compression metadata in checkpoints | `checkpoint.rs:153-155` | Restored on session resume at L159-169 |
+| Per-agent compression overrides via SKILL.md | `agent.rs:289-301` (`CompressionConfig`) | |
+| Schema compression after turn 0 | `prompt_budget.rs:116-136` | |
+| OpenRouter catalog-based context window resolution | `budget_tracker.rs:112-132` | `resolve_context_window_for_run()` |
+| Config types: `PromptBudgetConfig`, `ContextCompressionConfig` | `config.rs:1738-1842` | Fields exist but commented-out in template |
+
+## Root Causes
+
+1. Context growth was allowed to accumulate across planner + child loops until model hard limit was reached.
+2. Context window was not treated as a strict known bound in all paths (observability fields often `None`).
+3. Overflow errors were handled as generic task failure, not a dedicated recovery class.
+4. Retry/orchestration behavior allowed additional child runs when prior success should have been terminal for that stage.
+5. TUI/operator feedback did not clearly surface "overflow recovery in progress" states.
+
+## Architecture: Pluggable Context Governor
+
+### Problem with Current Layout
+
+The existing context management logic is scattered across three files with no unified entry point:
+
+- `prompt_budget.rs` — budget computation and enforcement strategies
+- `budget_tracker.rs` — `apply_prompt_budget()` wiring, context window resolution
+- `compression.rs` — summarization-based compression
+
+In `lifecycle.rs:1232-1352`, the reasoning loop calls these independently in sequence: compute breakdown, enforce budget, compress context. This means:
+- Adding a new reduction strategy requires touching multiple files.
+- The cascade (compress → recompute → trim → fail) must be hand-wired at each call site.
+- No single place to reason about the full context lifecycle.
+
+### Solution: `ContextGovernor` Module
+
+Introduce a new module `runtime/context_governor/` that owns the entire context budget lifecycle as a single pluggable pipeline. Existing code moves into this module as strategy implementations — the lifecycle loop calls one method.
+
+```
+runtime/context_governor/
+├── mod.rs              ContextGovernor struct, pipeline orchestration
+├── budget.rs           PromptBudgetBreakdown computation (from prompt_budget.rs)
+├── strategies.rs       ReductionStrategy trait + built-in implementations
+├── compression.rs      CompressionStrategy — wraps existing compression.rs logic
+├── trimming.rs         TrimHistoryStrategy — from prompt_budget.rs TrimHistoryStrategy
+├── demotion.rs         ToolDemotionStrategy — from prompt_budget.rs DemoteToolsStrategy
+├── error.rs            ContextOverflowError, ContextOverflowDiagnostic types
+└── resolver.rs         Context window resolution (from budget_tracker.rs)
+```
+
+### Core Trait: `ReductionStrategy`
+
+All context reduction approaches implement the same trait:
+
+```rust
+pub trait ReductionStrategy: Send + Sync + 'static {
+    fn name(&self) -> &'static str;
+
+    fn reduce(
+        &self,
+        ctx: &mut GovernorContext,
+    ) -> anyhow::Result<ReductionOutcome>;
+}
+
+pub struct GovernorContext {
+    pub history: Vec<Message>,
+    pub tools: Vec<ToolDefinition>,
+    pub breakdown: PromptBudgetBreakdown,
+    pub effective_limit: usize,
+    pub budget_config: PromptBudgetConfig,
+    pub compression_config: Option<ContextCompressionConfig>,
+    pub compression_metadata: Option<CompressionMetadata>,
+}
+
+pub enum ReductionOutcome {
+    Resolved { tokens_after: usize },
+    Insufficient { tokens_remaining: usize },
+}
+```
+
+Built-in strategies:
+- `CompressionStrategy` — LLM summarization (wraps existing `compress_context()`)
+- `TrimHistoryStrategy` — drop oldest message groups (from existing `TrimHistoryStrategy`)
+- `ToolDemotionStrategy` — remove specialized-tier tools (from existing `DemoteToolsStrategy`)
+- `ToolSchemaCompressionStrategy` — strip schemas after turn 0 (from existing `compress_tool_definitions()`)
+- `FailStrategy` — emit typed `ContextOverflowError`
+
+### Pipeline: `ContextGovernor::govern()`
+
+The governor runs strategies in a configurable ordered pipeline. Each strategy runs only if the previous one returned `Insufficient`:
+
+```rust
+pub struct ContextGovernor {
+    strategies: Vec<Box<dyn ReductionStrategy>>,
+    config: GovernorConfig,
+}
+
+impl ContextGovernor {
+    pub async fn govern(&self, ctx: &mut GovernorContext) -> GovernorResult {
+        let breakdown = PromptBudgetBreakdown::compute(...);
+        ctx.breakdown = breakdown;
+
+        if ctx.breakdown.total_tokens <= ctx.effective_limit {
+            return GovernorResult::WithinBudget;
+        }
+
+        let mut actions_taken: Vec<GovernorAction> = Vec::new();
+
+        for strategy in &self.strategies {
+            let outcome = strategy.reduce(ctx)?;
+            match outcome {
+                ReductionOutcome::Resolved { tokens_after } => {
+                    actions_taken.push(GovernorAction {
+                        strategy: strategy.name(),
+                        tokens_after,
+                    });
+                    return GovernorResult::Recovered { actions_taken };
+                }
+                ReductionOutcome::Insufficient { tokens_remaining } => {
+                    actions_taken.push(GovernorAction {
+                        strategy: strategy.name(),
+                        tokens_after: tokens_remaining,
+                    });
+                    continue;
+                }
+            }
+        }
+
+        GovernorResult::Overflow(ContextOverflowDiagnostic {
+            budget_snapshot: BudgetSnapshot::from(ctx),
+            actions_attempted: actions_taken,
+            recovery_action: RecoveryAction::Failed,
+        })
+    }
+}
+```
+
+### Plugging New Approaches
+
+Adding a new reduction method (e.g., "state capsule" from Phase 2) requires only:
+
+1. Implement `ReductionStrategy` for the new approach.
+2. Add it to the strategy pipeline in config or code.
+
+No changes to `lifecycle.rs` or `budget_tracker.rs`.
+
+### Lifecycle Integration
+
+The reasoning loop at `lifecycle.rs:1232-1352` currently has ~120 lines of budget computation, enforcement, and compression. This collapses to:
+
+```rust
+let mut gov_ctx = GovernorContext::new(
+    history.clone(),
+    tools,
+    context_window_resolved,
+    &budget_config,
+    compression_cfg.cloned(),
+    self.compression_metadata.clone(),
+);
+let result = self.context_governor.govern(&mut gov_ctx).await;
+match result {
+    GovernorResult::WithinBudget => {}
+    GovernorResult::Recovered { actions_taken } => {
+        tracer.log_event("context_governor", "recovered", Success, ...);
+        *history = gov_ctx.history;
+    }
+    GovernorResult::Overflow(diag) => {
+        tracer.log_event("context_governor", "overflow", Error, ...);
+        return Err(ContextOverflowError::new(diag).into());
+    }
+}
+```
+
+### Strategy Ordering
+
+Default pipeline order (configurable per profile):
+
+1. `ToolSchemaCompression` — if turn > 0, strip schemas (fast, lossless)
+2. `Compression` — LLM summarization (slow, preserves semantics)
+3. `TrimHistory` — drop oldest groups (fast, lossy)
+4. `ToolDemotion` — remove specialized tools (fast, reduces capability)
+5. `Fail` — typed overflow error (terminal)
+
+Each step only runs if the previous returned `Insufficient`.
+
+### Feature Flag Integration
+
+The governor checks feature flags to select pipeline:
+
+- `AUTONOETIC_STRICT_CONTEXT_GOVERNOR=1` — use full cascade pipeline above
+- Flag unset — use legacy behavior (warn-only, no cascade) for backward compatibility
+
+### Migration Plan for Existing Code
+
+| Current Code | Destination | Change |
+|---|---|---|
+| `prompt_budget::PromptBudgetBreakdown` | `context_governor::budget::PromptBudgetBreakdown` | Move, re-export from old location with deprecation |
+| `prompt_budget::BudgetEnforcementStrategy` trait | Removed | Replaced by `ReductionStrategy` |
+| `prompt_budget::WarnStrategy` | `context_governor::WarnOnlyStrategy` | Wraps old behavior |
+| `prompt_budget::TrimHistoryStrategy` | `context_governor::trimming::TrimHistoryStrategy` | Move, implement `ReductionStrategy` |
+| `prompt_budget::DemoteToolsStrategy` | `context_governor::demotion::ToolDemotionStrategy` | Move, implement `ReductionStrategy` |
+| `prompt_budget::FailStrategy` | `context_governor::FailStrategy` | Move, emit `ContextOverflowError` |
+| `prompt_budget::compress_tool_definitions()` | `context_governor::ToolSchemaCompressionStrategy` | Wrap as strategy |
+| `compression::compress_context()` | `context_governor::compression::CompressionStrategy` | Wrap as strategy |
+| `budget_tracker::apply_prompt_budget()` | Removed | Replaced by `ContextGovernor::govern()` |
+| `budget_tracker::resolve_context_window_*()` | `context_governor::resolver::*` | Move |
+| `budget_tracker::is_retryable_empty_other_response()` | Stays in `budget_tracker.rs` | Not context-governor concern |
+
+Old modules re-export moved types with `#[deprecated]` attributes during migration. Remove re-exports once all call sites are updated.
+
+## Plan
+
+## Phase 0: Safe Defaults (Configuration)
+
+Uncomment and set safe defaults in `config/config-template.yaml` (fields already exist at lines 307-316, 485-493 but are commented out):
+
+```yaml
+prompt_budget:
+  warn_at_pct: 75.0
+  margin_tokens: 4096
+  on_exceeded: trim_history
+  compress_tool_schemas_after_turn_0: true
+
+context_compression:
+  enabled: true
+  llm_preset: haiku
+  threshold_pct: 60.0
+  recent_turns_to_keep: 3
+  max_summary_tokens: 500
+  min_turns_between_compression: 2
+```
+
+Also require explicit context-window declaration for local OpenAI-compatible backends used by planner/factory/builder profiles (either in preset/manifest or via runtime env fallback).
+
+Deliverables:
+
+1. Config profile update in template/reference docs.
+2. Runtime warning on startup when context window is unknown for active preset (fire only when all resolution paths fail: manifest, env var, and provider catalog. The existing `resolve_context_window_for_run()` at `budget_tracker.rs:112-132` already has catalog fallback for OpenRouter — do not warn when catalog resolves successfully).
+3. Add telemetry field `system_prompt_tokens` from `PromptBudgetBreakdown` (already computed at `prompt_budget.rs:38-77`) to enable measurement before Phase 4 investment.
+
+## Phase 1: Context Governor Module
+
+### 1a. Scaffold the Module
+
+Create `runtime/context_governor/` with the trait, types, and pipeline from the architecture section above. Initially populate with thin wrappers around existing code:
+
+- `budget.rs` — move `PromptBudgetBreakdown` and `estimate_tokens`
+- `strategies.rs` — `ReductionStrategy` trait, `GovernorContext`, `ReductionOutcome`
+- `compression.rs` — `CompressionStrategy` wrapping `compress_context()`
+- `trimming.rs` — `TrimHistoryStrategy` from existing code
+- `demotion.rs` — `ToolDemotionStrategy` from existing code
+- `error.rs` — `ContextOverflowError`, `ContextOverflowDiagnostic`, `BudgetSnapshot`
+- `resolver.rs` — context window resolution functions
+- `mod.rs` — `ContextGovernor` struct with configurable pipeline
+
+### 1b. Wire into Lifecycle
+
+Replace the 120-line block at `lifecycle.rs:1232-1352` with a single `ContextGovernor::govern()` call. The governor is constructed once per `AgentExecutor` and stored as a field.
+
+### 1c. Provider-Side Error Classification
+
+Parse provider-specific overflow errors in LLM drivers and return typed `ContextOverflowError`:
+
+- `openai.rs`: match `context_length_exceeded` error code
+- `anthropic.rs`: match `max_context_window_reached` error code
+- `gemini.rs`: match `RESOURCE_EXHAUSTED` with context details
+
+Currently all return generic `anyhow::bail!()` at:
+- `openai.rs:213`
+- `anthropic.rs:148`
+- `gemini.rs:198`
+
+### 1d. Deprecation Shims
+
+Add `#[deprecated]` re-exports in `prompt_budget.rs` and `budget_tracker.rs` pointing to `context_governor::*`. This lets other call sites migrate incrementally.
+
+Deliverables:
+
+1. `runtime/context_governor/` module with trait, pipeline, and all built-in strategies.
+2. Lifecycle integration replacing `lifecycle.rs:1232-1352`.
+3. `ContextOverflowError` and `ContextOverflowDiagnostic` in `autonoetic-types` + `context_governor::error`.
+4. Provider error classification in all three LLM drivers.
+5. Deprecation shims in old modules.
+6. Unit tests: strategy isolation (each strategy works independently), pipeline ordering (cascade stops at first `Resolved`), fallback (all strategies exhausted → typed error).
+
+## Phase 2: Hierarchical Session Summarization (Future Strategy)
+
+> **Note**: This phase is deferred after Phases 0, 1, and 3 ship. The existing `CompressionStrategy` in the governor is sufficient for the immediate failure mode. The capsule design introduces a new state machine (versions, merge conflicts under concurrent compression) that warrants its own RFC. Because the governor is pluggable, the capsule ships as a new `ReductionStrategy` implementation with zero changes to the pipeline or lifecycle.
+
+Introduce a durable "state capsule" layer to prevent repeated long-form replay:
+
+1. Keep last N turns raw (N=3 default).
+2. Maintain rolling summary blocks:
+   1. Objective and success criteria.
+   2. Decisions and rationale.
+   3. Stable identifiers (artifact refs, revision ids, approvals).
+   4. Open tasks/blockers.
+3. On each compression cycle, update capsule from deltas rather than regenerating from full history.
+4. Preserve original snapshots in content store for audit/replay.
+
+Compression quality safeguards:
+
+1. Never summarize away unresolved approvals/escalations.
+2. Never mutate structured IDs in summaries (lossless copy only).
+3. Keep most recent tool-call/result group intact.
+
+Deliverables:
+
+1. `context_governor::capsule::CapsuleStrategy` implementing `ReductionStrategy`.
+2. Capsule schema and serializer.
+3. Compression tests for id-preservation and decision continuity — prefer property-based (quickcheck-style) invariants over fixed fixtures where feasible.
+4. Config entry to swap `CompressionStrategy` for `CapsuleStrategy` in the pipeline.
+
+## Phase 3: Overflow-Aware Orchestration and Retry
+
+Make scheduler behavior explicit for context overflow:
+
+1. Classify overflow as recoverable-once with compaction.
+2. Retry exactly once with `overflow_recovery=true` and forced aggressive pipeline: the retry governor uses a reduced pipeline that skips `CompressionStrategy` (already attempted) and goes straight to `TrimHistory`. The retry must also force `compress_tool_schemas_after_turn_0: true` regardless of original config.
+3. If second attempt overflows, mark task terminal with class `context_overflow_terminal`.
+4. Do not spawn sibling/duplicate builder tasks if install stage already reached success for same `(agent_id, revision_id)` tuple.
+5. Enforce idempotent stage transitions with a `stage_transitions` table in gateway SQLite keyed on `(agent_id, revision_id, stage)` with a `UNIQUE` constraint. This survives restarts unlike an in-memory lock. Follow the existing `gateway_store` migration pattern — increment `SCHEMA_VERSION_LATEST` and add an `apply_*_vN()` function.
+   - `install_requested`
+   - `install_succeeded`
+   - `promoted`
+6. Record `overflow_recovery_attempted: bool` in the task checkpoint (currently only `"status": "failed"` as a string at `scheduler.rs:1440`).
+
+Deliverables:
+
+1. Retry policy update for overflow class.
+2. Idempotency guard for builder/install stage (SQLite-backed).
+3. Regression test covering "first builder success + second overflow should not trigger duplicate install path".
+4. Overflow retry coordination through gateway store for concurrent sibling tasks (two builders overflowing simultaneously must not independently retry into the same stage transition).
+
+## Phase 4: Prompt Diet for High-Churn Agents
+
+> **Note**: Requires measurement data from Phase 0 deliverable 3 (`system_prompt_tokens` telemetry) before implementation. Do not invest until baseline is established.
+
+Reduce recurring token overhead for planner/factory/builder:
+
+1. Split SKILL guidance into:
+   1. Core runtime instructions (always injected).
+   2. Extended examples/reference (on-demand retrieval).
+2. Keep strict rules and contracts in core; move verbose examples to optional retrieval content.
+3. Enable tool schema demotion after turn 0 by default in these profiles.
+
+Deliverables:
+
+1. Instruction profile convention doc.
+2. Pilot reduction target: 25-40% system-token reduction for planner-like agents (validated against telemetry).
+
+## Phase 5: Operator/TUI Transparency
+
+Expose explicit context-health states in UI/events. Wire into the existing causal event chain, not a separate logging path.
+
+1. `context_pressure_high` warning with percentages and top contributors.
+2. `context_compression_applied` event with before/after token estimates.
+3. `overflow_retry_started` and `overflow_retry_exhausted` events.
+4. Session card badge when context window is unknown.
+
+Deliverables:
+
+1. Event types + renderers.
+2. TUI status line and workflow card updates.
+
+## StopReason::MaxTokens Recovery
+
+Currently `StopReason::MaxTokens` at `lifecycle.rs:2394` just breaks the loop. For multi-turn sessions that re-enter the agent, this should trigger the governor's pipeline before the next turn, not silently discard the partial response. Track as a Phase 1 follow-up.
+
+## Context Window Resolution for Non-OpenRouter Providers
+
+The existing `resolve_context_window_for_run()` at `budget_tracker.rs:112-132` has catalog fallback only for OpenRouter. Anthropic and Gemini model context sizes need a static lookup table (either hardcoded or in config) so the governor can enforce budgets for all providers. After Phase 1, this logic lives in `context_governor::resolver`.
+
+## Data Model and Telemetry Changes
+
+Add/extend fields in session/workflow telemetry:
+
+1. `context_window_tokens_effective` (required at dispatch time).
+2. `estimated_input_tokens_preflight`.
+3. `estimated_input_tokens_post_compression`.
+4. `compression_ratio`.
+5. `overflow_recovery_attempt` (bool).
+6. `overflow_error_class`.
+7. `system_prompt_tokens` (from `PromptBudgetBreakdown`, for Phase 4 measurement).
+8. `governor_actions_taken` (ordered list of strategy names that fired, with tokens after each).
+
+## Test Plan
+
+1. Unit tests (per-strategy isolation):
+   1. `CompressionStrategy` — threshold behavior, tool-call group preservation.
+   2. `TrimHistoryStrategy` — oldest-first removal, tool-call group integrity, message floor.
+   3. `ToolDemotionStrategy` — tier filtering, section cap compliance.
+   4. `ToolSchemaCompressionStrategy` — turn-0 skip, subsequent-turn compression.
+   5. `FailStrategy` — emits `ContextOverflowError` with diagnostic.
+2. Pipeline tests (cascade behavior):
+   1. Within budget → no strategies run.
+   2. Single strategy resolves → later strategies skipped.
+   3. All strategies exhausted → `GovernorResult::Overflow` with full diagnostic.
+   4. Custom pipeline order via config.
+3. Integration tests:
+   1. Simulated long-history planner run that would previously exceed context; verify no hard failure.
+   2. Overflow retry path emits expected events and terminal classification.
+   3. Builder duplicate-spawn prevention after successful promotion/install tuple.
+   4. Concurrent sibling overflow: both children overflow, only one retry proceeds, no duplicate stage transition.
+   5. Provider error classification (parse OpenAI/Anthropic/Gemini overflow error codes → `ContextOverflowError`).
+4. Soak test:
+   1. Long-running multi-agent session (50+ turns) with approvals and workflow joins.
+
+## Rollout Strategy
+
+**Shipped first: Phases 0, 1, and 3** — these directly fix the observed failure mode.
+
+1. Stage A: Config-only rollout (Phase 0) behind environment profile.
+2. Stage B: Scaffold `context_governor` module, migrate existing strategies behind `ReductionStrategy` trait, wire into lifecycle. Feature-gated behind `AUTONOETIC_STRICT_CONTEXT_GOVERNOR=1`.
+3. Stage C: Enable Phase 3 overflow retry classifier under `AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER=1`.
+4. Stage D: Enable Phase 2 capsule in canary (deferred — requires its own RFC, ships as a new `ReductionStrategy`).
+5. Stage E: Turn on Phase 5 UI transparency by default.
+
+Feature flags:
+
+1. `AUTONOETIC_STRICT_CONTEXT_GOVERNOR=1` — enable governor pipeline (replaces legacy `apply_prompt_budget` + inline compression)
+2. `AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER=1` — enable overflow retry in scheduler
+3. `AUTONOETIC_STATE_CAPSULE_COMPRESSION=1` — swap `CompressionStrategy` for `CapsuleStrategy` in pipeline
+
+Rollback: to disable the governor in production, unset `AUTONOETIC_STRICT_CONTEXT_GOVERNOR`. The lifecycle falls back to the existing `apply_prompt_budget()` + inline compression path (pre-existing behavior). The old code stays behind the feature flag until the governor is validated in production, then it is removed.
+
+## Acceptance Criteria
+
+1. No unclassified context-overflow 500s in planner/factory/builder paths for benchmark workflows.
+2. At most one overflow-recovery retry per failed task.
+3. No duplicate install/promotion tasks for the same revision once success recorded.
+4. Operators can see compression/retry status in TUI without consulting raw logs.
+5. Regression suite includes at least one previously failing trace replay that now completes.
+6. Provider-specific overflow errors (OpenAI, Anthropic, Gemini) are classified as `context_overflow`, not generic API errors.
+7. Adding a new reduction strategy requires implementing `ReductionStrategy` and adding to config — no changes to `lifecycle.rs` or the pipeline orchestrator.
+
+## Risks and Mitigations
+
+1. Over-compression can remove critical nuance.
+   - Mitigation: preserve recent turns + tool groups, keep audit snapshots, add id-preservation tests.
+2. Strict governor may increase deterministic failures if misconfigured.
+   - Mitigation: startup validation and explicit diagnostics with actionable recovery hints.
+3. Added orchestration guards may block legitimate retries.
+   - Mitigation: key retries on `(stage, agent_id, revision_id)` and expose override path for manual intervention.
+4. Synchronous cascade in Phase 1 adds latency before every LLM call.
+   - Mitigation: cascade only triggers when budget is exceeded (fast path is unchanged). Measure compression latency in soak test.
+5. State capsule (Phase 2) introduces concurrency complexity.
+   - Mitigation: deferred to separate RFC. Ships as isolated `ReductionStrategy` — no pipeline changes needed.
+6. Module migration may break callers depending on old `prompt_budget` / `budget_tracker` entry points.
+   - Mitigation: `#[deprecated]` re-exports with clear migration paths. Feature flag gates the new path; old path is default until flag is set.
+
+## Immediate Follow-up Tasks
+
+1. Uncomment safe defaults in `config/config-template.yaml` (lines 307-316, 485-493).
+2. Scaffold `runtime/context_governor/` module with `ReductionStrategy` trait and `ContextGovernor` pipeline.
+3. Move existing strategies behind `ReductionStrategy` with deprecation shims.
+4. Wire `ContextGovernor::govern()` into lifecycle behind `AUTONOETIC_STRICT_CONTEXT_GOVERNOR` feature flag.
+5. Add `ContextOverflowError` and `ContextOverflowDiagnostic` in `autonoetic-types` + `context_governor::error`.
+6. Implement provider-side error classification in OpenAI, Anthropic, and Gemini drivers.
+7. Add an integration test fixture reproducing the observed overflow trace.
+8. Implement stage idempotency guard for specialized builder promotion/install transitions (SQLite `stage_transitions` table with gateway store migration).
+9. Add static context window lookup table for Anthropic and Gemini models (in `context_governor::resolver`).
+10. Add `system_prompt_tokens` telemetry field for Phase 4 baseline measurement.


### PR DESCRIPTION
## Summary

Implements Phases 0 and 1 of the [LLM Context Overflow Mitigation Plan](https://github.com/mandubian/autonoetic/blob/feat/context-governor/docs/design/llm-context-overflow-mitigation-plan.md).

**Closes:** #210 (Phase 0) and #211 (Phase 1)
**Umbrella:** #209

---

## Phase 0 — Safe Defaults

- Uncommented and set safe defaults in `config-template.yaml`:
  - `warn_at_pct: 75`, `on_exceeded: trim_history`, `compress_tool_schemas_after_turn_0: true`
  - `context_compression.enabled: true`, `min_turns_between_compression: 2`
- Startup warning when any LLM preset lacks `context_window_tokens` (excludes OpenRouter which resolves from catalog)

## Phase 1 — Pluggable Context Governor

### New module: `runtime/context_governor/`

All compression/trimming logic now lives behind a **`ReductionStrategy`** trait in an ordered, configurable pipeline. Lifecycle calls a single `govern()` method.

```
runtime/context_governor/
├── mod.rs             ContextGovernor, pipeline orchestration
├── strategies.rs      ReductionStrategy trait, GovernorContext
├── budget.rs          Re-exports from prompt_budget
├── compression.rs     CompressionStrategy (wraps compress_context)
├── trimming.rs        TrimHistoryStrategy
├── demotion.rs        ToolDemotionStrategy
├── schema_compress.rs ToolSchemaCompressionStrategy
├── error.rs           ContextOverflowError, ContextOverflowDiagnostic
└── resolver.rs        Context window resolution + static model table
```

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| **`ReductionStrategy` trait** | Adding a new approach = implement trait + register in pipeline. Zero changes to lifecycle or orchestrator. |
| **Pipeline cascade** | Strategies run in order (schema→compress→trim→demote). First `Resolved` short-circuits. All exhausted → typed `Overflow` diagnostic. |
| **Feature flag** `AUTONOETIC_STRICT_CONTEXT_GOVERNOR=1` | Unset preserves legacy path for safe rollback. Old code stays until validated in production. |
| **Provider error classification** | Detects `context_length_exceeded` (OpenAI), `max_context_window_reached` (Anthropic), `RESOURCE_EXHAUSTED`+context (Gemini) and returns `context_overflow:` prefix. |
| **Static model table** | `resolver.rs:47-89` covers Claude, GPT-4o, Gemini, o1/o3/o4 series — no catalog dependency. |

### Testing

3 new unit tests for governor pipeline:
- `test_within_budget_returns_immediately`
- `test_first_resolve_skips_later_strategies`
- `test_all_exhausted_yields_overflow`

All 828 existing tests pass (25 pre-existing failures on `main` are unrelated).

## Files Changed

| File | Change |
|------|--------|
| `config/config-template.yaml` | Uncommented safe defaults |
| `server/mod.rs` | Startup context-window warning |
| `runtime/mod.rs` | Module registration |
| `runtime/context_governor/` (10 files) | New module |
| `runtime/lifecycle.rs` | Governor wiring (replaces 120-line inline block) |
| `llm/mod.rs` | `is_context_overflow_error()` shared function |
| `llm/openai.rs`, `anthropic.rs`, `gemini.rs` | Provider error classification |
| `docs/design/llm-context-overflow-mitigation-plan.md` | Updated with pluggable architecture