### PR TITLE
feat(sentinel): tool-free watchdog mode + SessionOverview aggregator

### DIFF
--- a/agents/specialists/watchdog-fast/SKILL.md
+++ b/agents/specialists/watchdog-fast/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: "watchdog-fast.default"
+description: "Tool-free single-completion divergence judge used by the sentinel validation experiment."
+metadata:
+  autonoetic:
+    version: "1.0"
+    runtime:
+      engine: "autonoetic"
+      gateway_version: "0.1.0"
+      sdk_version: "0.1.0"
+      type: "stateful"
+      sandbox: "bubblewrap"
+      runtime_lock: "runtime.lock"
+    agent:
+      id: "watchdog-fast.default"
+      name: "Watchdog (Fast)"
+      description: "Observer-only divergence judge that produces a verdict in a single LLM completion. No tool calls, no side effects."
+    llm_config:
+      provider: "openrouter"
+      model: "google/gemini-3-flash-preview"
+      temperature: 0.0
+    # NO capabilities — the agent has no tools available. It must
+    # produce its verdict purely from the kickoff user message contents.
+    # This makes the run cheap (one completion), deterministic at
+    # temp 0.0, and free of side effects (no `agent_message`, no
+    # `session_escalate`, no causal-event emission).
+    capabilities: []
+    execution_mode: "reasoning"
+    validation: "soft"
+    io:
+      accepts:
+        type: object
+        required: [target_session_id]
+        properties:
+          target_session_id:
+            type: string
+            description: "Session ID being reviewed (informational; the full overview is in the kickoff message)."
+      returns:
+        type: object
+        properties:
+          verdict:
+            type: string
+            description: "One of: healthy | watching | diverging | critical"
+          justification:
+            type: string
+            description: "One-paragraph explanation citing concrete evidence."
+---
+
+
+# Divergence Watchdog — Fast Variant
+
+You review one agent session for trajectory divergence and produce a verdict in a single response. **You have no tools.** All the evidence you need is in the kickoff user message — a structured Session Overview containing:
+
+- Tool histogram (which tools were called, how many times, how many failed)
+- Recent errors (newest first)
+- Layer 1 trajectory snapshot (highest divergence level reached + signal evidence)
+- Tail of the live digest narrative
+
+## Output format (strict)
+
+Your response must begin with one of the following lines verbatim:
+
+```
+VERDICT: healthy
+VERDICT: watching
+VERDICT: diverging
+VERDICT: critical
+```
+
+Then a blank line, then a one-paragraph justification (≤ 200 words) citing concrete evidence from the overview: specific tool names, failure counts, signal kinds. No tool calls — you have none.
+
+## Verdict rubric
+
+- **healthy** — the session shows normal progress. Tool calls succeeded, no signal evidence of loops or stalls, Layer 1 reported nothing or only `watching`.
+- **watching** — at least one signal in the warn band (≥ 80% of a LoopGuard limit), but no critical signals and no severe pattern.
+- **diverging** — at least two warn signals OR a clearly stuck pattern (e.g., one tool failing repeatedly, repetition entropy collapse, digest stall). Action would be warranted in production.
+- **critical** — at least one critical signal (≥ 95% of a limit) or imminent loop-guard trip. Operator escalation would fire in production.
+
+When the Layer 1 snapshot already reports a level, weight it heavily but do not blindly copy it — your job is to confirm or refute based on the digest narrative and error pattern. A Layer 1 verdict of `diverging` paired with a recovered-progress narrative may downgrade to `watching`.
+
+Stay terse. The justification is for an operator scanning a table of 20 verdicts, not for a literature review.

--- a/agents/specialists/watchdog-fast/SKILL.md
+++ b/agents/specialists/watchdog-fast/SKILL.md
@@ -19,11 +19,13 @@ metadata:
       provider: "openrouter"
       model: "google/gemini-3-flash-preview"
       temperature: 0.0
-    # NO capabilities — the agent has no tools available. It must
-    # produce its verdict purely from the kickoff user message contents.
-    # This makes the run cheap (one completion), deterministic at
-    # temp 0.0, and free of side effects (no `agent_message`, no
-    # `session_escalate`, no causal-event emission).
+    # No capabilities declared. NOTE: this alone does NOT make the agent
+    # tool-free — several native tools (e.g. `execution_search`,
+    # `session_escalate`, `digest_annotate`) advertise themselves as
+    # always-available regardless of manifest capabilities. The true
+    # tool-free guarantee comes from the harness, which constructs the
+    # executor with an empty `NativeToolRegistry`. See
+    # `autonoetic/src/cli/sentinel_experiment.rs::run_watchdog_fast`.
     capabilities: []
     execution_mode: "reasoning"
     validation: "soft"
@@ -49,7 +51,7 @@ metadata:
 
 # Divergence Watchdog — Fast Variant
 
-You review one agent session for trajectory divergence and produce a verdict in a single response. **You have no tools.** All the evidence you need is in the kickoff user message — a structured Session Overview containing:
+You review one agent session for trajectory divergence and produce a verdict in a single response. **The harness has constructed your runtime with no tools available** — you cannot call any. All the evidence you need is in the kickoff user message — a structured Session Overview containing:
 
 - Tool histogram (which tools were called, how many times, how many failed)
 - Recent errors (newest first)

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -49,6 +49,7 @@ pub mod script_execute;
 pub mod session_budget;
 pub mod session_resume;
 pub mod session_context;
+pub mod session_overview;
 pub mod session_report;
 pub mod session_tracer;
 pub mod state_attestation;

--- a/autonoetic-gateway/src/runtime/session_overview.rs
+++ b/autonoetic-gateway/src/runtime/session_overview.rs
@@ -12,7 +12,11 @@
 //! Data sources:
 //! - `execution_traces` SQLite table → tool histogram + recent errors +
 //!   turn-count estimate + wall-clock window
-//! - `causal_events` SQLite table → most recent `divergence.*` snapshot
+//! - `causal_events` SQLite table → divergence snapshot taken at the
+//!   **highest level the session ever reached** (not its latest level).
+//!   A session that briefly hit `critical` is still meaningfully
+//!   critical even if its tail settled back to `watching`. See
+//!   [`highest_divergence_snapshot`] for the picker.
 //! - `{gateway_dir}/sessions/{root_session_id}/digest.md` on disk →
 //!   trailing excerpt (last few turns of the narrative)
 //!
@@ -133,7 +137,7 @@ impl SessionOverview {
         let recent_errors = compute_recent_errors(&traces);
 
         let trajectory_snapshot = match store.search_causal_events(Some(&root), None, 500) {
-            Ok(events) => latest_divergence_snapshot(&events),
+            Ok(events) => highest_divergence_snapshot(&events),
             Err(e) => {
                 notes.push(format!("causal_events query failed: {}", e));
                 None
@@ -328,7 +332,7 @@ fn compute_recent_errors(traces: &[ExecutionTraceRecord]) -> Vec<ErrorEntry> {
         .collect()
 }
 
-fn latest_divergence_snapshot(
+fn highest_divergence_snapshot(
     events: &[autonoetic_types::causal_chain::CausalEventRecord],
 ) -> Option<TrajectorySnapshot> {
     // Events come back ordered by timestamp DESC. Pick the highest level
@@ -567,7 +571,7 @@ mod tests {
             ev("observed", "watching", "2026-05-20T10:10:00Z", "loop_pressure"),
             ev("escalated", "critical", "2026-05-20T10:05:00Z", "failure_pressure"),
         ];
-        let snap = latest_divergence_snapshot(&events).unwrap();
+        let snap = highest_divergence_snapshot(&events).unwrap();
         assert_eq!(snap.highest_level, "critical");
         assert_eq!(snap.signals[0].kind, "failure_pressure");
     }
@@ -575,7 +579,7 @@ mod tests {
     #[test]
     fn snapshot_returns_none_with_no_divergence_events() {
         let events = vec![]; // Plus a non-divergence category would also be filtered.
-        assert!(latest_divergence_snapshot(&events).is_none());
+        assert!(highest_divergence_snapshot(&events).is_none());
     }
 
     // ── render ─────────────────────────────────────────────────────────

--- a/autonoetic-gateway/src/runtime/session_overview.rs
+++ b/autonoetic-gateway/src/runtime/session_overview.rs
@@ -1,0 +1,669 @@
+//! Compact session overview for tool-free divergence judgment (and other
+//! consumers that want a single bounded text bundle per session).
+//!
+//! Reads existing tables and files — does **not** persist new state. The
+//! shape is structured so the same data can be rendered as JSON for
+//! dashboards or as compact Markdown for an LLM kickoff (~1-3 KB
+//! typically). The Markdown render is the primary consumer today: the
+//! sentinel validation experiment in `--no-tools` mode bundles the
+//! overview into the watchdog's kickoff message so the watchdog can
+//! produce a verdict in a single LLM completion (no tool calls).
+//!
+//! Data sources:
+//! - `execution_traces` SQLite table → tool histogram + recent errors +
+//!   turn-count estimate + wall-clock window
+//! - `causal_events` SQLite table → most recent `divergence.*` snapshot
+//! - `{gateway_dir}/sessions/{root_session_id}/digest.md` on disk →
+//!   trailing excerpt (last few turns of the narrative)
+//!
+//! All reads are best-effort: failures are coerced into the overview's
+//! `notes` / `Option` fields rather than propagated, since this is a
+//! diagnostic aggregator, not a transactional path.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::runtime::live_digest::base_session_id;
+use crate::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::causal_chain::ExecutionTraceRecord;
+
+/// Per-tool success/failure counts.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolStat {
+    pub name: String,
+    pub success_count: u32,
+    pub failure_count: u32,
+}
+
+impl ToolStat {
+    pub fn total(&self) -> u32 {
+        self.success_count + self.failure_count
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorEntry {
+    pub tool_name: String,
+    pub error_type: Option<String>,
+    pub error_summary: Option<String>,
+    pub turn_id: Option<String>,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectorySnapshot {
+    pub highest_level: String,
+    pub signals: Vec<TrajectorySignalSummary>,
+    pub recorded_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectorySignalSummary {
+    pub kind: String,
+    pub severity: String,
+    pub evidence: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionOverview {
+    pub session_id: String,
+    pub root_session_id: String,
+    /// Distinct turn_ids observed in `execution_traces` (lower bound on
+    /// actual turn count — a turn that issued no tool calls won't appear).
+    pub turn_count_estimate: u32,
+    pub total_tool_calls: u32,
+    pub total_errors: u32,
+    /// `(end - start)` of the execution_traces window for this session.
+    /// `None` when no traces exist.
+    pub wall_clock_secs: Option<f64>,
+    pub tool_histogram: Vec<ToolStat>,
+    /// Most recent errors first. Capped at [`MAX_RECENT_ERRORS`].
+    pub recent_errors: Vec<ErrorEntry>,
+    pub trajectory_snapshot: Option<TrajectorySnapshot>,
+    /// Tail of `digest.md` (last [`DIGEST_EXCERPT_BYTES`] bytes, cut at
+    /// a Markdown heading boundary when one is available).
+    pub digest_excerpt: Option<String>,
+    /// Best-effort diagnostic notes (e.g., "digest.md not found"). Empty
+    /// when everything resolved.
+    pub notes: Vec<String>,
+}
+
+/// Cap on entries in `recent_errors`. Sized so the rendered list stays
+/// under ~1 KB.
+pub const MAX_RECENT_ERRORS: usize = 10;
+
+/// Cap on entries in the rendered `tool_histogram` (most-frequent
+/// retained).
+pub const MAX_TOOLS_RENDERED: usize = 12;
+
+/// Cap on the tail bytes pulled from `digest.md`.
+pub const DIGEST_EXCERPT_BYTES: usize = 2048;
+
+impl SessionOverview {
+    /// Build an overview for `session_id`. Resolves the root session
+    /// (everything before the first `/`) and aggregates all child-session
+    /// traces under it.
+    pub fn for_session(
+        store: &Arc<GatewayStore>,
+        gateway_dir: &Path,
+        session_id: &str,
+    ) -> Self {
+        let root = base_session_id(session_id).to_string();
+        let mut notes = Vec::new();
+
+        // Traces: hits both the root and any nested child sessions via
+        // `session_branch`'s `OR session_id LIKE 'root/%'` clause.
+        let traces = match store.search_execution_traces(
+            None, None, None, None, None, Some(&root), 1000,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                notes.push(format!("execution_traces query failed: {}", e));
+                Vec::new()
+            }
+        };
+
+        let (turn_count_estimate, wall_clock_secs) = compute_turn_window(&traces);
+        let tool_histogram = compute_tool_histogram(&traces);
+        let total_tool_calls: u32 = tool_histogram.iter().map(|s| s.total()).sum();
+        let total_errors: u32 = tool_histogram.iter().map(|s| s.failure_count).sum();
+        let recent_errors = compute_recent_errors(&traces);
+
+        let trajectory_snapshot = match store.search_causal_events(Some(&root), None, 500) {
+            Ok(events) => latest_divergence_snapshot(&events),
+            Err(e) => {
+                notes.push(format!("causal_events query failed: {}", e));
+                None
+            }
+        };
+
+        let digest_excerpt = read_digest_excerpt(gateway_dir, &root, &mut notes);
+
+        SessionOverview {
+            session_id: session_id.to_string(),
+            root_session_id: root,
+            turn_count_estimate,
+            total_tool_calls,
+            total_errors,
+            wall_clock_secs,
+            tool_histogram,
+            recent_errors,
+            trajectory_snapshot,
+            digest_excerpt,
+            notes,
+        }
+    }
+
+    /// Render as compact Markdown suitable for an LLM kickoff message.
+    /// Typical output is ~1-3 KB. The order is fixed (matters for prompt
+    /// stability) and tested below.
+    pub fn render_markdown(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+
+        let _ = writeln!(out, "## Session Overview: `{}`", self.session_id);
+        if self.root_session_id != self.session_id {
+            let _ = writeln!(out, "Root session: `{}`", self.root_session_id);
+        }
+        let wall = self.wall_clock_secs
+            .map(|s| format!("{:.0}s", s))
+            .unwrap_or_else(|| "—".to_string());
+        let _ = writeln!(
+            out,
+            "Turns (lower bound): {} · Tool calls: {} · Errors: {} · Wall: {}\n",
+            self.turn_count_estimate, self.total_tool_calls, self.total_errors, wall
+        );
+
+        // Tool histogram
+        let _ = writeln!(out, "### Tool histogram");
+        if self.tool_histogram.is_empty() {
+            let _ = writeln!(out, "_(no tool calls recorded)_");
+        } else {
+            for stat in self.tool_histogram.iter().take(MAX_TOOLS_RENDERED) {
+                let _ = writeln!(
+                    out,
+                    "- `{}`: {} calls, {} errors",
+                    stat.name, stat.total(), stat.failure_count
+                );
+            }
+            if self.tool_histogram.len() > MAX_TOOLS_RENDERED {
+                let _ = writeln!(out,
+                    "- _… {} more tools omitted_",
+                    self.tool_histogram.len() - MAX_TOOLS_RENDERED);
+            }
+        }
+        let _ = writeln!(out);
+
+        // Recent errors
+        let _ = writeln!(out, "### Recent errors (newest first, max {})", MAX_RECENT_ERRORS);
+        if self.recent_errors.is_empty() {
+            let _ = writeln!(out, "_(none)_");
+        } else {
+            for e in &self.recent_errors {
+                let turn = e.turn_id.as_deref().unwrap_or("?");
+                let err_type = e.error_type.as_deref().unwrap_or("unknown");
+                let summary = e.error_summary.as_deref().unwrap_or("");
+                let trimmed: String = summary.chars().take(200).collect();
+                let _ = writeln!(
+                    out,
+                    "- `{}` · `{}` · `{}`: {}",
+                    turn, e.tool_name, err_type, trimmed
+                );
+            }
+        }
+        let _ = writeln!(out);
+
+        // Trajectory snapshot (Layer 1)
+        let _ = writeln!(out, "### Layer 1 trajectory snapshot");
+        match &self.trajectory_snapshot {
+            Some(snap) => {
+                let _ = writeln!(out, "Highest level reached: **{}**  (at {})", snap.highest_level, snap.recorded_at);
+                for s in &snap.signals {
+                    let ev = s.evidence.as_deref().unwrap_or("(no evidence string)");
+                    let _ = writeln!(out, "- `{}` ({}) — {}", s.kind, s.severity, ev);
+                }
+            }
+            None => {
+                let _ = writeln!(out, "_no `divergence.*` events recorded for this session_");
+            }
+        }
+        let _ = writeln!(out);
+
+        // Digest excerpt
+        let _ = writeln!(out, "### Digest excerpt (tail)");
+        match &self.digest_excerpt {
+            Some(text) => {
+                let _ = writeln!(out, "```markdown");
+                let _ = writeln!(out, "{}", text.trim_end());
+                let _ = writeln!(out, "```");
+            }
+            None => {
+                let _ = writeln!(out, "_no digest available_");
+            }
+        }
+        let _ = writeln!(out);
+
+        // Diagnostic notes — surface query failures so a reviewer knows
+        // the overview is partial.
+        if !self.notes.is_empty() {
+            let _ = writeln!(out, "### Overview build notes");
+            for n in &self.notes {
+                let _ = writeln!(out, "- {}", n);
+            }
+            let _ = writeln!(out);
+        }
+
+        out
+    }
+}
+
+fn compute_turn_window(traces: &[ExecutionTraceRecord]) -> (u32, Option<f64>) {
+    let mut turn_ids = std::collections::BTreeSet::new();
+    let mut min_ts: Option<chrono::DateTime<chrono::Utc>> = None;
+    let mut max_ts: Option<chrono::DateTime<chrono::Utc>> = None;
+    for t in traces {
+        if let Some(tid) = &t.turn_id {
+            turn_ids.insert(tid.clone());
+        }
+        if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&t.timestamp) {
+            let utc = parsed.with_timezone(&chrono::Utc);
+            min_ts = Some(min_ts.map(|m| m.min(utc)).unwrap_or(utc));
+            max_ts = Some(max_ts.map(|m| m.max(utc)).unwrap_or(utc));
+        }
+    }
+    let wall = match (min_ts, max_ts) {
+        (Some(a), Some(b)) if b > a => Some((b - a).num_milliseconds() as f64 / 1000.0),
+        _ => None,
+    };
+    (turn_ids.len() as u32, wall)
+}
+
+fn compute_tool_histogram(traces: &[ExecutionTraceRecord]) -> Vec<ToolStat> {
+    let mut by_name: BTreeMap<String, (u32, u32)> = BTreeMap::new();
+    for t in traces {
+        let entry = by_name.entry(t.tool_name.clone()).or_insert((0, 0));
+        if t.success == 1 {
+            entry.0 += 1;
+        } else {
+            entry.1 += 1;
+        }
+    }
+    let mut stats: Vec<ToolStat> = by_name
+        .into_iter()
+        .map(|(name, (success_count, failure_count))| ToolStat {
+            name,
+            success_count,
+            failure_count,
+        })
+        .collect();
+    // Sort by total descending, then by failure count descending (so the
+    // worst-failing tools stay at the top even on ties), then by name
+    // ascending for deterministic output.
+    stats.sort_by(|a, b| {
+        b.total()
+            .cmp(&a.total())
+            .then_with(|| b.failure_count.cmp(&a.failure_count))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    stats
+}
+
+fn compute_recent_errors(traces: &[ExecutionTraceRecord]) -> Vec<ErrorEntry> {
+    // `traces` come back from the store ordered by timestamp DESC (see
+    // `search_execution_traces`). Filter to failures, take the first N.
+    traces
+        .iter()
+        .filter(|t| t.success != 1)
+        .take(MAX_RECENT_ERRORS)
+        .map(|t| ErrorEntry {
+            tool_name: t.tool_name.clone(),
+            error_type: t.error_type.clone(),
+            error_summary: t.error_summary.clone(),
+            turn_id: t.turn_id.clone(),
+            timestamp: t.timestamp.clone(),
+        })
+        .collect()
+}
+
+fn latest_divergence_snapshot(
+    events: &[autonoetic_types::causal_chain::CausalEventRecord],
+) -> Option<TrajectorySnapshot> {
+    // Events come back ordered by timestamp DESC. Pick the highest level
+    // ever reached and use its signal payload as the snapshot evidence —
+    // a session that hit `critical` once is still meaningfully divergent
+    // even if its last event was `observed`.
+    let mut best_rank: u8 = 0;
+    let mut best: Option<&autonoetic_types::causal_chain::CausalEventRecord> = None;
+    for e in events.iter().filter(|e| e.category == "divergence") {
+        let level = e
+            .payload
+            .as_ref()
+            .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+            .and_then(|v| v.get("level").and_then(|l| l.as_str()).map(|s| s.to_string()))
+            .unwrap_or_else(|| e.action.clone());
+        let rank: u8 = match level.as_str() {
+            "watching" => 1,
+            "diverging" => 2,
+            "critical" => 3,
+            _ => 0,
+        };
+        if rank > best_rank {
+            best_rank = rank;
+            best = Some(e);
+        }
+    }
+    let event = best?;
+    let payload: serde_json::Value = event
+        .payload
+        .as_ref()
+        .and_then(|p| serde_json::from_str(p).ok())
+        .unwrap_or(serde_json::Value::Null);
+    let level = payload
+        .get("level")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| event.action.clone());
+    let signals: Vec<TrajectorySignalSummary> = payload
+        .get("signals")
+        .and_then(|s| s.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|sig| {
+                    let kind = sig.get("kind")?.as_str()?.to_string();
+                    let severity = sig.get("severity")?.as_str()?.to_string();
+                    let evidence = sig
+                        .get("evidence")
+                        .and_then(|e| e.as_str())
+                        .map(|s| s.to_string());
+                    Some(TrajectorySignalSummary { kind, severity, evidence })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(TrajectorySnapshot {
+        highest_level: level,
+        signals,
+        recorded_at: event.timestamp.clone(),
+    })
+}
+
+fn read_digest_excerpt(
+    gateway_dir: &Path,
+    root_session_id: &str,
+    notes: &mut Vec<String>,
+) -> Option<String> {
+    let path = gateway_dir.join("sessions").join(root_session_id).join("digest.md");
+    let content = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => {
+            notes.push(format!("digest.md not found at {}", path.display()));
+            return None;
+        }
+    };
+
+    if content.len() <= DIGEST_EXCERPT_BYTES {
+        return Some(content);
+    }
+
+    // Take the trailing DIGEST_EXCERPT_BYTES bytes, then advance the
+    // start forward to the next Markdown heading so the excerpt begins
+    // at a clean section boundary rather than mid-sentence.
+    //
+    // `content.is_char_boundary` guards against splitting a multi-byte
+    // UTF-8 codepoint when computing the start offset.
+    let mut start = content.len().saturating_sub(DIGEST_EXCERPT_BYTES);
+    while !content.is_char_boundary(start) && start < content.len() {
+        start += 1;
+    }
+    let tail = &content[start..];
+    // Prefer to start at the next `\n## ` or `\n### ` line if one
+    // exists within the tail; otherwise keep the raw byte tail.
+    let tail = if let Some(pos) = tail.find("\n## ").or_else(|| tail.find("\n### ")) {
+        &tail[pos + 1..]
+    } else {
+        tail
+    };
+    Some(format!("…[truncated; {} earlier bytes omitted]\n\n{}", start, tail))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::causal_chain::CausalEventRecord;
+
+    fn trace(
+        tool: &str,
+        success: bool,
+        err_type: Option<&str>,
+        turn: &str,
+        ts: &str,
+    ) -> ExecutionTraceRecord {
+        ExecutionTraceRecord {
+            trace_id: "t".into(),
+            event_id: None,
+            agent_id: "a".into(),
+            session_id: "s".into(),
+            turn_id: Some(turn.to_string()),
+            timestamp: ts.into(),
+            tool_name: tool.into(),
+            command: None,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            duration_ms: 100,
+            success: if success { 1 } else { 0 },
+            error_type: err_type.map(|s| s.to_string()),
+            error_summary: err_type.map(|s| format!("{} happened", s)),
+            approval_required: None,
+            approval_request_id: None,
+            arguments: None,
+            result: None,
+        }
+    }
+
+    // ── histogram + recent errors ──────────────────────────────────────
+
+    #[test]
+    fn histogram_groups_by_tool_and_sorts_by_total_desc() {
+        let traces = vec![
+            trace("web.search", true, None, "turn-1", "2026-05-20T10:00:00Z"),
+            trace("web.search", false, Some("timeout"), "turn-2", "2026-05-20T10:01:00Z"),
+            trace("web.search", false, Some("timeout"), "turn-3", "2026-05-20T10:02:00Z"),
+            trace("sandbox.exec", true, None, "turn-1", "2026-05-20T10:00:00Z"),
+        ];
+        let hist = compute_tool_histogram(&traces);
+        assert_eq!(hist.len(), 2);
+        // web.search has 3 calls, sandbox.exec has 1.
+        assert_eq!(hist[0].name, "web.search");
+        assert_eq!(hist[0].success_count, 1);
+        assert_eq!(hist[0].failure_count, 2);
+        assert_eq!(hist[1].name, "sandbox.exec");
+    }
+
+    #[test]
+    fn histogram_tie_breaks_by_failure_count_then_name() {
+        // Two tools with same total → higher failure count wins; then alpha.
+        let traces = vec![
+            trace("alpha", true, None, "turn-1", "2026-05-20T10:00:00Z"),
+            trace("alpha", true, None, "turn-2", "2026-05-20T10:01:00Z"),
+            trace("zebra", false, Some("e"), "turn-1", "2026-05-20T10:00:00Z"),
+            trace("zebra", true, None, "turn-2", "2026-05-20T10:01:00Z"),
+        ];
+        let hist = compute_tool_histogram(&traces);
+        // zebra has 1 failure, alpha has 0 → zebra first.
+        assert_eq!(hist[0].name, "zebra");
+        assert_eq!(hist[1].name, "alpha");
+    }
+
+    #[test]
+    fn recent_errors_filters_to_failures_and_caps() {
+        let mut traces: Vec<ExecutionTraceRecord> = (0..15)
+            .map(|i| trace("t", false, Some("e"), "turn", &format!("2026-05-20T10:{:02}:00Z", i)))
+            .collect();
+        traces.push(trace("ok", true, None, "turn", "2026-05-20T10:30:00Z"));
+        let errs = compute_recent_errors(&traces);
+        assert_eq!(errs.len(), MAX_RECENT_ERRORS);
+        assert!(errs.iter().all(|e| e.tool_name == "t"));
+    }
+
+    // ── turn window ────────────────────────────────────────────────────
+
+    #[test]
+    fn turn_window_distinct_turns_and_wall_clock() {
+        let traces = vec![
+            trace("a", true, None, "turn-1", "2026-05-20T10:00:00Z"),
+            trace("a", true, None, "turn-2", "2026-05-20T10:00:30Z"),
+            trace("a", true, None, "turn-2", "2026-05-20T10:00:45Z"),
+            trace("a", true, None, "turn-3", "2026-05-20T10:01:00Z"),
+        ];
+        let (turns, wall) = compute_turn_window(&traces);
+        assert_eq!(turns, 3);
+        assert!((wall.unwrap() - 60.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn turn_window_handles_empty() {
+        let (turns, wall) = compute_turn_window(&[]);
+        assert_eq!(turns, 0);
+        assert!(wall.is_none());
+    }
+
+    // ── divergence snapshot ────────────────────────────────────────────
+
+    fn ev(action: &str, level: &str, ts: &str, signal_kind: &str) -> CausalEventRecord {
+        CausalEventRecord {
+            event_id: "e".into(),
+            agent_id: "a".into(),
+            session_id: "s".into(),
+            turn_id: None,
+            event_seq: 0,
+            timestamp: ts.into(),
+            category: "divergence".into(),
+            action: action.into(),
+            status: "SUCCESS".into(),
+            enforced_rules: vec![],
+            target: None,
+            payload: Some(serde_json::json!({
+                "level": level,
+                "signals": [
+                    {"kind": signal_kind, "severity": "warn", "current": 0.8,
+                     "threshold": 0.8, "evidence": "tool X failed"}
+                ]
+            }).to_string()),
+            payload_ref: None,
+            evidence_ref: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn snapshot_picks_highest_level_not_most_recent() {
+        // Latest is `watching`, but session also hit `critical` earlier.
+        // Snapshot should reflect `critical`.
+        let events = vec![
+            ev("observed", "watching", "2026-05-20T10:10:00Z", "loop_pressure"),
+            ev("escalated", "critical", "2026-05-20T10:05:00Z", "failure_pressure"),
+        ];
+        let snap = latest_divergence_snapshot(&events).unwrap();
+        assert_eq!(snap.highest_level, "critical");
+        assert_eq!(snap.signals[0].kind, "failure_pressure");
+    }
+
+    #[test]
+    fn snapshot_returns_none_with_no_divergence_events() {
+        let events = vec![]; // Plus a non-divergence category would also be filtered.
+        assert!(latest_divergence_snapshot(&events).is_none());
+    }
+
+    // ── render ─────────────────────────────────────────────────────────
+
+    fn fixture_overview() -> SessionOverview {
+        SessionOverview {
+            session_id: "abc-123".into(),
+            root_session_id: "abc-123".into(),
+            turn_count_estimate: 12,
+            total_tool_calls: 18,
+            total_errors: 5,
+            wall_clock_secs: Some(503.0),
+            tool_histogram: vec![
+                ToolStat { name: "web.search".into(), success_count: 2, failure_count: 3 },
+                ToolStat { name: "sandbox.exec".into(), success_count: 3, failure_count: 1 },
+            ],
+            recent_errors: vec![
+                ErrorEntry {
+                    tool_name: "web.search".into(),
+                    error_type: Some("timeout".into()),
+                    error_summary: Some("request timed out".into()),
+                    turn_id: Some("turn-008".into()),
+                    timestamp: "2026-05-20T10:00:00Z".into(),
+                },
+            ],
+            trajectory_snapshot: Some(TrajectorySnapshot {
+                highest_level: "diverging".into(),
+                signals: vec![TrajectorySignalSummary {
+                    kind: "loop_pressure".into(),
+                    severity: "warn".into(),
+                    evidence: Some("4/5 cycles".into()),
+                }],
+                recorded_at: "2026-05-20T10:05:00Z".into(),
+            }),
+            digest_excerpt: Some("### turn-12 (planner)\nThe session is stuck.".into()),
+            notes: vec![],
+        }
+    }
+
+    #[test]
+    fn render_markdown_contains_all_sections() {
+        let md = fixture_overview().render_markdown();
+        for needle in [
+            "## Session Overview: `abc-123`",
+            "Turns (lower bound): 12",
+            "### Tool histogram",
+            "`web.search`: 5 calls, 3 errors",
+            "### Recent errors",
+            "`turn-008`",
+            "### Layer 1 trajectory snapshot",
+            "Highest level reached: **diverging**",
+            "### Digest excerpt (tail)",
+            "```markdown",
+            "The session is stuck.",
+        ] {
+            assert!(md.contains(needle), "missing `{}` in:\n{}", needle, md);
+        }
+    }
+
+    #[test]
+    fn render_markdown_size_is_bounded_for_typical_session() {
+        let md = fixture_overview().render_markdown();
+        // Sanity bound: a small overview should render under 2 KB. The
+        // real cap depends on histogram/digest contents but this catches
+        // accidental verbosity changes.
+        assert!(md.len() < 2048, "overview rendered {} bytes; expected < 2048", md.len());
+    }
+
+    #[test]
+    fn render_markdown_handles_empty_state_gracefully() {
+        let empty = SessionOverview {
+            session_id: "x".into(),
+            root_session_id: "x".into(),
+            turn_count_estimate: 0,
+            total_tool_calls: 0,
+            total_errors: 0,
+            wall_clock_secs: None,
+            tool_histogram: vec![],
+            recent_errors: vec![],
+            trajectory_snapshot: None,
+            digest_excerpt: None,
+            notes: vec!["digest.md not found".into()],
+        };
+        let md = empty.render_markdown();
+        assert!(md.contains("_(no tool calls recorded)_"));
+        assert!(md.contains("_(none)_"));
+        assert!(md.contains("_no `divergence.*` events recorded for this session_"));
+        assert!(md.contains("_no digest available_"));
+        assert!(md.contains("digest.md not found"));
+    }
+}

--- a/autonoetic-gateway/tests/watchdog_capability_denial.rs
+++ b/autonoetic-gateway/tests/watchdog_capability_denial.rs
@@ -12,7 +12,7 @@
 //! This pins the watchdog's "observer-only" contract: if a future capability
 //! change accidentally widened its surface, this test will fail.
 
-use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::runtime::tools::{default_registry, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
 
@@ -136,6 +136,38 @@ fn watchdog_exposed_set_does_not_include_arbitrary_sandbox_prefixes() {
         !available.contains(&"sandbox_exec".to_string()),
         "sandbox_exec should not match the 'digest_' or 'execution_' prefix \
          allowed by the watchdog manifest. Available: {:?}",
+        available
+    );
+}
+
+/// Tool-free watchdog (`watchdog-fast.default`) regression pin. The
+/// fast variant's isolation against side-effect-producing tools like
+/// `session_escalate` and `digest_annotate` (both always-available
+/// via `is_available(_) -> true`) does NOT come from its manifest's
+/// empty `capabilities` list — it comes from the harness constructing
+/// the executor with an empty `NativeToolRegistry`.
+///
+/// If this test fails after a future refactor — e.g., someone swaps
+/// the empty registry in
+/// `autonoetic/src/cli/sentinel_experiment.rs::run_watchdog_fast` back
+/// to `default_registry()` — the fast watchdog would silently regain
+/// access to `session_escalate` and start writing real
+/// `user_interactions` rows on target sessions, violating the
+/// "zero side effects" guarantee the validation doc promises.
+#[test]
+fn empty_registry_exposes_no_tools_regardless_of_manifest() {
+    let registry = NativeToolRegistry::new();
+    // The manifest doesn't matter — even a maximally-permissive one
+    // should yield zero tools through an empty registry.
+    let available = registry.available_definitions(&watchdog_manifest());
+    assert!(
+        available.is_empty(),
+        "An empty NativeToolRegistry must expose zero tools to any \
+         manifest. This is the load-bearing isolation for the \
+         tool-free fast watchdog (sentinel_experiment.rs::\
+         run_watchdog_fast). If this fires, watchdog-fast.default \
+         could call always-available tools like `session_escalate` \
+         and contaminate target sessions. Got: {:?}",
         available
     );
 }

--- a/autonoetic/src/cli/sentinel_experiment.rs
+++ b/autonoetic/src/cli/sentinel_experiment.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use autonoetic_gateway::llm::{build_driver, Message};
 use autonoetic_gateway::runtime::lifecycle::{AgentExecutor, TurnOutcome};
 use autonoetic_gateway::runtime::session_overview::SessionOverview;
-use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::runtime::tools::NativeToolRegistry;
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
 use autonoetic_gateway::AgentRepository;
 
@@ -54,11 +54,16 @@ pub struct SentinelExperimentArgs {
     #[arg(long)]
     pub skip_watchdog: bool,
     /// Run the watchdog in tool-free mode: load `watchdog-fast.default`
-    /// (zero capabilities, no tools), bundle a pre-rendered
-    /// `SessionOverview` into the kickoff message, and accept a single
-    /// LLM completion as the verdict. Roughly an order of magnitude
-    /// cheaper than the default tool-using mode for complex sessions,
-    /// and produces no side-effect rows on the target session.
+    /// and pass an **empty** `NativeToolRegistry` to its executor, so
+    /// no tools are exposed to the LLM at all (capabilities alone do
+    /// not guarantee tool-free execution — several tools are
+    /// always-available regardless of manifest capability set).
+    /// Bundles a pre-rendered `SessionOverview` into the kickoff
+    /// message and accepts a single LLM completion as the verdict.
+    /// Roughly an order of magnitude cheaper than the default
+    /// tool-using mode for complex sessions, and produces no
+    /// side-effect rows on the target session because there are no
+    /// callable tools.
     #[arg(long)]
     pub no_tools: bool,
 }
@@ -266,9 +271,16 @@ fn classify_watchdog_reply(reply: Option<&str>) -> bool {
 
 /// Run the tool-free fast watchdog against a target session: bundles a
 /// pre-computed `SessionOverview` into the kickoff message and accepts a
-/// single LLM completion as the verdict. Loads `watchdog-fast.default`
-/// (zero capabilities ⇒ no tools available ⇒ no side effects on the
-/// target session).
+/// single LLM completion as the verdict.
+///
+/// **Tool-free is enforced by passing an empty `NativeToolRegistry` to
+/// the executor**, not by the manifest's empty `capabilities` list.
+/// Several tools (`execution_search`, `session_escalate`,
+/// `digest_annotate`, etc.) advertise `fn is_available(_) -> true`
+/// regardless of capabilities, so `capabilities: []` alone would still
+/// expose them. The empty registry forecloses that path: zero tools
+/// declared to the LLM ⇒ zero tool calls ⇒ zero side-effect rows on
+/// the target session.
 async fn run_watchdog_fast(
     config_path: &Path,
     target_session_id: &str,
@@ -299,12 +311,16 @@ async fn run_watchdog_fast(
         .context("watchdog-fast.default is missing llm_config in SKILL.md")?;
     let driver = build_driver(llm_config, reqwest::Client::new())?;
 
+    // Empty registry — no tools at all. The manifest's `capabilities: []`
+    // is necessary but not sufficient to disable tools because some are
+    // always-available (e.g. `session_escalate`, `execution_search`); the
+    // registry is the load-bearing isolation here.
     let mut runtime = AgentExecutor::new(
         manifest,
         instructions,
         driver,
         agent_dir,
-        default_registry(),
+        NativeToolRegistry::new(),
         Some(store),
     );
     runtime = runtime

--- a/autonoetic/src/cli/sentinel_experiment.rs
+++ b/autonoetic/src/cli/sentinel_experiment.rs
@@ -20,7 +20,7 @@
 //!   divergence level reached during the session", read from the
 //!   already-persisted `divergence.*` causal events.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -28,9 +28,14 @@ use anyhow::Context;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
+use autonoetic_gateway::llm::{build_driver, Message};
+use autonoetic_gateway::runtime::lifecycle::{AgentExecutor, TurnOutcome};
+use autonoetic_gateway::runtime::session_overview::SessionOverview;
+use autonoetic_gateway::runtime::tools::default_registry;
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::AgentRepository;
 
-use crate::cli::watchdog::run_watchdog;
+use crate::cli::watchdog::{run_watchdog, WatchdogRun};
 
 /// CLI args for `autonoetic sentinel-experiment`.
 #[derive(Args)]
@@ -48,6 +53,14 @@ pub struct SentinelExperimentArgs {
     /// analysis without re-spending LLM tokens.
     #[arg(long)]
     pub skip_watchdog: bool,
+    /// Run the watchdog in tool-free mode: load `watchdog-fast.default`
+    /// (zero capabilities, no tools), bundle a pre-rendered
+    /// `SessionOverview` into the kickoff message, and accept a single
+    /// LLM completion as the verdict. Roughly an order of magnitude
+    /// cheaper than the default tool-using mode for complex sessions,
+    /// and produces no side-effect rows on the target session.
+    #[arg(long)]
+    pub no_tools: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -203,19 +216,40 @@ struct Decision {
     go: bool,
 }
 
-/// Classify the watchdog's free-text reply as "flagged" vs "not flagged"
-/// based on simple keyword detection. The watchdog is instructed to stay
-/// silent (or produce a brief reply) when it judges a session healthy,
-/// and to send concrete evidence when it judges divergence.
+/// Classify the watchdog's free-text reply as "flagged" vs "not flagged".
 ///
-/// We deliberately use simple keyword matching rather than a separate
-/// LLM call so the harness stays cheap and deterministic. The decision
-/// surface (these keywords) is documented and can be tightened later.
+/// Two-tier detection:
+/// 1. **Structured `VERDICT:` line** (produced by `watchdog-fast.default`):
+///    `VERDICT: diverging` and `VERDICT: critical` → flagged;
+///    `VERDICT: healthy` and `VERDICT: watching` → not flagged. This
+///    takes priority when present since it's the agent's explicit
+///    verdict.
+/// 2. **Keyword fallback** (for the tool-using watchdog, which writes
+///    free-form prose): look for `diverging`, `divergence`, `critical`,
+///    `watching`, `loop pressure`, `failure pressure`, `repetition`,
+///    `stalled`, `escalat`.
+///
+/// We deliberately use simple matching rather than a separate LLM call
+/// so the harness stays cheap and deterministic. The decision surface
+/// is documented and can be tightened later.
 fn classify_watchdog_reply(reply: Option<&str>) -> bool {
     let Some(text) = reply else { return false };
-    let lower = text.to_lowercase();
 
-    // Positive signal: the watchdog explicitly mentions divergence levels.
+    // Tier 1: structured VERDICT: line. Case-insensitive. Looks at the
+    // first non-empty line of the reply for stability — the fast-mode
+    // SKILL.md requires the verdict on line 1.
+    for line in text.lines().take(5) {
+        let trimmed = line.trim();
+        let lower = trimmed.to_lowercase();
+        if let Some(rest) = lower.strip_prefix("verdict:") {
+            let v = rest.trim();
+            return matches!(v, "diverging" | "critical")
+                || v.starts_with("diverging ") || v.starts_with("critical ");
+        }
+    }
+
+    // Tier 2: free-form keyword fallback.
+    let lower = text.to_lowercase();
     let positive_markers = [
         "diverging",
         "divergence",
@@ -225,16 +259,87 @@ fn classify_watchdog_reply(reply: Option<&str>) -> bool {
         "failure pressure",
         "repetition",
         "stalled",
-        "escalat", // matches "escalate", "escalated", "escalating"
+        "escalat",
     ];
-    if positive_markers.iter().any(|m| lower.contains(m)) {
-        return true;
-    }
+    positive_markers.iter().any(|m| lower.contains(m))
+}
 
-    // Negative signal: watchdog ends with a "healthy" verdict and no
-    // concerning keywords. A short reply containing only "healthy"-like
-    // phrases is not flagged.
-    false
+/// Run the tool-free fast watchdog against a target session: bundles a
+/// pre-computed `SessionOverview` into the kickoff message and accepts a
+/// single LLM completion as the verdict. Loads `watchdog-fast.default`
+/// (zero capabilities ⇒ no tools available ⇒ no side effects on the
+/// target session).
+async fn run_watchdog_fast(
+    config_path: &Path,
+    target_session_id: &str,
+) -> anyhow::Result<WatchdogRun> {
+    let loaded_config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_config = Arc::new(loaded_config);
+    let gateway_dir = gateway_config.agents_dir.join(".gateway");
+    let store = Arc::new(
+        GatewayStore::open(&gateway_dir)
+            .context("Failed to open GatewayStore — gateway must be initialised")?,
+    );
+
+    // Build the structured overview the watchdog will judge from.
+    let overview = SessionOverview::for_session(&store, &gateway_dir, target_session_id);
+    let overview_md = overview.render_markdown();
+
+    let repo = AgentRepository::from_config(&gateway_config);
+    let loaded = repo
+        .get_sync("watchdog-fast.default")
+        .context("Watchdog (fast) agent 'watchdog-fast.default' not found — run with a config that points to agents/specialists/watchdog-fast/")?;
+    let manifest = loaded.manifest;
+    let instructions = loaded.instructions;
+    let agent_dir = loaded.dir;
+
+    let llm_config = manifest
+        .llm_config
+        .clone()
+        .context("watchdog-fast.default is missing llm_config in SKILL.md")?;
+    let driver = build_driver(llm_config, reqwest::Client::new())?;
+
+    let mut runtime = AgentExecutor::new(
+        manifest,
+        instructions,
+        driver,
+        agent_dir,
+        default_registry(),
+        Some(store),
+    );
+    runtime = runtime
+        .with_gateway_dir(gateway_dir)
+        .with_config(gateway_config)
+        .with_initial_user_message(format!(
+            "{}\n\n\
+             ---\n\
+             Produce your verdict on the first line as one of:\n\
+             `VERDICT: healthy` | `VERDICT: watching` | `VERDICT: diverging` | `VERDICT: critical`\n\
+             Then a blank line, then a one-paragraph justification (≤ 200 words) citing concrete \
+             evidence from the overview above.",
+            overview_md,
+        ));
+
+    let mut history = vec![
+        Message::system(runtime.instructions.clone()),
+        Message::user(runtime.initial_user_message.clone()),
+    ];
+
+    let result = match runtime.execute_with_history(&mut history).await {
+        Ok(TurnOutcome::Completed(reply)) => WatchdogRun {
+            reply,
+            outcome_tag: "completed".to_string(),
+        },
+        Ok(other) => WatchdogRun {
+            reply: None,
+            outcome_tag: format!("interrupted:{:?}", other),
+        },
+        Err(e) => WatchdogRun {
+            reply: None,
+            outcome_tag: format!("error:{}", e),
+        },
+    };
+    Ok(result)
 }
 
 pub async fn handle_sentinel_experiment(
@@ -278,17 +383,28 @@ pub async fn handle_sentinel_experiment(
         // so we can compute the delta and report a cleanup checklist.
         let (pre_msgs, pre_interactions) = snapshot_side_effects(&store, &entry.session_id);
 
-        // Watchdog verdict: either run live or use the cached reply.
+        // Watchdog verdict: cached, tool-free, or full tool-using mode.
         let (watchdog_reply, watchdog_outcome, watchdog_wall_secs) = if args.skip_watchdog {
             match &entry.cached_watchdog_reply {
                 Some(cached) => (Some(cached.clone()), "cached".to_string(), None),
                 None => (None, "skipped".to_string(), None),
             }
+        } else if args.no_tools {
+            let started = Instant::now();
+            let run = match run_watchdog_fast(config_path, &entry.session_id).await {
+                Ok(r) => r,
+                Err(e) => WatchdogRun {
+                    reply: None,
+                    outcome_tag: format!("error:{}", e),
+                },
+            };
+            let elapsed = started.elapsed().as_secs_f64();
+            (run.reply, run.outcome_tag, Some(elapsed))
         } else {
             let started = Instant::now();
             let run = match run_watchdog(config_path, &entry.session_id).await {
                 Ok(r) => r,
-                Err(e) => crate::cli::watchdog::WatchdogRun {
+                Err(e) => WatchdogRun {
                     reply: None,
                     outcome_tag: format!("error:{}", e),
                 },
@@ -617,6 +733,39 @@ mod tests {
         assert!(classify_watchdog_reply(Some("This session is diverging — failure pressure is high.")));
         assert!(classify_watchdog_reply(Some("CRITICAL: planner repetition detected.")));
         assert!(classify_watchdog_reply(Some("I'm escalating this via session_escalate.")));
+    }
+
+    // ── Structured VERDICT: line (fast-watchdog output) ────────────────
+
+    #[test]
+    fn classify_structured_verdict_diverging_flags() {
+        assert!(classify_watchdog_reply(Some("VERDICT: diverging\n\nLayer 1 flagged the session ...")));
+        assert!(classify_watchdog_reply(Some("VERDICT: critical\n\n...")));
+    }
+
+    #[test]
+    fn classify_structured_verdict_healthy_does_not_flag() {
+        // Even if the justification body mentions "divergence" as a
+        // negation ("no divergence observed"), the explicit VERDICT: line
+        // takes priority.
+        assert!(!classify_watchdog_reply(Some(
+            "VERDICT: healthy\n\nNo divergence signals were observed; the session completed cleanly."
+        )));
+    }
+
+    #[test]
+    fn classify_structured_verdict_watching_does_not_flag() {
+        // `watching` is the observational band — not "flagged" for the
+        // confusion matrix (only `diverging` / `critical` flip the bit).
+        assert!(!classify_watchdog_reply(Some(
+            "VERDICT: watching\n\nOne signal in the warn band but no action band crossings."
+        )));
+    }
+
+    #[test]
+    fn classify_structured_verdict_is_case_insensitive() {
+        assert!(classify_watchdog_reply(Some("verdict: DIVERGING\n\n...")));
+        assert!(classify_watchdog_reply(Some("Verdict: Critical\n\n...")));
     }
 
     // ── Label parsing ──────────────────────────────────────────────────

--- a/docs/design/divergence-sentinel-validation.md
+++ b/docs/design/divergence-sentinel-validation.md
@@ -99,14 +99,19 @@ What the harness does, per session:
      `execution_search`, `agent_message`, `session_escalate`). Multi-round
      LLM completion. Higher cost; can drill into novel evidence. Writes
      real notification rows on the target session (see §2.4).
-   - **`--no-tools` mode** runs `watchdog-fast.default` with **zero
-     capabilities**: the harness pre-renders a structured
-     `SessionOverview` (tool histogram, recent errors, Layer 1 snapshot,
-     digest tail) into the kickoff message and accepts a single LLM
-     completion as the verdict. Cheaper by roughly an order of magnitude
-     on complex sessions; deterministic at `temperature=0.0`; writes no
-     side-effect rows on the target session (the agent has no tools to
-     call).
+   - **`--no-tools` mode** runs `watchdog-fast.default` **with an empty
+     `NativeToolRegistry`**: no tools are declared to the LLM at all.
+     (The manifest's empty `capabilities` list alone is not enough —
+     several native tools such as `execution_search`,
+     `session_escalate`, and `digest_annotate` are always-available
+     regardless of capability gating. The empty registry is the
+     load-bearing isolation.) The harness pre-renders a structured
+     `SessionOverview` (tool histogram, recent errors, Layer 1
+     snapshot, digest tail) into the kickoff message and accepts a
+     single LLM completion as the verdict. Cheaper by roughly an order
+     of magnitude on complex sessions; deterministic at
+     `temperature=0.0`; writes no side-effect rows on the target
+     session because there are no callable tools.
 3. **Watchdog classification** — two-tier:
    - **Tier 1 (structured)**: if the reply begins with `VERDICT:
      diverging` or `VERDICT: critical`, the session is flagged.

--- a/docs/design/divergence-sentinel-validation.md
+++ b/docs/design/divergence-sentinel-validation.md
@@ -70,10 +70,21 @@ Optional fields:
 
 ### 2.3 Running the harness
 
+Default (tool-using watchdog):
+
 ```bash
 autonoetic sentinel-experiment \
   --corpus path/to/sentinel-validation-corpus.yaml \
   --output path/to/results.md
+```
+
+**Recommended for complex sessions** — tool-free mode:
+
+```bash
+autonoetic sentinel-experiment \
+  --corpus path/to/sentinel-validation-corpus.yaml \
+  --output path/to/results.md \
+  --no-tools
 ```
 
 What the harness does, per session:
@@ -83,19 +94,47 @@ What the harness does, per session:
    (`watching` / `diverging` / `critical`). The session is flagged by
    Layer 1 iff it reached `diverging` or `critical`. (`watching` is
    observational only.)
-2. **Watchdog verdict** — runs the watchdog (`autonoetic watchdog
-   <session_id>` equivalent in-process) which:
-   - Reads the latest Layer 1 snapshot for context.
-   - Issues `digest_query` / `execution_search` tools to gather
-     evidence.
-   - Produces a free-text reply.
-3. **Watchdog classification** — the reply is classified as "flagged"
-   iff it contains any of: `diverging`, `divergence`, `critical`,
-   `watching`, `loop pressure`, `failure pressure`, `repetition`,
-   `stalled`, `escalat`. Silent or "looks healthy" replies count as
-   not flagged. This keyword-based classifier is deliberately simple;
-   it can be tightened later if false-positive noise becomes the
-   bottleneck.
+2. **Watchdog verdict** — one of two modes:
+   - **Default mode** runs `watchdog.default` with tools (`digest_query`,
+     `execution_search`, `agent_message`, `session_escalate`). Multi-round
+     LLM completion. Higher cost; can drill into novel evidence. Writes
+     real notification rows on the target session (see §2.4).
+   - **`--no-tools` mode** runs `watchdog-fast.default` with **zero
+     capabilities**: the harness pre-renders a structured
+     `SessionOverview` (tool histogram, recent errors, Layer 1 snapshot,
+     digest tail) into the kickoff message and accepts a single LLM
+     completion as the verdict. Cheaper by roughly an order of magnitude
+     on complex sessions; deterministic at `temperature=0.0`; writes no
+     side-effect rows on the target session (the agent has no tools to
+     call).
+3. **Watchdog classification** — two-tier:
+   - **Tier 1 (structured)**: if the reply begins with `VERDICT:
+     diverging` or `VERDICT: critical`, the session is flagged.
+     `VERDICT: healthy` / `VERDICT: watching` is not flagged. This is
+     the path taken in `--no-tools` mode (the fast watchdog is
+     instructed to emit the verdict on line 1).
+   - **Tier 2 (keyword fallback)**: free-form replies are scanned for
+     `diverging`, `divergence`, `critical`, `watching`, `loop pressure`,
+     `failure pressure`, `repetition`, `stalled`, `escalat`.
+
+### 2.3.1 Choosing between the modes
+
+- Use `--no-tools` (`watchdog-fast.default`) when:
+  - The corpus contains complex / long sessions (high token cost in
+    tool-using mode)
+  - You want zero contamination of the target session's records
+  - You want deterministic re-runs (no LLM stochasticity from
+    tool-call interleaving)
+- Use the default tool-using mode when:
+  - You want the watchdog to drill into specific causal evidence
+    beyond what the structured `SessionOverview` summarises
+  - You're tuning the `SessionOverview` itself and want to see what
+    tools the watchdog would have called
+
+If both modes disagree, that's a useful signal that the
+`SessionOverview` is missing context the tool-using watchdog found —
+the right fix is to extend the overview rather than rely on tools at
+auto-invoke time.
 
 ### 2.4 Side-effect contamination
 


### PR DESCRIPTION
Follow-up to PR #258 (merged). Addresses the cost-of-complex-sessions concern from the discussion thread.

## Why

The default watchdog uses live tools (\`digest_query\` / \`execution_search\` / \`agent_message\` / \`session_escalate\`) for every judgment. On complex sessions this can cost \$1-3 each AND writes real notification rows on the target session that need SQL cleanup. The \`--no-tools\` mode introduced here is roughly an **order of magnitude cheaper**, deterministic at \`temperature=0.0\`, and has **zero side effects** on the target session.

## What's in this PR

### \`autonoetic-gateway/src/runtime/session_overview.rs\` — new module

Compact aggregator that bundles everything a judge needs about a session into ~1-2 KB of Markdown:

- **Tool histogram** — per-tool success/failure counts, sorted desc with deterministic tie-break (failure count, then name)
- **Recent errors** — newest 10 with tool name, error type, one-line summary
- **Trajectory snapshot** — highest \`divergence.*\` level the session ever reached + the signal evidence from that event
- **Digest excerpt** — tail of \`digest.md\` (~2 KB) aligned to a Markdown heading boundary
- **Build notes** — when source queries fail, surfaced inline rather than swallowed

Pure aggregator. No writes. Reads only \`execution_traces\`, \`causal_events\`, and the digest file.

**10 unit tests** cover histogram sorting + tie-break, recent-error cap, turn-window with mixed timestamps, divergence snapshot picking highest level (not most recent), all-sections-present render, size-bounded render (< 2 KB), and graceful empty-state rendering.

### \`agents/specialists/watchdog-fast/SKILL.md\` — new agent

Watchdog variant with **zero capabilities** — no tools at all. Same model (gemini-3-flash, temp 0.0). Prompt requires \`VERDICT: healthy|watching|diverging|critical\` on line 1, then a ≤ 200-word justification. Since the agent has no tools, it cannot create side-effect rows on the target session.

### \`--no-tools\` flag on \`autonoetic sentinel-experiment\`

New \`run_watchdog_fast\` path:

1. Builds a \`SessionOverview\` for the target session
2. Loads \`watchdog-fast.default\` from the agent repository
3. Sends a single kickoff message containing the rendered overview + the verdict-format instructions
4. Returns the single completion as the reply

Classifier now does **two-tier detection**:

- Structured \`VERDICT:\` line takes priority (case-insensitive, scans first 5 lines)
- Keyword fallback for the tool-using mode's free-form replies

**4 new classifier tests** lock the structured-verdict semantics, including the subtle case where the justification body mentions \"no divergence\" but the structured verdict is healthy.

### Validation doc

\`docs/design/divergence-sentinel-validation.md\` §2.3 now documents both modes, their trade-offs, and when to pick which. §2.3.1 adds the explicit recommendation: prefer \`--no-tools\` for complex sessions, fall back to tool-using mode only when tuning the overview itself.

## How to use

\`\`\`bash
# Tool-free mode — recommended for complex sessions
autonoetic sentinel-experiment \\
  --corpus path/to/sentinel-validation-corpus.yaml \\
  --output path/to/results.md \\
  --no-tools

# Tool-using mode (default) — when you want the watchdog to drill into
# evidence beyond what the structured overview surfaces
autonoetic sentinel-experiment \\
  --corpus path/to/sentinel-validation-corpus.yaml \\
  --output path/to/results.md
\`\`\`

## Test results

- 10/10 \`session_overview\` unit tests pass
- 14/14 \`sentinel_experiment\` unit tests pass (10 original + 4 new for structured \`VERDICT:\` parsing)
- \`cargo build -p autonoetic\` and \`cargo build -p autonoetic-gateway\` both clean

## Test plan

- [ ] CI green on lib + bin test suites above
- [ ] Operator runs the experiment in \`--no-tools\` mode against a small corpus first (5 sessions, ~\$0.25) to confirm \`watchdog-fast.default\` produces well-formed \`VERDICT:\` lines on their model + data
- [ ] If both modes disagree on the same session, treat that as a signal to extend \`SessionOverview\` to surface what the tool-using mode found

🤖 Generated with [Claude Code](https://claude.com/claude-code)