### PR TITLE
feat(sentinel): divergence detection, planner messaging, and sentinel.suppress (P0+P1+P2)

### DIFF
--- a/autonoetic-gateway/src/runtime/active_execution_registry.rs
+++ b/autonoetic-gateway/src/runtime/active_execution_registry.rs
@@ -2,6 +2,7 @@
 //! child PIDs for emergency stop.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 use tokio::task::AbortHandle;
 
@@ -20,6 +21,10 @@ pub struct NativeToolRunContext {
     pub user_id: Option<String>,
     /// Artifact ID whose layers should be auto-mounted into sandbox.exec calls.
     pub artifact_id: Option<String>,
+    /// Shared suppression target for `sentinel.suppress`. The tool writes a
+    /// suppress-until turn counter here; the lifecycle reads it after tool
+    /// batches to gate divergence messaging.
+    pub sentinel_suppress_target: Option<Arc<AtomicU64>>,
 }
 
 #[derive(Clone)]

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -26,7 +26,7 @@ use crate::runtime::store::SecretStoreRuntime;
 use crate::runtime::tool_call_processor::ToolCallProcessor;
 use autonoetic_types::agent::{AgentManifest, LlmExchangeUsage, Middleware};
 use autonoetic_types::background::{ApprovalRequest, ScheduledAction};
-use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::config::{GatewayConfig, TrajectoryConfig};
 use autonoetic_types::disclosure::DisclosurePolicy;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -2413,10 +2413,9 @@ impl AgentExecutor {
                                                 self.turn_counter,
                                                 self.manifest.agent.id,
                                             );
-                                            let msg_id_clone = msg_id.clone();
                                             let record = crate::scheduler::gateway_store::AgentMessageRecord {
-                                                message_id: msg_id_clone,
-                                                sender_session_id: format!("gateway:{}", self.manifest.agent.id),
+                                                message_id: msg_id.clone(),
+                                                sender_session_id: "gateway:sentinel".to_string(),
                                                 sender_agent_id: "gateway".to_string(),
                                                 target_pattern: format!("session:{}", root_sid),
                                                 message,
@@ -2424,18 +2423,21 @@ impl AgentExecutor {
                                             };
                                             if let Err(e) = store.save_agent_message(&record) {
                                                 tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to save divergence planner message");
+                                            } else if let Err(e) = store.insert_message_delivery(&msg_id, &root_sid) {
+                                                tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to insert divergence message delivery");
                                             } else {
-                                                let _ = store.insert_message_delivery(&msg_id, &root_sid);
                                                 let signal = crate::scheduler::signal::Signal::AgentMessage {
                                                     message_id: msg_id.clone(),
-                                                    sender_session_id: record.sender_session_id.clone(),
-                                                    sender_agent_id: record.sender_agent_id.clone(),
+                                                    sender_session_id: "gateway:sentinel".to_string(),
+                                                    sender_agent_id: "gateway".to_string(),
                                                     message: record.message.clone(),
                                                     timestamp: now,
                                                 };
-                                                let _ = crate::scheduler::signal::write_signal(
+                                                if let Err(e) = crate::scheduler::signal::write_signal(
                                                     Some(store), &root_sid, &msg_id, &signal,
-                                                );
+                                                ) {
+                                                    tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to write divergence wake signal");
+                                                }
                                             }
                                         }
                                     }
@@ -2446,7 +2448,7 @@ impl AgentExecutor {
                                             .map(|c| c.trajectory.notify_operator)
                                             .unwrap_or(true);
                                         if notify_operator {
-                                            let _ = tracer.log_event(
+                                            if let Err(e) = tracer.log_event(
                                                 "operator_alert",
                                                 "critical_divergence",
                                                 EntryStatus::Success,
@@ -2456,7 +2458,9 @@ impl AgentExecutor {
                                                     "agent_id": self.manifest.agent.id,
                                                     "message": "Trajectory divergence has reached critical level. Review divergence.* events in the causal chain.",
                                                 })),
-                                            );
+                                            ) {
+                                                tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to log operator_alert event");
+                                            }
                                         }
                                     }
                                 }

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -184,12 +184,18 @@ pub struct AgentExecutor {
     /// Context utilization fraction from the most recent prompt budget
     /// computation. Passed into the trajectory monitor each turn.
     pub last_context_utilization: Option<f32>,
+
+    /// Shared suppression target for `sentinel.suppress`. The tool writes a
+    /// turn counter here; the lifecycle reads it before emitting divergence
+    /// messages. A value of `0` means no suppression is active.
+    pub suppress_until_turn: Arc<AtomicU64>,
 }
 
 use crate::runtime::tool_dispatch::{
     loop_guard_from_config_and_manifest, tool_result_counts_as_progress,
 };
 pub use crate::runtime::tool_dispatch::determine_tool_tier_filter;
+use std::sync::atomic::AtomicU64;
 
 impl AgentExecutor {
     pub fn new(
@@ -241,6 +247,7 @@ impl AgentExecutor {
             extended_instructions: None,
             trajectory_monitor: TrajectoryMonitor::new(Default::default()),
             last_context_utilization: None,
+            suppress_until_turn: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -2007,6 +2014,7 @@ impl AgentExecutor {
                             live_report: self.live_report.clone(),
                             user_id: self.user_id.clone(),
                             artifact_id: self.artifact_id.clone(),
+                            sentinel_suppress_target: Some(self.suppress_until_turn.clone()),
                         }
                     });
                     let mut processor = ToolCallProcessor::new(
@@ -2370,6 +2378,89 @@ impl AgentExecutor {
                                         "Failed to log divergence event"
                                     );
                                 }
+                            }
+
+                            // ── P2: Planner messaging & operator escalation ──────
+                            use crate::runtime::trajectory_health::TrajectoryHealth;
+                            use std::sync::atomic::Ordering;
+
+                            let suppressed =
+                                self.turn_counter < self.suppress_until_turn.load(Ordering::Relaxed);
+                            let cfg = self.config.as_ref();
+
+                            match &result.health {
+                                TrajectoryHealth::Diverging { .. }
+                                | TrajectoryHealth::Critical { .. }
+                                    if !suppressed =>
+                                {
+                                    let notify_planner = cfg
+                                        .map(|c| c.trajectory.notify_planner)
+                                        .unwrap_or(true);
+                                    if notify_planner {
+                                        if let Some(store) = self.gateway_store.as_ref() {
+                                            let root_sid = crate::runtime::content_store::root_session_id(&session_id).to_string();
+                                            let now = chrono::Utc::now().to_rfc3339();
+                                            let level = result.health.level_str();
+                                            let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+                                            let message = format!(
+                                                "[Sentinel Notice]\n\
+                                                 Level: {}\n\
+                                                 Turn: {}\n\
+                                                 Agent: {}\n\
+                                                 The trajectory monitor has detected a divergence pattern. \
+                                                 Review the causal chain for divergence.* events.",
+                                                level,
+                                                self.turn_counter,
+                                                self.manifest.agent.id,
+                                            );
+                                            let msg_id_clone = msg_id.clone();
+                                            let record = crate::scheduler::gateway_store::AgentMessageRecord {
+                                                message_id: msg_id_clone,
+                                                sender_session_id: format!("gateway:{}", self.manifest.agent.id),
+                                                sender_agent_id: "gateway".to_string(),
+                                                target_pattern: format!("session:{}", root_sid),
+                                                message,
+                                                created_at: now.clone(),
+                                            };
+                                            if let Err(e) = store.save_agent_message(&record) {
+                                                tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to save divergence planner message");
+                                            } else {
+                                                let _ = store.insert_message_delivery(&msg_id, &root_sid);
+                                                let signal = crate::scheduler::signal::Signal::AgentMessage {
+                                                    message_id: msg_id.clone(),
+                                                    sender_session_id: record.sender_session_id.clone(),
+                                                    sender_agent_id: record.sender_agent_id.clone(),
+                                                    message: record.message.clone(),
+                                                    timestamp: now,
+                                                };
+                                                let _ = crate::scheduler::signal::write_signal(
+                                                    Some(store), &root_sid, &msg_id, &signal,
+                                                );
+                                            }
+                                        }
+                                    }
+
+                                    // Critical also escalates to the operator
+                                    if matches!(result.health, TrajectoryHealth::Critical { .. }) {
+                                        let notify_operator = cfg
+                                            .map(|c| c.trajectory.notify_operator)
+                                            .unwrap_or(true);
+                                        if notify_operator {
+                                            let _ = tracer.log_event(
+                                                "operator_alert",
+                                                "critical_divergence",
+                                                EntryStatus::Success,
+                                                Some(serde_json::json!({
+                                                    "level": "critical",
+                                                    "turn": self.turn_counter,
+                                                    "agent_id": self.manifest.agent.id,
+                                                    "message": "Trajectory divergence has reached critical level. Review divergence.* events in the causal chain.",
+                                                })),
+                                            );
+                                        }
+                                    }
+                                }
+                                _ => {}
                             }
                         }
                     }

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -969,6 +969,7 @@ pub mod quality_trend;
 pub mod sandbox;
 pub mod scheduler;
 pub mod security_redteam;
+pub mod sentinel;
 pub mod session;
 pub mod skill;
 pub mod user_interaction;
@@ -1018,6 +1019,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::admin_proposal::register_tools(&mut registry);
     crate::runtime::tools::constitution::register_tools(&mut registry);
     crate::runtime::tools::security_redteam::register_tools(&mut registry);
+    crate::runtime::tools::sentinel::register_tools(&mut registry);
     registry
 }
 

--- a/autonoetic-gateway/src/runtime/tools/sentinel.rs
+++ b/autonoetic-gateway/src/runtime/tools/sentinel.rs
@@ -1,0 +1,113 @@
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::tools::{NativeTool, NativeToolRegistry};
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::tool_error::ToolError;
+use serde::Deserialize;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+
+pub fn register_tools(registry: &mut NativeToolRegistry) {
+    registry.register(Box::new(SentinelSuppressTool));
+}
+
+pub struct SentinelSuppressTool;
+
+impl NativeTool for SentinelSuppressTool {
+    fn name(&self) -> &'static str {
+        "sentinel_suppress"
+    }
+
+    fn is_available(&self, _manifest: &AgentManifest) -> bool {
+        true
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Suppress divergence monitoring messages for the specified number of turns. Use this when you are already aware of a divergence pattern and do not need repeated planner notifications. The suppression is bounded by the gateway configuration (`trajectory.suppress_max_turns`).".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "turns": {
+                        "type": "integer",
+                        "description": "Number of turns to suppress divergence messages for (clamped to suppress_max_turns)",
+                        "minimum": 1,
+                        "maximum": 100
+                    }
+                },
+                "required": ["turns"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        turn_id: Option<&str>,
+        config: Option<&autonoetic_types::config::GatewayConfig>,
+        _gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            turns: u32,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        if args.turns == 0 {
+            return Ok(ToolError::validation(
+                "turns must be >= 1".to_string(),
+                None::<String>,
+            )
+            .to_error_response());
+        }
+
+        let max_turns = config
+            .map(|c| c.trajectory.suppress_max_turns)
+            .unwrap_or(10);
+        let clamped = args.turns.min(max_turns);
+
+        let current_turn: u64 = turn_id
+            .and_then(|id| id.strip_prefix("turn-"))
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let suppress_until = current_turn + clamped as u64;
+
+        if let Some(ctx) = run_context {
+            if let Some(target) = &ctx.sentinel_suppress_target {
+                target.store(suppress_until, Ordering::Release);
+                tracing::debug!(
+                    target: "autonoetic::trajectory",
+                    current_turn,
+                    clamped,
+                    suppress_until,
+                    "sentinel.suppress activated"
+                );
+            } else {
+                tracing::warn!(
+                    target: "autonoetic::trajectory",
+                    "sentinel.suppress called but no shared suppression target available"
+                );
+            }
+        }
+
+        Ok(serde_json::json!({
+            "ok": true,
+            "suppressed_for_turns": clamped,
+            "suppress_until_turn": suppress_until,
+            "current_turn": current_turn,
+            "max_allowed": max_turns,
+        })
+        .to_string())
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/sentinel.rs
+++ b/autonoetic-gateway/src/runtime/tools/sentinel.rs
@@ -79,20 +79,26 @@ impl NativeTool for SentinelSuppressTool {
         let current_turn: u64 = match turn_id.and_then(|id| id.strip_prefix("turn-")).and_then(|s| s.parse().ok()) {
             Some(t) => t,
             None => {
-                return Ok(serde_json::json!({
-                    "ok": false,
-                    "error_type": "internal",
-                    "error": "invalid_turn_context",
-                    "message": "sentinel.suppress requires a valid turn_id (turn-<N>)".to_string(),
-                }).to_string());
+                return Ok(ToolError::resource(
+                    "sentinel.suppress requires a valid turn_id (turn-<N>) — no active turn context",
+                    Some("invoke this tool only from within an agent turn"),
+                )
+                .to_error_response());
             }
         };
 
         let suppress_until = current_turn + clamped as u64;
 
-        let target = run_context
-            .and_then(|ctx| ctx.sentinel_suppress_target.as_ref())
-            .ok_or_else(|| anyhow::anyhow!("sentinel.suppress: suppression target unavailable (no active session context)"))?;
+        let target = match run_context.and_then(|ctx| ctx.sentinel_suppress_target.as_ref()) {
+            Some(t) => t,
+            None => {
+                return Ok(ToolError::resource(
+                    "sentinel.suppress: suppression target unavailable (no active session context)",
+                    Some("ensure the tool is invoked from a live agent session"),
+                )
+                .to_error_response());
+            }
+        };
 
         target.store(suppress_until, Ordering::Release);
         tracing::debug!(

--- a/autonoetic-gateway/src/runtime/tools/sentinel.rs
+++ b/autonoetic-gateway/src/runtime/tools/sentinel.rs
@@ -3,6 +3,7 @@ use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::config::TrajectoryConfig;
 use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
@@ -33,8 +34,7 @@ impl NativeTool for SentinelSuppressTool {
                     "turns": {
                         "type": "integer",
                         "description": "Number of turns to suppress divergence messages for (clamped to suppress_max_turns)",
-                        "minimum": 1,
-                        "maximum": 100
+                        "minimum": 1
                     }
                 },
                 "required": ["turns"],
@@ -73,33 +73,35 @@ impl NativeTool for SentinelSuppressTool {
 
         let max_turns = config
             .map(|c| c.trajectory.suppress_max_turns)
-            .unwrap_or(10);
+            .unwrap_or(TrajectoryConfig::default().suppress_max_turns);
         let clamped = args.turns.min(max_turns);
 
-        let current_turn: u64 = turn_id
-            .and_then(|id| id.strip_prefix("turn-"))
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        let current_turn: u64 = match turn_id.and_then(|id| id.strip_prefix("turn-")).and_then(|s| s.parse().ok()) {
+            Some(t) => t,
+            None => {
+                return Ok(serde_json::json!({
+                    "ok": false,
+                    "error_type": "internal",
+                    "error": "invalid_turn_context",
+                    "message": "sentinel.suppress requires a valid turn_id (turn-<N>)".to_string(),
+                }).to_string());
+            }
+        };
 
         let suppress_until = current_turn + clamped as u64;
 
-        if let Some(ctx) = run_context {
-            if let Some(target) = &ctx.sentinel_suppress_target {
-                target.store(suppress_until, Ordering::Release);
-                tracing::debug!(
-                    target: "autonoetic::trajectory",
-                    current_turn,
-                    clamped,
-                    suppress_until,
-                    "sentinel.suppress activated"
-                );
-            } else {
-                tracing::warn!(
-                    target: "autonoetic::trajectory",
-                    "sentinel.suppress called but no shared suppression target available"
-                );
-            }
-        }
+        let target = run_context
+            .and_then(|ctx| ctx.sentinel_suppress_target.as_ref())
+            .ok_or_else(|| anyhow::anyhow!("sentinel.suppress: suppression target unavailable (no active session context)"))?;
+
+        target.store(suppress_until, Ordering::Release);
+        tracing::debug!(
+            target: "autonoetic::trajectory",
+            current_turn,
+            clamped,
+            suppress_until,
+            "sentinel.suppress activated"
+        );
 
         Ok(serde_json::json!({
             "ok": true,

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1828,6 +1828,21 @@ pub struct TrajectoryConfig {
     /// `context_pressure` thresholds as utilization fraction `[0.0, 1.0]`.
     #[serde(default)]
     pub context_pressure: TrajectoryContextPressureConfig,
+
+    /// When `true` (default), the monitor sends an `agent.message` to the
+    /// root planner on `Diverging` level transitions.
+    #[serde(default = "default_trajectory_notify_planner")]
+    pub notify_planner: bool,
+
+    /// When `true` (default), the monitor notifies the operator via
+    /// `user_interactions` on `Critical` level transitions.
+    #[serde(default = "default_trajectory_notify_operator")]
+    pub notify_operator: bool,
+
+    /// Maximum turns `sentinel.suppress` can request (default 10).
+    /// Serves as a safety bound on planner self-suppression.
+    #[serde(default = "default_trajectory_suppress_max_turns")]
+    pub suppress_max_turns: u32,
 }
 
 fn default_trajectory_enabled() -> bool {
@@ -1836,6 +1851,18 @@ fn default_trajectory_enabled() -> bool {
 
 fn default_trajectory_window() -> usize {
     8
+}
+
+fn default_trajectory_notify_planner() -> bool {
+    true
+}
+
+fn default_trajectory_notify_operator() -> bool {
+    true
+}
+
+fn default_trajectory_suppress_max_turns() -> u32 {
+    10
 }
 
 impl Default for TrajectoryConfig {
@@ -1848,6 +1875,9 @@ impl Default for TrajectoryConfig {
             repetition_entropy: TrajectoryRepetitionEntropyConfig::default(),
             error_burst: TrajectoryErrorBurstConfig::default(),
             context_pressure: TrajectoryContextPressureConfig::default(),
+            notify_planner: default_trajectory_notify_planner(),
+            notify_operator: default_trajectory_notify_operator(),
+            suppress_max_turns: default_trajectory_suppress_max_turns(),
         }
     }
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1830,12 +1830,13 @@ pub struct TrajectoryConfig {
     pub context_pressure: TrajectoryContextPressureConfig,
 
     /// When `true` (default), the monitor sends an `agent.message` to the
-    /// root planner on `Diverging` level transitions.
+    /// root planner on `Diverging` and `Critical` level transitions.
     #[serde(default = "default_trajectory_notify_planner")]
     pub notify_planner: bool,
 
-    /// When `true` (default), the monitor notifies the operator via
-    /// `user_interactions` on `Critical` level transitions.
+    /// When `true` (default), the monitor emits an `operator_alert` causal
+    /// event on `Critical` level transitions (non-blocking, visible in the
+    /// causal chain for operator tooling).
     #[serde(default = "default_trajectory_notify_operator")]
     pub notify_operator: bool,
 

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -19,6 +19,8 @@ rules:
     tier: core
   - prefix: sandbox_exec
     tier: core
+  - prefix: sentinel_
+    tier: core
 
   # Workflow tier: orchestration and approval flow.
   - prefix: agent_spawn


### PR DESCRIPTION
## Summary

Implements the Sentinel divergence monitoring system across three phases:

### P0 — Trajectory Health substrate
- Define `TrajectoryHealth` data model (`Healthy`/`Watching`/`Diverging`/`Critical` levels)
- Define `DivergenceSignal` + `DivergenceSignalKind` enumeration
- `build_event_payload()` for causal-chain serialization
- Pure data + logic, no IO or wiring into turn loop

### P1 — Deterministic trajectory monitor
- `TrajectoryMonitor` state machine with 7 signal extractors:
  - `loop_pressure`, `failure_pressure`, `child_failure_pressure` (from LoopGuard)
  - `digest_stall` (turns since last new causal event fingerprint)
  - `repetition_entropy` (Shannon entropy over tool-call fingerprints in sliding window)
  - `error_burst` (tool failures within window)
  - `context_pressure` (context utilization fraction)
- Sliding window (default 8 turns), configurable per-signal thresholds (warn/critical)
- Causal event emission on level transitions (category `divergence`, actions `observed`/`detected`/`escalated`)
- Registered in runtime/mod.rs, wired in lifecycle.rs turn loop after guard updates
- 5 integration tests + full unit test coverage

### P2 — Planner messaging, operator escalation, sentinel.suppress
- `agent.message` sent to root planner on `Diverging` level transitions
- `operator_alert` causal event on `Critical` level transitions (non-blocking)
- `notify_planner`/`notify_operator` toggles in `TrajectoryConfig` (default `true`)
- `sentinel.suppress(turns=N)` tool (core tier, bounded by `suppress_max_turns` default 10)
- Suppression via shared `AtomicU64` between tool and executor lifecycle
- All messaging gated behind `suppress_until_turn` check

## Testing
- All 5 trajectory monitor integration tests pass
- All 37 security sentinel integration tests pass
- 887 unit tests pass (24 pre-existing failures in router/server/sealed_network unchanged)
- `cargo build` clean