### PR TITLE
fix(skills): coder writes unit tests + stop unit_test_runner discovery loop

### DIFF
--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -91,26 +91,25 @@ If the task is ephemeral execution only, tell the planner to use `executor.defau
 
 When the planner asks you to create an agent (e.g. "create a weather agent"):
 
-1. **Write the implementation files** using content_write
-2. **Test your code** with `sandbox_exec` using the base runtime only
-  - If external packages are required, stop and return a `needs_packager` handoff instead of trying to install them directly
-3. **Write unit tests** for the implementation. **Required for `kind: "agent_bundle"`** — without tests the promotion gate's `unit_test_runner` has nothing to run and the artifact cannot promote.
-   - Filename convention: `test_<entry>.py` (Python) or `*.test.js` / `*.spec.js` (Node). The runner discovers these patterns automatically.
-   - **Cover at minimum:** happy path + one error case (e.g. invalid input, HTTP failure, missing env var).
-   - **Stdlib only** — the promotion sandbox has no network (R+16), so use `unittest.mock` / `monkeypatch` to fake any HTTP/file/subprocess interaction. **A test that makes a real HTTP call will fail with `ECONNREFUSED`.**
-   - **No external test frameworks** unless they are vendored in the artifact — prefer `unittest` (Python) or Node's built-in `node:test` over pytest/mocha.
-   - Smoke-run the tests once via `sandbox_exec` (e.g. `python3 -m unittest test_weather.py`) before bundling.
-   - Include the test file(s) in `artifact_build` inputs so the runner can discover them inside `/tmp/`.
+1. **Write the implementation files** using `content_write`. While Python is a primary language of implementation, other languages (such as JavaScript/Node.js, Go, Rust, etc.) can be used too.
+2. **Write unit tests** alongside the implementation when building a `kind: "agent_bundle"`.
+   - Use filename conventions standard for the target language (e.g., `test_*.py` or `*_test.py` for Python; `*.test.js` or `*.spec.js` for JavaScript/Node.js; `*_test.go` for Go).
+   - Use the language's standard library or built-in test features and mocking capabilities, avoiding external test framework dependencies.
+   - **Do NOT perform real side effects:** Ensure tests do not trigger real external operations (e.g., executing actual network registrations, posting live messages to external services, or mutating shared external databases/state). Always mock out external network requests, communications, and side-effect-heavy APIs.
+   - If your implementation or tests require external libraries/packages, you must explicitly declare them in the appropriate dependency manifest (e.g., `requirements.txt` for Python, `package.json` for JavaScript/Node.js, etc.) so they can be resolved, rather than trying to install them during execution.
+3. **Test your code** with `sandbox_exec` using the base runtime only to verify the basic correctness of your implementation (smoke-testing). You only need to run basic verification for your code; running and validating the entire unit test suite for promotion is the responsibility of `unit_test_runner.default` and other evaluation agents.
+   - If external packages/libraries are required, make sure they are declared, and return a `needs_packager` handoff to the planner if package resolution/layering is needed before running.
 4. **Write free-form instructions content only** (for example `agent_instructions.md`). Do NOT write SKILL metadata/frontmatter.
 5. **Do NOT write `runtime.lock`**. The gateway generates canonical runtime lock content.
-6. **Build an artifact** from implementation files, tests, and optional free-form instructions with `kind: "agent_bundle"`:
+6. **Build an artifact** from implementation files, test files, dependency manifests, and optional free-form instructions with `kind: "agent_bundle"`:
    ```json
    artifact_build({
-     "inputs": ["weather.py", "test_weather.py", "agent_instructions.md"],
+     "inputs": ["weather.py", "test_weather.py", "requirements.txt", "agent_instructions.md"],
      "entrypoints": ["weather.py"],
      "kind": "agent_bundle"
    })
    ```
+   If no test files are included, the promotion `unit_test_runner` may return `unable_to_evaluate`; this does not block promotion.
 7. **Return the artifact_ref + install intent payload** to the planner. Include:
     - `agent_id`
     - `description`

--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -94,17 +94,24 @@ When the planner asks you to create an agent (e.g. "create a weather agent"):
 1. **Write the implementation files** using content_write
 2. **Test your code** with `sandbox_exec` using the base runtime only
   - If external packages are required, stop and return a `needs_packager` handoff instead of trying to install them directly
-3. **Write free-form instructions content only** (for example `agent_instructions.md`). Do NOT write SKILL metadata/frontmatter.
-4. **Do NOT write `runtime.lock`**. The gateway generates canonical runtime lock content.
-5. **Build an artifact** from implementation files (and optional free-form instructions) with `kind: "agent_bundle"`:
+3. **Write unit tests** for the implementation. **Required for `kind: "agent_bundle"`** — without tests the promotion gate's `unit_test_runner` has nothing to run and the artifact cannot promote.
+   - Filename convention: `test_<entry>.py` (Python) or `*.test.js` / `*.spec.js` (Node). The runner discovers these patterns automatically.
+   - **Cover at minimum:** happy path + one error case (e.g. invalid input, HTTP failure, missing env var).
+   - **Stdlib only** — the promotion sandbox has no network (R+16), so use `unittest.mock` / `monkeypatch` to fake any HTTP/file/subprocess interaction. **A test that makes a real HTTP call will fail with `ECONNREFUSED`.**
+   - **No external test frameworks** unless they are vendored in the artifact — prefer `unittest` (Python) or Node's built-in `node:test` over pytest/mocha.
+   - Smoke-run the tests once via `sandbox_exec` (e.g. `python3 -m unittest test_weather.py`) before bundling.
+   - Include the test file(s) in `artifact_build` inputs so the runner can discover them inside `/tmp/`.
+4. **Write free-form instructions content only** (for example `agent_instructions.md`). Do NOT write SKILL metadata/frontmatter.
+5. **Do NOT write `runtime.lock`**. The gateway generates canonical runtime lock content.
+6. **Build an artifact** from implementation files, tests, and optional free-form instructions with `kind: "agent_bundle"`:
    ```json
    artifact_build({
-     "inputs": ["weather.py", "agent_instructions.md"],
+     "inputs": ["weather.py", "test_weather.py", "agent_instructions.md"],
      "entrypoints": ["weather.py"],
      "kind": "agent_bundle"
    })
    ```
-6. **Return the artifact_ref + install intent payload** to the planner. Include:
+7. **Return the artifact_ref + install intent payload** to the planner. Include:
     - `agent_id`
     - `description`
     - `instructions` (free-form markdown body)
@@ -114,9 +121,9 @@ When the planner asks you to create an agent (e.g. "create a weather agent"):
     - `capabilities`
     - optional `io` / `middleware` (including `io.output_policy`)
   The returned `artifact_ref` is the canonical install handoff. Prefer it over loose `cnt_...` handles for later packaging, validation, or installation.
-7. Suggested handoff text:
+8. Suggested handoff text:
   "Artifact ready with semantic install intent. Reuse this artifact_ref for downstream packaging/install; do not rebuild from loose content. Ask agent-factory.default to continue the full pipeline, or specialized_builder.default only if you are already at the final install step."
-8. If a tool returns **`approval_required: true`**, **stop** and return the **exact** approval id fields to the planner — **never** invent an `approval_ref` or retry with a guessed id.
+9. If a tool returns **`approval_required: true`**, **stop** and return the **exact** approval id fields to the planner — **never** invent an `approval_ref` or retry with a guessed id.
 
 <!-- extended -->
 

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -38,7 +38,9 @@ metadata:
         properties:
           status:
             type: string
-            enum: ["pass", "fail"]
+            enum: ["pass", "fail", "unable_to_evaluate"]
+          # status "unable_to_evaluate" is used when no tests exist or tests
+          # require live network — see parse_status_str in task_completion.rs.
           evaluator_pass:
             type: boolean
           findings:
@@ -63,19 +65,19 @@ If the test suite consists entirely of integration tests that require live netwo
 ## Behavior
 
 1. `artifact_inspect(artifact_ref)` — review file list and entrypoints
-2. `content_read(handle)` — read source files to find test files
-3. **Discover tests**: look for common test patterns:
-   - Python: files matching `test_*.py` or `*_test.py`, directories named `tests/`
-   - Node.js: files matching `*.test.js` or `*.spec.js`, `__tests__/` directories
-   - Use `sandbox_exec` with `ls -la` or `find` to explore the artifact directory
-4. If no tests exist → stop and skip (do NOT call `promotion_record`)
-5. If tests exist → run them with the appropriate command in the sandbox:
-   - Python: `python3 -m pytest /tmp/tests/ -v` or `python3 /tmp/test_*.py`
-   - Node.js: `node /tmp/node_modules/.bin/mocha /tmp/test/*.test.js`
+2. **Single-pass test discovery** from the inspect result — look for these filename patterns in the artifact's file list:
+   - Python: `test_*.py`, `*_test.py`, anything under a `tests/` directory
+   - Node.js: `*.test.js`, `*.spec.js`, anything under `__tests__/`
+   - Go: `*_test.go`
+   - Rust: `Cargo.toml` (then `cargo test` discovers the rest)
+3. **If zero test files match the patterns above → STOP IMMEDIATELY.** Do not list directories, do not `find`, do not `grep` source files for the substring "test", do not `content_read` files looking for embedded tests. Return the `unable_to_evaluate` JSON below. Iterating on discovery wastes a turn cycle and trips `LoopGuard`. The promotion gate accepts `unable_to_evaluate` for trivial scripts.
+4. If tests exist → run them with the appropriate command in the sandbox:
+   - Python: `python3 -m unittest discover /tmp -v` or `python3 -m pytest /tmp/tests/ -v` or `python3 /tmp/test_*.py`
+   - Node.js: `node --test /tmp/*.test.js` or `node /tmp/node_modules/.bin/mocha /tmp/test/*.test.js`
    - Go: `go test /tmp/...`
    - Rust: `cargo test` (only if Cargo.toml exists)
-6. Collect output — pass if all tests pass, fail if any test fails
-7. Call `promotion_record` with test stats
+5. Collect output — pass if all tests pass, fail if any test fails
+6. Call `promotion_record` with test stats
 
 ## Recording Promotion
 
@@ -99,30 +101,34 @@ If you found and ran tests:
 - `findings`: array of test result findings
 - `summary`: string with test execution summary
 
-If you found NO tests, skip — do NOT call `promotion_record`. The operator understands that this role is inapplicable for this artifact. **However, you MUST still return a structured JSON reply** — never return prose:
+If you found NO tests, **do NOT call `promotion_record`**. The role is inapplicable for this artifact — that is not a failure. Return this JSON exactly:
 
 ```json
 {
-  "status": "fail",
+  "status": "unable_to_evaluate",
   "evaluator_pass": false,
   "findings": [],
   "summary": "No test files found in artifact"
 }
 ```
 
+`evaluator_pass: false` here means "this gate did not pass affirmatively" — not "the artifact is bad". The `status: "unable_to_evaluate"` is the signal downstream consumers (`promotion_query`, the operator UI) use to skip this gate for trivial scripts. Returning `status: "fail"` instead causes the LLM to second-guess itself and re-search for tests that don't exist; do not do that.
+
 ## Key Rules
 
 - **Do NOT install packages** — the sandbox has no network
 - **Do NOT modify test code** — run what exists
-- **If no tests exist**: skip, do NOT call `promotion_record`
+- **Do NOT write new tests** — that's `coder.default`'s job when building the agent_bundle
+- **If no tests exist**: return `status: "unable_to_evaluate"` after a single inspect pass; do NOT loop on discovery
 - **If some tests exist**: run all of them, report total/passed/failed
 - **If all tests pass**: `status = "pass"`, `evaluator_pass = true`
 - **If any test fails**: `status = "fail"`, `evaluator_pass = false`, include failure output in findings
-- **If tests require network**: report `status = "fail"`, `evaluator_pass = false`, document as finding
+- **If tests require network**: return `status = "unable_to_evaluate"` with a finding describing the integration-test dependency (cannot be evaluated in sealed sandbox per R+16)
 
 ## Status Field Mapping
 
 When returning your final response JSON, map your test execution result to the status field:
-- If all tests pass → `status: "pass"`, `evaluator_pass: true`
-- If any test fails → `status: "fail"`, `evaluator_pass: false`
-- If no tests found → `status: "fail"`, `evaluator_pass: false`, do NOT call `promotion_record`
+- All tests pass → `status: "pass"`, `evaluator_pass: true`
+- Any test fails → `status: "fail"`, `evaluator_pass: false`
+- No tests found → `status: "unable_to_evaluate"`, `evaluator_pass: false`, do NOT call `promotion_record`
+- Tests require network → `status: "unable_to_evaluate"`, `evaluator_pass: false`, do NOT call `promotion_record`

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -71,13 +71,13 @@ If the test suite consists entirely of integration tests that require live netwo
    - Go: `*_test.go`
    - Rust: `Cargo.toml` (then `cargo test` discovers the rest)
 3. **If zero test files match the patterns above → STOP IMMEDIATELY.** Do not list directories, do not `find`, do not `grep` source files for the substring "test", do not `content_read` files looking for embedded tests. Return the `unable_to_evaluate` JSON below. Iterating on discovery wastes a turn cycle and trips `LoopGuard`. The promotion gate accepts `unable_to_evaluate` for trivial scripts.
-4. If tests exist → run them with the appropriate command in the sandbox:
-   - Python: `python3 -m unittest discover /tmp -v` or `python3 -m pytest /tmp/tests/ -v` or `python3 /tmp/test_*.py`
-   - Node.js: `node --test /tmp/*.test.js` or `node /tmp/node_modules/.bin/mocha /tmp/test/*.test.js`
+4. If test files exist → run them in the sandbox using the appropriate test runner for that language, prioritizing built-in or standard library test runners:
+   - Python: Prefer stdlib runners (e.g., `python3 -m unittest discover /tmp -v` or running `python3 /tmp/test_*.py`). Only use `pytest` (e.g., `python3 -m pytest /tmp/tests/ -v`) if `artifact_inspect` shows it is vendored or declared in the dependencies.
+   - Node.js: Prefer the built-in runner (e.g., `node --test /tmp/*.test.js`). Only use `mocha` (e.g., `node /tmp/node_modules/.bin/mocha`) if `artifact_inspect` shows a vendored runner in `node_modules`.
    - Go: `go test /tmp/...`
-   - Rust: `cargo test` (only if Cargo.toml exists)
-5. Collect output — pass if all tests pass, fail if any test fails
-6. Call `promotion_record` with test stats
+   - Rust: `cargo test` (only if `Cargo.toml` is present).
+5. Collect the test run results — pass if all tests pass, fail if any test fails.
+6. Call `promotion_record` with the test stats.
 
 ## Recording Promotion
 


### PR DESCRIPTION
## Context

Session `session-3b4485d4` (moltbook install) showed two related symptoms:

1. **`unit_test_runner.default` looped 5 turns** on missing-test discovery despite its own SKILL saying "if no tests exist, skip — not a failure"
2. **`specialized_builder.default` LoopGuard tripped** on a downstream issue (tracked separately — see analysis on the prior comment thread)

This PR fixes #1 by closing the "who writes the tests" hole.

## Diagnosis

Neither agent's SKILL.md actually says to write unit tests:

- **`coder.default`** mentions "tested" 3 times but only refers to *smoke-testing your own code via `sandbox_exec` before returning*. The "Creating Agent Scripts" recipe (steps 1–8) never mentions writing `test_*.py` files.
- **`unit_test_runner.default`** explicitly forbids writing tests ("Do NOT modify test code — run what exists", L116) and has `WriteAccess` scoped to `self.*` / `skills/*` — it physically cannot bundle tests into someone else's artifact.

The runner's no-tests path was also self-contradictory: L71 says "skip, do NOT call promotion_record" but L106 gave the JSON template `{"status": "fail", "evaluator_pass": false, …}`. The LLM reads `fail` and re-tries discovery, hence the loop.

## Fix

### `coder.default/SKILL.md`

Added an explicit "Write unit tests" step to the "Creating Agent Scripts for the Planner" recipe:

- Filename conventions (`test_*.py`, `*.test.js`, etc.) — match runner discovery patterns
- Minimum coverage: happy path + one error case
- Stdlib only (no `pytest` / `mocha`) since promotion sandbox has no network (R+16) — mock external IO via `unittest.mock` / `monkeypatch`
- Smoke-run via `sandbox_exec` before bundling
- Include test files in `artifact_build` inputs

Recipe steps renumbered 6→9.

### `unit_test_runner.default/SKILL.md`

- Status enum extended: `["pass", "fail", "unable_to_evaluate"]`. The new value is the existing canonical that already parses to `AgentOutcome::UnableToEvaluate` in `task_completion.rs:260`.
- No-tests path returns `status: "unable_to_evaluate"` (was `"fail"`)
- Tests-require-network path also returns `unable_to_evaluate` (was `"fail"`)
- New **explicit early-exit rule**: stop after the single `artifact_inspect` pass if no test files match the patterns. Don't `find`, don't `grep`, don't `content_read` source files looking for embedded "test" substrings. This was the looping behavior.
- Added "do NOT write new tests" rule pointing to coder

## Downstream impact: zero

- `is_fully_promoted()` (`promotion_store.rs:300`) requires `static_evaluator OR sealed_evaluator OR evaluator` AND `auditor`. Unit_test_runner is informational, never blocking.
- `unable_to_evaluate` already parses cleanly in `task_completion.rs` — no Rust changes needed.
- YAML frontmatter still parses (verified with PyYAML).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test -p autonoetic-gateway --lib parser` passes (35/35)
- [x] PyYAML parses the updated frontmatter; enum reflects new value
- [ ] Manual: build a new script agent end-to-end; verify coder includes test_*.py and runner finds them on first inspect
- [ ] Manual: build a script agent with no logic to test (e.g. echo-style); verify runner returns `unable_to_evaluate` on first turn rather than looping
- [ ] Verify promotion still succeeds with `unable_to_evaluate` from runner (auditor + static_evaluator carry the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)