### PR TITLE
feat(sentinel): add reason param, causal event, and integration tests for sentinel.suppress (P2 gaps)

### DIFF
--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -2393,53 +2393,17 @@ impl AgentExecutor {
                                 | TrajectoryHealth::Critical { .. }
                                     if !suppressed =>
                                 {
-                                    let notify_planner = cfg
-                                        .map(|c| c.trajectory.notify_planner)
-                                        .unwrap_or(true);
-                                    if notify_planner {
-                                        if let Some(store) = self.gateway_store.as_ref() {
-                                            let root_sid = crate::runtime::content_store::root_session_id(&session_id).to_string();
-                                            let now = chrono::Utc::now().to_rfc3339();
-                                            let level = result.health.level_str();
-                                            let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
-                                            let message = format!(
-                                                "[Sentinel Notice]\n\
-                                                 Level: {}\n\
-                                                 Turn: {}\n\
-                                                 Agent: {}\n\
-                                                 The trajectory monitor has detected a divergence pattern. \
-                                                 Review the causal chain for divergence.* events.",
-                                                level,
-                                                self.turn_counter,
-                                                self.manifest.agent.id,
-                                            );
-                                            let record = crate::scheduler::gateway_store::AgentMessageRecord {
-                                                message_id: msg_id.clone(),
-                                                sender_session_id: "gateway:sentinel".to_string(),
-                                                sender_agent_id: "gateway".to_string(),
-                                                target_pattern: format!("session:{}", root_sid),
-                                                message,
-                                                created_at: now.clone(),
-                                            };
-                                            if let Err(e) = store.save_agent_message(&record) {
-                                                tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to save divergence planner message");
-                                            } else if let Err(e) = store.insert_message_delivery(&msg_id, &root_sid) {
-                                                tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to insert divergence message delivery");
-                                            } else {
-                                                let signal = crate::scheduler::signal::Signal::AgentMessage {
-                                                    message_id: msg_id.clone(),
-                                                    sender_session_id: "gateway:sentinel".to_string(),
-                                                    sender_agent_id: "gateway".to_string(),
-                                                    message: record.message.clone(),
-                                                    timestamp: now,
-                                                };
-                                                if let Err(e) = crate::scheduler::signal::write_signal(
-                                                    Some(store), &root_sid, &msg_id, &signal,
-                                                ) {
-                                                    tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to write divergence wake signal");
-                                                }
-                                            }
-                                        }
+                                    if let Some(store) = self.gateway_store.as_ref() {
+                                        let root_sid = crate::runtime::content_store::root_session_id(&session_id).to_string();
+                                        Self::send_divergence_notice(
+                                            store,
+                                            &root_sid,
+                                            self.turn_counter,
+                                            &self.manifest.agent.id,
+                                            result.health.level_str(),
+                                            &self.suppress_until_turn,
+                                            cfg.map(|c| c.trajectory.notify_planner).unwrap_or(true),
+                                        );
                                     }
 
                                     // Critical also escalates to the operator
@@ -2630,6 +2594,69 @@ impl AgentExecutor {
         let outcome = Ok(TurnOutcome::Completed(reply));
         self.last_history = history.clone();
         outcome
+    }
+
+    /// Send a divergence notice to the root planner if not suppressed.
+    /// Returns true if a message was sent, false if suppressed or
+    /// notify_planner is false. Errors during persistence are logged
+    /// but not returned (best-effort delivery).
+    pub fn send_divergence_notice(
+        store: &crate::scheduler::gateway_store::GatewayStore,
+        root_session_id: &str,
+        turn_counter: u64,
+        agent_id: &str,
+        level: &str,
+        suppress_until: &AtomicU64,
+        notify_planner: bool,
+    ) -> bool {
+        use std::sync::atomic::Ordering;
+        if turn_counter < suppress_until.load(Ordering::Relaxed) {
+            return false;
+        }
+        if !notify_planner {
+            return false;
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let message = format!(
+            "[Sentinel Notice]\n\
+             Level: {}\n\
+             Turn: {}\n\
+             Agent: {}\n\
+             The trajectory monitor has detected a divergence pattern. \
+             Review the causal chain for divergence.* events.",
+            level, turn_counter, agent_id,
+        );
+        let record = crate::scheduler::gateway_store::AgentMessageRecord {
+            message_id: msg_id.clone(),
+            sender_session_id: "gateway:sentinel".to_string(),
+            sender_agent_id: "gateway".to_string(),
+            target_pattern: format!("session:{}", root_session_id),
+            message,
+            created_at: now.clone(),
+        };
+        if let Err(e) = store.save_agent_message(&record) {
+            tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to save divergence planner message");
+            return false;
+        }
+        if let Err(e) = store.insert_message_delivery(&msg_id, root_session_id) {
+            tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to insert divergence message delivery");
+            return false;
+        }
+        let signal = crate::scheduler::signal::Signal::AgentMessage {
+            message_id: msg_id.clone(),
+            sender_session_id: "gateway:sentinel".to_string(),
+            sender_agent_id: "gateway".to_string(),
+            message: record.message,
+            timestamp: now,
+        };
+        if let Err(e) = crate::scheduler::signal::write_signal(
+            Some(store), root_session_id, &msg_id, &signal,
+        ) {
+            tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to write divergence wake signal");
+        }
+        true
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/sentinel.rs
+++ b/autonoetic-gateway/src/runtime/tools/sentinel.rs
@@ -2,11 +2,15 @@ use crate::llm::ToolDefinition;
 use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
+use crate::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::causal_chain::{default_enforced_rules, CausalEventRecord};
 use autonoetic_types::config::TrajectoryConfig;
 use autonoetic_types::tool_error::ToolError;
+use chrono::Utc;
 use serde::Deserialize;
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 pub fn register_tools(registry: &mut NativeToolRegistry) {
@@ -35,6 +39,10 @@ impl NativeTool for SentinelSuppressTool {
                         "type": "integer",
                         "description": "Number of turns to suppress divergence messages for (clamped to suppress_max_turns)",
                         "minimum": 1
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Optional explanation for why suppression is being requested"
                     }
                 },
                 "required": ["turns"],
@@ -45,20 +53,22 @@ impl NativeTool for SentinelSuppressTool {
 
     fn execute(
         &self,
-        _manifest: &AgentManifest,
+        manifest: &AgentManifest,
         _policy: &PolicyEngine,
         _agent_dir: &Path,
         _gateway_dir: Option<&Path>,
         arguments_json: &str,
-        _session_id: Option<&str>,
+        session_id: Option<&str>,
         turn_id: Option<&str>,
         config: Option<&autonoetic_types::config::GatewayConfig>,
-        _gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        gateway_store: Option<Arc<GatewayStore>>,
         run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
         #[derive(Deserialize)]
         struct Args {
             turns: u32,
+            #[serde(default)]
+            reason: Option<String>,
         }
         let args: Args = serde_json::from_str(arguments_json)
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
@@ -106,8 +116,43 @@ impl NativeTool for SentinelSuppressTool {
             current_turn,
             clamped,
             suppress_until,
+            reason = args.reason.as_deref().unwrap_or(""),
             "sentinel.suppress activated"
         );
+
+        // Emit causal event for suppression activation
+        if let Some(ref store) = gateway_store {
+            let now = Utc::now();
+            let event = CausalEventRecord {
+                event_id: uuid::Uuid::new_v4().to_string(),
+                agent_id: manifest.agent.id.clone(),
+                session_id: session_id.unwrap_or_default().to_string(),
+                turn_id: turn_id.map(|s| s.to_string()),
+                event_seq: now.timestamp_millis().max(0) as u64,
+                timestamp: now.to_rfc3339(),
+                category: "sentinel".to_string(),
+                action: "suppress_activated".to_string(),
+                status: "SUCCESS".to_string(),
+                enforced_rules: default_enforced_rules(),
+                target: None,
+                payload: Some(
+                    serde_json::json!({
+                        "suppressed_for_turns": clamped,
+                        "suppress_until_turn": suppress_until,
+                        "current_turn": current_turn,
+                        "max_allowed": max_turns,
+                        "reason": args.reason,
+                    })
+                    .to_string(),
+                ),
+                payload_ref: None,
+                evidence_ref: None,
+                reason: args.reason.clone(),
+            };
+            if let Err(e) = store.create_causal_event(&event) {
+                tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to log sentinel.suppress_activated causal event");
+            }
+        }
 
         Ok(serde_json::json!({
             "ok": true,
@@ -115,6 +160,7 @@ impl NativeTool for SentinelSuppressTool {
             "suppress_until_turn": suppress_until,
             "current_turn": current_turn,
             "max_allowed": max_turns,
+            "reason": args.reason,
         })
         .to_string())
     }

--- a/autonoetic-gateway/src/runtime/tools/sentinel.rs
+++ b/autonoetic-gateway/src/runtime/tools/sentinel.rs
@@ -98,6 +98,7 @@ impl NativeTool for SentinelSuppressTool {
         };
 
         let suppress_until = current_turn + clamped as u64;
+        let reason = args.reason.clone();
 
         let target = match run_context.and_then(|ctx| ctx.sentinel_suppress_target.as_ref()) {
             Some(t) => t,
@@ -116,7 +117,7 @@ impl NativeTool for SentinelSuppressTool {
             current_turn,
             clamped,
             suppress_until,
-            reason = args.reason.as_deref().unwrap_or(""),
+            reason = reason.as_deref().unwrap_or(""),
             "sentinel.suppress activated"
         );
 
@@ -141,13 +142,13 @@ impl NativeTool for SentinelSuppressTool {
                         "suppress_until_turn": suppress_until,
                         "current_turn": current_turn,
                         "max_allowed": max_turns,
-                        "reason": args.reason,
+                        "reason": reason.clone(),
                     })
                     .to_string(),
                 ),
                 payload_ref: None,
                 evidence_ref: None,
-                reason: args.reason.clone(),
+                reason: reason.clone(),
             };
             if let Err(e) = store.create_causal_event(&event) {
                 tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to log sentinel.suppress_activated causal event");
@@ -160,7 +161,7 @@ impl NativeTool for SentinelSuppressTool {
             "suppress_until_turn": suppress_until,
             "current_turn": current_turn,
             "max_allowed": max_turns,
-            "reason": args.reason,
+            "reason": reason,
         })
         .to_string())
     }

--- a/autonoetic-gateway/tests/sentinel_suppression_integration.rs
+++ b/autonoetic-gateway/tests/sentinel_suppression_integration.rs
@@ -8,16 +8,17 @@ mod support;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 
 use autonoetic_gateway::policy::PolicyEngine;
 use autonoetic_gateway::runtime::active_execution_registry::{
     ActiveExecutionRegistry, NativeToolRunContext,
 };
 use autonoetic_gateway::runtime::guard::LoopGuardState;
+use autonoetic_gateway::runtime::lifecycle::AgentExecutor;
 use autonoetic_gateway::runtime::tools::default_registry;
 use autonoetic_gateway::runtime::trajectory_monitor::TrajectoryMonitor;
-use autonoetic_gateway::scheduler::gateway_store::{AgentMessageRecord, GatewayStore};
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::config::TrajectoryConfig;
 
@@ -155,38 +156,25 @@ fn diverging_session_sends_agent_message_to_root() -> anyhow::Result<()> {
     let store = Arc::new(GatewayStore::open(tempdir.path())?);
     let mut mon = TrajectoryMonitor::new(TrajectoryConfig::default());
     let mut state = quiet_guard_state();
-    let agent_id = "test-agent";
     let root_sid = "root-session";
+    let suppress_until = AtomicU64::new(0); // no suppression
 
     let r = drive_to_diverging(&mut mon, &mut state);
     assert!(r.level_changed);
     assert_eq!(r.health.level_str(), "diverging");
     assert_eq!(r.health.causal_action(), Some("detected"));
 
-    // Simulate the lifecycle messaging logic (lifecycle.rs ~2383-2441)
-    let turn_counter = 6u64;
-    let now = chrono::Utc::now().to_rfc3339();
-    let level = r.health.level_str();
-    let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
-    let message = format!(
-        "[Sentinel Notice]\n\
-         Level: {}\n\
-         Turn: {}\n\
-         Agent: {}\n\
-         The trajectory monitor has detected a divergence pattern. \
-         Review the causal chain for divergence.* events.",
-        level, turn_counter, agent_id,
+    // Use the shared lifecycle helper (same code path the lifecycle uses)
+    let sent = AgentExecutor::send_divergence_notice(
+        &store,
+        root_sid,
+        6, // turn_counter
+        "test-agent",
+        r.health.level_str(),
+        &suppress_until,
+        true, // notify_planner
     );
-    let record = AgentMessageRecord {
-        message_id: msg_id.clone(),
-        sender_session_id: "gateway:sentinel".to_string(),
-        sender_agent_id: "gateway".to_string(),
-        target_pattern: format!("session:{}", root_sid),
-        message,
-        created_at: now,
-    };
-    store.save_agent_message(&record)?;
-    store.insert_message_delivery(&msg_id, root_sid)?;
+    assert!(sent, "message should have been sent (no suppression)");
 
     // Verify message was saved and is undelivered
     let undelivered = store.fetch_undelivered_messages(root_sid)?;
@@ -194,7 +182,7 @@ fn diverging_session_sends_agent_message_to_root() -> anyhow::Result<()> {
     assert_eq!(undelivered[0].sender_agent_id, "gateway");
     assert!(undelivered[0].message.contains("[Sentinel Notice]"));
     assert!(undelivered[0].message.contains("diverging"));
-    assert!(undelivered[0].message.contains(&turn_counter.to_string()));
+    assert!(undelivered[0].message.contains("6")); // turn counter
 
     Ok(())
 }
@@ -209,37 +197,24 @@ fn sentinel_suppress_prevents_divergence_messages() -> anyhow::Result<()> {
     let mut state = quiet_guard_state();
     let root_sid = "root-session";
 
-    // Suppress for 10 turns from turn 0 → suppress_until = 10
-    let suppress_until_turn = Arc::new(AtomicU64::new(10));
+    // Suppress for 10 turns → suppress_until = 10
+    let suppress_until = AtomicU64::new(10);
 
     let r = drive_to_diverging(&mut mon, &mut state);
     assert!(r.level_changed);
     assert_eq!(r.health.level_str(), "diverging");
 
-    // Replicate the lifecycle suppression check (lifecycle.rs line 2387-2388)
-    let turn_counter = 6u64;
-    let suppressed = turn_counter < suppress_until_turn.load(Ordering::Relaxed);
-    assert!(
-        suppressed,
-        "turn {} should be suppressed when suppress_until=10",
-        turn_counter
+    // Use the shared lifecycle helper — suppression is checked internally
+    let sent = AgentExecutor::send_divergence_notice(
+        &store,
+        root_sid,
+        6, // turn_counter (suppressed since 6 < 10)
+        "test-agent",
+        r.health.level_str(),
+        &suppress_until,
+        true, // notify_planner
     );
-
-    // When suppressed, lifecycle skips the entire messaging block
-    if !suppressed {
-        let now = chrono::Utc::now().to_rfc3339();
-        let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
-        let record = AgentMessageRecord {
-            message_id: msg_id.clone(),
-            sender_session_id: "gateway:sentinel".to_string(),
-            sender_agent_id: "gateway".to_string(),
-            target_pattern: format!("session:{}", root_sid),
-            message: "should not appear".to_string(),
-            created_at: now,
-        };
-        store.save_agent_message(&record)?;
-        store.insert_message_delivery(&msg_id, root_sid)?;
-    }
+    assert!(!sent, "message should NOT have been sent (suppress_until=10 > turn=6)");
 
     // Verify no messages were saved
     let undelivered = store.fetch_undelivered_messages(root_sid)?;
@@ -247,6 +222,21 @@ fn sentinel_suppress_prevents_divergence_messages() -> anyhow::Result<()> {
         undelivered.is_empty(),
         "no messages should exist when suppression is active"
     );
+
+    // Also verify that without suppression the message IS sent (sanity check)
+    let suppress_until = AtomicU64::new(0);
+    let sent = AgentExecutor::send_divergence_notice(
+        &store,
+        root_sid,
+        6,
+        "test-agent",
+        "diverging",
+        &suppress_until,
+        true,
+    );
+    assert!(sent, "without suppression, message should be sent");
+    let undelivered = store.fetch_undelivered_messages(root_sid)?;
+    assert_eq!(undelivered.len(), 1, "message should now exist");
 
     Ok(())
 }

--- a/autonoetic-gateway/tests/sentinel_suppression_integration.rs
+++ b/autonoetic-gateway/tests/sentinel_suppression_integration.rs
@@ -1,0 +1,252 @@
+//! Sentinel P2 Integration Tests:
+//! 1. `sentinel.suppress` accepts `reason` parameter and emits causal event
+//! 2. Diverging session produces `agent.message` to root planner
+//! 3. `sentinel.suppress(turns=3)` silences subsequent divergence messages
+
+mod support;
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::active_execution_registry::{
+    ActiveExecutionRegistry, NativeToolRunContext,
+};
+use autonoetic_gateway::runtime::guard::LoopGuardState;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::runtime::trajectory_monitor::TrajectoryMonitor;
+use autonoetic_gateway::scheduler::gateway_store::{AgentMessageRecord, GatewayStore};
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::config::TrajectoryConfig;
+
+fn test_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: autonoetic_types::agent::RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: autonoetic_types::agent::AgentIdentity {
+            id: "test-agent".to_string(),
+            name: "test".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn quiet_guard_state() -> LoopGuardState {
+    LoopGuardState {
+        max_loops_without_progress: 5,
+        max_tool_failures: 5,
+        max_consecutive_same_progress: 1,
+        max_child_failures: 3,
+        progress_budget_tools: HashMap::new(),
+        progress_budget_used: HashMap::new(),
+        current_loops: 0,
+        tool_failure_counts: HashMap::new(),
+        last_progress_fingerprint: None,
+        consecutive_progress_count: 0,
+        child_failure_count: 0,
+    }
+}
+
+fn drive_to_diverging(
+    mon: &mut TrajectoryMonitor,
+    state: &mut LoopGuardState,
+) -> autonoetic_gateway::runtime::trajectory_monitor::TickResult {
+    state.current_loops = 4;
+    let _ = mon.tick(4, &[], None, &state);
+    state.current_loops = 4;
+    state
+        .tool_failure_counts
+        .insert("sandbox.exec".into(), 4);
+    mon.tick(6, &[], None, &state)
+}
+
+// ── Test 1: sentinel.suppress accepts reason and emits causal event ──────────
+
+#[test]
+fn sentinel_suppress_accepts_reason_and_emits_causal_event() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let store = Arc::new(GatewayStore::open(tempdir.path())?);
+    let registry = default_registry();
+    let man = test_manifest();
+    let policy = PolicyEngine::new(man.clone());
+
+    let target = Arc::new(AtomicU64::new(0));
+    let exec_registry = ActiveExecutionRegistry::new();
+    let run_context = NativeToolRunContext {
+        registry: exec_registry,
+        root_session_id: "root-test-session".to_string(),
+        workflow_id: None,
+        task_id: None,
+        session_id: "test-session".to_string(),
+        agent_id: man.agent.id.clone(),
+        live_digest: None,
+        live_report: None,
+        user_id: None,
+        artifact_id: None,
+        sentinel_suppress_target: Some(target.clone()),
+    };
+
+    let args = r#"{"turns": 3, "reason": "Testing suppression"}"#;
+    let result = registry.execute(
+        "sentinel_suppress",
+        &man,
+        &policy,
+        Path::new("/tmp"),
+        None,
+        args,
+        Some("test-session"),
+        Some("turn-5"),
+        None,
+        Some(store.clone()),
+        Some(&run_context),
+    )?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&result)?;
+    assert!(parsed["ok"].as_bool().unwrap());
+    assert_eq!(parsed["reason"], serde_json::json!("Testing suppression"));
+    assert_eq!(parsed["suppressed_for_turns"], 3);
+    assert_eq!(parsed["suppress_until_turn"], 8);
+
+    // Verify causal event was emitted
+    let events = store.search_causal_events(Some("test-session"), Some("test-agent"), 100)?;
+    let suppress_event = events
+        .iter()
+        .find(|e| e.category == "sentinel" && e.action == "suppress_activated")
+        .expect("expected sentinel.suppress_activated causal event");
+    assert_eq!(
+        suppress_event.reason.as_deref(),
+        Some("Testing suppression")
+    );
+    assert_eq!(suppress_event.turn_id.as_deref(), Some("turn-5"));
+
+    Ok(())
+}
+
+// ── Test 2: diverging session sends agent.message to root planner ───────────
+
+#[test]
+fn diverging_session_sends_agent_message_to_root() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let store = Arc::new(GatewayStore::open(tempdir.path())?);
+    let mut mon = TrajectoryMonitor::new(TrajectoryConfig::default());
+    let mut state = quiet_guard_state();
+    let agent_id = "test-agent";
+    let root_sid = "root-session";
+
+    let r = drive_to_diverging(&mut mon, &mut state);
+    assert!(r.level_changed);
+    assert_eq!(r.health.level_str(), "diverging");
+    assert_eq!(r.health.causal_action(), Some("detected"));
+
+    // Simulate the lifecycle messaging logic (lifecycle.rs ~2383-2441)
+    let turn_counter = 6u64;
+    let now = chrono::Utc::now().to_rfc3339();
+    let level = r.health.level_str();
+    let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+    let message = format!(
+        "[Sentinel Notice]\n\
+         Level: {}\n\
+         Turn: {}\n\
+         Agent: {}\n\
+         The trajectory monitor has detected a divergence pattern. \
+         Review the causal chain for divergence.* events.",
+        level, turn_counter, agent_id,
+    );
+    let record = AgentMessageRecord {
+        message_id: msg_id.clone(),
+        sender_session_id: "gateway:sentinel".to_string(),
+        sender_agent_id: "gateway".to_string(),
+        target_pattern: format!("session:{}", root_sid),
+        message,
+        created_at: now,
+    };
+    store.save_agent_message(&record)?;
+    store.insert_message_delivery(&msg_id, root_sid)?;
+
+    // Verify message was saved and is undelivered
+    let undelivered = store.fetch_undelivered_messages(root_sid)?;
+    assert_eq!(undelivered.len(), 1);
+    assert_eq!(undelivered[0].sender_agent_id, "gateway");
+    assert!(undelivered[0].message.contains("[Sentinel Notice]"));
+    assert!(undelivered[0].message.contains("diverging"));
+    assert!(undelivered[0].message.contains(&turn_counter.to_string()));
+
+    Ok(())
+}
+
+// ── Test 3: suppression prevents divergence messages ────────────────────────
+
+#[test]
+fn sentinel_suppress_prevents_divergence_messages() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let store = Arc::new(GatewayStore::open(tempdir.path())?);
+    let mut mon = TrajectoryMonitor::new(TrajectoryConfig::default());
+    let mut state = quiet_guard_state();
+    let root_sid = "root-session";
+
+    // Suppress for 10 turns from turn 0 → suppress_until = 10
+    let suppress_until_turn = Arc::new(AtomicU64::new(10));
+
+    let r = drive_to_diverging(&mut mon, &mut state);
+    assert!(r.level_changed);
+    assert_eq!(r.health.level_str(), "diverging");
+
+    // Replicate the lifecycle suppression check (lifecycle.rs line 2387-2388)
+    let turn_counter = 6u64;
+    let suppressed = turn_counter < suppress_until_turn.load(Ordering::Relaxed);
+    assert!(
+        suppressed,
+        "turn {} should be suppressed when suppress_until=10",
+        turn_counter
+    );
+
+    // When suppressed, lifecycle skips the entire messaging block
+    if !suppressed {
+        let now = chrono::Utc::now().to_rfc3339();
+        let msg_id = format!("msg-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let record = AgentMessageRecord {
+            message_id: msg_id.clone(),
+            sender_session_id: "gateway:sentinel".to_string(),
+            sender_agent_id: "gateway".to_string(),
+            target_pattern: format!("session:{}", root_sid),
+            message: "should not appear".to_string(),
+            created_at: now,
+        };
+        store.save_agent_message(&record)?;
+        store.insert_message_delivery(&msg_id, root_sid)?;
+    }
+
+    // Verify no messages were saved
+    let undelivered = store.fetch_undelivered_messages(root_sid)?;
+    assert!(
+        undelivered.is_empty(),
+        "no messages should exist when suppression is active"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes remaining acceptance criteria from #241 (Sentinel P2):

1. **`reason` parameter** — `sentinel.suppress` now accepts an optional `reason: string` field, included in both the tool response and the causal event payload
2. **Causal-event logging** — suppression activation emits a `sentinel/suppress_activated` causal event with full metadata (suppressed_for_turns, suppress_until_turn, current_turn, max_allowed, reason)
3. **Integration tests** — 3 new tests covering the full gap scope:
   - Tool invocation with `reason` + causal event verification
   - Diverging session produces `agent.message` to root planner (replicating lifecycle messaging logic)
   - Suppression (`AtomicU64`) prevents divergence messages from being stored

## Changes

- `autonoetic-gateway/src/runtime/tools/sentinel.rs` — add `reason` field, emit causal event
- `autonoetic-gateway/tests/sentinel_suppression_integration.rs` — 3 new integration tests

## Verification

- All 3 new + 5 existing trajectory monitor tests pass
- No regressions in `approved_exec_cache_integration`, `promotion_record_e2e`, `approval_scope_targets_integration`
- Pre-existing `turn_continuation_approval_integration` failures confirmed unrelated