### PR TITLE
fix(promotion): unbreak promotion_query schema + cover FullJury escalation in SKILL

### DIFF
--- a/agents/evolution/specialized_builder.default/SKILL.md
+++ b/agents/evolution/specialized_builder.default/SKILL.md
@@ -407,6 +407,26 @@ When `agent_revision_promote` returns `"Promotion gate: no promotion_record foun
 3. Do NOT attempt to create promotion records yourself — only evaluator and auditor can call `promotion_record`
 4. Do NOT retry the promote call — the promotion gate is mechanically enforced and will always block until the records exist
 
+### FullJury Escalation Required
+
+When `agent_revision_promote` returns `"Promotion gate (FullJury): artifact 'art_X' has federation role verdicts but no approved operator escalation for revision 'rev_X'. The planner must call federation.escalate ..."`:
+
+1. **STOP immediately** — do NOT retry the promote call. The gate is mechanically enforced.
+2. **Report back to planner** with the exact `artifact_id` and `revision_id` from the error message.
+3. The planner is responsible for calling `federation_escalate` to request operator approval. You cannot do this yourself.
+4. Once the operator approves the escalation, the planner will re-delegate the install to you. At that point retry `agent_revision_promote` once.
+
+### `promotion_query` Returns "No promotion record found"
+
+When you query a freshly-built artifact and `promotion_query` returns `{"error":"No promotion record found for this artifact"}`:
+
+1. **Do NOT loop on `promotion_query`** with different argument shapes. The schema accepts either `artifact_id` (canonical `art_*` form) OR `artifact_ref` (short `ar.*` form) — pass exactly one. A failed query is a fact, not a syntax problem to debug.
+2. **Two legitimate causes** for this result:
+   - The evaluator federation has not yet run on this artifact (e.g., agent-factory rebuilt the artifact after evaluator findings but did not re-trigger federation).
+   - The artifact_ref points to a different artifact than the one with verdicts (rebuilds get new artifact_ids).
+3. **Stop and report back to planner**: "No promotion record exists for `<artifact_ref>` (canonical id `<artifact_id>`). The evaluator federation must be re-run on this artifact before promotion is possible."
+4. Do NOT proceed with `agent_revision_create_from_intent` + `agent_revision_promote` hoping the gate will pass — it won't, and you'll only learn that at the promote step after creating an orphan revision.
+
 ### Other Revision Tools
 
 You also have access to these revision management tools:

--- a/agents/evolution/specialized_builder.default/SKILL.md
+++ b/agents/evolution/specialized_builder.default/SKILL.md
@@ -413,12 +413,12 @@ When `agent_revision_promote` returns `"Promotion gate (FullJury): artifact 'art
 
 1. **STOP immediately** — do NOT retry the promote call. The gate is mechanically enforced.
 2. **Report back to planner** with the exact `artifact_id` and `revision_id` from the error message.
-3. The planner is responsible for calling `federation_escalate` to request operator approval. You cannot do this yourself.
+3. The planner is responsible for calling `federation.escalate` to request operator approval. You cannot do this yourself.
 4. Once the operator approves the escalation, the planner will re-delegate the install to you. At that point retry `agent_revision_promote` once.
 
 ### `promotion_query` Returns "No promotion record found"
 
-When you query a freshly-built artifact and `promotion_query` returns `{"error":"No promotion record found for this artifact"}`:
+When you query a freshly-built artifact and `promotion_query` returns `{"artifact_id": null, "error": "No promotion record found for this artifact"}`:
 
 1. **Do NOT loop on `promotion_query`** with different argument shapes. The schema accepts either `artifact_id` (canonical `art_*` form) OR `artifact_ref` (short `ar.*` form) — pass exactly one. A failed query is a fact, not a syntax problem to debug.
 2. **Two legitimate causes** for this result:

--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -284,17 +284,17 @@ impl NativeTool for PromotionQueryTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Queries the promotion status of an artifact. Returns all role validation results (evaluator, auditor, static_evaluator, unit_test_runner, sealed_evaluator), or null if no promotion record exists.".to_string(),
+            description: "Queries the promotion status of an artifact. Returns all role validation results (evaluator, auditor, static_evaluator, unit_test_runner, sealed_evaluator), or 'No promotion record found for this artifact' if no promotion record exists. Provide EXACTLY ONE of `artifact_id` (canonical, `art_*` prefix) or `artifact_ref` (short, `ar.*` prefix) — not both, not neither. The two fields are alternative input forms for the same lookup.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "artifact_id": {
                         "type": "string",
-                        "description": "Canonical artifact ID (e.g., 'art_a1b2c3d4'). Alternative: use artifact_ref."
+                        "description": "Canonical artifact ID (e.g., 'art_a1b2c3d4'). Alternative input form to artifact_ref — pass exactly one of the two."
                     },
                     "artifact_ref": {
                         "type": "string",
-                        "description": "Short artifact ref (e.g., 'ar.386f5b222421'). Resolved server-side to the canonical artifact_id. Alternative to artifact_id."
+                        "description": "Short artifact ref (e.g., 'ar.386f5b222421'). Resolved server-side to the canonical artifact_id. Alternative input form to artifact_id — pass exactly one of the two."
                     }
                 },
                 "additionalProperties": false
@@ -327,9 +327,21 @@ impl NativeTool for PromotionQueryTool {
         let args: PromotionQueryArgs = serde_json::from_str(arguments_json)
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
-        let artifact_id = match (&args.artifact_id, &args.artifact_ref) {
-            (id, _) if id.starts_with("art_") => id.clone(),
-            (_, Some(ref_id)) => {
+        // Resolve artifact_id from whichever form the caller provided. Prefer
+        // an explicit `art_`-prefixed canonical id; fall back to resolving an
+        // `ar.`-prefixed ref via the gateway store. A single error message
+        // covers all bad-input cases so the LLM doesn't see one rejection
+        // shape from serde and a different shape from the runtime.
+        let artifact_id = match (args.artifact_id.as_deref(), args.artifact_ref.as_deref()) {
+            // Canonical id supplied — must have the `art_` prefix.
+            (Some(id), _) if id.starts_with("art_") => id.to_string(),
+            (Some(id), _) => anyhow::bail!(
+                "promotion_query: artifact_id must start with 'art_' (got '{}'). \
+                 If you have a short ref like 'ar.X', pass it as 'artifact_ref' instead.",
+                id
+            ),
+            // Only a short ref was supplied — resolve it via the gateway store.
+            (None, Some(ref_id)) => {
                 let Some(gs) = _gateway_store.as_ref() else {
                     anyhow::bail!("promotion_query: artifact_ref requires GatewayStore");
                 };
@@ -346,8 +358,10 @@ impl NativeTool for PromotionQueryTool {
                     })?;
                 record.artifact_id
             }
-            _ => anyhow::bail!(
-                "promotion_query: either artifact_id (starting with 'art_') or artifact_ref is required"
+            (None, None) => anyhow::bail!(
+                "promotion_query: provide either 'artifact_id' (e.g. 'art_a1b2c3d4') \
+                 or 'artifact_ref' (e.g. 'ar.386f5b222421'). Both are alternatives — \
+                 pass one, not neither."
             ),
         };
 

--- a/autonoetic-types/src/promotion.rs
+++ b/autonoetic-types/src/promotion.rs
@@ -169,11 +169,17 @@ pub struct PromotionRecordResponse {
 }
 
 /// Arguments for the `promotion.query` tool.
+///
+/// At least one of `artifact_id` or `artifact_ref` must be supplied. Both
+/// are optional at the serde level so callers can use either form; the
+/// runtime tool checks that at least one is present and rejects the
+/// "neither" case with a clear error.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromotionQueryArgs {
-    /// Artifact ID to query promotion status for.
-    pub artifact_id: String,
-    /// Short artifact ref (e.g., 'ar.386f5b222421'). Alternative to artifact_id.
+    /// Canonical artifact ID (e.g., `art_a1b2c3d4`). Alternative: `artifact_ref`.
+    #[serde(default)]
+    pub artifact_id: Option<String>,
+    /// Short artifact ref (e.g., `ar.386f5b222421`). Alternative: `artifact_id`.
     #[serde(default)]
     pub artifact_ref: Option<String>,
 }
@@ -205,4 +211,51 @@ pub struct PromotionQueryResponse {
     pub sealed_evaluator_findings: Vec<Finding>,
     pub sealed_evaluator_timestamp: Option<String>,
     pub promotion_gate_version: String,
+}
+
+#[cfg(test)]
+mod promotion_query_args_tests {
+    use super::PromotionQueryArgs;
+
+    // Regression: prior version had `artifact_id: String` (required). Agents
+    // passing only `artifact_ref` got serde "missing field" errors, which
+    // contradicted the tool's input_schema (both advertised as alternatives).
+    // See session-3b4485d4 — five LoopGuard cycles burned on this mismatch.
+
+    #[test]
+    fn parses_artifact_ref_only() {
+        let args: PromotionQueryArgs =
+            serde_json::from_str(r#"{"artifact_ref": "ar.dd5058d99426"}"#).expect("should parse");
+        assert!(args.artifact_id.is_none());
+        assert_eq!(args.artifact_ref.as_deref(), Some("ar.dd5058d99426"));
+    }
+
+    #[test]
+    fn parses_artifact_id_only() {
+        let args: PromotionQueryArgs =
+            serde_json::from_str(r#"{"artifact_id": "art_dd5058d9"}"#).expect("should parse");
+        assert_eq!(args.artifact_id.as_deref(), Some("art_dd5058d9"));
+        assert!(args.artifact_ref.is_none());
+    }
+
+    #[test]
+    fn parses_both_fields() {
+        let args: PromotionQueryArgs = serde_json::from_str(
+            r#"{"artifact_id": "art_dd5058d9", "artifact_ref": "ar.dd5058d99426"}"#,
+        )
+        .expect("should parse");
+        assert_eq!(args.artifact_id.as_deref(), Some("art_dd5058d9"));
+        assert_eq!(args.artifact_ref.as_deref(), Some("ar.dd5058d99426"));
+    }
+
+    #[test]
+    fn parses_empty_object() {
+        // Serde accepts both fields missing; the runtime tool rejects "neither"
+        // with a clear error message rather than letting serde say
+        // "missing field `artifact_id`".
+        let args: PromotionQueryArgs =
+            serde_json::from_str("{}").expect("should parse empty object");
+        assert!(args.artifact_id.is_none());
+        assert!(args.artifact_ref.is_none());
+    }
 }


### PR DESCRIPTION
## Context

Analysis of session-3b4485d4 (continuation of the moltbook agent install thread, see PR #230, #231) found `specialized_builder.default` tripped LoopGuard after 5 failed `promotion_query` calls. Root cause turned out to be a clean schema/struct mismatch, compounded by missing SKILL guidance for two failure modes that actually fired.

## Bug 1 — `PromotionQueryArgs.artifact_id` was non-optional but schema said it was

The Rust struct (`autonoetic-types/src/promotion.rs:175`):

\`\`\`rust
pub struct PromotionQueryArgs {
    pub artifact_id: String,         // <-- not Option!
    #[serde(default)]
    pub artifact_ref: Option<String>,
}
\`\`\`

But the tool's \`input_schema\` and runtime logic advertised them as alternatives:

\`\`\`json
{"artifact_id": {"description": "...Alternative: use artifact_ref."},
 "artifact_ref": {"description": "...Alternative to artifact_id."}}
\`\`\`

Result: agent sees three different error vocabularies for one tool with one valid call shape.

| Attempt | Args | Failure source |
|---|---|---|
| 1 | \`{artifact_ref: "ar.X"}\` | serde: \`missing field artifact_id\` |
| 2 | \`{artifact_id: "ar.X"}\` (no prefix) | runtime: "either artifact_id (starting with 'art_') or artifact_ref is required" |
| 3 | \`{artifact_id: "art_X", artifact_ref: "ar.X"}\` | succeeds |

5 LoopGuard cycles burned chasing the right shape. **Fix:** make \`artifact_id\` \`Option<String>\` so schema/struct/runtime agree; single match in the tool handles all four input cases with one clear error per case.

## Bug 2 — Better tool description + error messages

- Tool description now states: "Provide **EXACTLY ONE** of \`artifact_id\` or \`artifact_ref\` — not both, not neither."
- Bad-prefix error now points to the right field: "If you have a short ref like 'ar.X', pass it as 'artifact_ref' instead."
- Both-missing error now reads: "pass one, not neither."

## Bug 3 — \`specialized_builder.default\` SKILL coverage gaps

The SKILL already covered "no promotion_record found" (L401-408). Two scenarios that actually fired in the session were not covered:

**FullJury escalation required.** When \`agent_revision_promote\` reports "has federation role verdicts but no approved operator escalation", the agent should stop, report \`artifact_id\`/\`revision_id\` back to planner, and let planner call \`federation_escalate\`.

**\`promotion_query\` returns "No promotion record found"** for a freshly-built artifact. Explicit do-not-loop rule. Two legitimate causes documented: (a) federation didn't re-run after rebuild; (b) artifact_ref points to a different artifact than the one with verdicts. Report back to planner instead of speculatively proceeding to \`agent_revision_create_from_intent\`.

## Test plan

- [x] 4 new serde unit tests in \`promotion_query_args_tests\` cover artifact_ref-only, artifact_id-only, both, and empty (regression pins)
- [x] All 21 existing \`promotion\` tests still pass
- [x] specialized_builder SKILL YAML frontmatter still parses
- [ ] Manual: a fresh planner → agent-factory → specialized_builder run should now show specialized_builder choosing one valid \`promotion_query\` form and not retrying on schema errors

## Not in this PR

**Bug 4** — agent-factory orchestration: when coder rebuilds an artifact in response to evaluator findings, agent-factory should re-trigger the evaluator federation on the new \`artifact_ref\` before handing off to specialized_builder. This is the root cause of the FullJury escalation firing here in the first place. Larger orchestration change; deserves its own issue/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)