### PR TITLE
Phase 3: Overflow-aware retry classifier

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -1829,6 +1829,16 @@ impl GatewayExecutionService {
             .with_degraded_sessions(Some(self.degraded_sessions.clone()))
             .with_persona(self.persona.clone());
 
+            // Phase 3: propagate overflow_recovery flag so the governor
+            // uses an aggressive reduction pipeline on retry.
+            let overflow_recovery = metadata
+                .and_then(|m| m.get("overflow_recovery"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if overflow_recovery {
+                runtime = runtime.with_overflow_recovery(true);
+            }
+
             use crate::runtime::lifecycle::TurnOutcome;
 
             // --- Turn continuation / checkpoint resume ---

--- a/autonoetic-gateway/src/runtime/context_governor/mod.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/mod.rs
@@ -44,11 +44,28 @@ impl ContextGovernor {
     /// Build the default pipeline.
     pub fn new(config: &GovernorConfig) -> Self {
         let strategies: Vec<Box<dyn ReductionStrategy>> = vec![
-            Box::new(schema_compress::ToolSchemaCompressionStrategy),
+            Box::new(schema_compress::ToolSchemaCompressionStrategy::new()),
             Box::new(compression::CompressionStrategy::new(
                 config.http_client.clone(),
                 config.presets.clone(),
             )),
+            Box::new(trimming::TrimHistoryStrategy),
+            Box::new(demotion::ToolDemotionStrategy),
+        ];
+        Self { strategies }
+    }
+
+    /// Build the aggressive pipeline for overflow recovery retry.
+    ///
+    /// Skips `CompressionStrategy` (already attempted) and forces schema
+    /// compression on turn 0 + straight to trimming. This pipeline will
+    /// never attempt LLM-based summarisation — it goes directly to lossy
+    /// reduction.
+    pub fn new_aggressive(config: &GovernorConfig) -> Self {
+        let strategies: Vec<Box<dyn ReductionStrategy>> = vec![
+            // Force schema compression on every turn (even turn 0)
+            Box::new(schema_compress::ToolSchemaCompressionStrategy::forced()),
+            // Skip CompressionStrategy (already attempted in prior run)
             Box::new(trimming::TrimHistoryStrategy),
             Box::new(demotion::ToolDemotionStrategy),
         ];

--- a/autonoetic-gateway/src/runtime/context_governor/schema_compress.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/schema_compress.rs
@@ -8,7 +8,27 @@ fn tool_token_total(tools: &[ToolDefinition]) -> usize {
 }
 
 /// Strip tool JSON schemas to `{}` after turn 0.
-pub struct ToolSchemaCompressionStrategy;
+/// When `force_on_turn_0` is true, also compresses on the first turn
+/// (used by the aggressive overflow-recovery pipeline).
+pub struct ToolSchemaCompressionStrategy {
+    pub force_on_turn_0: bool,
+}
+
+impl ToolSchemaCompressionStrategy {
+    pub fn new() -> Self {
+        Self { force_on_turn_0: false }
+    }
+
+    pub fn forced() -> Self {
+        Self { force_on_turn_0: true }
+    }
+}
+
+impl Default for ToolSchemaCompressionStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl super::ReductionStrategy for ToolSchemaCompressionStrategy {
@@ -17,7 +37,7 @@ impl super::ReductionStrategy for ToolSchemaCompressionStrategy {
     }
 
     async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
-        if ctx.turn_number == 0 {
+        if ctx.turn_number == 0 && !self.force_on_turn_0 {
             return Ok(ReductionOutcome::Insufficient {
                 tokens_remaining: ctx.breakdown.total_tokens,
             });
@@ -26,7 +46,9 @@ impl super::ReductionStrategy for ToolSchemaCompressionStrategy {
         let before_tool_tokens = tool_token_total(&ctx.tools);
         let compressed = compress_tool_definitions(
             ctx.tools.clone(),
-            ctx.turn_number as usize,
+            // When forcing compression on turn 0, pass a non-zero turn
+            // because the helper skips turn_number == 0.
+            if self.force_on_turn_0 && ctx.turn_number == 0 { 1 } else { ctx.turn_number as usize },
         );
         let after_tool_tokens = tool_token_total(&compressed);
         let saved = before_tool_tokens.saturating_sub(after_tool_tokens);

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -164,6 +164,10 @@ pub struct AgentExecutor {
     /// Cross-agent persona text loaded from `persona.md`. Injected into every
     /// agent's system prompt between the foundation and agent-specific instructions.
     pub persona: Option<String>,
+    /// When true, the context governor uses an aggressive reduction pipeline
+    /// that skips CompressionStrategy and goes straight to TrimHistory.
+    /// Set by the scheduler on overflow retry.
+    pub overflow_recovery: bool,
 }
 
 use crate::runtime::tool_dispatch::{
@@ -216,6 +220,7 @@ impl AgentExecutor {
             artifact_id: None,
             ri_0_6_previous_snapshot: None,
             persona: None,
+            overflow_recovery: false,
         }
     }
 
@@ -237,6 +242,12 @@ impl AgentExecutor {
 
     pub fn with_persona(mut self, persona: Option<String>) -> Self {
         self.persona = persona;
+        self
+    }
+
+    /// Phase 3: Enable aggressive context governor pipeline for overflow retry.
+    pub fn with_overflow_recovery(mut self, enabled: bool) -> Self {
+        self.overflow_recovery = enabled;
         self
     }
 
@@ -1294,11 +1305,23 @@ impl AgentExecutor {
                     compression_cfg.cloned(),
                     self.manifest.compression.clone(),
                 );
-                let governor = ContextGovernor::new(&GovernorConfig {
-                    http_client: self.http_client.clone(),
-                    presets: self.config.as_ref().map(|c| c.llm_presets.clone())
-                        .unwrap_or_default(),
-                });
+                let governor = if self.overflow_recovery {
+                    tracing::info!(
+                        target: "autonoetic::context_governor",
+                        "Using aggressive governor pipeline (overflow recovery)"
+                    );
+                    ContextGovernor::new_aggressive(&GovernorConfig {
+                        http_client: self.http_client.clone(),
+                        presets: self.config.as_ref().map(|c| c.llm_presets.clone())
+                            .unwrap_or_default(),
+                    })
+                } else {
+                    ContextGovernor::new(&GovernorConfig {
+                        http_client: self.http_client.clone(),
+                        presets: self.config.as_ref().map(|c| c.llm_presets.clone())
+                            .unwrap_or_default(),
+                    })
+                };
                 match governor.govern(&mut ctx).await {
                     Ok(GovernorResult::Recovered { actions_taken }) => {
                         tracing::info!(

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -28,6 +28,7 @@ pub mod signal;
 pub mod store;
 pub mod system_agents;
 pub mod auto_learning_jobs;
+pub mod overflow_classifier;
 pub mod workflow_causal;
 pub mod workflow_store;
 
@@ -1418,13 +1419,101 @@ async fn spawn_task_execution(
             finish_active_row("stopped");
         }
         Err(e) => {
+            let error_str = e.to_string();
+
+            // ── Phase 3: Overflow-aware retry ──────────────────────────
+            // When the overflow retry classifier is enabled, detect context
+            // overflow errors and retry exactly once with an aggressive
+            // governor pipeline. A second overflow is terminal.
+            if crate::scheduler::overflow_classifier::overflow_retry_classifier_enabled()
+                && crate::scheduler::overflow_classifier::is_context_overflow(&e)
+            {
+                let already_retried = prev_checkpoint
+                    .as_ref()
+                    .and_then(|cp| cp.state.get("overflow_recovery_attempted"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                if !already_retried {
+                    tracing::warn!(
+                        target: "workflow",
+                        task_id = %t_id,
+                        error = %error_str,
+                        "Context overflow detected — retrying once with aggressive governor"
+                    );
+                    let _ = workflow_store::checkpoint_task(
+                        &cfg, store, &wf_id, &t_id,
+                        "failed".to_string(),
+                        serde_json::json!({
+                            "status": "failed",
+                            "error": error_str,
+                            "overflow_recovery_attempted": true,
+                        }),
+                    );
+                    // Tag the task metadata so the governor knows to use the
+                    // aggressive reduction pipeline on retry. Merge into any
+                    // existing metadata rather than replacing it outright.
+                    let existing_meta = workflow_store::load_task_run(&cfg, store, &wf_id, &t_id)
+                        .ok()
+                        .flatten()
+                        .and_then(|t| t.metadata)
+                        .unwrap_or(serde_json::json!({}));
+                    let merged = if let serde_json::Value::Object(mut m) = existing_meta {
+                        m.insert("overflow_recovery".to_string(), serde_json::Value::Bool(true));
+                        serde_json::Value::Object(m)
+                    } else {
+                        serde_json::json!({ "overflow_recovery": true })
+                    };
+                    let _ = workflow_store::update_task_run_metadata(
+                        &cfg, store, &wf_id, &t_id, merged,
+                    );
+                    // Set to Runnable so the scheduler re-queues this task
+                    let _ = workflow_store::update_task_run_status(
+                        &cfg, store, &wf_id, &t_id,
+                        autonoetic_types::workflow::TaskRunStatus::Runnable,
+                        Some("overflow_recovery_retry".to_string()),
+                        None, None,
+                    );
+                    let _ = workflow_store::dequeue_task(&cfg, store, &wf_id, &t_id);
+                    finish_active_row("stopped");
+                    return;
+                }
+
+                tracing::warn!(
+                    target: "workflow",
+                    task_id = %t_id,
+                    error = %error_str,
+                    "Context overflow retry exhausted — marking terminal"
+                );
+                // Fall through to normal failure path with terminal classification
+                let terminal_error = format!("context_overflow_terminal: task={} {}", t_id, error_str);
+                let _ = workflow_store::update_task_run_status(
+                    &cfg, store, &wf_id, &t_id,
+                    autonoetic_types::workflow::TaskRunStatus::Failed,
+                    Some(terminal_error.clone()),
+                    None, None,
+                );
+                let _ = workflow_store::checkpoint_task(
+                    &cfg, store, &wf_id, &t_id,
+                    "failed".to_string(),
+                    serde_json::json!({
+                        "status": "failed",
+                        "error": terminal_error,
+                        "overflow_recovery_exhausted": true,
+                    }),
+                );
+                let _ = workflow_store::dequeue_task(&cfg, store, &wf_id, &t_id);
+                finish_active_row("stopped");
+                return;
+            }
+
             if let Err(inner) = workflow_store::update_task_run_status(
                 &cfg,
                 store,
                 &wf_id,
                 &t_id,
                 autonoetic_types::workflow::TaskRunStatus::Failed,
-                Some(e.to_string()),
+                Some(error_str.clone()),
                 None,
                 None,
             ) {
@@ -1437,10 +1526,9 @@ async fn spawn_task_execution(
                 &wf_id,
                 &t_id,
                 "failed".to_string(),
-                serde_json::json!({ "status": "failed", "error": e.to_string() }),
+                serde_json::json!({ "status": "failed", "error": error_str }),
             );
             // Append validation errors to digest for better visibility
-            let error_str = e.to_string();
             let is_validation_error = error_str.contains("validation failed")
                 || error_str.contains("response_validation")
                 || error_str.contains("artifact_build_evidence")

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 36;
+const SCHEMA_VERSION_LATEST: i64 = 37;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -521,7 +521,45 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_recordings_v34(conn)?;
     apply_post_promotion_reviews_v35(conn)?;
     apply_escalation_code_excerpts_v36(conn)?;
+    apply_stage_transitions_v37(conn)?;
 
+    Ok(())
+}
+
+fn apply_stage_transitions_v37(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 37 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS stage_transitions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id TEXT NOT NULL,
+            revision_id TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            transition_type TEXT NOT NULL DEFAULT 'attempt',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(agent_id, revision_id, stage)
+        );
+        CREATE INDEX IF NOT EXISTS idx_stage_transitions_agent_revision
+            ON stage_transitions(agent_id, revision_id);
+        CREATE INDEX IF NOT EXISTS idx_stage_transitions_stage
+            ON stage_transitions(stage);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            37_i64,
+            "stage_transitions",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
     Ok(())
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -312,6 +312,38 @@ impl GatewayStore {
         let conn = self.conn.lock().unwrap();
         messages::mark_message_delivered(&conn, message_id, session_id)
     }
+    /// Record a stage transition for idempotent builder/install/promotion flow.
+    /// Returns `true` if the transition was newly inserted, `false` if it already existed.
+    pub fn record_stage_transition(
+        &self,
+        agent_id: &str,
+        revision_id: &str,
+        stage: &str,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let result = conn.execute(
+            "INSERT OR IGNORE INTO stage_transitions (agent_id, revision_id, stage, created_at)
+             VALUES (?1, ?2, ?3, datetime('now'))",
+            params![agent_id, revision_id, stage],
+        )?;
+        Ok(result > 0)
+    }
+
+    /// Check whether a given stage transition has already been recorded.
+    pub fn has_stage_transition(
+        &self,
+        agent_id: &str,
+        revision_id: &str,
+        stage: &str,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM stage_transitions WHERE agent_id = ?1 AND revision_id = ?2 AND stage = ?3",
+            params![agent_id, revision_id, stage],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
 }
 
 #[cfg(test)]

--- a/autonoetic-gateway/src/scheduler/overflow_classifier.rs
+++ b/autonoetic-gateway/src/scheduler/overflow_classifier.rs
@@ -1,0 +1,25 @@
+//! Overflow error classifier for Phase 3 overflow-aware orchestration.
+//!
+//! Distinguishes context overflow errors from other API errors so the
+//! scheduler can retry exactly once with an aggressive governor pipeline.
+
+/// Whether the error chain contains a `context_overflow:` classification
+/// emitted by the LLM drivers or the context governor.
+pub fn is_context_overflow(err: &anyhow::Error) -> bool {
+    let msg = format!("{:#}", err);
+    msg.contains("context_overflow:")
+}
+
+/// Whether the error chain indicates the task already exhausted its
+/// overflow retry and should be marked terminal.
+pub fn is_terminal_overflow(err: &anyhow::Error) -> bool {
+    let msg = format!("{:#}", err);
+    msg.contains("context_overflow_terminal")
+}
+
+/// Whether the overflow retry classifier feature flag is enabled.
+pub fn overflow_retry_classifier_enabled() -> bool {
+    std::env::var("AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER")
+        .as_deref()
+        == Ok("1")
+}

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -517,6 +517,21 @@ pub fn save_task_run(
     Ok(())
 }
 
+/// Update a task run's metadata.
+pub fn update_task_run_metadata(
+    config: &GatewayConfig,
+    store: Option<&GatewayStore>,
+    workflow_id: &str,
+    task_id: &str,
+    metadata: serde_json::Value,
+) -> anyhow::Result<()> {
+    let mut task = load_task_run(config, store, workflow_id, task_id)?
+        .ok_or_else(|| anyhow::anyhow!("task '{}' not in workflow '{}'", task_id, workflow_id))?;
+    task.metadata = Some(metadata);
+    task.updated_at = now_rfc3339();
+    save_task_run(config, store, &task)
+}
+
 /// Load a task run if the file exists.
 pub fn load_task_run(
     config: &GatewayConfig,


### PR DESCRIPTION
## Phase 3: Overflow-Aware Retry Classifier

Adds overflow-aware orchestration and retry, gated behind `AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER=1`.

### Changes

**overflow_classifier.rs** — New module that detects `context_overflow:` errors from the governor/provider pipeline.

**Overflow retry in spawn_task_execution** — On first overflow error, the task is set to `Runnable` (instead of `Failed`) and re-queued. A second overflow marks the task terminal with `context_overflow_terminal`.

**Aggressive governor pipeline** — `ContextGovernor::new_aggressive()` skips `CompressionStrategy` (already attempted) and forces schema compression even on turn 0 before going to `TrimHistory` / `ToolDemotion`.

**overflow_recovery propagation** — The flag flows from scheduler metadata → `spawn_agent_once` → `AgentExecutor.overflow_recovery` → lifecycle governor selection.

**stage_transitions SQLite table** — Migration v37 with `UNIQUE(agent_id, revision_id, stage)` for idempotent builder/install/promotion stages.

**workflow_store helper** — `update_task_run_metadata()` for updating task metadata without full status transition.

### Testing
- `cargo build -p autonoetic-gateway` — passes
- `cargo test -p autonoetic-gateway --lib` — 828 passed / 25 pre-existing failures (same baseline)
- All 3 context_governor unit tests pass

### Related
- Closes #213
- Umbrella: #209