### PR TITLE
feat(sentinel): add reason param, suppression causal event, watchdog agent bundle, and CLI trigger (P2 gaps + P3)

### DIFF
--- a/agents/specialists/watchdog/SKILL.md
+++ b/agents/specialists/watchdog/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: "watchdog.default"
+description: "Observer agent that reviews agent sessions for trajectory divergence patterns."
+metadata:
+  autonoetic:
+    version: "1.0"
+    runtime:
+      engine: "autonoetic"
+      gateway_version: "0.1.0"
+      sdk_version: "0.1.0"
+      type: "stateful"
+      sandbox: "bubblewrap"
+      runtime_lock: "runtime.lock"
+    agent:
+      id: "watchdog.default"
+      name: "Watchdog"
+      description: "Observer that reviews agent sessions for trajectory divergence. Read-only — no execution capabilities."
+    llm_config:
+      provider: "openrouter"
+      model: "google/gemini-3-flash-preview"
+      temperature: 0.0
+    capabilities:
+      - type: "SandboxFunctions"
+        allowed: ["digest_", "execution_"]
+      - type: "AgentMessage"
+        patterns: ["*"]
+    execution_mode: "reasoning"
+    validation: "soft"
+    io:
+      accepts:
+        type: object
+        required: [target_session_id]
+        properties:
+          target_session_id:
+            type: string
+            description: "Session ID of the target session to review"
+      returns:
+        type: object
+        properties:
+          judgment:
+            type: string
+            description: "Assessment of trajectory health for the target session"
+---
+
+
+# Divergence Watchdog
+
+You are the divergence watchdog. You review agent sessions for trajectory divergence patterns.
+
+You are **observer-only** — you cannot execute code, make network requests, or modify state. Your job is to read and judge.
+
+## Tools
+
+- `digest_query` — Read the live digest and causal events of a session. Use this to understand what the agent did, what errors occurred, and whether patterns repeat.
+- `execution_search` — Search execution traces by tool name, success/failure, agent_id, and session_id. Use this to count failures, find repeated errors, and identify looping behavior.
+- `agent_message` — Send a judgment summary to the root planner (target agent). Use this to report findings.
+- `session_escalate` — Escalate to a human operator if you find critical divergence.
+
+## Workflow
+
+1. Start with `digest_query` on the target session to get an overview.
+2. If you find suspicious patterns, use `execution_search` to drill into specific tools or error types.
+3. Form a judgment:
+
+   - **Healthy**: The session shows normal progress. No divergence detected. Stay silent.
+   - **Watching**: Mild divergence signals (some loop pressure, occasional failures). Mention it briefly.
+   - **Diverging**: Clear divergence pattern: repeated failures, looping, context stall. Send a detailed `agent_message` to the root planner with concrete evidence.
+   - **Critical**: Severe divergence: many repeated failures, no progress, entropy collapse. Escalate immediately via `session_escalate` with urgency `high`.
+
+4. Your judgment must cite specific evidence: tool names, failure counts, fingerprint values, error types.

--- a/agents/specialists/watchdog/SKILL.md
+++ b/agents/specialists/watchdog/SKILL.md
@@ -20,8 +20,11 @@ metadata:
       model: "google/gemini-3-flash-preview"
       temperature: 0.0
     capabilities:
-      - type: "SandboxFunctions"
-        allowed: ["digest_", "execution_"]
+      # digest_query gates on ReadAccess (see knowledge.rs::DigestQueryTool).
+      # execution_search and session_escalate are always available (no
+      # capability required); listing them here would be a no-op.
+      - type: "ReadAccess"
+        scopes: ["*"]
       - type: "AgentMessage"
         patterns: ["*"]
     execution_mode: "reasoning"

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -2406,7 +2406,10 @@ impl AgentExecutor {
                                         );
                                     }
 
-                                    // Critical also escalates to the operator
+                                    // Critical also escalates to the operator via the
+                                    // user_interactions channel (per #241 spec — a
+                                    // non-blocking notification, not a gate). We also
+                                    // keep the causal event for durable audit.
                                     if matches!(result.health, TrajectoryHealth::Critical { .. }) {
                                         let notify_operator = cfg
                                             .map(|c| c.trajectory.notify_operator)
@@ -2424,6 +2427,60 @@ impl AgentExecutor {
                                                 })),
                                             ) {
                                                 tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to log operator_alert event");
+                                            }
+
+                                            if let Some(store) = self.gateway_store.as_ref() {
+                                                let root_sid = crate::runtime::content_store::root_session_id(&session_id).to_string();
+                                                let signals_summary = result
+                                                    .health
+                                                    .signals()
+                                                    .iter()
+                                                    .map(|s| {
+                                                        let kind = s.kind.as_str();
+                                                        match &s.evidence {
+                                                            Some(e) => format!("- {} ({}): {}", kind, s.severity.as_str(), e),
+                                                            None => format!("- {} ({})", kind, s.severity.as_str()),
+                                                        }
+                                                    })
+                                                    .collect::<Vec<_>>()
+                                                    .join("\n");
+                                                let interaction = autonoetic_types::background::UserInteraction {
+                                                    interaction_id: format!("ui-{}", &uuid::Uuid::new_v4().to_string()[..8]),
+                                                    session_id: session_id.clone(),
+                                                    root_session_id: root_sid,
+                                                    agent_id: self.manifest.agent.id.clone(),
+                                                    turn_id: format!("turn-{:06}", self.turn_counter),
+                                                    kind: autonoetic_types::background::UserInteractionKind::Decision,
+                                                    question: format!(
+                                                        "Critical trajectory divergence in agent '{}' at turn {}. Acknowledge?",
+                                                        self.manifest.agent.id, self.turn_counter
+                                                    ),
+                                                    context: Some(if signals_summary.is_empty() {
+                                                        "See divergence.* events in the causal chain for details.".to_string()
+                                                    } else {
+                                                        format!("Signals:\n{}\n\nSee divergence.* events in the causal chain for full payload.", signals_summary)
+                                                    }),
+                                                    options: vec![autonoetic_types::background::UserInteractionOption {
+                                                        id: "ack".to_string(),
+                                                        label: "Acknowledge".to_string(),
+                                                        value: "acknowledged".to_string(),
+                                                    }],
+                                                    allow_freeform: false,
+                                                    status: autonoetic_types::background::UserInteractionStatus::Pending,
+                                                    answer_option_id: None,
+                                                    answer_text: None,
+                                                    answered_by: None,
+                                                    created_at: chrono::Utc::now().to_rfc3339(),
+                                                    answered_at: None,
+                                                    expires_at: None,
+                                                    workflow_id: self.workflow_id.clone(),
+                                                    task_id: self.task_id.clone(),
+                                                    // No checkpoint — non-blocking notification.
+                                                    checkpoint_turn_id: None,
+                                                };
+                                                if let Err(e) = store.create_user_interaction(&interaction) {
+                                                    tracing::warn!(target: "autonoetic::trajectory", error = %e, "Failed to create critical_divergence user_interaction");
+                                                }
                                             }
                                         }
                                     }

--- a/autonoetic-gateway/tests/watchdog_capability_denial.rs
+++ b/autonoetic-gateway/tests/watchdog_capability_denial.rs
@@ -1,0 +1,141 @@
+//! Policy denial test for the watchdog agent (closes #242 acceptance bullet).
+//!
+//! Mirrors the capability set declared in `agents/specialists/watchdog/SKILL.md`
+//! and asserts:
+//!
+//! 1. The four tools the watchdog needs to do its job are exposed:
+//!    `digest_query`, `execution_search`, `agent_message`, `session_escalate`.
+//! 2. Privileged tools the watchdog must NOT have access to are denied:
+//!    `sandbox_exec`, `agent_spawn`, `agent_revision_create`,
+//!    `agent_revision_promote`.
+//!
+//! This pins the watchdog's "observer-only" contract: if a future capability
+//! change accidentally widened its surface, this test will fail.
+
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
+
+/// Construct a manifest that mirrors `agents/specialists/watchdog/SKILL.md`
+/// exactly — same capabilities, no more. Any change to the SKILL.md
+/// capability list should be reflected here, otherwise this test stops
+/// being a faithful pin of that file.
+fn watchdog_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: autonoetic_types::agent::RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: autonoetic_types::agent::AgentIdentity {
+            id: "watchdog.default".to_string(),
+            name: "Watchdog".to_string(),
+            description: "Observer that reviews agent sessions for trajectory divergence.".to_string(),
+        },
+        capabilities: vec![
+            // digest_query gates on ReadAccess. execution_search and
+            // session_escalate are always available (no capability gate).
+            Capability::ReadAccess {
+                scopes: vec!["*".to_string()],
+            },
+            Capability::AgentMessage {
+                patterns: vec!["*".to_string()],
+            },
+        ],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+#[test]
+fn watchdog_can_call_its_four_declared_tools() {
+    let registry = default_registry();
+    let manifest = watchdog_manifest();
+    let available: Vec<String> = registry
+        .available_definitions(&manifest)
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+
+    for required in [
+        "digest_query",
+        "execution_search",
+        "agent_message",
+        "session_escalate",
+    ] {
+        assert!(
+            available.iter().any(|n| n == required),
+            "watchdog manifest must expose '{}', but available tools are: {:?}",
+            required,
+            available
+        );
+    }
+}
+
+#[test]
+fn watchdog_cannot_call_privileged_tools() {
+    let registry = default_registry();
+    let manifest = watchdog_manifest();
+    let available: Vec<String> = registry
+        .available_definitions(&manifest)
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+
+    // These tools each gate on a capability the watchdog does NOT declare.
+    // If any of them appear in `available`, the watchdog has been
+    // accidentally promoted beyond its observer-only contract.
+    for forbidden in [
+        "sandbox_exec",      // SandboxFunctions { allowed: ["sandbox."] } or similar
+        "agent_spawn",       // AgentSpawn capability
+        "agent_revision_create", // AgentRevision capability
+        "agent_revision_promote", // AgentRevision capability
+    ] {
+        assert!(
+            !available.iter().any(|n| n == forbidden),
+            "watchdog manifest must NOT expose '{}', but available tools are: {:?}",
+            forbidden,
+            available
+        );
+    }
+}
+
+#[test]
+fn watchdog_exposed_set_does_not_include_arbitrary_sandbox_prefixes() {
+    // The watchdog's SandboxFunctions capability allows only "digest_" and
+    // "execution_". A tool whose name starts with neither must not be
+    // exposed via this capability. We check one representative tool
+    // ("sandbox_exec") that uses the SandboxFunctions capability but a
+    // different prefix — if it leaked through, the prefix-matching logic
+    // is broken (which would be a security-critical regression).
+    let registry = default_registry();
+    let manifest = watchdog_manifest();
+    let available: Vec<String> = registry
+        .available_definitions(&manifest)
+        .into_iter()
+        .map(|d| d.name)
+        .collect();
+    assert!(
+        !available.contains(&"sandbox_exec".to_string()),
+        "sandbox_exec should not match the 'digest_' or 'execution_' prefix \
+         allowed by the watchdog manifest. Available: {:?}",
+        available
+    );
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1834,9 +1834,13 @@ pub struct TrajectoryConfig {
     #[serde(default = "default_trajectory_notify_planner")]
     pub notify_planner: bool,
 
-    /// When `true` (default), the monitor emits an `operator_alert` causal
-    /// event on `Critical` level transitions (non-blocking, visible in the
-    /// causal chain for operator tooling).
+    /// When `true` (default), the monitor escalates to the operator on
+    /// `Critical` level transitions via two channels:
+    ///
+    /// 1. A non-blocking `user_interactions` row (operator can acknowledge
+    ///    via the chat TUI or REST API). The agent's turn is NOT suspended.
+    /// 2. An `operator_alert` causal event with the same payload, for
+    ///    durable audit-chain visibility.
     #[serde(default = "default_trajectory_notify_operator")]
     pub notify_operator: bool,
 

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -167,6 +167,8 @@ pub enum Commands {
     Eval(EvalArgs),
     /// Post-promotion review status
     Review(ReviewArgs),
+    /// Launch the divergence watchdog against a session
+    Watchdog(WatchdogArgs),
 }
 
 /// Arguments for the all-in-one `run` command.
@@ -1474,6 +1476,13 @@ pub enum ReviewCommands {
         #[arg(long)]
         json: bool,
     },
+}
+
+/// Launch the divergence watchdog against a session.
+#[derive(Args)]
+pub struct WatchdogArgs {
+    /// Target session ID to review.
+    pub session_id: String,
 }
 
 #[cfg(test)]

--- a/autonoetic/src/cli/mod.rs
+++ b/autonoetic/src/cli/mod.rs
@@ -9,3 +9,4 @@ pub mod recording;
 pub mod run;
 pub mod security;
 pub mod trace;
+pub mod watchdog;

--- a/autonoetic/src/cli/watchdog.rs
+++ b/autonoetic/src/cli/watchdog.rs
@@ -41,6 +41,13 @@ pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Re
         .context("watchdog.default is missing llm_config in SKILL.md")?;
     let driver = build_driver(llm_config, reqwest::Client::new())?;
 
+    // Surface the latest Layer 1 trajectory health snapshot to the watchdog
+    // so it does not re-derive what the deterministic monitor already computed.
+    // We look back for the most recent `divergence.*` causal event on the
+    // target session and include its level + signal evidence in the kickoff
+    // message. Falls back gracefully when no events are present.
+    let trajectory_snapshot = build_trajectory_snapshot_summary(&store, session_id);
+
     let mut runtime = AgentExecutor::new(
         manifest,
         instructions,
@@ -54,10 +61,14 @@ pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Re
         .with_config(gateway_config)
         .with_initial_user_message(format!(
             "Review session {} for trajectory divergence patterns.\n\
-             Use digest_query and execution_search to gather evidence, \
-             then produce a judgment. If you find critical divergence, \
-             escalate via session_escalate with high urgency.",
-            session_id
+             \n\
+             {}\n\
+             \n\
+             Use digest_query and execution_search to gather additional evidence \
+             if the snapshot above is missing or stale, then produce a judgment. \
+             If you find critical divergence, escalate via session_escalate with \
+             high urgency.",
+            session_id, trajectory_snapshot,
         ));
 
     let mut history = vec![
@@ -97,4 +108,78 @@ pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Re
     }
 
     Ok(())
+}
+
+/// Build a short, human-readable trajectory snapshot for the kickoff
+/// message. Pulls the most recent `divergence.*` causal event from the
+/// store and renders its level + signal evidence. Returns a fallback
+/// string when no events are found so the watchdog still has a stable
+/// kickoff structure.
+fn build_trajectory_snapshot_summary(
+    store: &Arc<GatewayStore>,
+    target_session_id: &str,
+) -> String {
+    match store.search_causal_events(Some(target_session_id), None, 200) {
+        Ok(events) => {
+            let latest = events
+                .iter()
+                .find(|e| e.category == "divergence");
+            match latest {
+                Some(event) => {
+                    let level = event
+                        .payload
+                        .as_ref()
+                        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                        .and_then(|v| v.get("level").and_then(|l| l.as_str()).map(|s| s.to_string()))
+                        .unwrap_or_else(|| event.action.clone());
+                    let evidence: Vec<String> = event
+                        .payload
+                        .as_ref()
+                        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                        .and_then(|v| {
+                            v.get("signals")
+                                .and_then(|s| s.as_array())
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|sig| {
+                                            let kind = sig.get("kind")?.as_str()?;
+                                            let severity = sig.get("severity")?.as_str()?;
+                                            let ev = sig
+                                                .get("evidence")
+                                                .and_then(|e| e.as_str())
+                                                .unwrap_or("");
+                                            Some(format!("  - {} ({}): {}", kind, severity, ev))
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
+                        })
+                        .unwrap_or_default();
+                    if evidence.is_empty() {
+                        format!(
+                            "Layer 1 snapshot (most recent divergence event at {}):\n  level = {}",
+                            event.timestamp, level
+                        )
+                    } else {
+                        format!(
+                            "Layer 1 snapshot (most recent divergence event at {}):\n  level = {}\n  signals:\n{}",
+                            event.timestamp,
+                            level,
+                            evidence.join("\n")
+                        )
+                    }
+                }
+                None => {
+                    "Layer 1 snapshot: no divergence.* events recorded for this session yet. \
+                     The deterministic monitor either has not flagged anything or has not run; \
+                     gather evidence from scratch."
+                        .to_string()
+                }
+            }
+        }
+        Err(e) => format!(
+            "Layer 1 snapshot: unavailable (causal-event query failed: {}). \
+             Proceed by gathering evidence from scratch.",
+            e
+        ),
+    }
 }

--- a/autonoetic/src/cli/watchdog.rs
+++ b/autonoetic/src/cli/watchdog.rs
@@ -1,0 +1,100 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context;
+use tracing::info;
+
+use autonoetic_gateway::llm::{build_driver, Message};
+use autonoetic_gateway::runtime::lifecycle::AgentExecutor;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::AgentRepository;
+
+/// Run the divergence watchdog against a target session.
+pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Result<()> {
+    info!(
+        target: "watchdog",
+        session_id = %session_id,
+        "Launching divergence watchdog"
+    );
+
+    let loaded_config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_config = Arc::new(loaded_config);
+
+    let gateway_dir = gateway_config.agents_dir.join(".gateway");
+    let store = Arc::new(
+        GatewayStore::open(&gateway_dir)
+            .context("Failed to open GatewayStore — is the gateway running and configured?")?,
+    );
+
+    let repo = AgentRepository::from_config(&gateway_config);
+    let loaded = repo
+        .get_sync("watchdog.default")
+        .context("Watchdog agent 'watchdog.default' not found — run with a config that points to the agents directory containing agents/specialists/watchdog/")?;
+    let manifest = loaded.manifest;
+    let instructions = loaded.instructions;
+    let agent_dir = loaded.dir;
+
+    let llm_config = manifest
+        .llm_config
+        .clone()
+        .context("watchdog.default is missing llm_config in SKILL.md")?;
+    let driver = build_driver(llm_config, reqwest::Client::new())?;
+
+    let mut runtime = AgentExecutor::new(
+        manifest,
+        instructions,
+        driver,
+        agent_dir,
+        default_registry(),
+        Some(store),
+    );
+    runtime = runtime
+        .with_gateway_dir(gateway_dir)
+        .with_config(gateway_config)
+        .with_initial_user_message(format!(
+            "Review session {} for trajectory divergence patterns.\n\
+             Use digest_query and execution_search to gather evidence, \
+             then produce a judgment. If you find critical divergence, \
+             escalate via session_escalate with high urgency.",
+            session_id
+        ));
+
+    let mut history = vec![
+        Message::system(runtime.instructions.clone()),
+        Message::user(runtime.initial_user_message.clone()),
+    ];
+
+    match runtime.execute_with_history(&mut history).await {
+        Ok(outcome) => match &outcome {
+            autonoetic_gateway::runtime::lifecycle::TurnOutcome::Completed(Some(reply)) => {
+                println!("{}", reply);
+            }
+            autonoetic_gateway::runtime::lifecycle::TurnOutcome::Completed(None) => {
+                println!("[Watchdog produced no judgment]");
+            }
+            autonoetic_gateway::runtime::lifecycle::TurnOutcome::Suspended {
+                approval_request_id,
+                ..
+            } => {
+                println!(
+                    "[Watchdog suspended for approval: {}]",
+                    approval_request_id
+                );
+            }
+            autonoetic_gateway::runtime::lifecycle::TurnOutcome::SuspendedUserInput {
+                interaction_id,
+            } => {
+                println!("[Watchdog waiting for input: {}]", interaction_id);
+            }
+            other => {
+                println!("[Watchdog interrupted: {:?}]", other);
+            }
+        },
+        Err(e) => {
+            eprintln!("Watchdog error: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -627,6 +627,9 @@ async fn main() -> anyhow::Result<()> {
                 cli::recording::handle_recording_cancel(&config_path, session_id)?;
             }
         },
+        Commands::Watchdog(args) => {
+            cli::watchdog::handle_watchdog(&config_path, &args.session_id).await?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

**P2 gaps** — sentinel.suppress hardening (2 commits already on branch):
- Add `reason: Option<String>` param to `sentinel.suppress`
- Emit `sentinel/suppress_activated` causal event with reason
- Extract `send_divergence_notice` shared helper in `AgentExecutor`
- Three integration tests for suppression flow

**P3 — Watchdog agent bundle + CLI trigger** (this commit):
- New `watchdog.default` agent bundle at `agents/specialists/watchdog/SKILL.md` — observer-only agent with `digest_query`, `execution_search`, `agent_message`, and `session_escalate` capabilities
- New `autonoetic watchdog <session-id>` CLI command — opens GatewayStore, loads watchdog agent, runs headless with target session_id in kickoff message, prints judgment
- Wiring: `Commands::Watchdog` variant in clap CLI

## Key design decisions
- Watchdog directly opens GatewayStore from gateway directory (no daemon needed, follows `agent run` CLI pattern)
- Uses `session_escalate` for operator escalation (not a hypothetical tool — always available)
- SandboxFunction allowed prefixes use underscore notation (`digest_`, `execution_`) matching native tool names
- Uses cheap/fast LLM (`google/gemini-3-flash-preview`, temp 0.0)

## Files changed
- `agents/specialists/watchdog/SKILL.md` — new watchdog agent bundle (70 lines)
- `autonoetic/src/cli/watchdog.rs` — new CLI handler (100 lines)
- `autonoetic/src/cli/common.rs` — `Watchdog(WatchdogArgs)` variant + struct
- `autonoetic/src/cli/mod.rs` — `pub mod watchdog;`
- `autonoetic/src/main.rs` — dispatch arm for `Commands::Watchdog`
- `autonoetic-gateway/src/runtime/lifecycle.rs` — shared messaging helper (P2 gaps)
- `autonoetic-gateway/src/runtime/tools/sentinel.rs` — reason param + causal event (P2 gaps)
- `autonoetic-gateway/tests/sentinel_suppression_integration.rs` — integration tests (P2 gaps)

## Next steps
- P4: auto-invoke watchdog via config flag in gateway lifecycle (gated behind experiment)