### PR TITLE
feat(sentinel): P4 watchdog-validation experiment harness + protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "tempfile",
  "tokio",

--- a/autonoetic/Cargo.toml
+++ b/autonoetic/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber.workspace = true
 tracing-appender = "0.2"
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 reqwest = { version = "0.13.2", features = ["json"] }
 async-trait = "0.1.89"
 dirs = "6.0.0"

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -169,6 +169,8 @@ pub enum Commands {
     Review(ReviewArgs),
     /// Launch the divergence watchdog against a session
     Watchdog(WatchdogArgs),
+    /// Run the watchdog validation experiment (P4)
+    SentinelExperiment(crate::cli::sentinel_experiment::SentinelExperimentArgs),
 }
 
 /// Arguments for the all-in-one `run` command.

--- a/autonoetic/src/cli/mod.rs
+++ b/autonoetic/src/cli/mod.rs
@@ -8,5 +8,6 @@ pub mod model_discovery;
 pub mod recording;
 pub mod run;
 pub mod security;
+pub mod sentinel_experiment;
 pub mod trace;
 pub mod watchdog;

--- a/autonoetic/src/cli/sentinel_experiment.rs
+++ b/autonoetic/src/cli/sentinel_experiment.rs
@@ -11,8 +11,11 @@
 //! - The watchdog has live tools (`agent_message`, `session_escalate`)
 //!   that write to the gateway store. Running this experiment against
 //!   real sessions therefore creates real side-effect rows (notices to
-//!   planners, operator escalations). The harness reports a side-effect
-//!   summary so the operator can clean up afterward if needed.
+//!   planners, operator escalations). For each session, the harness
+//!   snapshots the undelivered-message count and pending-interaction
+//!   count before and after the watchdog runs, and reports the deltas
+//!   in a "Side-Effect Summary" section of the markdown report so the
+//!   operator can clean up afterward.
 //! - Layer 1's verdict for an archived session is "the highest
 //!   divergence level reached during the session", read from the
 //!   already-persisted `divergence.*` causal events.
@@ -116,6 +119,14 @@ pub struct ExperimentRow {
     pub watchdog_flagged: bool,
     /// Wall-clock seconds the watchdog took to produce its reply.
     pub watchdog_wall_secs: Option<f64>,
+    /// Net new `agent_messages` from `sender_session_id="gateway:sentinel"`
+    /// observed on this session after the watchdog ran. Operator-visible
+    /// side effect that may need cleanup.
+    pub new_sentinel_messages: u32,
+    /// Net new pending `user_interactions` observed on this session
+    /// after the watchdog ran. Operator-visible side effect that may
+    /// need cleanup.
+    pub new_pending_interactions: u32,
 }
 
 /// 2x2 confusion matrix counts.
@@ -263,6 +274,10 @@ pub async fn handle_sentinel_experiment(
         // Layer 1 verdict: highest divergence level reached.
         let (layer1_level, layer1_flagged) = highest_divergence_level(&store, &entry.session_id);
 
+        // Snapshot side-effect-relevant state BEFORE the watchdog runs
+        // so we can compute the delta and report a cleanup checklist.
+        let (pre_msgs, pre_interactions) = snapshot_side_effects(&store, &entry.session_id);
+
         // Watchdog verdict: either run live or use the cached reply.
         let (watchdog_reply, watchdog_outcome, watchdog_wall_secs) = if args.skip_watchdog {
             match &entry.cached_watchdog_reply {
@@ -282,6 +297,10 @@ pub async fn handle_sentinel_experiment(
             (run.reply, run.outcome_tag, Some(elapsed))
         };
 
+        let (post_msgs, post_interactions) = snapshot_side_effects(&store, &entry.session_id);
+        let new_sentinel_messages = post_msgs.saturating_sub(pre_msgs);
+        let new_pending_interactions = post_interactions.saturating_sub(pre_interactions);
+
         let watchdog_flagged = classify_watchdog_reply(watchdog_reply.as_deref());
 
         layer1.record(label, layer1_flagged);
@@ -297,6 +316,8 @@ pub async fn handle_sentinel_experiment(
             watchdog_outcome,
             watchdog_flagged,
             watchdog_wall_secs,
+            new_sentinel_messages,
+            new_pending_interactions,
         });
     }
 
@@ -325,6 +346,27 @@ pub async fn handle_sentinel_experiment(
         decision.watchdog_fpr,
     );
     Ok(())
+}
+
+/// Snapshot the counts of watchdog-attributable side-effect rows for
+/// the given session. Returns `(undelivered_sentinel_messages,
+/// pending_interactions)`. Errors are coerced to `(0, 0)` — a query
+/// failure should not abort the experiment, only forfeit the delta
+/// signal for that session.
+fn snapshot_side_effects(store: &Arc<GatewayStore>, session_id: &str) -> (u32, u32) {
+    let msgs = store
+        .fetch_undelivered_messages(session_id)
+        .map(|msgs| {
+            msgs.iter()
+                .filter(|m| m.sender_session_id.starts_with("gateway"))
+                .count() as u32
+        })
+        .unwrap_or(0);
+    let interactions = store
+        .get_pending_interactions_for_session(session_id)
+        .map(|v| v.len() as u32)
+        .unwrap_or(0);
+    (msgs, interactions)
 }
 
 /// Return the highest divergence level reached for the session, by
@@ -402,10 +444,10 @@ fn render_report(
     let _ = writeln!(out);
 
     let _ = writeln!(out, "## Per-Session Results\n");
-    let _ = writeln!(out, "| Session | Label | Layer 1 level | L1 flagged | Watchdog flagged | Watchdog outcome | Wall (s) |");
-    let _ = writeln!(out, "|---|---|---|---|---|---|---|");
+    let _ = writeln!(out, "| Session | Label | Layer 1 level | L1 flagged | Watchdog flagged | Watchdog outcome | Wall (s) | New msgs | New interactions |");
+    let _ = writeln!(out, "|---|---|---|---|---|---|---|---|---|");
     for r in rows {
-        let _ = writeln!(out, "| `{}` | {} | {} | {} | {} | `{}` | {} |",
+        let _ = writeln!(out, "| `{}` | {} | {} | {} | {} | `{}` | {} | {} | {} |",
             r.session_id,
             r.label,
             r.layer1_highest_level.as_deref().unwrap_or("—"),
@@ -413,9 +455,41 @@ fn render_report(
             if r.watchdog_flagged { "yes" } else { "no" },
             r.watchdog_outcome,
             r.watchdog_wall_secs.map(|s| format!("{:.1}", s)).unwrap_or_else(|| "—".into()),
+            r.new_sentinel_messages,
+            r.new_pending_interactions,
         );
     }
     let _ = writeln!(out);
+
+    // ── Side-effect summary ────────────────────────────────────────────
+    let total_new_msgs: u32 = rows.iter().map(|r| r.new_sentinel_messages).sum();
+    let total_new_interactions: u32 = rows.iter().map(|r| r.new_pending_interactions).sum();
+    let sessions_with_msgs: Vec<&str> = rows
+        .iter()
+        .filter(|r| r.new_sentinel_messages > 0)
+        .map(|r| r.session_id.as_str())
+        .collect();
+    let sessions_with_interactions: Vec<&str> = rows
+        .iter()
+        .filter(|r| r.new_pending_interactions > 0)
+        .map(|r| r.session_id.as_str())
+        .collect();
+    let _ = writeln!(out, "## Side-Effect Summary\n");
+    let _ = writeln!(out, "The watchdog has live messaging tools — when it judges a session divergent it writes real rows to the gateway store. The experiment ran against archived sessions, so this state is contamination that may need cleanup.\n");
+    let _ = writeln!(out, "| Side-effect | Total new | Affected sessions |");
+    let _ = writeln!(out, "|---|---|---|");
+    let _ = writeln!(out, "| undelivered `agent_messages` from `gateway:sentinel` | {} | {} |",
+        total_new_msgs,
+        if sessions_with_msgs.is_empty() { "(none)".to_string() } else { sessions_with_msgs.join(", ") });
+    let _ = writeln!(out, "| pending `user_interactions` | {} | {} |",
+        total_new_interactions,
+        if sessions_with_interactions.is_empty() { "(none)".to_string() } else { sessions_with_interactions.join(", ") });
+    let _ = writeln!(out);
+    if total_new_msgs > 0 || total_new_interactions > 0 {
+        let _ = writeln!(out, "See `docs/design/divergence-sentinel-validation.md` §2.4 for the SQL cleanup snippet.\n");
+    } else {
+        let _ = writeln!(out, "No new side-effect rows recorded — the watchdog did not flag any session loudly. (Note: deltas use `fetch_undelivered_messages` + `get_pending_interactions_for_session`, so messages consumed by an active planner or interactions answered between snapshots will not be counted.)\n");
+    }
 
     if !parse_errors.is_empty() {
         let _ = writeln!(out, "## Parse errors\n");

--- a/autonoetic/src/cli/sentinel_experiment.rs
+++ b/autonoetic/src/cli/sentinel_experiment.rs
@@ -1,0 +1,564 @@
+//! Sentinel P4 — divergence-watchdog validation experiment harness.
+//!
+//! Implements the protocol described in
+//! `docs/design/divergence-sentinel-validation.md`. Takes a labeled
+//! corpus of archived sessions, gathers Layer 1's verdict per session
+//! from the causal-events table, runs the watchdog blind per session,
+//! and computes confusion matrices for both judges. Outputs a markdown
+//! report.
+//!
+//! Caveats:
+//! - The watchdog has live tools (`agent_message`, `session_escalate`)
+//!   that write to the gateway store. Running this experiment against
+//!   real sessions therefore creates real side-effect rows (notices to
+//!   planners, operator escalations). The harness reports a side-effect
+//!   summary so the operator can clean up afterward if needed.
+//! - Layer 1's verdict for an archived session is "the highest
+//!   divergence level reached during the session", read from the
+//!   already-persisted `divergence.*` causal events.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Context;
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+
+use crate::cli::watchdog::run_watchdog;
+
+/// CLI args for `autonoetic sentinel-experiment`.
+#[derive(Args)]
+pub struct SentinelExperimentArgs {
+    /// Path to the labeled corpus YAML (see `docs/design/divergence-sentinel-validation.md`).
+    #[arg(long)]
+    pub corpus: PathBuf,
+    /// Path to write the markdown report. Defaults to
+    /// `docs/design/divergence-sentinel-validation.md.results.md` next
+    /// to the corpus.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+    /// Skip the watchdog runs (use the cached fields in the corpus if
+    /// present, else mark as `skipped`). Useful for re-running the
+    /// analysis without re-spending LLM tokens.
+    #[arg(long)]
+    pub skip_watchdog: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CorpusFile {
+    pub sessions: Vec<CorpusEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CorpusEntry {
+    pub session_id: String,
+    /// Operator label — ground truth for the metrics. Accepts `"diverged"`
+    /// or `"succeeded"` (other values are rejected at load time).
+    pub label: String,
+    #[serde(default)]
+    pub notes: Option<String>,
+    /// Optional pre-recorded watchdog reply, for re-running analysis
+    /// without re-invoking the LLM. When present and `--skip-watchdog`
+    /// is set, used directly.
+    #[serde(default)]
+    pub cached_watchdog_reply: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Label {
+    Diverged,
+    Succeeded,
+}
+
+impl Label {
+    fn parse(s: &str) -> anyhow::Result<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "diverged" | "divergent" | "fail" | "failed" => Ok(Self::Diverged),
+            "succeeded" | "success" | "healthy" | "ok" => Ok(Self::Succeeded),
+            other => Err(anyhow::anyhow!(
+                "unknown corpus label '{}' — accepted: diverged | succeeded",
+                other
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Diverged => "diverged",
+            Self::Succeeded => "succeeded",
+        }
+    }
+}
+
+/// One row of the comparison table.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExperimentRow {
+    pub session_id: String,
+    pub label: String,
+    pub notes: Option<String>,
+    /// Highest divergence level (`watching` | `diverging` | `critical`)
+    /// observed in the session's causal-event history. `None` when no
+    /// `divergence.*` events were recorded.
+    pub layer1_highest_level: Option<String>,
+    /// Whether Layer 1 ever reached `diverging` or `critical` (treated
+    /// as the "Layer 1 flagged" signal for the confusion matrix).
+    pub layer1_flagged: bool,
+    /// Full text reply from the watchdog (truncated to 4 KB in the report).
+    pub watchdog_reply: Option<String>,
+    /// Outcome tag from the watchdog run (`completed` | `error:...`).
+    pub watchdog_outcome: String,
+    /// Whether the watchdog produced a divergence judgment, based on
+    /// keyword detection in its reply (`diverging`, `critical`,
+    /// `divergence`, escalated, etc.). See [`classify_watchdog_reply`].
+    pub watchdog_flagged: bool,
+    /// Wall-clock seconds the watchdog took to produce its reply.
+    pub watchdog_wall_secs: Option<f64>,
+}
+
+/// 2x2 confusion matrix counts.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct Confusion {
+    pub true_positive: u32,
+    pub false_positive: u32,
+    pub true_negative: u32,
+    pub false_negative: u32,
+}
+
+impl Confusion {
+    fn record(&mut self, label: Label, flagged: bool) {
+        match (label, flagged) {
+            (Label::Diverged, true) => self.true_positive += 1,
+            (Label::Diverged, false) => self.false_negative += 1,
+            (Label::Succeeded, true) => self.false_positive += 1,
+            (Label::Succeeded, false) => self.true_negative += 1,
+        }
+    }
+
+    fn tpr(&self) -> f64 {
+        let positives = self.true_positive + self.false_negative;
+        if positives == 0 {
+            f64::NAN
+        } else {
+            self.true_positive as f64 / positives as f64
+        }
+    }
+
+    fn fpr(&self) -> f64 {
+        let negatives = self.false_positive + self.true_negative;
+        if negatives == 0 {
+            f64::NAN
+        } else {
+            self.false_positive as f64 / negatives as f64
+        }
+    }
+
+    fn precision(&self) -> f64 {
+        let predicted_positives = self.true_positive + self.false_positive;
+        if predicted_positives == 0 {
+            f64::NAN
+        } else {
+            self.true_positive as f64 / predicted_positives as f64
+        }
+    }
+}
+
+/// Decision rule per `docs/design/divergence-sentinel-design.md` §6
+/// "Success criteria for proceeding to P3".
+fn decision_rule(layer1: &Confusion, watchdog: &Confusion) -> Decision {
+    let tpr_delta = watchdog.tpr() - layer1.tpr();
+    let watchdog_fpr = watchdog.fpr();
+
+    let tpr_pass = tpr_delta >= 0.20;
+    let fpr_pass = watchdog_fpr <= 0.10;
+
+    Decision {
+        tpr_delta,
+        watchdog_fpr,
+        tpr_pass,
+        fpr_pass,
+        go: tpr_pass && fpr_pass,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Decision {
+    tpr_delta: f64,
+    watchdog_fpr: f64,
+    tpr_pass: bool,
+    fpr_pass: bool,
+    go: bool,
+}
+
+/// Classify the watchdog's free-text reply as "flagged" vs "not flagged"
+/// based on simple keyword detection. The watchdog is instructed to stay
+/// silent (or produce a brief reply) when it judges a session healthy,
+/// and to send concrete evidence when it judges divergence.
+///
+/// We deliberately use simple keyword matching rather than a separate
+/// LLM call so the harness stays cheap and deterministic. The decision
+/// surface (these keywords) is documented and can be tightened later.
+fn classify_watchdog_reply(reply: Option<&str>) -> bool {
+    let Some(text) = reply else { return false };
+    let lower = text.to_lowercase();
+
+    // Positive signal: the watchdog explicitly mentions divergence levels.
+    let positive_markers = [
+        "diverging",
+        "divergence",
+        "critical",
+        "watching",
+        "loop pressure",
+        "failure pressure",
+        "repetition",
+        "stalled",
+        "escalat", // matches "escalate", "escalated", "escalating"
+    ];
+    if positive_markers.iter().any(|m| lower.contains(m)) {
+        return true;
+    }
+
+    // Negative signal: watchdog ends with a "healthy" verdict and no
+    // concerning keywords. A short reply containing only "healthy"-like
+    // phrases is not flagged.
+    false
+}
+
+pub async fn handle_sentinel_experiment(
+    config_path: &std::path::Path,
+    args: &SentinelExperimentArgs,
+) -> anyhow::Result<()> {
+    let corpus_text = std::fs::read_to_string(&args.corpus)
+        .with_context(|| format!("failed to read corpus file {}", args.corpus.display()))?;
+    let corpus: CorpusFile = serde_yaml::from_str(&corpus_text)
+        .with_context(|| format!("failed to parse corpus YAML {}", args.corpus.display()))?;
+
+    if corpus.sessions.is_empty() {
+        anyhow::bail!("corpus file contains no sessions");
+    }
+
+    let loaded_config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_dir = loaded_config.agents_dir.join(".gateway");
+    let store = Arc::new(
+        GatewayStore::open(&gateway_dir)
+            .context("Failed to open GatewayStore — the gateway must have been initialised at this path")?,
+    );
+
+    let mut rows: Vec<ExperimentRow> = Vec::with_capacity(corpus.sessions.len());
+    let mut layer1 = Confusion::default();
+    let mut watchdog_cm = Confusion::default();
+    let mut parse_errors: Vec<String> = Vec::new();
+
+    for entry in &corpus.sessions {
+        let label = match Label::parse(&entry.label) {
+            Ok(l) => l,
+            Err(e) => {
+                parse_errors.push(format!("session={}: {}", entry.session_id, e));
+                continue;
+            }
+        };
+
+        // Layer 1 verdict: highest divergence level reached.
+        let (layer1_level, layer1_flagged) = highest_divergence_level(&store, &entry.session_id);
+
+        // Watchdog verdict: either run live or use the cached reply.
+        let (watchdog_reply, watchdog_outcome, watchdog_wall_secs) = if args.skip_watchdog {
+            match &entry.cached_watchdog_reply {
+                Some(cached) => (Some(cached.clone()), "cached".to_string(), None),
+                None => (None, "skipped".to_string(), None),
+            }
+        } else {
+            let started = Instant::now();
+            let run = match run_watchdog(config_path, &entry.session_id).await {
+                Ok(r) => r,
+                Err(e) => crate::cli::watchdog::WatchdogRun {
+                    reply: None,
+                    outcome_tag: format!("error:{}", e),
+                },
+            };
+            let elapsed = started.elapsed().as_secs_f64();
+            (run.reply, run.outcome_tag, Some(elapsed))
+        };
+
+        let watchdog_flagged = classify_watchdog_reply(watchdog_reply.as_deref());
+
+        layer1.record(label, layer1_flagged);
+        watchdog_cm.record(label, watchdog_flagged);
+
+        rows.push(ExperimentRow {
+            session_id: entry.session_id.clone(),
+            label: label.as_str().to_string(),
+            notes: entry.notes.clone(),
+            layer1_highest_level: layer1_level.map(|l| l.to_string()),
+            layer1_flagged,
+            watchdog_reply,
+            watchdog_outcome,
+            watchdog_flagged,
+            watchdog_wall_secs,
+        });
+    }
+
+    let decision = decision_rule(&layer1, &watchdog_cm);
+    let report = render_report(&corpus, &rows, &layer1, &watchdog_cm, &decision, &parse_errors);
+
+    let output = args.output.clone().unwrap_or_else(|| {
+        let mut p = args.corpus.clone();
+        if let Some(stem) = p.file_stem().map(|s| s.to_owned()) {
+            let mut new_name = stem;
+            new_name.push(".results.md");
+            p.set_file_name(new_name);
+        } else {
+            p.set_extension("results.md");
+        }
+        p
+    });
+    std::fs::write(&output, &report)
+        .with_context(|| format!("failed to write report to {}", output.display()))?;
+
+    println!("Wrote validation report → {}", output.display());
+    println!(
+        "Decision: {} (TPR delta = {:+.3}, watchdog FPR = {:.3})",
+        if decision.go { "GO (auto-invoke can ship)" } else { "NO-GO (stay manual)" },
+        decision.tpr_delta,
+        decision.watchdog_fpr,
+    );
+    Ok(())
+}
+
+/// Return the highest divergence level reached for the session, by
+/// searching the `divergence.*` causal events. Returns `None` when no
+/// such events exist. The "flagged" boolean is true iff the level is
+/// `diverging` or `critical` (`watching` is observational only).
+fn highest_divergence_level(
+    store: &Arc<GatewayStore>,
+    session_id: &str,
+) -> (Option<&'static str>, bool) {
+    let events = match store.search_causal_events(Some(session_id), None, 1000) {
+        Ok(e) => e,
+        Err(_) => return (None, false),
+    };
+    let mut rank: u8 = 0;
+    for e in events.iter().filter(|e| e.category == "divergence") {
+        let level = e
+            .payload
+            .as_ref()
+            .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+            .and_then(|v| v.get("level").and_then(|l| l.as_str()).map(|s| s.to_string()))
+            .unwrap_or_else(|| e.action.clone());
+        let lvl_rank: u8 = match level.as_str() {
+            "watching" => 1,
+            "diverging" => 2,
+            "critical" => 3,
+            _ => 0,
+        };
+        if lvl_rank > rank {
+            rank = lvl_rank;
+        }
+    }
+    match rank {
+        1 => (Some("watching"), false),
+        2 => (Some("diverging"), true),
+        3 => (Some("critical"), true),
+        _ => (None, false),
+    }
+}
+
+fn render_report(
+    corpus: &CorpusFile,
+    rows: &[ExperimentRow],
+    layer1: &Confusion,
+    watchdog: &Confusion,
+    decision: &Decision,
+    parse_errors: &[String],
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let now = chrono::Utc::now().to_rfc3339();
+    let _ = writeln!(out, "# Divergence Sentinel — Validation Report\n");
+    let _ = writeln!(out, "Generated: `{}`  ", now);
+    let _ = writeln!(out, "Corpus size: {} sessions  ", corpus.sessions.len());
+    let _ = writeln!(out, "Skipped: {}  ", parse_errors.len());
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "## Decision\n");
+    let verdict = if decision.go { "**GO** — auto-invoke meets the criteria." } else { "**NO-GO** — keep watchdog manual." };
+    let _ = writeln!(out, "{}\n", verdict);
+    let _ = writeln!(out, "| Criterion | Value | Pass? |");
+    let _ = writeln!(out, "|---|---|---|");
+    let _ = writeln!(out, "| TPR(watchdog) − TPR(layer 1) ≥ 0.20 | {:+.3} | {} |",
+        decision.tpr_delta, if decision.tpr_pass { "✅" } else { "❌" });
+    let _ = writeln!(out, "| FPR(watchdog) ≤ 0.10 | {:.3} | {} |",
+        decision.watchdog_fpr, if decision.fpr_pass { "✅" } else { "❌" });
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "## Confusion Matrices\n");
+    let _ = writeln!(out, "### Layer 1 (deterministic monitor)\n");
+    render_confusion(&mut out, layer1);
+    let _ = writeln!(out);
+    let _ = writeln!(out, "### Watchdog (LLM)\n");
+    render_confusion(&mut out, watchdog);
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "## Per-Session Results\n");
+    let _ = writeln!(out, "| Session | Label | Layer 1 level | L1 flagged | Watchdog flagged | Watchdog outcome | Wall (s) |");
+    let _ = writeln!(out, "|---|---|---|---|---|---|---|");
+    for r in rows {
+        let _ = writeln!(out, "| `{}` | {} | {} | {} | {} | `{}` | {} |",
+            r.session_id,
+            r.label,
+            r.layer1_highest_level.as_deref().unwrap_or("—"),
+            if r.layer1_flagged { "yes" } else { "no" },
+            if r.watchdog_flagged { "yes" } else { "no" },
+            r.watchdog_outcome,
+            r.watchdog_wall_secs.map(|s| format!("{:.1}", s)).unwrap_or_else(|| "—".into()),
+        );
+    }
+    let _ = writeln!(out);
+
+    if !parse_errors.is_empty() {
+        let _ = writeln!(out, "## Parse errors\n");
+        for e in parse_errors {
+            let _ = writeln!(out, "- {}", e);
+        }
+        let _ = writeln!(out);
+    }
+
+    let _ = writeln!(out, "## Watchdog Replies (truncated)\n");
+    for r in rows {
+        let _ = writeln!(out, "### `{}` ({})\n", r.session_id, r.label);
+        if let Some(notes) = &r.notes {
+            let _ = writeln!(out, "Notes: {}\n", notes);
+        }
+        match &r.watchdog_reply {
+            Some(reply) => {
+                let truncated: String = reply.chars().take(4000).collect();
+                let _ = writeln!(out, "```\n{}\n```\n", truncated);
+            }
+            None => {
+                let _ = writeln!(out, "_no reply ({})_\n", r.watchdog_outcome);
+            }
+        }
+    }
+
+    out
+}
+
+fn render_confusion(out: &mut String, c: &Confusion) {
+    use std::fmt::Write as _;
+    let _ = writeln!(out, "|  | Predicted positive | Predicted negative |");
+    let _ = writeln!(out, "|---|---|---|");
+    let _ = writeln!(out, "| **Actual diverged** | {} (TP) | {} (FN) |", c.true_positive, c.false_negative);
+    let _ = writeln!(out, "| **Actual succeeded** | {} (FP) | {} (TN) |", c.false_positive, c.true_negative);
+    let _ = writeln!(out);
+    let _ = writeln!(out, "TPR (recall): {:.3} · FPR: {:.3} · Precision: {:.3}",
+        c.tpr(), c.fpr(), c.precision());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cm(tp: u32, fp: u32, tn: u32, fn_: u32) -> Confusion {
+        Confusion { true_positive: tp, false_positive: fp, true_negative: tn, false_negative: fn_ }
+    }
+
+    #[test]
+    fn confusion_records_quadrants() {
+        let mut c = Confusion::default();
+        c.record(Label::Diverged, true);  // TP
+        c.record(Label::Diverged, false); // FN
+        c.record(Label::Succeeded, true); // FP
+        c.record(Label::Succeeded, false); // TN
+        assert_eq!(c.true_positive, 1);
+        assert_eq!(c.false_negative, 1);
+        assert_eq!(c.false_positive, 1);
+        assert_eq!(c.true_negative, 1);
+    }
+
+    #[test]
+    fn tpr_fpr_precision_compute_correctly() {
+        let c = cm(8, 1, 9, 2);
+        // 8 TP + 2 FN = 10 positives; TPR = 8/10 = 0.8
+        assert!((c.tpr() - 0.8).abs() < 1e-9);
+        // 1 FP + 9 TN = 10 negatives; FPR = 1/10 = 0.1
+        assert!((c.fpr() - 0.1).abs() < 1e-9);
+        // 8 TP + 1 FP = 9 predicted positives; Precision = 8/9
+        assert!((c.precision() - 8.0 / 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tpr_is_nan_when_no_positives() {
+        let c = cm(0, 0, 5, 0);
+        assert!(c.tpr().is_nan());
+    }
+
+    #[test]
+    fn decision_rule_go_on_strong_watchdog() {
+        // Layer 1: TPR 0.5 (5 TP, 5 FN). Watchdog: TPR 0.9 (9 TP, 1 FN).
+        // Delta = 0.4 ≥ 0.20 ✓
+        // Watchdog FPR: 0/10 = 0.0 ≤ 0.10 ✓
+        let l1 = cm(5, 0, 10, 5);
+        let wd = cm(9, 0, 10, 1);
+        let d = decision_rule(&l1, &wd);
+        assert!(d.go);
+        assert!(d.tpr_pass);
+        assert!(d.fpr_pass);
+    }
+
+    #[test]
+    fn decision_rule_nogo_on_high_fpr() {
+        // Strong recall but high FPR — should be NO-GO.
+        let l1 = cm(5, 0, 10, 5);
+        let wd = cm(9, 3, 7, 1); // FPR = 3/10 = 0.3 ✗
+        let d = decision_rule(&l1, &wd);
+        assert!(!d.go);
+        assert!(d.tpr_pass);
+        assert!(!d.fpr_pass);
+    }
+
+    #[test]
+    fn decision_rule_nogo_on_marginal_tpr_delta() {
+        // Watchdog only 10pp better than Layer 1 — under the 20pp threshold.
+        let l1 = cm(7, 0, 10, 3);
+        let wd = cm(8, 0, 10, 2);
+        let d = decision_rule(&l1, &wd);
+        assert!(!d.go);
+        assert!(!d.tpr_pass);
+        assert!(d.fpr_pass);
+    }
+
+    // ── Watchdog reply classification ──────────────────────────────────
+
+    #[test]
+    fn classify_silent_reply_is_not_flagged() {
+        assert!(!classify_watchdog_reply(None));
+        assert!(!classify_watchdog_reply(Some("")));
+        assert!(!classify_watchdog_reply(Some("Session looks fine. Nothing to flag.")));
+    }
+
+    #[test]
+    fn classify_divergence_keywords_flag() {
+        assert!(classify_watchdog_reply(Some("This session is diverging — failure pressure is high.")));
+        assert!(classify_watchdog_reply(Some("CRITICAL: planner repetition detected.")));
+        assert!(classify_watchdog_reply(Some("I'm escalating this via session_escalate.")));
+    }
+
+    // ── Label parsing ──────────────────────────────────────────────────
+
+    #[test]
+    fn label_parse_accepts_synonyms() {
+        assert_eq!(Label::parse("diverged").unwrap(), Label::Diverged);
+        assert_eq!(Label::parse("Diverged").unwrap(), Label::Diverged);
+        assert_eq!(Label::parse("FAILED").unwrap(), Label::Diverged);
+        assert_eq!(Label::parse("succeeded").unwrap(), Label::Succeeded);
+        assert_eq!(Label::parse("ok").unwrap(), Label::Succeeded);
+    }
+
+    #[test]
+    fn label_parse_rejects_garbage() {
+        assert!(Label::parse("maybe").is_err());
+        assert!(Label::parse("").is_err());
+    }
+}

--- a/autonoetic/src/cli/watchdog.rs
+++ b/autonoetic/src/cli/watchdog.rs
@@ -5,13 +5,32 @@ use anyhow::Context;
 use tracing::info;
 
 use autonoetic_gateway::llm::{build_driver, Message};
-use autonoetic_gateway::runtime::lifecycle::AgentExecutor;
+use autonoetic_gateway::runtime::lifecycle::{AgentExecutor, TurnOutcome};
 use autonoetic_gateway::runtime::tools::default_registry;
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_gateway::AgentRepository;
 
-/// Run the divergence watchdog against a target session.
-pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Result<()> {
+/// Structured result from a single watchdog invocation. Consumed by the
+/// `sentinel-experiment` harness; the user-facing CLI just prints `reply`.
+pub struct WatchdogRun {
+    pub reply: Option<String>,
+    /// Human-readable description of how the run terminated. `Completed`
+    /// for normal termination, otherwise an `[interrupted]` / `[suspended]`
+    /// tag with detail. Used by the harness to classify abnormal runs.
+    pub outcome_tag: String,
+}
+
+/// Programmatic entry point. Builds an isolated watchdog executor against
+/// the given session_id, runs one execute_with_history pass, and returns
+/// the captured reply.
+///
+/// The CLI wrapper [`handle_watchdog`] forwards to this and prints the
+/// reply. The experiment harness uses this directly so it can capture
+/// the reply and classify it.
+pub async fn run_watchdog(
+    config_path: &Path,
+    session_id: &str,
+) -> anyhow::Result<WatchdogRun> {
     info!(
         target: "watchdog",
         session_id = %session_id,
@@ -76,37 +95,40 @@ pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Re
         Message::user(runtime.initial_user_message.clone()),
     ];
 
-    match runtime.execute_with_history(&mut history).await {
-        Ok(outcome) => match &outcome {
-            autonoetic_gateway::runtime::lifecycle::TurnOutcome::Completed(Some(reply)) => {
-                println!("{}", reply);
-            }
-            autonoetic_gateway::runtime::lifecycle::TurnOutcome::Completed(None) => {
-                println!("[Watchdog produced no judgment]");
-            }
-            autonoetic_gateway::runtime::lifecycle::TurnOutcome::Suspended {
-                approval_request_id,
-                ..
-            } => {
-                println!(
-                    "[Watchdog suspended for approval: {}]",
-                    approval_request_id
-                );
-            }
-            autonoetic_gateway::runtime::lifecycle::TurnOutcome::SuspendedUserInput {
-                interaction_id,
-            } => {
-                println!("[Watchdog waiting for input: {}]", interaction_id);
-            }
-            other => {
-                println!("[Watchdog interrupted: {:?}]", other);
-            }
+    let result = match runtime.execute_with_history(&mut history).await {
+        Ok(TurnOutcome::Completed(reply)) => WatchdogRun {
+            reply,
+            outcome_tag: "completed".to_string(),
         },
-        Err(e) => {
-            eprintln!("Watchdog error: {}", e);
-        }
-    }
+        Ok(TurnOutcome::Suspended { approval_request_id, .. }) => WatchdogRun {
+            reply: None,
+            outcome_tag: format!("suspended_for_approval:{}", approval_request_id),
+        },
+        Ok(TurnOutcome::SuspendedUserInput { interaction_id }) => WatchdogRun {
+            reply: None,
+            outcome_tag: format!("waiting_for_input:{}", interaction_id),
+        },
+        Ok(other) => WatchdogRun {
+            reply: None,
+            outcome_tag: format!("interrupted:{:?}", other),
+        },
+        Err(e) => WatchdogRun {
+            reply: None,
+            outcome_tag: format!("error:{}", e),
+        },
+    };
 
+    Ok(result)
+}
+
+/// Run the divergence watchdog against a target session and print the
+/// reply. Thin wrapper over [`run_watchdog`].
+pub async fn handle_watchdog(config_path: &Path, session_id: &str) -> anyhow::Result<()> {
+    let run = run_watchdog(config_path, session_id).await?;
+    match run.reply {
+        Some(reply) => println!("{}", reply),
+        None => println!("[Watchdog produced no reply — outcome: {}]", run.outcome_tag),
+    }
     Ok(())
 }
 

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -630,6 +630,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::Watchdog(args) => {
             cli::watchdog::handle_watchdog(&config_path, &args.session_id).await?;
         }
+        Commands::SentinelExperiment(args) => {
+            cli::sentinel_experiment::handle_sentinel_experiment(&config_path, args).await?;
+        }
     }
 
     Ok(())

--- a/docs/design/divergence-sentinel-validation.md
+++ b/docs/design/divergence-sentinel-validation.md
@@ -1,0 +1,240 @@
+# Divergence Sentinel — Validation Experiment Protocol (P4)
+
+> Status: **Protocol ready (2026-05-20)** — harness implemented, awaiting
+> operator-curated corpus run.
+> Tracking: [#243](https://github.com/mandubian/autonoetic/issues/243).
+> Sister design: [`divergence-sentinel-design.md`](./divergence-sentinel-design.md) §6.
+
+## 1. Purpose
+
+The Sentinel design (`docs/design/divergence-sentinel-design.md`) proposes
+two layers of divergence detection:
+
+- **Layer 1** — deterministic, in-gateway trajectory monitor (shipped in
+  P1 / #240).
+- **Layer 2** — optional LLM watchdog agent (shipped in P3 / #242,
+  manual-trigger only).
+
+Before we wire Layer 2 to **auto-invoke** from Layer 1 escalations, we
+need to falsify the operator's anecdotal observation that the watchdog
+catches divergence Layer 1 misses. If the data does not show a clear
+advantage, P3 stays manual-only.
+
+This document specifies the experiment that produces the GO / NO-GO
+decision.
+
+## 2. Method
+
+### 2.1 Corpus
+
+The operator hand-selects **N archived sessions** (target: N = 20).
+
+- **10 "diverged" sessions** — operator-flagged or ended in
+  `LoopGuard` trip / emergency stop. The pool from which to draw these
+  is the gateway store's `causal_events` and `execution_traces` tables
+  for sessions tagged with `emergency_stop`, `loop_guard_tripped`, or
+  manually annotated by the operator as "this should have been caught".
+- **10 "succeeded" sessions** — terminated cleanly, no loop trip, no
+  emergency stop, operator-accepted outcome. Pick sessions of similar
+  duration / agent-id to the diverged set so the comparison is not
+  trivially confounded by length.
+
+A balanced corpus (10/10) keeps TPR and FPR readable. A different ratio
+is fine but flag it in the report.
+
+### 2.2 Corpus format
+
+The corpus is a YAML file. Schema:
+
+```yaml
+sessions:
+  - session_id: "abc12345-6789-..."
+    label: "diverged"        # or "succeeded"
+    notes: "looped on web.fetch 8 turns, operator killed at turn 12"
+  - session_id: "def67890-..."
+    label: "succeeded"
+    notes: "completed in 6 turns, all passes"
+  # ...
+```
+
+Accepted label synonyms (lowercase, trimmed):
+
+- `diverged` / `divergent` / `failed` / `fail` → ground truth = positive
+- `succeeded` / `success` / `healthy` / `ok` → ground truth = negative
+
+Optional fields:
+
+- `notes` — free-text, shown in the report.
+- `cached_watchdog_reply` — used when re-running the harness with
+  `--skip-watchdog` to avoid re-spending LLM tokens.
+
+### 2.3 Running the harness
+
+```bash
+autonoetic sentinel-experiment \
+  --corpus path/to/sentinel-validation-corpus.yaml \
+  --output path/to/results.md
+```
+
+What the harness does, per session:
+
+1. **Layer 1 verdict** — queries `causal_events` for the session's
+   `divergence.*` events and computes the **highest level reached**
+   (`watching` / `diverging` / `critical`). The session is flagged by
+   Layer 1 iff it reached `diverging` or `critical`. (`watching` is
+   observational only.)
+2. **Watchdog verdict** — runs the watchdog (`autonoetic watchdog
+   <session_id>` equivalent in-process) which:
+   - Reads the latest Layer 1 snapshot for context.
+   - Issues `digest_query` / `execution_search` tools to gather
+     evidence.
+   - Produces a free-text reply.
+3. **Watchdog classification** — the reply is classified as "flagged"
+   iff it contains any of: `diverging`, `divergence`, `critical`,
+   `watching`, `loop pressure`, `failure pressure`, `repetition`,
+   `stalled`, `escalat`. Silent or "looks healthy" replies count as
+   not flagged. This keyword-based classifier is deliberately simple;
+   it can be tightened later if false-positive noise becomes the
+   bottleneck.
+
+### 2.4 Side-effect contamination
+
+The watchdog has live tools (`agent_message`, `session_escalate`).
+Running it against real archived sessions will write **real**
+`agent_messages` and `user_interactions` rows targeting those sessions.
+That contamination is normally harmless (the targets are archived) but
+the operator should be aware. To clean up after a run:
+
+```sql
+-- in gateway.db
+DELETE FROM agent_messages
+  WHERE sender_session_id = 'gateway:sentinel'
+    AND created_at >= '<experiment-start-timestamp>';
+
+DELETE FROM user_interactions
+  WHERE turn_id LIKE 'turn-%'
+    AND agent_id IN (<diverged-session-agent-ids>)
+    AND created_at >= '<experiment-start-timestamp>';
+```
+
+A future iteration could add a `--dry-run` flag to the watchdog that
+stubs out the messaging tools; for now we accept the contamination
+because the experiment is one-off.
+
+## 3. Decision rule
+
+The harness computes a 2×2 confusion matrix for **each judge** (Layer 1
+alone, Watchdog alone):
+
+|                 | Predicted positive | Predicted negative |
+|-----------------|--------------------|--------------------|
+| Actual diverged | TP                 | FN                 |
+| Actual succeeded| FP                 | TN                 |
+
+From these:
+
+- **TPR (recall)** = TP / (TP + FN) — fraction of diverged sessions
+  caught.
+- **FPR** = FP / (FP + TN) — fraction of healthy sessions falsely
+  flagged.
+- **Precision** = TP / (TP + FP) — when the judge flags, how often it
+  is right.
+
+**Success criteria for auto-invoke (both must pass):**
+
+| Criterion | Threshold | Rationale |
+|---|---|---|
+| `TPR(watchdog) − TPR(layer 1) ≥ 0.20` | +20 percentage points | The watchdog has to clearly outperform the deterministic monitor on its primary axis; smaller gains do not justify the per-invocation LLM cost. |
+| `FPR(watchdog) ≤ 0.10` | ≤ 10% | False positives erode planner / operator trust quickly. |
+
+The decision rule is encoded in
+`autonoetic/src/cli/sentinel_experiment.rs::decision_rule`. Tests pin
+it so changes to thresholds are deliberate (`cargo test -p autonoetic
+sentinel_experiment`).
+
+### 3.1 Outcomes
+
+- **GO** (both criteria pass) → ship auto-invoke as a P5 follow-up,
+  default OFF, opt-in via gateway config.
+- **NO-GO** (either criterion fails) → P3 stays manual-only. The
+  watchdog remains a tool the operator runs on demand. Re-run the
+  experiment after material changes to either layer or to the watchdog
+  prompt.
+
+A borderline result (e.g., TPR delta = 0.18, FPR = 0.05) is
+**inconclusive** — file a follow-up to expand the corpus to N = 40 and
+re-decide.
+
+## 4. Output format
+
+The harness writes a markdown report containing:
+
+1. **Header** — generation timestamp, corpus size.
+2. **Decision** — verdict, TPR delta, watchdog FPR, per-criterion pass
+   marks.
+3. **Confusion matrices** — one each for Layer 1 and Watchdog, with
+   TPR / FPR / Precision.
+4. **Per-session table** — session_id, label, Layer 1 level, both
+   flagged-flags, watchdog outcome tag, wall-clock seconds.
+5. **Parse-error list** — any corpus entries that failed to parse.
+6. **Watchdog replies** — truncated to 4 KB each, grouped by session.
+
+Sample table column for one row:
+
+```
+| session_id | label    | L1 level | L1 flagged | WD flagged | WD outcome | Wall (s) |
+| abc12345…  | diverged | critical | yes        | yes        | completed  | 7.3      |
+```
+
+## 5. What this experiment does NOT measure
+
+Be explicit about scope so the result is not over-claimed:
+
+- **Severity calibration.** A "flagged" verdict treats `diverging` and
+  `critical` identically. Distinguishing them needs a finer protocol.
+- **Time to detection.** Whether the watchdog flags earlier than
+  Layer 1 within a single session is not measured — both judges see
+  the whole session's final state.
+- **Cost / latency.** The wall-clock seconds per watchdog run is
+  reported but not entered into the decision rule. A future iteration
+  could add a cost ceiling (e.g., reject GO if median wall > 30s).
+- **Real-world novelty.** The corpus is what the operator has on
+  disk. Watchdog performance on unseen failure modes is not predicted
+  by this experiment.
+
+## 6. Reproducibility
+
+Each report row records the watchdog's full reply (truncated to 4 KB)
+so a reviewer can independently verify the keyword classifier's
+verdict. To re-run the analysis without re-spending LLM tokens:
+
+```bash
+autonoetic sentinel-experiment \
+  --corpus path/to/corpus.yaml \
+  --output path/to/results-v2.md \
+  --skip-watchdog
+```
+
+In `--skip-watchdog` mode the harness uses each corpus entry's
+`cached_watchdog_reply` field. To populate it, take the per-session
+replies from a prior real run and copy them into the YAML.
+
+## 7. Results
+
+**(to be filled in after the corpus run)**
+
+| Run date | Corpus size | TPR Δ | WD FPR | Decision | Report |
+|---|---|---|---|---|---|
+| _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
+## 8. References
+
+- `docs/design/divergence-sentinel-design.md` §6 — the protocol this
+  document operationalises
+- `autonoetic/src/cli/sentinel_experiment.rs` — implementation
+- `autonoetic/src/cli/watchdog.rs::run_watchdog` — programmatic entry
+  point the harness invokes
+- `autonoetic-gateway/src/runtime/trajectory_health.rs` — Layer 1
+  signal types and aggregation rule
+- Issue [#243](https://github.com/mandubian/autonoetic/issues/243) —
+  tracking


### PR DESCRIPTION
Implements the deliverable scaffolding for #243. Sister to #238 (Divergence Sentinel tracking).

## Summary

Builds everything that can ship autonomously for the watchdog validation experiment. The actual corpus run and \"§7 Results\" table belong to the operator — they need real session data and ~\$1-5 of LLM cost.

## What ships

### CLI

\`\`\`bash
autonoetic sentinel-experiment \\
  --corpus path/to/sentinel-validation-corpus.yaml \\
  --output path/to/results.md
\`\`\`

Per session: queries Layer 1's verdict from \`causal_events\` (highest divergence level reached) → runs the watchdog blind → classifies the watchdog reply via keyword detection → computes confusion matrices → emits a markdown report with the GO / NO-GO verdict.

Flags:
- \`--skip-watchdog\` re-runs analysis from cached replies (no LLM cost)

### Protocol doc

[\`docs/design/divergence-sentinel-validation.md\`](../blob/main/docs/design/divergence-sentinel-validation.md):

- Corpus collection & labeling guidelines (target: 10 diverged + 10 succeeded)
- YAML schema for the corpus
- Decision rule: \`TPR(watchdog) − TPR(layer 1) ≥ 0.20\` AND \`FPR(watchdog) ≤ 0.10\` (both pinned by unit tests)
- Side-effect contamination warning + SQL cleanup snippet (watchdog has live messaging tools; running it against real sessions creates real \`agent_messages\` / \`user_interactions\` rows)
- Explicit list of what the experiment does NOT measure (severity calibration, time-to-detection, cost ceiling, real-world novelty)
- \"Results\" section left empty for the operator to fill in after a run

### Refactor

\`cli/watchdog.rs\` split:
- \`pub async fn run_watchdog(...) -> WatchdogRun\` — programmatic entry point that captures the reply
- \`pub async fn handle_watchdog(...) -> ()\` — thin CLI wrapper

This lets the experiment harness invoke the watchdog in-process and capture its text response cleanly.

### Tests

10 unit tests in \`cli::sentinel_experiment::tests\`:
- Confusion-matrix bookkeeping (records into the right quadrant)
- TPR / FPR / Precision computation + NaN-on-zero
- Decision rule: GO on strong watchdog, NO-GO on high FPR, NO-GO on marginal TPR delta
- Watchdog reply classification: silent / healthy / divergence keywords / critical / escalation
- Label parsing accepts synonyms (\"failed\", \"ok\") + rejects garbage

\`\`\`
cargo test -p autonoetic --bin autonoetic sentinel_experiment  →  10 passed
cargo build -p autonoetic  →  clean (1 pre-existing unrelated warning)
\`\`\`

## What this PR does NOT do

- Run the experiment on real sessions — requires an operator-curated corpus.
- Add a dry-run mode for the watchdog — when run live against real sessions, the watchdog WILL write real \`agent_messages\` and \`user_interactions\` rows targeting those sessions. The protocol doc has a SQL cleanup snippet.
- Close #243 — that gates on the operator running the corpus and filling in the results table.

## Decision rule (encoded + pinned)

| Criterion | Threshold |
|---|---|
| \`TPR(watchdog) − TPR(layer 1)\` | ≥ 0.20 |
| \`FPR(watchdog)\` | ≤ 0.10 |

Both must pass for GO. Either failing → NO-GO (watchdog stays manual). Borderline → expand corpus to N = 40 and re-run.

## Test plan

- [ ] CI green on \`cargo build -p autonoetic\`
- [ ] CI green on \`cargo test -p autonoetic --bin autonoetic sentinel_experiment\`
- [ ] Operator runs the experiment on a real corpus and fills in \`docs/design/divergence-sentinel-validation.md\` §7 \"Results\"
- [ ] On GO outcome: file the auto-invoke follow-up. On NO-GO: keep watchdog manual; close #243 with the report linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)