### PR TITLE
docs(skills): document the privilege boundary between agent-factory and specialized_builder

### DIFF
--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -288,6 +288,10 @@ operator's explicit intent.
 
 ### Step 5: Install via specialized_builder
 
+**Why we delegate** (not optional): you do **not** have the `AgentRevision` capability — see your manifest above. The gateway's policy engine will reject `agent_revision_create_from_intent` and `agent_revision_promote` calls from this agent. `specialized_builder.default` is the **only** agent licensed to call those tools.
+
+This separation exists by design (see `docs/protected-agents.md`, recursive trust problem): the orchestrator that *decides* what to install must not be the same agent that *executes* the install — otherwise a regressed orchestrator could silently promote broken revisions, including a broken version of itself.
+
 Call `agent_spawn` with `agent_id="specialized_builder.default"`, `async=true`, passing the full install intent. Then call `workflow_wait` with the returned `task_id`. Include:
 - `artifact_ref` (for code agents) or omit (for reasoning agents)
 - `instructions`, `description`, `capabilities`, `execution_mode`

--- a/agents/evolution/specialized_builder.default/SKILL.md
+++ b/agents/evolution/specialized_builder.default/SKILL.md
@@ -48,7 +48,20 @@ metadata:
 ---
 # Specialized Builder
 
-You are the **exclusive** specialized builder agent. **Only you can install new agents** - no other agent has this capability.
+You are the **exclusive** specialized builder agent. **Only you can install new agents** — no other agent has this capability.
+
+## Privilege Boundary (Why You Exist)
+
+You hold the `AgentRevision` capability exclusively. **agent-factory.default does not have it** — see its manifest: no `AgentRevision` line. The gateway's policy engine will mechanically reject any attempt by agent-factory (or any other agent) to call `agent_revision_create_from_intent` or `agent_revision_promote`.
+
+This is a **deliberate privilege isolation**, not a style choice:
+
+- **agent-factory orchestrates** the pipeline (architect → coder → packager → evaluation federation) and decides *what* should be installed.
+- **You execute** the install (revision.create + revision.promote) and validate the artifact structure independently of how it was built.
+
+The reason for the split is the **recursive trust problem** (`docs/protected-agents.md`): a regressed agent-factory cannot be trusted to fix or promote itself. If agent-factory held `AgentRevision`, a buggy orchestrator could silently install broken revisions — including a broken update of itself. By holding the install privilege in a small, single-purpose agent, the orchestrator cannot bypass the validation step you provide.
+
+Your refusal to write code, rebuild artifacts, or rewrite SKILL metadata (see **You are an installer, not a builder** below) is what makes this safe. If you start fixing inputs, you become a second orchestrator and the safeguard collapses.
 
 ## Resumption
 


### PR DESCRIPTION
## Context

Question raised during PR #235 review: is \`specialized_builder.default\` still needed given the FullJury federation mechanism? Could \`agent-factory.default\` manage promotion gathering and operator escalation by itself?

**Answer: yes, specialized_builder is mechanically required.** It exists as a privilege isolation boundary — the gateway's policy engine reserves the \`AgentRevision\` capability to specialized_builder exclusively. agent-factory does not have it; revision-tool calls from agent-factory are rejected at dispatch time. Folding them would require granting agent-factory \`AgentRevision\`, which re-creates the recursive trust hole that \`docs/protected-agents.md\` was written to close.

The current design is correct. It's the *documentation* of why it's correct that was missing — neither SKILL explained the privilege boundary or the safety reason for the split.

## Change

Two purely additive doc edits, no behavior change.

**\`specialized_builder.default/SKILL.md\`** — new "Privilege Boundary (Why You Exist)" section in the intro. Calls out:
- agent-factory does not have \`AgentRevision\`; the gateway mechanically rejects its revision-tool calls
- The orchestrator/executor split exists to prevent the recursive trust problem (regressed orchestrator silently promoting broken revisions, including of itself)
- The agent's refusal to write code or fix artifacts is what makes the safeguard work — drift toward "fixing inputs" turns it into a second orchestrator and the safety property collapses

**\`agent-factory.default/SKILL.md\`** — Step 5 gains a "Why we delegate (not optional)" preface explaining that you don't have \`AgentRevision\` so the policy engine will reject the call, and citing \`protected-agents.md\` for the rationale.

## Test plan

- [x] Both SKILL YAML frontmatters still parse (verified with PyYAML)
- [x] No code change; no Rust build needed
- [ ] Manual: an LLM running these agents reads the new sections and understands the constraint rather than seeing it as arbitrary

## Independent of other open PRs

- Touches new sections only; no overlap with #235 (which touches the gate-failure section at the bottom of specialized_builder's SKILL)
- No code, no tests, no schema changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)