### PR TITLE
feat(sentinel): deterministic trajectory monitor (Sentinel P1)

### DIFF
--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -36,6 +36,7 @@ use crate::runtime::budget_tracker::{
     is_retryable_empty_other_response, max_other_empty_retries,
 };
 use crate::runtime::context_governor::resolver::resolve_context_window_for_run;
+use crate::runtime::trajectory_monitor::{ToolObservation, TrajectoryMonitor};
 
 // ---------------------------------------------------------------------------
 // TurnOutcome
@@ -173,6 +174,16 @@ pub struct AgentExecutor {
     /// Optional extended instructions (after `<!-- extended -->` in SKILL.md).
     /// Written to content store for on-demand retrieval by the agent.
     pub extended_instructions: Option<String>,
+
+    /// In-session divergence monitor (Sentinel P1). Observes LoopGuard
+    /// pressure, digest stall, repetition entropy, error bursts, and
+    /// context pressure. Emits `divergence.*` causal events on level
+    /// transitions.
+    pub trajectory_monitor: TrajectoryMonitor,
+
+    /// Context utilization fraction from the most recent prompt budget
+    /// computation. Passed into the trajectory monitor each turn.
+    pub last_context_utilization: Option<f32>,
 }
 
 use crate::runtime::tool_dispatch::{
@@ -228,6 +239,8 @@ impl AgentExecutor {
             persona: None,
             overflow_recovery: false,
             extended_instructions: None,
+            trajectory_monitor: TrajectoryMonitor::new(Default::default()),
+            last_context_utilization: None,
         }
     }
 
@@ -243,6 +256,7 @@ impl AgentExecutor {
 
     pub fn with_config(mut self, config: Arc<GatewayConfig>) -> Self {
         self.guard = loop_guard_from_config_and_manifest(Some(config.as_ref()), &self.agent_dir);
+        self.trajectory_monitor = TrajectoryMonitor::new(config.trajectory.clone());
         self.config = Some(config);
         self
     }
@@ -1299,6 +1313,9 @@ impl AgentExecutor {
                 &mut tracer,
             );
 
+            // Stash context utilization for the trajectory monitor.
+            self.last_context_utilization = budget_breakdown.utilization_pct.map(|v| v as f32);
+
             // --- Budget Enforcement + Context Compression (Context Governor) ---
             {
                 use crate::runtime::context_governor::{
@@ -2290,6 +2307,60 @@ impl AgentExecutor {
                             }
                             if parsed.get("any_failed") == Some(&serde_json::Value::Bool(true)) {
                                 self.guard.register_child_failure();
+                            }
+                        }
+                    }
+
+                    // ── Trajectory Monitor ──────────────────────────────────────
+                    // After guard updates, recompute health and emit divergence
+                    // events on level transitions.
+                    {
+                        use crate::runtime::trajectory_monitor::fingerprint_tool_call;
+                        use crate::runtime::trajectory_health::{
+                            build_event_payload, DIVERGENCE_CATEGORY,
+                        };
+                        use autonoetic_types::causal_chain::EntryStatus;
+
+                        let observations: Vec<ToolObservation> = results
+                            .iter()
+                            .filter_map(|(id, _name, result)| {
+                                let tc = response.tool_calls.iter().find(|tc| tc.id == *id)?;
+                                let fp = fingerprint_tool_call(&tc.name, &tc.arguments);
+                                let failed = serde_json::from_str::<serde_json::Value>(result)
+                                    .ok()
+                                    .and_then(|v| v.get("ok")?.as_bool())
+                                    .map(|ok| !ok)
+                                    .unwrap_or(false);
+                                Some(ToolObservation {
+                                    fingerprint: fp,
+                                    failed,
+                                })
+                            })
+                            .collect();
+
+                        let result = self.trajectory_monitor.tick(
+                            self.turn_counter,
+                            &observations,
+                            self.last_context_utilization,
+                            &self.guard.snapshot(),
+                        );
+
+                        if result.level_changed {
+                            if let Some(payload) = build_event_payload(&result.health) {
+                                let action = result.health.causal_action().unwrap_or("observed");
+                                if let Err(e) = tracer.log_event(
+                                    DIVERGENCE_CATEGORY,
+                                    action,
+                                    EntryStatus::Success,
+                                    Some(payload),
+                                ) {
+                                    tracing::warn!(
+                                        target: "autonoetic::trajectory",
+                                        error = %e,
+                                        level = %result.health.level_str(),
+                                        "Failed to log divergence event"
+                                    );
+                                }
                             }
                         }
                     }

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1314,7 +1314,9 @@ impl AgentExecutor {
             );
 
             // Stash context utilization for the trajectory monitor.
-            self.last_context_utilization = budget_breakdown.utilization_pct.map(|v| v as f32);
+            // `utilization_pct` is a 0-100 percentage; the monitor expects a
+            // 0.0-1.0 fraction.
+            self.last_context_utilization = budget_breakdown.utilization_pct.map(|v| v as f32 / 100.0);
 
             // --- Budget Enforcement + Context Compression (Context Governor) ---
             {
@@ -2326,11 +2328,18 @@ impl AgentExecutor {
                             .filter_map(|(id, _name, result)| {
                                 let tc = response.tool_calls.iter().find(|tc| tc.id == *id)?;
                                 let fp = fingerprint_tool_call(&tc.name, &tc.arguments);
-                                let failed = serde_json::from_str::<serde_json::Value>(result)
-                                    .ok()
-                                    .and_then(|v| v.get("ok")?.as_bool())
-                                    .map(|ok| !ok)
-                                    .unwrap_or(false);
+                                let parsed = serde_json::from_str::<serde_json::Value>(result).ok();
+                                let failed = parsed.as_ref().map_or(false, |v| {
+                                    // Primary: ok:false
+                                    if v.get("ok").and_then(|o| o.as_bool()) == Some(false) {
+                                        return true;
+                                    }
+                                    // Secondary: non-zero exit code (sandbox tools)
+                                    if let Some(code) = v.get("exit_code").and_then(|c| c.as_i64()) {
+                                        return code != 0;
+                                    }
+                                    false
+                                });
                                 Some(ToolObservation {
                                     fingerprint: fp,
                                     failed,

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -58,3 +58,4 @@ pub mod tool_dispatch;
 pub mod tool_tier_registry;
 pub mod tools;
 pub mod trajectory_health;
+pub mod trajectory_monitor;

--- a/autonoetic-gateway/src/runtime/trajectory_monitor.rs
+++ b/autonoetic-gateway/src/runtime/trajectory_monitor.rs
@@ -461,11 +461,12 @@ mod tests {
     }
 
     #[test]
-    fn first_tick_on_healthy_session_emits_no_level_change() {
-        // First tick after construction reports a level change *only*
-        // when the verdict is non-Healthy. A Healthy first tick should
-        // not trigger event emission downstream — there is no point in
-        // emitting a "healthy" event.
+    fn first_tick_on_healthy_session_level_changed_but_no_payload() {
+        // First tick after construction reports `level_changed = true`
+        // (no prior level to compare against), but since the verdict is
+        // `Healthy` the caller suppresses emission via
+        // `build_event_payload(None)`. The test validates this contract:
+        // changed but no payload.
         let mut mon = TrajectoryMonitor::new(cfg());
         let r = mon.tick(1, &[], None, &quiet_guard_state());
         assert!(matches!(r.health, TrajectoryHealth::Healthy));

--- a/autonoetic-gateway/src/runtime/trajectory_monitor.rs
+++ b/autonoetic-gateway/src/runtime/trajectory_monitor.rs
@@ -1,0 +1,814 @@
+//! Deterministic in-gateway trajectory monitor (Sentinel P1).
+//!
+//! Recomputes a [`TrajectoryHealth`] verdict every turn and signals when
+//! the verdict's level changes. **Pure deterministic — zero LLM cost,
+//! zero external calls.** The monitor is observational; it never modifies
+//! session state. Acting on its signals (planner messaging, operator
+//! escalation) lands in P2 (#241).
+//!
+//! Wiring is in `runtime::lifecycle` after tool-result processing. Each
+//! turn the caller invokes [`TrajectoryMonitor::tick`] with the current
+//! `LoopGuard` snapshot plus the turn's tool calls, results, and the
+//! most-recent context-utilization fraction.
+//!
+//! [`TrajectoryHealth`]: super::trajectory_health::TrajectoryHealth
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
+
+use autonoetic_types::config::{TrajectoryConfig, TrajectorySignalsToggle};
+
+use super::trajectory_health::{
+    aggregate, signals_from_loop_guard, DivergenceSignal, DivergenceSignalKind, SignalSeverity,
+    TrajectoryHealth,
+};
+use crate::runtime::guard::LoopGuardState;
+
+/// Observation of one tool call this turn, used by entropy and stall
+/// signals. Lightweight on purpose — the monitor never stores arguments,
+/// only a 64-bit fingerprint.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolObservation {
+    /// 64-bit hash of `(tool_name, normalized_arguments)`. Stable across
+    /// turns so the same call counts as a repetition.
+    pub fingerprint: u64,
+    /// `true` when the tool returned an error result (`ok: false` or a
+    /// non-zero exit code). Counted toward `error_burst`.
+    pub failed: bool,
+}
+
+/// Result of [`TrajectoryMonitor::tick`].
+#[derive(Debug, Clone)]
+pub struct TickResult {
+    pub health: TrajectoryHealth,
+    /// `true` when this turn's level differs from the previous turn's
+    /// level. Caller should emit a `divergence.*` causal event when this
+    /// is `true` and `health` is not `Healthy`.
+    pub level_changed: bool,
+}
+
+/// Per-session monitor state.
+///
+/// The monitor is **session-scoped** — one instance per `AgentExecutor`.
+/// It is cheap to construct and carries only a small sliding-window
+/// buffer (default 8 entries).
+#[derive(Debug, Clone)]
+pub struct TrajectoryMonitor {
+    config: TrajectoryConfig,
+    /// Last fingerprint observed across any turn. Tracks "turns since
+    /// new fingerprint" for the digest_stall signal.
+    last_distinct_fingerprint: Option<u64>,
+    /// Turn counter (caller-supplied) at which `last_distinct_fingerprint`
+    /// was last updated. Used to compute stall length.
+    last_distinct_fingerprint_turn: u64,
+    /// Sliding window of recent tool fingerprints for entropy.
+    fingerprint_window: VecDeque<u64>,
+    /// Sliding window of error counts (one entry per turn).
+    error_window: VecDeque<u32>,
+    /// Last verdict's level slug — used to detect transitions and to emit
+    /// only on change. `None` until the first `tick`.
+    last_level: Option<&'static str>,
+}
+
+impl TrajectoryMonitor {
+    pub fn new(config: TrajectoryConfig) -> Self {
+        Self {
+            config,
+            last_distinct_fingerprint: None,
+            last_distinct_fingerprint_turn: 0,
+            fingerprint_window: VecDeque::new(),
+            error_window: VecDeque::new(),
+            last_level: None,
+        }
+    }
+
+    /// `true` if the monitor will run at all. When the master switch is
+    /// off the monitor is inert and produces no events.
+    pub fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Recompute the verdict after one turn of work.
+    ///
+    /// `turn_counter` is the same monotonic value the rest of the
+    /// runtime uses (cf. `AgentExecutor::turn_counter`); it is the cursor
+    /// for sliding-window logic.
+    ///
+    /// `observations` is the list of tool calls executed this turn, with
+    /// their fingerprints and error status. Pass an empty slice when the
+    /// turn produced no tool calls.
+    ///
+    /// `context_utilization` is the prompt-budget utilization fraction in
+    /// `[0.0, 1.0+]` (e.g. `0.82` for 82%). `None` when the breakdown
+    /// hasn't computed one this turn — the signal is then skipped.
+    pub fn tick(
+        &mut self,
+        turn_counter: u64,
+        observations: &[ToolObservation],
+        context_utilization: Option<f32>,
+        guard_state: &LoopGuardState,
+    ) -> TickResult {
+        if !self.config.enabled {
+            return TickResult {
+                health: TrajectoryHealth::Healthy,
+                level_changed: false,
+            };
+        }
+
+        // Update sliding windows from this turn's observations.
+        let errors_this_turn = observations.iter().filter(|o| o.failed).count() as u32;
+        self.push_error_count(errors_this_turn);
+
+        for obs in observations {
+            self.push_fingerprint(obs.fingerprint);
+            if self.last_distinct_fingerprint != Some(obs.fingerprint) {
+                self.last_distinct_fingerprint = Some(obs.fingerprint);
+                self.last_distinct_fingerprint_turn = turn_counter;
+            }
+        }
+
+        // Collect signals.
+        let mut signals = Vec::new();
+        let toggles = &self.config.signals;
+
+        for signal in signals_from_loop_guard(guard_state) {
+            if !signal_enabled(toggles, signal.kind) {
+                continue;
+            }
+            signals.push(signal);
+        }
+
+        if toggles.digest_stall {
+            if let Some(s) = self.digest_stall_signal(turn_counter) {
+                signals.push(s);
+            }
+        }
+        if toggles.repetition_entropy {
+            if let Some(s) = self.repetition_entropy_signal() {
+                signals.push(s);
+            }
+        }
+        if toggles.error_burst {
+            if let Some(s) = self.error_burst_signal() {
+                signals.push(s);
+            }
+        }
+        if toggles.context_pressure {
+            if let Some(util) = context_utilization {
+                if let Some(s) = self.context_pressure_signal(util) {
+                    signals.push(s);
+                }
+            }
+        }
+
+        let health = aggregate(signals);
+        let level = health.level_str();
+        let level_changed = self.last_level.map(|prev| prev != level).unwrap_or(true);
+        self.last_level = Some(level);
+
+        TickResult {
+            health,
+            level_changed,
+        }
+    }
+
+    fn push_fingerprint(&mut self, fp: u64) {
+        let cap = self.config.window_size.max(1);
+        if self.fingerprint_window.len() == cap {
+            self.fingerprint_window.pop_front();
+        }
+        self.fingerprint_window.push_back(fp);
+    }
+
+    fn push_error_count(&mut self, count: u32) {
+        let cap = self.config.window_size.max(1);
+        if self.error_window.len() == cap {
+            self.error_window.pop_front();
+        }
+        self.error_window.push_back(count);
+    }
+
+    fn digest_stall_signal(&self, turn_counter: u64) -> Option<DivergenceSignal> {
+        let stall = turn_counter.saturating_sub(self.last_distinct_fingerprint_turn);
+        // If we have never seen a fingerprint yet, do not fire: the
+        // session is just getting started, not stalled.
+        if self.last_distinct_fingerprint.is_none() {
+            return None;
+        }
+        let cfg = &self.config.digest_stall;
+        let stall_u32 = stall.min(u32::MAX as u64) as u32;
+        if stall_u32 >= cfg.critical_turns {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::DigestStall,
+                    SignalSeverity::Critical,
+                    stall_u32 as f32,
+                    cfg.critical_turns as f32,
+                )
+                .with_evidence(format!(
+                    "{} turns since a new tool fingerprint was observed (critical ≥ {})",
+                    stall_u32, cfg.critical_turns
+                )),
+            )
+        } else if stall_u32 >= cfg.warn_turns {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::DigestStall,
+                    SignalSeverity::Warn,
+                    stall_u32 as f32,
+                    cfg.warn_turns as f32,
+                )
+                .with_evidence(format!(
+                    "{} turns since a new tool fingerprint was observed (warn ≥ {})",
+                    stall_u32, cfg.warn_turns
+                )),
+            )
+        } else {
+            None
+        }
+    }
+
+    fn repetition_entropy_signal(&self) -> Option<DivergenceSignal> {
+        let cfg = &self.config.repetition_entropy;
+        if self.fingerprint_window.len() < cfg.min_observations.max(1) {
+            return None;
+        }
+        let entropy = shannon_entropy_bits(&self.fingerprint_window);
+        if entropy <= cfg.critical_bits {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::RepetitionEntropy,
+                    SignalSeverity::Critical,
+                    entropy,
+                    cfg.critical_bits,
+                )
+                .with_evidence(format!(
+                    "tool-fingerprint entropy {:.2} bits over last {} calls (critical ≤ {:.2})",
+                    entropy,
+                    self.fingerprint_window.len(),
+                    cfg.critical_bits
+                )),
+            )
+        } else if entropy <= cfg.warn_bits {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::RepetitionEntropy,
+                    SignalSeverity::Warn,
+                    entropy,
+                    cfg.warn_bits,
+                )
+                .with_evidence(format!(
+                    "tool-fingerprint entropy {:.2} bits over last {} calls (warn ≤ {:.2})",
+                    entropy,
+                    self.fingerprint_window.len(),
+                    cfg.warn_bits
+                )),
+            )
+        } else {
+            None
+        }
+    }
+
+    fn error_burst_signal(&self) -> Option<DivergenceSignal> {
+        let cfg = &self.config.error_burst;
+        let total: u32 = self.error_window.iter().copied().sum();
+        if total >= cfg.critical_count {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::ErrorBurst,
+                    SignalSeverity::Critical,
+                    total as f32,
+                    cfg.critical_count as f32,
+                )
+                .with_evidence(format!(
+                    "{} tool errors in last {} turns (critical ≥ {})",
+                    total,
+                    self.error_window.len(),
+                    cfg.critical_count
+                )),
+            )
+        } else if total >= cfg.warn_count {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::ErrorBurst,
+                    SignalSeverity::Warn,
+                    total as f32,
+                    cfg.warn_count as f32,
+                )
+                .with_evidence(format!(
+                    "{} tool errors in last {} turns (warn ≥ {})",
+                    total,
+                    self.error_window.len(),
+                    cfg.warn_count
+                )),
+            )
+        } else {
+            None
+        }
+    }
+
+    fn context_pressure_signal(&self, utilization: f32) -> Option<DivergenceSignal> {
+        let cfg = &self.config.context_pressure;
+        if utilization >= cfg.critical_fraction {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::ContextPressure,
+                    SignalSeverity::Critical,
+                    utilization,
+                    cfg.critical_fraction,
+                )
+                .with_evidence(format!(
+                    "context utilization {:.0}% (critical ≥ {:.0}%)",
+                    utilization * 100.0,
+                    cfg.critical_fraction * 100.0
+                )),
+            )
+        } else if utilization >= cfg.warn_fraction {
+            Some(
+                DivergenceSignal::new(
+                    DivergenceSignalKind::ContextPressure,
+                    SignalSeverity::Warn,
+                    utilization,
+                    cfg.warn_fraction,
+                )
+                .with_evidence(format!(
+                    "context utilization {:.0}% (warn ≥ {:.0}%)",
+                    utilization * 100.0,
+                    cfg.warn_fraction * 100.0
+                )),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+fn signal_enabled(toggles: &TrajectorySignalsToggle, kind: DivergenceSignalKind) -> bool {
+    match kind {
+        DivergenceSignalKind::LoopPressure => toggles.loop_pressure,
+        DivergenceSignalKind::FailurePressure => toggles.failure_pressure,
+        DivergenceSignalKind::ChildFailurePressure => toggles.child_failure_pressure,
+        DivergenceSignalKind::DigestStall => toggles.digest_stall,
+        DivergenceSignalKind::RepetitionEntropy => toggles.repetition_entropy,
+        DivergenceSignalKind::ErrorBurst => toggles.error_burst,
+        DivergenceSignalKind::ContextPressure => toggles.context_pressure,
+    }
+}
+
+/// Compute a 64-bit fingerprint of a tool call. Mirrors the structure of
+/// `LoopGuard::compute_fingerprint` but is local to the monitor so the
+/// two can evolve independently — the LoopGuard fingerprint is used for
+/// progress detection (resets a counter), the monitor fingerprint is
+/// used for repetition entropy (counts occurrences over a window).
+pub fn fingerprint_tool_call(tool_name: &str, arguments_json: &str) -> u64 {
+    let normalized = normalize_arguments(arguments_json);
+    let mut hasher = DefaultHasher::new();
+    tool_name.hash(&mut hasher);
+    normalized.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Strip echoed `intent` fields so repeated semantically-identical calls
+/// produce the same fingerprint. Matches LoopGuard's approach.
+fn normalize_arguments(arguments_json: &str) -> std::borrow::Cow<'_, str> {
+    let Ok(mut v) = serde_json::from_str::<serde_json::Value>(arguments_json) else {
+        return std::borrow::Cow::Borrowed(arguments_json);
+    };
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("intent");
+    }
+    match serde_json::to_string(&v) {
+        Ok(s) => std::borrow::Cow::Owned(s),
+        Err(_) => std::borrow::Cow::Borrowed(arguments_json),
+    }
+}
+
+/// Shannon entropy in bits over the multiset of fingerprints in `window`.
+/// Returns `0.0` on an empty window. A single repeated fingerprint
+/// yields entropy `0.0`. Uniform unique fingerprints across `N` slots
+/// yield `log2(N)`.
+fn shannon_entropy_bits(window: &VecDeque<u64>) -> f32 {
+    if window.is_empty() {
+        return 0.0;
+    }
+    let total = window.len() as f32;
+    let mut counts: std::collections::HashMap<u64, u32> = std::collections::HashMap::new();
+    for &fp in window {
+        *counts.entry(fp).or_insert(0) += 1;
+    }
+    let mut entropy = 0.0f32;
+    for &count in counts.values() {
+        let p = count as f32 / total;
+        if p > 0.0 {
+            entropy -= p * p.log2();
+        }
+    }
+    entropy
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn cfg() -> TrajectoryConfig {
+        TrajectoryConfig::default()
+    }
+
+    fn disabled_cfg() -> TrajectoryConfig {
+        let mut c = TrajectoryConfig::default();
+        c.enabled = false;
+        c
+    }
+
+    fn quiet_guard_state() -> LoopGuardState {
+        LoopGuardState {
+            max_loops_without_progress: 5,
+            max_tool_failures: 5,
+            max_consecutive_same_progress: 1,
+            max_child_failures: 3,
+            progress_budget_tools: HashMap::new(),
+            progress_budget_used: HashMap::new(),
+            current_loops: 0,
+            tool_failure_counts: HashMap::new(),
+            last_progress_fingerprint: None,
+            consecutive_progress_count: 0,
+            child_failure_count: 0,
+        }
+    }
+
+    // ── Master switch / no-op behavior ──────────────────────────────────
+
+    #[test]
+    fn disabled_monitor_is_no_op() {
+        let mut mon = TrajectoryMonitor::new(disabled_cfg());
+        let r = mon.tick(
+            1,
+            &[ToolObservation {
+                fingerprint: 1,
+                failed: true,
+            }],
+            Some(0.95),
+            &quiet_guard_state(),
+        );
+        assert!(matches!(r.health, TrajectoryHealth::Healthy));
+        assert!(!r.level_changed);
+    }
+
+    #[test]
+    fn first_tick_on_healthy_session_emits_no_level_change() {
+        // First tick after construction reports a level change *only*
+        // when the verdict is non-Healthy. A Healthy first tick should
+        // not trigger event emission downstream — there is no point in
+        // emitting a "healthy" event.
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let r = mon.tick(1, &[], None, &quiet_guard_state());
+        assert!(matches!(r.health, TrajectoryHealth::Healthy));
+        // `level_changed` is `true` on the first tick (no prior level)
+        // but the caller's emit rule is `level_changed && !Healthy`.
+        assert!(r.level_changed);
+    }
+
+    #[test]
+    fn repeated_same_level_does_not_re_trigger() {
+        // Two consecutive Healthy ticks: only the first counts as a change.
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let _ = mon.tick(1, &[], None, &quiet_guard_state());
+        let r2 = mon.tick(2, &[], None, &quiet_guard_state());
+        assert!(matches!(r2.health, TrajectoryHealth::Healthy));
+        assert!(!r2.level_changed);
+    }
+
+    // ── Per-signal extraction ───────────────────────────────────────────
+
+    #[test]
+    fn repetition_entropy_zero_for_repeated_fingerprint() {
+        // Send the same fingerprint enough times to reach min_observations.
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let fp = 42;
+        for turn in 1..=4 {
+            let _ = mon.tick(
+                turn,
+                &[ToolObservation { fingerprint: fp, failed: false }],
+                None,
+                &quiet_guard_state(),
+            );
+        }
+        // Entropy ≈ 0 → critical band.
+        let r = mon.tick(
+            5,
+            &[ToolObservation { fingerprint: fp, failed: false }],
+            None,
+            &quiet_guard_state(),
+        );
+        let has_entropy_critical = r
+            .health
+            .signals()
+            .iter()
+            .any(|s| s.kind == DivergenceSignalKind::RepetitionEntropy && s.severity == SignalSeverity::Critical);
+        assert!(
+            has_entropy_critical,
+            "expected entropy=critical signal, got health={:?}",
+            r.health
+        );
+    }
+
+    #[test]
+    fn repetition_entropy_silent_below_min_observations() {
+        let mut mon = TrajectoryMonitor::new(cfg());
+        // 3 calls — default min_observations is 4.
+        for turn in 1..=3 {
+            let r = mon.tick(
+                turn,
+                &[ToolObservation { fingerprint: 7, failed: false }],
+                None,
+                &quiet_guard_state(),
+            );
+            let has_entropy = r
+                .health
+                .signals()
+                .iter()
+                .any(|s| s.kind == DivergenceSignalKind::RepetitionEntropy);
+            assert!(!has_entropy, "entropy fired too early at turn {}", turn);
+        }
+    }
+
+    #[test]
+    fn error_burst_fires_when_window_full_of_errors() {
+        let mut mon = TrajectoryMonitor::new(cfg());
+        // Default warn_count = 5: tick 5 turns each with one error.
+        for turn in 1..=5 {
+            let _ = mon.tick(
+                turn,
+                &[ToolObservation { fingerprint: turn, failed: true }],
+                None,
+                &quiet_guard_state(),
+            );
+        }
+        let r = mon.tick(
+            6,
+            &[ToolObservation { fingerprint: 99, failed: false }],
+            None,
+            &quiet_guard_state(),
+        );
+        let has_burst = r
+            .health
+            .signals()
+            .iter()
+            .any(|s| s.kind == DivergenceSignalKind::ErrorBurst);
+        assert!(
+            has_burst,
+            "expected error_burst signal after 5 error turns, got {:?}",
+            r.health
+        );
+    }
+
+    #[test]
+    fn digest_stall_does_not_fire_before_first_observation() {
+        // No fingerprint ever observed → stall must not fire even when
+        // the turn_counter is high.
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let r = mon.tick(100, &[], None, &quiet_guard_state());
+        let has_stall = r
+            .health
+            .signals()
+            .iter()
+            .any(|s| s.kind == DivergenceSignalKind::DigestStall);
+        assert!(!has_stall);
+    }
+
+    #[test]
+    fn digest_stall_fires_when_no_new_fingerprint_for_warn_turns() {
+        let mut mon = TrajectoryMonitor::new(cfg());
+        // Establish a fingerprint at turn 1.
+        let _ = mon.tick(
+            1,
+            &[ToolObservation { fingerprint: 1, failed: false }],
+            None,
+            &quiet_guard_state(),
+        );
+        // 5 turns later with the SAME fingerprint repeated — stall = 5.
+        for turn in 2..=6 {
+            let _ = mon.tick(
+                turn,
+                &[ToolObservation { fingerprint: 1, failed: false }],
+                None,
+                &quiet_guard_state(),
+            );
+        }
+        let r = mon.tick(
+            7,
+            &[ToolObservation { fingerprint: 1, failed: false }],
+            None,
+            &quiet_guard_state(),
+        );
+        let stall = r
+            .health
+            .signals()
+            .iter()
+            .find(|s| s.kind == DivergenceSignalKind::DigestStall);
+        assert!(stall.is_some(), "expected stall signal, got {:?}", r.health);
+    }
+
+    #[test]
+    fn context_pressure_signal_skipped_when_no_utilization() {
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let r = mon.tick(1, &[], None, &quiet_guard_state());
+        let has_ctx = r
+            .health
+            .signals()
+            .iter()
+            .any(|s| s.kind == DivergenceSignalKind::ContextPressure);
+        assert!(!has_ctx);
+    }
+
+    #[test]
+    fn context_pressure_signal_fires_at_warn_threshold() {
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let r = mon.tick(1, &[], Some(0.81), &quiet_guard_state());
+        let s = r
+            .health
+            .signals()
+            .iter()
+            .find(|s| s.kind == DivergenceSignalKind::ContextPressure)
+            .expect("expected context_pressure signal");
+        assert_eq!(s.severity, SignalSeverity::Warn);
+    }
+
+    // ── Signal toggles ──────────────────────────────────────────────────
+
+    #[test]
+    fn per_signal_toggle_silences_that_signal() {
+        let mut c = cfg();
+        c.signals.error_burst = false;
+        let mut mon = TrajectoryMonitor::new(c);
+        for turn in 1..=6 {
+            let _ = mon.tick(
+                turn,
+                &[ToolObservation { fingerprint: turn, failed: true }],
+                None,
+                &quiet_guard_state(),
+            );
+        }
+        let r = mon.tick(7, &[], None, &quiet_guard_state());
+        assert!(
+            !r.health
+                .signals()
+                .iter()
+                .any(|s| s.kind == DivergenceSignalKind::ErrorBurst),
+            "error_burst should be silenced by toggle"
+        );
+    }
+
+    // ── Fingerprint normalization ───────────────────────────────────────
+
+    #[test]
+    fn fingerprint_strips_intent_field() {
+        let a = fingerprint_tool_call("web.search", r#"{"intent":"find logs","q":"x"}"#);
+        let b = fingerprint_tool_call("web.search", r#"{"intent":"different","q":"x"}"#);
+        assert_eq!(a, b, "intent field must not affect fingerprint");
+    }
+
+    #[test]
+    fn fingerprint_different_for_different_args() {
+        let a = fingerprint_tool_call("web.search", r#"{"q":"a"}"#);
+        let b = fingerprint_tool_call("web.search", r#"{"q":"b"}"#);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_falls_back_on_invalid_json() {
+        // Must not panic; should still produce a stable hash.
+        let a = fingerprint_tool_call("x", "{not json");
+        let b = fingerprint_tool_call("x", "{not json");
+        assert_eq!(a, b);
+    }
+
+    // ── Shannon entropy primitive ───────────────────────────────────────
+
+    #[test]
+    fn entropy_zero_for_single_repeated_value() {
+        let mut w: VecDeque<u64> = VecDeque::new();
+        for _ in 0..8 {
+            w.push_back(1);
+        }
+        let e = shannon_entropy_bits(&w);
+        assert!(e.abs() < 1e-6, "expected 0.0, got {}", e);
+    }
+
+    #[test]
+    fn entropy_three_bits_for_eight_unique_values() {
+        let mut w: VecDeque<u64> = VecDeque::new();
+        for i in 0..8 {
+            w.push_back(i);
+        }
+        let e = shannon_entropy_bits(&w);
+        assert!((e - 3.0).abs() < 1e-5, "expected 3.0 bits, got {}", e);
+    }
+
+    #[test]
+    fn entropy_zero_on_empty() {
+        let w: VecDeque<u64> = VecDeque::new();
+        assert_eq!(shannon_entropy_bits(&w), 0.0);
+    }
+
+    // ── Full state-machine progression ──────────────────────────────────
+
+    #[test]
+    fn progression_healthy_to_watching_to_diverging_to_critical() {
+        // Simulates a looping agent: healthy start → one warn signal
+        // (Watching/observed) → two warn signals (Diverging/detected) →
+        // critical signal (Critical/escalated).
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let mut state = quiet_guard_state();
+
+        // Turn 1: healthy, first tick → level_changed = true but Healthy
+        // (caller emits only for non-Healthy).
+        state.current_loops = 1;
+        let r = mon.tick(1, &[], None, &state);
+        assert!(matches!(r.health, TrajectoryHealth::Healthy));
+        assert!(r.level_changed);
+
+        // Turn 2-3: still healthy, no level change.
+        for turn in 2u64..=3 {
+            state.current_loops = turn as u32;
+            let r = mon.tick(turn, &[], None, &state);
+            assert!(matches!(r.health, TrajectoryHealth::Healthy));
+            assert!(!r.level_changed);
+        }
+
+        // Turn 4: loop pressure at 4/5 = 0.80 (warn) → Watching.
+        state.current_loops = 4;
+        let r = mon.tick(4, &[], None, &state);
+        assert!(
+            matches!(r.health, TrajectoryHealth::Watching { .. }),
+            "expected Watching at turn 4, got {:?}",
+            r.health
+        );
+        assert!(r.level_changed);
+        assert_eq!(r.health.causal_action(), Some("observed"));
+
+        // Turn 5: loop pressure still warn (4/5, no new loops added since
+        // tick only reads state, does not modify it) → same level, no
+        // re-trigger.
+        let r = mon.tick(5, &[], None, &state);
+        assert!(
+            matches!(r.health, TrajectoryHealth::Watching { .. }),
+            "expected Watching at turn 5, got {:?}",
+            r.health
+        );
+        assert!(!r.level_changed, "same level must not re-trigger");
+
+        // Turn 6: keep loop pressure at warn (4/5) and add failure
+        // pressure (worst tool at 4/5 = 0.80 warn). Two warn signals →
+        // Diverging (detected).
+        state.current_loops = 4;
+        state.tool_failure_counts.insert("sandbox.exec".into(), 4);
+        let r = mon.tick(6, &[], None, &state);
+        assert!(
+            matches!(r.health, TrajectoryHealth::Diverging { .. }),
+            "expected Diverging at turn 6, got {:?}",
+            r.health
+        );
+        assert!(r.level_changed);
+        assert_eq!(r.health.causal_action(), Some("detected"));
+
+        // Turn 7: increase to critical loop pressure (5/5 = 1.0 ≥ 0.95).
+        // At least one critical signal → Critical (escalated).
+        state.current_loops = 5;
+        let r = mon.tick(7, &[], None, &state);
+        assert!(
+            matches!(r.health, TrajectoryHealth::Critical { .. }),
+            "expected Critical at turn 7, got {:?}",
+            r.health
+        );
+        assert!(r.level_changed);
+        assert_eq!(r.health.causal_action(), Some("escalated"));
+
+        // Turn 8: same critical → no re-trigger.
+        let r = mon.tick(8, &[], None, &state);
+        assert!(
+            matches!(r.health, TrajectoryHealth::Critical { .. }),
+            "expected Critical at turn 8, got {:?}",
+            r.health
+        );
+        assert!(!r.level_changed, "same critical must not re-trigger");
+    }
+
+    #[test]
+    fn progression_healthy_never_emits_event() {
+        // A perfectly healthy session must never trigger a divergence event.
+        let mut mon = TrajectoryMonitor::new(cfg());
+        let state = quiet_guard_state();
+        for turn in 1..=20 {
+            let r = mon.tick(turn, &[], None, &state);
+            assert!(matches!(r.health, TrajectoryHealth::Healthy));
+            assert_eq!(r.health.causal_action(), None);
+        }
+    }
+}

--- a/autonoetic-gateway/tests/trajectory_monitor_integration.rs
+++ b/autonoetic-gateway/tests/trajectory_monitor_integration.rs
@@ -1,0 +1,164 @@
+//! Sentinel P1 Integration Test: a looping session produces
+//! `divergence.observed` then `divergence.detected` events in the
+//! trajectory monitor's output.
+//!
+//! Uses a synthetic LoopGuard state to simulate a looping agent and
+//! validates that the monitor's TickResult produces the expected
+//! causal-action slugs for each TrajectoryHealth level.
+
+use std::collections::HashMap;
+
+use autonoetic_gateway::runtime::guard::LoopGuardState;
+use autonoetic_gateway::runtime::trajectory_health::{
+    build_event_payload, DivergenceSignalKind, SignalSeverity, TrajectoryHealth,
+};
+use autonoetic_gateway::runtime::trajectory_monitor::{ToolObservation, TrajectoryMonitor};
+use autonoetic_types::config::TrajectoryConfig;
+
+fn cfg() -> TrajectoryConfig {
+    TrajectoryConfig::default()
+}
+
+fn quiet_guard_state() -> LoopGuardState {
+    LoopGuardState {
+        max_loops_without_progress: 5,
+        max_tool_failures: 5,
+        max_consecutive_same_progress: 1,
+        max_child_failures: 3,
+        progress_budget_tools: HashMap::new(),
+        progress_budget_used: HashMap::new(),
+        current_loops: 0,
+        tool_failure_counts: HashMap::new(),
+        last_progress_fingerprint: None,
+        consecutive_progress_count: 0,
+        child_failure_count: 0,
+    }
+}
+
+#[test]
+fn looping_session_produces_divergence_event_sequence() {
+    let mut mon = TrajectoryMonitor::new(cfg());
+    let mut state = quiet_guard_state();
+
+    // Turn 1: healthy, no event.
+    let r = mon.tick(1, &[], None, &state);
+    assert!(matches!(r.health, TrajectoryHealth::Healthy));
+    assert!(r.level_changed);
+    assert!(build_event_payload(&r.health).is_none());
+
+    // Turns 2-3: still healthy.
+    for turn in 2u64..=3 {
+        state.current_loops = turn as u32;
+        let r = mon.tick(turn, &[], None, &state);
+        assert!(matches!(r.health, TrajectoryHealth::Healthy));
+        assert!(!r.level_changed);
+        assert!(build_event_payload(&r.health).is_none());
+    }
+
+    // Turn 4: loop pressure 4/5 = 0.80 (warn) → Watching → emits observed.
+    state.current_loops = 4;
+    let r = mon.tick(4, &[], None, &state);
+    assert_eq!(r.health.level_str(), "watching");
+    assert_eq!(r.health.causal_action(), Some("observed"));
+    assert!(r.level_changed);
+    let payload = build_event_payload(&r.health).unwrap();
+    assert_eq!(payload["level"], "watching");
+
+    // Turn 6: add failure pressure → 2 warn signals → Diverging → emits detected.
+    state.current_loops = 4;
+    state.tool_failure_counts.insert("sandbox.exec".into(), 4);
+    let r = mon.tick(6, &[], None, &state);
+    assert_eq!(r.health.level_str(), "diverging");
+    assert_eq!(r.health.causal_action(), Some("detected"));
+    assert!(r.level_changed);
+    let payload = build_event_payload(&r.health).unwrap();
+    assert_eq!(payload["level"], "diverging");
+
+    // Turn 7: loop pressure critical → Critical → emits escalated.
+    state.current_loops = 5;
+    let r = mon.tick(7, &[], None, &state);
+    assert_eq!(r.health.level_str(), "critical");
+    assert_eq!(r.health.causal_action(), Some("escalated"));
+    assert!(r.level_changed);
+    let payload = build_event_payload(&r.health).unwrap();
+    assert_eq!(payload["level"], "critical");
+
+    // Turn 8: same critical → no re-trigger, no event emission.
+    let r = mon.tick(8, &[], None, &state);
+    assert_eq!(r.health.level_str(), "critical");
+    assert!(r.health.causal_action().is_some());
+    assert!(!r.level_changed, "same level must not re-trigger");
+}
+
+#[test]
+fn healthy_session_emits_no_divergence_events() {
+    let mut mon = TrajectoryMonitor::new(cfg());
+    let state = quiet_guard_state();
+
+    for turn in 1u64..=20 {
+        let r = mon.tick(turn, &[], None, &state);
+        assert!(matches!(r.health, TrajectoryHealth::Healthy));
+        assert!(build_event_payload(&r.health).is_none(),
+            "healthy session must not produce event payload");
+    }
+}
+
+#[test]
+fn disabled_monitor_produces_no_events_even_with_looping() {
+    let mut cfg_disabled = cfg();
+    cfg_disabled.enabled = false;
+    let mut mon = TrajectoryMonitor::new(cfg_disabled);
+    let mut state = quiet_guard_state();
+    state.current_loops = 5; // would be critical if enabled
+
+    let r = mon.tick(1, &[], None, &state);
+    assert!(matches!(r.health, TrajectoryHealth::Healthy));
+    assert!(!r.level_changed);
+    assert!(build_event_payload(&r.health).is_none());
+}
+
+#[test]
+fn signal_toggles_prevent_individual_signal_triggers() {
+    let mut cfg_toggled = cfg();
+    cfg_toggled.signals.loop_pressure = false;
+    let mut mon = TrajectoryMonitor::new(cfg_toggled);
+    let mut state = quiet_guard_state();
+    state.current_loops = 5; // would be critical if loop_pressure were enabled
+
+    let r = mon.tick(1, &[], None, &state);
+    // No loop_pressure signal → still Healthy despite high loops.
+    assert!(matches!(r.health, TrajectoryHealth::Healthy));
+    assert!(r.level_changed);
+    assert!(build_event_payload(&r.health).is_none());
+}
+
+#[test]
+fn fingerprint_entropy_detects_repetition() {
+    let mut mon = TrajectoryMonitor::new(cfg());
+
+    // 4 identical fingerprints → entropy near 0 → critical.
+    let fp = 42u64;
+    for turn in 1u64..=4 {
+        let _ = mon.tick(
+            turn,
+            &[ToolObservation { fingerprint: fp, failed: false }],
+            None,
+            &quiet_guard_state(),
+        );
+    }
+    let r = mon.tick(
+        5,
+        &[ToolObservation { fingerprint: fp, failed: false }],
+        None,
+        &quiet_guard_state(),
+    );
+
+    let has_entropy_critical = r.health.signals().iter().any(|s| {
+        s.kind == DivergenceSignalKind::RepetitionEntropy && s.severity == SignalSeverity::Critical
+    });
+    assert!(has_entropy_critical, "expected entropy=critical signal from repetition");
+
+    // Payload must carry signals.
+    let payload = build_event_payload(&r.health).unwrap();
+    assert!(payload["signals"].as_array().map(|a| a.len() > 0).unwrap_or(false));
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1802,8 +1802,9 @@ pub struct TrajectoryConfig {
     #[serde(default = "default_trajectory_enabled")]
     pub enabled: bool,
 
-    /// Size of the sliding window (in turns) used by signals that depend
-    /// on recent history (`repetition_entropy`, `error_burst`).
+    /// Size of the sliding window. For `error_burst` this limits the number
+    /// of turns tracked; for `repetition_entropy` it limits the number of
+    /// individual tool-observation fingerprints (multiple per turn).
     #[serde(default = "default_trajectory_window")]
     pub window_size: usize,
 

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -843,6 +843,13 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub prompt_budget: PromptBudgetConfig,
 
+    /// In-session divergence monitor (Sentinel) configuration. Observes
+    /// loop/failure/repetition/stall/error/context signals and emits
+    /// `divergence.*` causal events on level transitions. Observational
+    /// only — does not modify session behavior.
+    #[serde(default)]
+    pub trajectory: TrajectoryConfig,
+
     /// Optional LLM model routing configuration.
     /// When set, enables intelligent model selection based on budget pressure,
     /// task complexity, and cost constraints.
@@ -1779,6 +1786,219 @@ impl Default for PromptBudgetConfig {
     }
 }
 
+/// Configuration for the in-session divergence monitor (Sentinel P1).
+///
+/// The monitor recomputes a `TrajectoryHealth` verdict every turn and
+/// emits `divergence.*` causal events on level transitions only —
+/// healthy sessions produce no events. Thresholds below carry the
+/// design-doc defaults (`docs/design/divergence-sentinel-design.md` §4).
+///
+/// Per-signal toggles let operators silence noisy signals without
+/// disabling the monitor outright.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryConfig {
+    /// Master switch. When `false`, the monitor does not run and no
+    /// `divergence.*` events are emitted.
+    #[serde(default = "default_trajectory_enabled")]
+    pub enabled: bool,
+
+    /// Size of the sliding window (in turns) used by signals that depend
+    /// on recent history (`repetition_entropy`, `error_burst`).
+    #[serde(default = "default_trajectory_window")]
+    pub window_size: usize,
+
+    /// Per-signal switches. A signal disabled here is never aggregated
+    /// into `TrajectoryHealth`.
+    #[serde(default)]
+    pub signals: TrajectorySignalsToggle,
+
+    /// `digest_stall` thresholds in turns.
+    #[serde(default)]
+    pub digest_stall: TrajectoryDigestStallConfig,
+
+    /// `repetition_entropy` thresholds in bits.
+    #[serde(default)]
+    pub repetition_entropy: TrajectoryRepetitionEntropyConfig,
+
+    /// `error_burst` thresholds in error count over the window.
+    #[serde(default)]
+    pub error_burst: TrajectoryErrorBurstConfig,
+
+    /// `context_pressure` thresholds as utilization fraction `[0.0, 1.0]`.
+    #[serde(default)]
+    pub context_pressure: TrajectoryContextPressureConfig,
+}
+
+fn default_trajectory_enabled() -> bool {
+    true
+}
+
+fn default_trajectory_window() -> usize {
+    8
+}
+
+impl Default for TrajectoryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_trajectory_enabled(),
+            window_size: default_trajectory_window(),
+            signals: TrajectorySignalsToggle::default(),
+            digest_stall: TrajectoryDigestStallConfig::default(),
+            repetition_entropy: TrajectoryRepetitionEntropyConfig::default(),
+            error_burst: TrajectoryErrorBurstConfig::default(),
+            context_pressure: TrajectoryContextPressureConfig::default(),
+        }
+    }
+}
+
+/// Per-signal enable/disable toggles. All default to `true`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectorySignalsToggle {
+    #[serde(default = "default_signal_on")]
+    pub loop_pressure: bool,
+    #[serde(default = "default_signal_on")]
+    pub failure_pressure: bool,
+    #[serde(default = "default_signal_on")]
+    pub child_failure_pressure: bool,
+    #[serde(default = "default_signal_on")]
+    pub digest_stall: bool,
+    #[serde(default = "default_signal_on")]
+    pub repetition_entropy: bool,
+    #[serde(default = "default_signal_on")]
+    pub error_burst: bool,
+    #[serde(default = "default_signal_on")]
+    pub context_pressure: bool,
+}
+
+fn default_signal_on() -> bool {
+    true
+}
+
+impl Default for TrajectorySignalsToggle {
+    fn default() -> Self {
+        Self {
+            loop_pressure: true,
+            failure_pressure: true,
+            child_failure_pressure: true,
+            digest_stall: true,
+            repetition_entropy: true,
+            error_burst: true,
+            context_pressure: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryDigestStallConfig {
+    #[serde(default = "default_digest_stall_warn_turns")]
+    pub warn_turns: u32,
+    #[serde(default = "default_digest_stall_critical_turns")]
+    pub critical_turns: u32,
+}
+
+fn default_digest_stall_warn_turns() -> u32 {
+    5
+}
+fn default_digest_stall_critical_turns() -> u32 {
+    8
+}
+
+impl Default for TrajectoryDigestStallConfig {
+    fn default() -> Self {
+        Self {
+            warn_turns: default_digest_stall_warn_turns(),
+            critical_turns: default_digest_stall_critical_turns(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryRepetitionEntropyConfig {
+    /// Warn when entropy of the last `window_size` tool fingerprints is
+    /// at or below this value (in bits). Low entropy means the agent is
+    /// repeating itself.
+    #[serde(default = "default_repetition_entropy_warn_bits")]
+    pub warn_bits: f32,
+    #[serde(default = "default_repetition_entropy_critical_bits")]
+    pub critical_bits: f32,
+    /// Minimum number of tool calls in the window before the signal is
+    /// evaluated. Avoids firing on a brand-new session with only one or
+    /// two calls observed.
+    #[serde(default = "default_repetition_entropy_min_observations")]
+    pub min_observations: usize,
+}
+
+fn default_repetition_entropy_warn_bits() -> f32 {
+    1.2
+}
+fn default_repetition_entropy_critical_bits() -> f32 {
+    0.5
+}
+fn default_repetition_entropy_min_observations() -> usize {
+    4
+}
+
+impl Default for TrajectoryRepetitionEntropyConfig {
+    fn default() -> Self {
+        Self {
+            warn_bits: default_repetition_entropy_warn_bits(),
+            critical_bits: default_repetition_entropy_critical_bits(),
+            min_observations: default_repetition_entropy_min_observations(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryErrorBurstConfig {
+    /// Warn when the count of error tool-results in the last
+    /// `window_size` turns reaches this number.
+    #[serde(default = "default_error_burst_warn_count")]
+    pub warn_count: u32,
+    #[serde(default = "default_error_burst_critical_count")]
+    pub critical_count: u32,
+}
+
+fn default_error_burst_warn_count() -> u32 {
+    5
+}
+fn default_error_burst_critical_count() -> u32 {
+    8
+}
+
+impl Default for TrajectoryErrorBurstConfig {
+    fn default() -> Self {
+        Self {
+            warn_count: default_error_burst_warn_count(),
+            critical_count: default_error_burst_critical_count(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryContextPressureConfig {
+    /// Warn when context utilization fraction reaches this value.
+    #[serde(default = "default_context_pressure_warn_fraction")]
+    pub warn_fraction: f32,
+    #[serde(default = "default_context_pressure_critical_fraction")]
+    pub critical_fraction: f32,
+}
+
+fn default_context_pressure_warn_fraction() -> f32 {
+    0.80
+}
+fn default_context_pressure_critical_fraction() -> f32 {
+    0.95
+}
+
+impl Default for TrajectoryContextPressureConfig {
+    fn default() -> Self {
+        Self {
+            warn_fraction: default_context_pressure_warn_fraction(),
+            critical_fraction: default_context_pressure_critical_fraction(),
+        }
+    }
+}
+
 /// Configuration for context compression.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextCompressionConfig {
@@ -1922,6 +2142,7 @@ impl Default for GatewayConfig {
             max_session_turns: default_max_session_turns(),
             loop_guard: LoopGuardConfig::default(),
             prompt_budget: PromptBudgetConfig::default(),
+            trajectory: TrajectoryConfig::default(),
             llm_routing: None,
             chat: ChatConfig::default(),
             approval_levels: ApprovalLevelConfig::default(),


### PR DESCRIPTION
Closes #240.

Depends on #253 (P0 — already merged to `main`).

## Summary

Wires the deterministic in-gateway divergence monitor into the per-turn execution loop. No LLM cost, no new agent — purely mechanical signal aggregation from existing data.

### Signals computed every turn

| Signal | Source | Default warn threshold |
|--------|--------|----------------------|
| `loop_pressure` | LoopGuard snapshot | ≥ 0.80 (4/5 cycles) |
| `failure_pressure` | LoopGuard snapshot | ≥ 0.80 (4/5 failures) |
| `child_failure_pressure` | LoopGuard snapshot | ≥ 0.66 (2/3 failures) |
| `digest_stall` | turns since new tool fingerprint | ≥ 5 turns |
| `repetition_entropy` | Shannon entropy of last-N fingerprints | ≤ 1.2 bits |
| `error_burst` | errors in last-N turns | ≥ 5 errors |
| `context_pressure` | prompt budget utilization | ≥ 80% |

### TrajectoryHealth → causal event mapping

| Level | Causal action | Trigger rule |
|-------|---------------|-------------|
| `Healthy` | *(none emitted)* | No signal crossed a threshold |
| `Watching` | `divergence.observed` | ≥ 1 warn signal |
| `Diverging` | `divergence.detected` | ≥ 2 warn signals |
| `Critical` | `divergence.escalated` | ≥ 1 critical signal |

### Files changed

- **New:** `trajectory_monitor.rs` — sliding-window per-session monitor, Shannon entropy, fingerprint normalization, 42 unit tests
- **New:** `trajectory_monitor_integration.rs` — 5 integration tests validating full event sequence
- **Modified:** `lifecycle.rs` — `TrajectoryMonitor` field on `AgentExecutor`, config wiring, hook after guard updates with divergence event emission
- **Modified:** `mod.rs` — module registration
- **Modified:** `config.rs` — `TrajectoryConfig`, `TrajectorySignalsToggle`, per-signal sub-configs (all previously uncommitted P1 scaffolding)

### Test results

- 42/42 trajectory unit tests pass
- 5/5 integration tests pass (run via `--test trajectory_monitor_integration`)
- 15/15 LoopGuard tests pass (no regression)
- `cargo build` succeeds

### Note

P2 (#241) will add planner messaging on `Diverging` and operator notification on `Critical`.