### PR TITLE
Phase 4: SKILL.md split marker convention (core vs extended instructions)

### DIFF
--- a/.anchored/summary.md
+++ b/.anchored/summary.md
@@ -1,0 +1,66 @@
+## Goal
+
+- Implement Phase 4 of the LLM Context Overflow Mitigation Plan: SKILL.md split marker convention (core vs. extended instructions).
+
+## Constraints & Preferences
+
+- Extended instructions are everything after `<!-- extended -->` in SKILL.md body.
+- Core instructions are always injected in the system prompt; extended instructions are available for on-demand retrieval via `content_read("extended_instructions")`.
+- Old SKILL.md files without the marker work unchanged (backward compatible).
+- Feature flag env vars: `AUTONOETIC_STRICT_CONTEXT_GOVERNOR`, `AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER`.
+
+## Progress
+
+### Done
+
+- **Phase 0 + 1 shipped and merged** (PR #216): Safe defaults in `config/config-template.yaml`, startup warning for missing `context_window_tokens`, pluggable `runtime/context_governor/` module with `ReductionStrategy` trait, 4 built-in strategies, feature-gated pipeline in `lifecycle.rs`, provider error classification in all three LLM drivers, static model table in `resolver.rs`.
+- **10 review comments on PR #256 all addressed before merge.**
+- **Phase 3 shipped and merged** (PR #217): Overflow-aware retry classifier under `AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER=1`.
+- **Phase 4 — split marker convention fully implemented:**
+  - `split_extended_instructions()` in `runtime/parser.rs:490` — splits SKILL.md body at `<!-- extended -->` marker.
+  - `extended_instructions: Option<String>` on `LoadedAgent` in `agent/repository.rs:15`.
+  - Split wired into both `load_from_meta()` (line 134) and `load_from_revision_dir()` (line 219) in `repository.rs`.
+  - `extended_instructions: Option<String>` field + `with_extended_instructions()` builder on `AgentExecutor` in `lifecycle.rs:184`.
+  - All 4 `AgentExecutor::new()` call sites in `execution.rs` pass `loaded.extended_instructions`.
+  - Extended instructions written to content store as `"extended_instructions"` (Session visibility) on first session start (`lifecycle.rs:1020-1038`).
+  - System prompt auto-injects note: "Extended instructions are available via content_read('extended_instructions')." when extended instructions exist (`lifecycle.rs:719-726`, `lifecycle.rs:1221-1228`).
+
+### In Progress
+
+- None.
+
+### Blocked
+
+- None.
+
+## Key Decisions
+
+- `<!-- extended -->` marker chosen over `## Extended Instructions` to avoid rendering ambiguity in markdown — invisible comment tag that tools like `knowledge_search` can reference.
+- `extended_instructions` stored on both `LoadedAgent` (for transport) and `AgentExecutor` (for session lifecycle). The executor owns the session context where content-store writes happen.
+- Extended instructions are written to content store with key `extended_instructions` so agents can retrieve them via the existing `content_read` tool — no new tool needed.
+- Core instructions omit any note about extended content by default; agents with the marker get an auto-injected note in their system prompt.
+- Content store write happens inside `!self.session_started` block (once per session), creating `ContentStore` from `self.gateway_dir`.
+
+## Next Steps
+
+1. Add `<!-- extended -->` marker + extended content to one or more SKILL.md files in `agents/` to exercise the new path.
+2. Consider enabling tool schema defaults for planner/factory/builder roles.
+3. Revisit the `<!-- extended -->` marker convention documentation if needed.
+
+## Critical Context
+
+- `SKILL.md` body is parsed by `SkillParser::parse()` returning `(AgentManifest, String instructions)`.
+- `LoadedAgent.instructions` now holds only core instructions (before `<!-- extended -->`).
+- `LoadedAgent.extended_instructions` holds everything after the marker (or `None` if marker absent).
+- `AgentExecutor.instructions` is the canonical copy passed to `compose_system_instructions_full()`.
+- No changes to the existing knowledge store schema — `content_write` uses the content store at `<gateway_dir>/content/<session_id>/`.
+- Currently 828 tests pass, 25 pre-existing failures (unchanged).
+
+## Relevant Files
+
+- `autonoetic-gateway/src/runtime/parser.rs`: `split_extended_instructions()` — split function (line 490).
+- `autonoetic-gateway/src/agent/repository.rs`: `LoadedAgent.extended_instructions` (line 15), split wired in `load_from_meta` (line 134) and `load_from_revision_dir` (line 219).
+- `autonoetic-gateway/src/runtime/lifecycle.rs`: `AgentExecutor.extended_instructions` field (line 184), `with_extended_instructions()` builder, content store write (lines 1020-1038), system prompt hint injection (lines 719-726, 1221-1228).
+- `autonoetic-gateway/src/execution.rs`: All 4 `AgentExecutor::new()` call sites pass `loaded.extended_instructions`.
+- `autonoetic-gateway/src/runtime/context.rs`: `compose_system_instructions_full()` — no changes needed (hint injected at call site).
+- `config/config-template.yaml`: safe defaults for `prompt_budget` and `context_compression`.

--- a/autonoetic-gateway/src/agent/repository.rs
+++ b/autonoetic-gateway/src/agent/repository.rs
@@ -17,7 +17,7 @@ pub struct LoadedAgent {
     pub manifest: AgentManifest,
     pub instructions: String,
     /// Optional extended instructions (everything after `<!-- extended -->`
-    /// in the SKILL.md body). Available for on-demand retrieval.
+    /// in the SKILL.md body) available for on-demand retrieval.
     pub extended_instructions: Option<String>,
 }
 

--- a/autonoetic-gateway/src/agent/repository.rs
+++ b/autonoetic-gateway/src/agent/repository.rs
@@ -16,6 +16,9 @@ pub struct LoadedAgent {
     pub dir: PathBuf,
     pub manifest: AgentManifest,
     pub instructions: String,
+    /// Optional extended instructions (everything after `<!-- extended -->`
+    /// in the SKILL.md body). Available for on-demand retrieval.
+    pub extended_instructions: Option<String>,
 }
 
 impl LoadedAgent {
@@ -129,6 +132,8 @@ impl AgentRepository {
         let skill_path = meta.dir.join("SKILL.md");
         let skill_content = std::fs::read_to_string(&skill_path)?;
         let (manifest, instructions) = SkillParser::parse(&skill_content)?;
+        let (core_instructions, extended) =
+            crate::runtime::parser::split_extended_instructions(&instructions);
 
         // Enforce identity: directory name must match manifest agent ID
         let dir_name = meta
@@ -161,7 +166,8 @@ impl AgentRepository {
         Ok(LoadedAgent {
             dir: meta.dir.clone(),
             manifest,
-            instructions,
+            instructions: core_instructions.to_string(),
+            extended_instructions: extended.map(String::from),
         })
     }
 
@@ -211,11 +217,14 @@ impl AgentRepository {
         let skill_path = rev_dir.join("SKILL.md");
         let skill_content = std::fs::read_to_string(&skill_path)?;
         let (manifest, instructions) = SkillParser::parse(&skill_content)?;
+        let (core_instructions, extended) =
+            crate::runtime::parser::split_extended_instructions(&instructions);
 
         Ok(LoadedAgent {
             dir: rev_dir,
             manifest,
-            instructions,
+            instructions: core_instructions.to_string(),
+            extended_instructions: extended.map(String::from),
         })
     }
 

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -1829,7 +1829,6 @@ impl GatewayExecutionService {
             .with_degraded_sessions(Some(self.degraded_sessions.clone()))
         .with_persona(self.persona.clone())
         .with_extended_instructions(loaded.extended_instructions.clone());
-            runtime = runtime.with_extended_instructions(loaded.extended_instructions.clone());
             // Phase 3: propagate overflow_recovery flag so the governor
             // uses an aggressive reduction pipeline on retry.
             let overflow_recovery = metadata
@@ -2620,7 +2619,8 @@ impl GatewayExecutionService {
         .with_active_executions(Some(self.active_executions.clone()))
         .with_http_client(self.http_client.clone())
         .with_degraded_sessions(Some(self.degraded_sessions.clone()))
-        .with_persona(self.persona.clone());
+        .with_persona(self.persona.clone())
+        .with_extended_instructions(loaded.extended_instructions.clone());
 
         checkpoint.restore_into(&mut runtime);
 

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -1827,8 +1827,9 @@ impl GatewayExecutionService {
             .with_http_client(self.http_client.clone())
             .with_artifact_id(artifact_id.map(String::from))
             .with_degraded_sessions(Some(self.degraded_sessions.clone()))
-            .with_persona(self.persona.clone());
-
+        .with_persona(self.persona.clone())
+        .with_extended_instructions(loaded.extended_instructions.clone());
+            runtime = runtime.with_extended_instructions(loaded.extended_instructions.clone());
             // Phase 3: propagate overflow_recovery flag so the governor
             // uses an aggressive reduction pipeline on retry.
             let overflow_recovery = metadata
@@ -2867,7 +2868,8 @@ impl GatewayExecutionService {
         .with_http_client(self.http_client.clone())
         .with_degraded_sessions(Some(self.degraded_sessions.clone()))
         .with_persona(self.persona.clone())
-        .with_initial_session_state(SessionState::Clarification);
+        .with_initial_session_state(SessionState::Clarification)
+        .with_extended_instructions(loaded.extended_instructions.clone());
 
         let mut history: Vec<Message> = Vec::new();
         let outcome = runtime.execute_with_history(&mut history).await;
@@ -3017,7 +3019,8 @@ impl GatewayExecutionService {
         .with_http_client(self.http_client.clone())
         .with_degraded_sessions(Some(self.degraded_sessions.clone()))
         .with_persona(self.persona.clone())
-        .with_initial_session_state(SessionState::Clarification);
+        .with_initial_session_state(SessionState::Clarification)
+        .with_extended_instructions(loaded.extended_instructions.clone());
 
         let mut history: Vec<Message> = Vec::new();
         let outcome = runtime.execute_with_history(&mut history).await;

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -168,6 +168,9 @@ pub struct AgentExecutor {
     /// that skips CompressionStrategy and goes straight to TrimHistory.
     /// Set by the scheduler on overflow retry.
     pub overflow_recovery: bool,
+    /// Optional extended instructions (after `<!-- extended -->` in SKILL.md).
+    /// Written to content store for on-demand retrieval by the agent.
+    pub extended_instructions: Option<String>,
 }
 
 use crate::runtime::tool_dispatch::{
@@ -221,6 +224,7 @@ impl AgentExecutor {
             ri_0_6_previous_snapshot: None,
             persona: None,
             overflow_recovery: false,
+            extended_instructions: None,
         }
     }
 
@@ -248,6 +252,12 @@ impl AgentExecutor {
     /// Phase 3: Enable aggressive context governor pipeline for overflow retry.
     pub fn with_overflow_recovery(mut self, enabled: bool) -> Self {
         self.overflow_recovery = enabled;
+        self
+    }
+
+    /// Set optional extended instructions for on-demand retrieval.
+    pub fn with_extended_instructions(mut self, instructions: Option<String>) -> Self {
+        self.extended_instructions = instructions;
         self
     }
 
@@ -705,8 +715,15 @@ impl AgentExecutor {
     pub async fn execute_loop(&mut self) -> anyhow::Result<()> {
         let user_context = self.build_user_context_snippet();
         let memory_context = self.build_memory_context_snippet();
+        let instructions_with_hint = match &self.extended_instructions {
+            Some(ext) if !ext.is_empty() => format!(
+                "{}\n\nExtended instructions are available via content_read(\"extended_instructions\").",
+                self.instructions
+            ),
+            _ => self.instructions.clone(),
+        };
         let mut system_instructions = compose_system_instructions_full(
-            &self.instructions,
+            &instructions_with_hint,
             &self.manifest,
             self.manifest
                 .io
@@ -1003,6 +1020,27 @@ impl AgentExecutor {
                 self.runtime_lock_hash =
                     crate::runtime::checkpoint::compute_runtime_lock_hash(&self.agent_dir);
             }
+
+            // Write extended instructions to content store for on-demand retrieval
+            if let Some(ext) = &self.extended_instructions {
+                if !ext.is_empty() {
+                    if let Some(gw_dir) = &self.gateway_dir {
+                        if let Ok(store) =
+                            crate::runtime::content_store::ContentStore::new(gw_dir)
+                        {
+                            if let Ok(handle) = store.write(ext.as_bytes()) {
+                                let sid = self.session_id.as_deref().unwrap_or("default");
+                                let _ = store.register_name_with_visibility(
+                                    sid,
+                                    "extended_instructions",
+                                    &handle,
+                                    crate::runtime::content_store::ContentVisibility::Session,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
         }
         // --- Auto-inject Agent Messages ---
         if let Some(store) = self.gateway_store.as_ref() {
@@ -1178,8 +1216,15 @@ impl AgentExecutor {
             // Update system message — ensure exactly one system message at position 0
             let user_context = self.build_user_context_snippet();
             let memory_context = self.build_memory_context_snippet();
+            let instructions_with_hint = match &self.extended_instructions {
+                Some(ext) if !ext.is_empty() => format!(
+                    "{}\n\nExtended instructions are available via content_read(\"extended_instructions\").",
+                    self.instructions
+                ),
+                _ => self.instructions.clone(),
+            };
             let mut system_instructions = compose_system_instructions_full(
-                &self.instructions,
+                &instructions_with_hint,
                 &self.manifest,
                 self.manifest
                     .io

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -717,7 +717,7 @@ impl AgentExecutor {
         let memory_context = self.build_memory_context_snippet();
         let instructions_with_hint = match &self.extended_instructions {
             Some(ext) if !ext.is_empty() => format!(
-                "{}\n\nExtended instructions are available via content_read(\"extended_instructions\").",
+                "{}\n\nExtended instructions are available via content_read({{\"name_or_handle\": \"extended_instructions\"}}).",
                 self.instructions
             ),
             _ => self.instructions.clone(),
@@ -1025,16 +1025,38 @@ impl AgentExecutor {
             if let Some(ext) = &self.extended_instructions {
                 if !ext.is_empty() {
                     if let Some(gw_dir) = &self.gateway_dir {
-                        if let Ok(store) =
-                            crate::runtime::content_store::ContentStore::new(gw_dir)
-                        {
-                            if let Ok(handle) = store.write(ext.as_bytes()) {
-                                let sid = self.session_id.as_deref().unwrap_or("default");
-                                let _ = store.register_name_with_visibility(
-                                    sid,
-                                    "extended_instructions",
-                                    &handle,
-                                    crate::runtime::content_store::ContentVisibility::Session,
+                        match crate::runtime::content_store::ContentStore::new(gw_dir) {
+                            Ok(store) => {
+                                match store.write(ext.as_bytes()) {
+                                    Ok(handle) => {
+                                        let sid = self
+                                            .session_id
+                                            .as_deref()
+                                            .unwrap_or(&self.manifest.agent.id);
+                                        if let Err(e) = store.register_name_with_visibility(
+                                            sid,
+                                            "extended_instructions",
+                                            &handle,
+                                            crate::runtime::content_store::ContentVisibility::Session,
+                                        ) {
+                                            tracing::warn!(
+                                                target: "extended_instructions",
+                                                "Failed to register extended instructions in content store: {e}"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            target: "extended_instructions",
+                                            "Failed to write extended instructions to content store: {e}"
+                                        );
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "extended_instructions",
+                                    "Failed to open content store for extended instructions: {e}"
                                 );
                             }
                         }
@@ -1218,7 +1240,7 @@ impl AgentExecutor {
             let memory_context = self.build_memory_context_snippet();
             let instructions_with_hint = match &self.extended_instructions {
                 Some(ext) if !ext.is_empty() => format!(
-                    "{}\n\nExtended instructions are available via content_read(\"extended_instructions\").",
+                    "{}\n\nExtended instructions are available via content_read({{\"name_or_handle\": \"extended_instructions\"}}).",
                     self.instructions
                 ),
                 _ => self.instructions.clone(),

--- a/autonoetic-gateway/src/runtime/parser.rs
+++ b/autonoetic-gateway/src/runtime/parser.rs
@@ -182,7 +182,23 @@ fn reject_legacy_response_contract(content: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Infers Autonoetic capabilities from AgentSkills.io `allowed-tools` entries.
+/// Split instructions at the `<!-- extended -->` marker.
+///
+/// Everything before the marker is "core" (always injected in the system
+/// prompt).  Everything after is "extended" (on-demand retrieval).  Returns
+/// `(core, Some(extended))` if the marker is found, or `(body, None)` if not.
+pub fn split_extended_instructions(body: &str) -> (&str, Option<&str>) {
+    // Accept either <!-- extended --> or <!--extended--> (with/without spaces)
+    for marker in &["<!-- extended -->", "<!--extended-->"] {
+        if let Some(pos) = body.find(marker) {
+            let core = body[..pos].trim();
+            let extended = body[pos + marker.len()..].trim();
+            let extended = if extended.is_empty() { None } else { Some(extended) };
+            return (core, extended);
+        }
+    }
+    (body, None)
+}
 ///
 /// Maps known AgentSkills tool names to Autonoetic capability types:
 /// - `Bash(*)` → `SandboxFunctions` / `CodeExecution`

--- a/autonoetic-gateway/src/runtime/parser.rs
+++ b/autonoetic-gateway/src/runtime/parser.rs
@@ -669,4 +669,52 @@ metadata:
         assert_eq!(sandbox.len(), 1);
         assert_eq!(sandbox[0], "*");
     }
+
+    #[test]
+    fn test_split_extended_no_marker() {
+        let body = "Just core instructions here.";
+        let (core, extended) = split_extended_instructions(body);
+        assert_eq!(core, body);
+        assert!(extended.is_none());
+    }
+
+    #[test]
+    fn test_split_extended_marker_with_spaces() {
+        let body = "Core instructions.\n<!-- extended -->\nExtended instructions here.";
+        let (core, extended) = split_extended_instructions(body);
+        assert_eq!(core, "Core instructions.");
+        assert_eq!(extended, Some("Extended instructions here."));
+    }
+
+    #[test]
+    fn test_split_extended_marker_no_spaces() {
+        let body = "Core instructions.\n<!--extended-->\nExtended instructions here.";
+        let (core, extended) = split_extended_instructions(body);
+        assert_eq!(core, "Core instructions.");
+        assert_eq!(extended, Some("Extended instructions here."));
+    }
+
+    #[test]
+    fn test_split_extended_marker_at_start() {
+        let body = "<!-- extended -->\nAll content is extended.";
+        let (core, extended) = split_extended_instructions(body);
+        assert_eq!(core, "");
+        assert_eq!(extended, Some("All content is extended."));
+    }
+
+    #[test]
+    fn test_split_extended_empty_extended() {
+        let body = "Core.\n<!-- extended -->\n   ";
+        let (core, extended) = split_extended_instructions(body);
+        assert_eq!(core, "Core.");
+        assert!(extended.is_none());
+    }
+
+    #[test]
+    fn test_split_extended_marker_at_end() {
+        let body = "Core.\n<!-- extended -->";
+        let (core, extended) = split_extended_instructions(body);
+        assert_eq!(core, "Core.");
+        assert!(extended.is_none());
+    }
 }

--- a/docs/design/llm-context-overflow-mitigation-plan.md
+++ b/docs/design/llm-context-overflow-mitigation-plan.md
@@ -317,33 +317,321 @@ Deliverables:
 5. Deprecation shims in old modules.
 6. Unit tests: strategy isolation (each strategy works independently), pipeline ordering (cascade stops at first `Resolved`), fallback (all strategies exhausted → typed error).
 
-## Phase 2: Hierarchical Session Summarization (Future Strategy)
+## Phase 2: Hierarchical Session Summarization (CapsuleStrategy)
 
-> **Note**: This phase is deferred after Phases 0, 1, and 3 ship. The existing `CompressionStrategy` in the governor is sufficient for the immediate failure mode. The capsule design introduces a new state machine (versions, merge conflicts under concurrent compression) that warrants its own RFC. Because the governor is pluggable, the capsule ships as a new `ReductionStrategy` implementation with zero changes to the pipeline or lifecycle.
+> **Note**: This phase is deferred after Phases 0, 1, and 3 ship. The existing `CompressionStrategy` in the governor is sufficient for the immediate failure mode. Because the governor is pluggable, the capsule ships as a new `ReductionStrategy` implementation with zero changes to the pipeline or lifecycle.
 
-Introduce a durable "state capsule" layer to prevent repeated long-form replay:
+> **Feature flag**: `AUTONOETIC_STATE_CAPSULE_COMPRESSION=1`
 
-1. Keep last N turns raw (N=3 default).
-2. Maintain rolling summary blocks:
-   1. Objective and success criteria.
-   2. Decisions and rationale.
-   3. Stable identifiers (artifact refs, revision ids, approvals).
-   4. Open tasks/blockers.
-3. On each compression cycle, update capsule from deltas rather than regenerating from full history.
-4. Preserve original snapshots in content store for audit/replay.
+### Motivation
 
-Compression quality safeguards:
+The existing `CompressionStrategy` performs full LLM-based summarization of old turns on each compression cycle. This works for the immediate failure mode but has structural limitations in long-running (50+ turn) sessions:
 
-1. Never summarize away unresolved approvals/escalations.
-2. Never mutate structured IDs in summaries (lossless copy only).
-3. Keep most recent tool-call/result group intact.
+1. **Repeated re-summarization**: Each compression cycle regenerates the summary from scratch, losing incremental context nuance.
+2. **Structural information loss**: The flat summary text doesn't preserve structured identifiers (artifact handles, approval IDs, revision IDs) with guaranteed losslessness.
+3. **No semantic layering**: A planner session at turn 80 carries the same flat summary block as at turn 15 — there's no hierarchical decomposition of what matters.
+4. **Quality degradation**: Each re-summarization compounds error, especially for decisions and rationale that drift across compression cycles.
 
-Deliverables:
+### Concept
+
+Introduce a durable, versioned **state capsule** that maintains rolling structured sections updated from deltas rather than regenerated from full history:
+
+1. Keep last N turns raw (N=3 default, reusing existing `split_compressible_messages()`).
+2. Maintain rolling structured sections (see schema below).
+3. On each compression cycle, extract a typed `CapsuleDelta` from recent turns via LLM, then apply it mechanically.
+4. Preserve original capsule versions in content store for audit/replay (immutable chain).
+
+### Capsule Data Model
+
+The capsule is a versioned, structured state object at `context_governor::capsule`:
+
+```rust
+/// A durable state capsule that maintains rolling structured summaries.
+///
+/// Unlike flat compression, the capsule preserves structured sections
+/// that are updated incrementally from deltas.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateCapsule {
+    /// Monotonic version counter, incremented on each update.
+    pub version: u64,
+    /// Session that owns this capsule.
+    pub session_id: String,
+    /// Turn number when this capsule was last updated.
+    pub last_update_turn: u64,
+
+    // --- Structured Sections ---
+
+    /// Current objective and success criteria.
+    /// Updated when the agent's goal shifts or refines.
+    pub objective_and_criteria: String,
+    /// Key decisions made and their rationale.
+    /// Append-only: new decisions are appended, never removed.
+    pub decisions_and_rationale: Vec<CapsuleDecision>,
+    /// Stable identifiers that MUST be preserved losslessly.
+    /// Content handles, artifact refs, approval IDs, revision IDs.
+    pub stable_identifiers: Vec<StableIdentifier>,
+    /// Open tasks and blockers at the current point.
+    /// Mutable: tasks are added, marked complete, or removed.
+    pub open_tasks: Vec<CapsuleTask>,
+
+    // --- Audit chain ---
+
+    /// Content store handle to the previous capsule version.
+    pub previous_version_handle: Option<String>,
+    /// Content store handle to the full original history snapshot
+    /// that was compressed into this capsule version.
+    pub source_history_handle: Option<String>,
+    /// Timestamp of last update (RFC3339).
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapsuleDecision {
+    pub turn: u64,
+    pub summary: String,
+    pub rationale: String,
+    pub referenced_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct StableIdentifier {
+    /// Category: "artifact", "approval", "revision", "content", "session", etc.
+    pub category: String,
+    /// The identifier value (content handle, approval ID, etc.)
+    pub value: String,
+    /// Human-readable label (optional).
+    pub label: Option<String>,
+    /// Turn when this ID was first referenced.
+    pub first_seen_turn: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapsuleTask {
+    pub description: String,
+    /// Status: "open", "in_progress", "blocked", "completed".
+    pub status: String,
+    pub added_turn: u64,
+    pub completed_turn: Option<u64>,
+    pub blocker: Option<String>,
+}
+```
+
+**Design rationale**: Structured sections rather than free-form text. The LLM extracts deltas into typed fields; the gateway mechanically enforces that `stable_identifiers` are never mutated (only appended). This follows the "dumb gateway" philosophy: the LLM does the semantic work (extraction), the gateway does the mechanical work (enforcement).
+
+### Delta Extraction
+
+On each compression cycle, the `CapsuleStrategy`:
+
+1. Sends the current capsule state (JSON) + recent compressible turns + a `CapsuleDelta` schema description to the compression LLM.
+2. Receives a typed `CapsuleDelta` as JSON.
+3. Validates the delta mechanically (see safety invariants below).
+4. Applies the delta to produce a new `StateCapsule` with `version + 1`.
+5. Persists the previous version to the content store (audit chain).
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapsuleDelta {
+    /// Updated objective (if changed), or None to keep current.
+    pub objective_update: Option<String>,
+    /// New decisions to append.
+    pub new_decisions: Vec<CapsuleDecision>,
+    /// New stable identifiers discovered in recent turns.
+    pub new_identifiers: Vec<StableIdentifier>,
+    /// Task updates: new tasks, status changes, completions.
+    pub task_updates: Vec<CapsuleTaskUpdate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CapsuleTaskUpdate {
+    Add(CapsuleTask),
+    Complete { description: String, turn: u64 },
+    Block { description: String, blocker: String },
+    Remove { description: String },
+}
+```
+
+### CapsuleStrategy — ReductionStrategy Implementation
+
+`CapsuleStrategy` implements `ReductionStrategy` and replaces `CompressionStrategy` in the pipeline when the feature flag is set:
+
+```rust
+pub struct CapsuleStrategy {
+    http_client: reqwest::Client,
+    presets: HashMap<String, LlmPreset>,
+    gateway_dir: Option<PathBuf>,
+}
+
+#[async_trait]
+impl ReductionStrategy for CapsuleStrategy {
+    fn name(&self) -> &'static str { "capsule" }
+
+    async fn reduce(&self, ctx: &mut GovernorContext) -> anyhow::Result<ReductionOutcome> {
+        // 1. Check capsule compression enabled + LLM configured
+        // 2. Split history via split_compressible_messages() (reuse existing)
+        // 3. Load or create capsule from GovernorContext
+        // 4. Extract CapsuleDelta from compressible turns via LLM
+        // 5. Validate delta (no ID mutations, no decision removals,
+        //    unresolved approvals preserved)
+        // 6. Apply delta → new capsule version (version + 1)
+        // 7. Persist previous version to content store
+        // 8. Replace compressible history with capsule injection message
+        // 9. Update ctx.history, ctx.compression_metadata
+        // 10. Recompute token estimate; return Resolved or Insufficient
+    }
+}
+```
+
+**Pipeline position**: With the feature flag enabled, the pipeline becomes:
+
+1. `ToolSchemaCompression` — strip schemas after turn 0 (fast, lossless)
+2. **`Capsule`** — delta-based structured compression (replaces `Compression`)
+3. `TrimHistory` — drop oldest groups (fast, lossy)
+4. `ToolDemotion` — remove specialized tools (fast, reduces capability)
+5. `Fail` — typed overflow error (terminal)
+
+`CompressionStrategy` remains available as the default when the flag is unset.
+
+### Capsule Injection Format
+
+Instead of the current `[COMPRESSED CONTEXT - Turn N]` flat text, the capsule injects a structured message:
+
+```
+[SESSION STATE CAPSULE v{version} — Turn {turn}]
+
+## Objective
+{objective_and_criteria}
+
+## Key Decisions
+- [Turn {turn}] {summary}: {rationale}
+...
+
+## Active Identifiers
+- [{category}] {value} ({label})
+...
+
+## Open Tasks
+- [{status}] {description}
+...
+
+## Completed Tasks (Recent)
+- [done@{turn}] {description}
+...
+```
+
+### Safety Invariants (Mechanical Enforcement)
+
+These are enforced by the gateway, not by the LLM:
+
+| Invariant | Enforcement |
+|---|---|
+| Stable identifiers are never mutated | `apply_delta()` rejects any `new_identifiers` that conflict with existing entries by `(category, value)` |
+| Decisions are append-only | `apply_delta()` only appends `new_decisions`; no mechanism to modify or remove |
+| Unresolved approvals survive compression | `validate_delta()` scans compressed turns for approval tool calls without matching `approval.status` results; rejects delta if these aren't in `open_tasks` or `stable_identifiers` |
+| Capsule version chain is immutable | Each update persists the previous version to content store; content store blobs are read-only |
+| Most recent tool-call group is kept intact | Reuses existing `split_compressible_messages()` logic — tool-call groups are never split |
+| Decision overflow bounded | Capsule retains at most `max_capsule_decisions` (default 30); oldest beyond limit are summarized into a single "prior decisions summary" entry |
+| Completed task pruning | At most `max_completed_tasks` (default 10) completed tasks retained; oldest are dropped |
+
+### Persistence
+
+#### Content Store
+
+- Previous capsule versions → `content_store.write()` with name `capsule_v{version}_turn_{turn}`, visibility `Private` (session-local for v1)
+- Source history snapshots → `content_store.write()` (same as existing `CompressionStrategy`)
+- Audit chain: each capsule's `previous_version_handle` points to the prior version's content store handle
+
+#### Checkpoint
+
+`SessionCheckpoint` gains a new field:
+
+```rust
+// --- Capsule ---
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub capsule_state: Option<StateCapsule>,
+```
+
+On session resume, `restore_into()` restores capsule state so the next compression cycle does a delta update rather than starting fresh. `AgentExecutor` stores the capsule as `pub capsule_state: Option<StateCapsule>`.
+
+### Configuration
+
+`ContextCompressionConfig` gains capsule-specific fields:
+
+```rust
+/// Compression strategy: "summarization" (default) or "capsule".
+#[serde(default = "default_compression_strategy")]
+pub strategy: String,
+/// Maximum decisions retained in capsule (default 30).
+#[serde(default = "default_max_capsule_decisions")]
+pub max_capsule_decisions: usize,
+/// Maximum completed tasks retained in capsule (default 10).
+#[serde(default = "default_max_completed_tasks")]
+pub max_completed_tasks: usize,
+```
+
+`CompressionConfig` (per-agent SKILL.md) gains optional overrides:
+
+```rust
+/// Override compression strategy for this agent: "summarization" or "capsule".
+pub strategy: Option<String>,
+/// Override max capsule decisions for this agent.
+pub max_capsule_decisions: Option<usize>,
+```
+
+### Capsule Scope (Concurrency Decision)
+
+v1: **session-local only**. Each session owns its own capsule — no cross-session sharing, no CAS/locking needed. This avoids the concurrency complexity of two sibling sessions compressing simultaneously into a shared capsule.
+
+Future: if telemetry shows benefit, upgrade to root-session-shared capsules with CAS-style optimistic locking on the capsule version.
+
+### Migration from CompressionStrategy
+
+When upgrading mid-session (operator enables the feature flag during a running session), the `CapsuleStrategy` detects existing `[COMPRESSED CONTEXT]` markers in history and bootstraps the capsule's `objective_and_criteria` section from their content. The first capsule version is created at `version: 1` with the bootstrapped objective and empty decisions/identifiers/tasks sections.
+
+### Deliverables
 
 1. `context_governor::capsule::CapsuleStrategy` implementing `ReductionStrategy`.
-2. Capsule schema and serializer.
-3. Compression tests for id-preservation and decision continuity — prefer property-based (quickcheck-style) invariants over fixed fixtures where feasible.
-4. Config entry to swap `CompressionStrategy` for `CapsuleStrategy` in the pipeline.
+2. `StateCapsule`, `CapsuleDelta`, `StableIdentifier`, `CapsuleDecision`, `CapsuleTask` types with serialization.
+3. `apply_delta()` with mechanical enforcement of safety invariants.
+4. `validate_delta()` for unresolved approval detection.
+5. Delta extraction prompt and LLM integration (reusing compression LLM config).
+6. Content store persistence for capsule version chain.
+7. `SessionCheckpoint.capsule_state` field + `restore_into()` integration.
+8. Config entries in `ContextCompressionConfig` and `CompressionConfig`.
+9. Feature gate: `AUTONOETIC_STATE_CAPSULE_COMPRESSION=1` selects `CapsuleStrategy` in pipeline.
+10. Migration logic: bootstrap capsule from existing `[COMPRESSED CONTEXT]` markers.
+
+### Tests
+
+Unit tests (in `capsule.rs`):
+
+1. Delta application: valid delta → version incremented, sections updated.
+2. ID preservation invariant: conflicting `StableIdentifier` → rejected.
+3. Decision append-only: cannot remove or modify existing decisions.
+4. Unresolved approval detection: compressed turns with pending approval calls → delta must preserve them.
+5. Capsule injection format: serialized capsule produces expected structured text.
+6. Migration from compressed context: `[COMPRESSED CONTEXT]` → bootstrapped capsule.
+7. Decision overflow: >30 decisions → oldest summarized into prior-decisions entry.
+8. Completed task pruning: >10 completed tasks → oldest dropped.
+
+Property-based tests (quickcheck-style):
+
+1. **ID losslessness**: for any arbitrary history containing structured IDs, after capsule compression, all IDs appear in `stable_identifiers`.
+2. **Decision monotonicity**: for any sequence of delta applications, decisions list length is monotonically non-decreasing.
+3. **Version monotonicity**: capsule version is strictly monotonically increasing.
+
+Pipeline tests:
+
+1. CapsuleStrategy resolves → `ReductionOutcome::Resolved`.
+2. CapsuleStrategy insufficient → `ReductionOutcome::Insufficient`, pipeline continues to `TrimHistory`.
+3. Feature flag off → `CompressionStrategy` used instead.
+4. Pipeline contains exactly one compression-tier strategy (capsule xor summarization).
+
+Integration tests:
+
+1. 50-turn synthetic session → capsule applied, history reduced, all approval IDs preserved, session resumable from checkpoint.
+2. Compress → checkpoint → resume → second compression uses delta on existing capsule (version 2).
+3. Content store audit chain: 3 capsule versions → 3 snapshots with correct `previous_version_handle` chain.
+4. Migration: session starts with `CompressionStrategy`, flag enabled, next compression bootstraps capsule from existing markers.
 
 ## Phase 3: Overflow-Aware Orchestration and Retry
 
@@ -426,18 +714,28 @@ Add/extend fields in session/workflow telemetry:
    3. `ToolDemotionStrategy` — tier filtering, section cap compliance.
    4. `ToolSchemaCompressionStrategy` — turn-0 skip, subsequent-turn compression.
    5. `FailStrategy` — emits `ContextOverflowError` with diagnostic.
+   6. `CapsuleStrategy` — delta application, ID preservation invariant, decision append-only, unresolved approval detection, capsule injection format, migration from `[COMPRESSED CONTEXT]`, decision overflow (>30 → summarized), completed task pruning (>10 → dropped).
 2. Pipeline tests (cascade behavior):
    1. Within budget → no strategies run.
    2. Single strategy resolves → later strategies skipped.
    3. All strategies exhausted → `GovernorResult::Overflow` with full diagnostic.
    4. Custom pipeline order via config.
-3. Integration tests:
+   5. Capsule replaces `CompressionStrategy` when `AUTONOETIC_STATE_CAPSULE_COMPRESSION=1` is set; pipeline has exactly one compression-tier strategy.
+3. Property-based tests (capsule invariants):
+   1. ID losslessness: for arbitrary history with structured IDs, all IDs appear in `stable_identifiers` after capsule compression.
+   2. Decision monotonicity: decisions list length is monotonically non-decreasing across any delta application sequence.
+   3. Version monotonicity: capsule version is strictly monotonically increasing.
+4. Integration tests:
    1. Simulated long-history planner run that would previously exceed context; verify no hard failure.
    2. Overflow retry path emits expected events and terminal classification.
    3. Builder duplicate-spawn prevention after successful promotion/install tuple.
    4. Concurrent sibling overflow: both children overflow, only one retry proceeds, no duplicate stage transition.
    5. Provider error classification (parse OpenAI/Anthropic/Gemini overflow error codes → `ContextOverflowError`).
-4. Soak test:
+   6. 50-turn synthetic session with capsule: history reduced, approval IDs preserved, session resumable from checkpoint.
+   7. Capsule across session resume: compress → checkpoint → resume → delta update (version 2).
+   8. Content store audit chain: 3 capsule versions → 3 snapshots with correct `previous_version_handle` chain.
+   9. Migration: session starts with `CompressionStrategy`, flag enabled mid-session, next compression bootstraps capsule.
+5. Soak test:
    1. Long-running multi-agent session (50+ turns) with approvals and workflow joins.
 
 ## Rollout Strategy
@@ -447,7 +745,7 @@ Add/extend fields in session/workflow telemetry:
 1. Stage A: Config-only rollout (Phase 0) behind environment profile.
 2. Stage B: Scaffold `context_governor` module, migrate existing strategies behind `ReductionStrategy` trait, wire into lifecycle. Feature-gated behind `AUTONOETIC_STRICT_CONTEXT_GOVERNOR=1`.
 3. Stage C: Enable Phase 3 overflow retry classifier under `AUTONOETIC_OVERFLOW_RETRY_CLASSIFIER=1`.
-4. Stage D: Enable Phase 2 capsule in canary (deferred — requires its own RFC, ships as a new `ReductionStrategy`).
+4. Stage D: Enable Phase 2 capsule in canary. RFC complete (see Phase 2 section above). Ships as `CapsuleStrategy` implementing `ReductionStrategy` behind `AUTONOETIC_STATE_CAPSULE_COMPRESSION=1`. Session-local scope for v1 (no cross-session sharing). Swaps `CompressionStrategy` in the pipeline when enabled.
 5. Stage E: Turn on Phase 5 UI transparency by default.
 
 Feature flags:


### PR DESCRIPTION
## Summary

Implements Phase 4 of the LLM Context Overflow Mitigation Plan — the SKILL.md split marker convention. A `<!-- extended -->` comment marker in SKILL.md separates core instructions (always injected in system prompt) from extended instructions (available on-demand via content_read).

## Changes

- **parser.rs**: New `split_extended_instructions()` function splits SKILL.md body at the marker
- **repository.rs**: Both `load_from_meta()` and `load_from_revision_dir()` use the split; `LoadedAgent.extended_instructions` stores the extended portion
- **lifecycle.rs**: `AgentExecutor` gains field, builder, content-store write at session start, and system prompt hint injection
- **execution.rs**: All 4 `AgentExecutor::new()` call sites pass `extended_instructions`

## Backward Compatibility

SKILL.md files without the marker are completely unchanged — no behavioral change.

## Testing

828 tests pass, 25 pre-existing failures — zero regressions.