### PR TITLE
refactor(extended-instructions): inline into system prompt by default

### DIFF
--- a/autonoetic-gateway/src/runtime/context.rs
+++ b/autonoetic-gateway/src/runtime/context.rs
@@ -162,6 +162,27 @@ pub(crate) fn compose_system_instructions_with_user_context(
     compose_system_instructions_full(agent_instructions, manifest, output_policy, user_context_snippet, None)
 }
 
+/// Concatenate core + extended SKILL.md sections for the system prompt.
+///
+/// The `<!-- extended -->` marker in `SKILL.md` was originally a "deferred
+/// load via content_read" optimization (Phase 4 / PR #218), but an audit of
+/// session-3b4485d4 found that agents with the marker never actually issued
+/// `content_read("extended_instructions")` — they just operated on the core
+/// section and silently lost critical guidance (e.g. promotion-gate handling,
+/// "if evaluator finds issues" recipe). The marker still serves as a visual
+/// section divider in the source, but at runtime the two halves are inlined.
+///
+/// The parser-level split (`split_extended_instructions`) and the
+/// `LoadedAgent.extended_instructions` field are retained so a future
+/// optimization (e.g. dynamic tiered loading) can re-wire the split without
+/// re-introducing the source structure.
+pub(crate) fn inline_extended(core: &str, extended: Option<&str>) -> String {
+    match extended {
+        Some(ext) if !ext.is_empty() => format!("{core}\n\n{ext}"),
+        _ => core.to_string(),
+    }
+}
+
 /// Full system prompt composition.
 ///
 /// Layer order (each layer is structurally positioned so it cannot override
@@ -556,6 +577,29 @@ impl AgentExecutor {
              Evidence: {}\n",
             rules, degraded_event.event_id, evidence
         )))
+    }
+}
+
+#[cfg(test)]
+mod inline_extended_tests {
+    use super::inline_extended;
+
+    #[test]
+    fn no_extended_returns_core_unchanged() {
+        assert_eq!(inline_extended("core only", None), "core only");
+    }
+
+    #[test]
+    fn empty_extended_returns_core_unchanged() {
+        assert_eq!(inline_extended("core only", Some("")), "core only");
+    }
+
+    #[test]
+    fn concatenates_with_blank_line_separator() {
+        assert_eq!(
+            inline_extended("core part", Some("extended part")),
+            "core part\n\nextended part"
+        );
     }
 }
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -10,7 +10,7 @@ use crate::runtime::checkpoint::{
     SessionCheckpoint, YieldReason,
 };
 use crate::runtime::context::{
-    compose_system_instructions_full, safe_prefix_by_bytes,
+    compose_system_instructions_full, inline_extended, safe_prefix_by_bytes,
     workflow_status_user_message_for_chat,
 };
 pub(crate) use crate::runtime::context::compose_system_instructions_with_metadata;
@@ -719,15 +719,9 @@ impl AgentExecutor {
     pub async fn execute_loop(&mut self) -> anyhow::Result<()> {
         let user_context = self.build_user_context_snippet();
         let memory_context = self.build_memory_context_snippet();
-        let instructions_with_hint = match &self.extended_instructions {
-            Some(ext) if !ext.is_empty() => format!(
-                "{}\n\nExtended instructions are available via content_read({{\"name_or_handle\": \"extended_instructions\"}}).",
-                self.instructions
-            ),
-            _ => self.instructions.clone(),
-        };
+        let inlined_instructions = inline_extended(&self.instructions, self.extended_instructions.as_deref());
         let mut system_instructions = compose_system_instructions_full(
-            &instructions_with_hint,
+            &inlined_instructions,
             &self.manifest,
             self.manifest
                 .io
@@ -1024,49 +1018,6 @@ impl AgentExecutor {
                 self.runtime_lock_hash =
                     crate::runtime::checkpoint::compute_runtime_lock_hash(&self.agent_dir);
             }
-
-            // Write extended instructions to content store for on-demand retrieval
-            if let Some(ext) = &self.extended_instructions {
-                if !ext.is_empty() {
-                    if let Some(gw_dir) = &self.gateway_dir {
-                        match crate::runtime::content_store::ContentStore::new(gw_dir) {
-                            Ok(store) => {
-                                match store.write(ext.as_bytes()) {
-                                    Ok(handle) => {
-                                        let sid = self
-                                            .session_id
-                                            .as_deref()
-                                            .unwrap_or(&self.manifest.agent.id);
-                                        if let Err(e) = store.register_name_with_visibility(
-                                            sid,
-                                            "extended_instructions",
-                                            &handle,
-                                            crate::runtime::content_store::ContentVisibility::Session,
-                                        ) {
-                                            tracing::warn!(
-                                                target: "extended_instructions",
-                                                "Failed to register extended instructions in content store: {e}"
-                                            );
-                                        }
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            target: "extended_instructions",
-                                            "Failed to write extended instructions to content store: {e}"
-                                        );
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: "extended_instructions",
-                                    "Failed to open content store for extended instructions: {e}"
-                                );
-                            }
-                        }
-                    }
-                }
-            }
         }
         // --- Auto-inject Agent Messages ---
         if let Some(store) = self.gateway_store.as_ref() {
@@ -1242,15 +1193,9 @@ impl AgentExecutor {
             // Update system message — ensure exactly one system message at position 0
             let user_context = self.build_user_context_snippet();
             let memory_context = self.build_memory_context_snippet();
-            let instructions_with_hint = match &self.extended_instructions {
-                Some(ext) if !ext.is_empty() => format!(
-                    "{}\n\nExtended instructions are available via content_read({{\"name_or_handle\": \"extended_instructions\"}}).",
-                    self.instructions
-                ),
-                _ => self.instructions.clone(),
-            };
+            let inlined_instructions = inline_extended(&self.instructions, self.extended_instructions.as_deref());
             let mut system_instructions = compose_system_instructions_full(
-                &instructions_with_hint,
+                &inlined_instructions,
                 &self.manifest,
                 self.manifest
                     .io


### PR DESCRIPTION
## Summary

Audit of session-3b4485d4 found the Phase 4 / PR #218 deferred-load mechanism for SKILL.md extended sections is silently broken. This PR reverts the *runtime* behavior to inlining while keeping the parser/field infrastructure intact for future use cases.

## Audit findings

- Only **two SKILLs** use the `<!-- extended -->` marker: `planner.default` and `coder.default`.
- Their extended sections contain **critical operational guidance**:
  - planner: Promotion Gate, Failure Handling (incl. `unable_to_evaluate` / `clarification_needed` recipe), Stuck Tasks, Parallel Delegation
  - coder: "If Evaluator/Auditor Finds Issues", Running Code, "Promotion Evaluation Has No Network"
- In a 3047-line session with **96 `content_read` calls across all agents, zero targeted `extended_instructions`**. The one-line hint appended to the system prompt is too weak a trigger.
- **Bundle-leak bug discovered**: `create_implicit_artifact` (`workflow_store.rs:871`) enumerates all content names registered under the child session and exposes them as `named_outputs`. Since the gateway wrote `extended_instructions` with `ContentVisibility::Session` at session start, coder's own extended instructions leaked into every `agent_bundle` it built (visible as `extended_instructions: cnt_4400ece5` in `ar.7625d4b68794` and `ar.82c9f30704af`).

## Change

- New helper `inline_extended(core, extended)` in `runtime/context.rs` concatenates the two halves with a blank-line separator.
- Both call sites in `lifecycle.rs::execute_loop` (`L722`, `L1245`) now call `inline_extended` instead of appending the `content_read` hint.
- Removed the session-start content_store write for `extended_instructions` (`L1022–1063`). **This automatically fixes the bundle-leak** — no entry in the store → no entry in `named_outputs`.

## Preserved for future use cases

The Phase 4 infrastructure stays intact:
- `LoadedAgent.extended_instructions` field
- `AgentExecutor.extended_instructions` + `with_extended_instructions`
- `runtime/parser.rs::split_extended_instructions` (all 6 unit tests still pass)
- The `<!-- extended -->` marker remains a meaningful section divider in source

The split mechanism can be re-wired to power genuinely useful patterns without re-introducing the silent-fail risk:

1. **Gateway-triggered playbooks** — tool result wrappers attach hints when patterns appear (e.g., `gate: fail` → "see playbook_evaluator_findings"). Removes LLM judgment from the trigger.
2. **Per-deployment overlay** — extended loaded from a separate file operators can edit without forking the SKILL.
3. **Just-in-time error vocabulary** — error_type → recovery procedure mapping injected on-demand.

(Filed as separate issues.)

## Test plan

- [x] `cargo build` clean
- [x] `cargo test -p autonoetic-gateway --lib inline_extended` — 3 new tests pass
- [x] `cargo test -p autonoetic-gateway --lib runtime::parser::tests` — 20 pass (no regression)
- [x] `cargo test -p autonoetic-gateway --lib runtime::context` — 22 pass (no regression)
- [ ] Manual: run a planner workflow; verify the system prompt contains the full SKILL body (use `session_peek` or chat trace)
- [ ] Manual: build a script agent via coder; verify the artifact's `named_outputs` does NOT include `extended_instructions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)