### PR TITLE
docs(design): add divergence-sentinel and self-improvement-loop plans

### DIFF
--- a/docs/design/divergence-sentinel-design.md
+++ b/docs/design/divergence-sentinel-design.md
@@ -1,0 +1,316 @@
+# Divergence Sentinel — Design
+
+> Status: **Draft (2026-05-20)** — feedback wanted before implementation.
+> Tracking issue: [#238](https://github.com/mandubian/autonoetic/issues/238).
+> Phase issues: P0 [#239](https://github.com/mandubian/autonoetic/issues/239),
+> P1 [#240](https://github.com/mandubian/autonoetic/issues/240),
+> P2 [#241](https://github.com/mandubian/autonoetic/issues/241),
+> P3 [#242](https://github.com/mandubian/autonoetic/issues/242),
+> P4 [#243](https://github.com/mandubian/autonoetic/issues/243).
+
+## 1. Problem Statement
+
+Autonoetic enforces a lawful environment where agents are free to plan and act, as
+long as they obey constitutional rules. Many guards already exist to catch concrete
+violations (capability misuse, repeated failures, budget exhaustion, etc.).
+
+However, operators have observed a recurring failure mode that **none of the
+existing guards catch reliably**:
+
+> The planner believes it is making progress, but a human reading the live digest
+> can immediately see it is going in circles, repeatedly retrying a doomed strategy,
+> drilling into the wrong sub-problem, or "succeeding" on the wrong axis.
+
+This is a **meta-cognitive blind spot**, not a rule violation. The agent's
+self-narrative inside its own context window says "I'm progressing." The aggregate
+view across many turns says "you're diverging." Existing guards trip on _patterns_
+(same tool+args N times) but not on _aggregate trajectory_.
+
+Anecdotal observation by the operator: when a separate Claude session is shown
+the live `digest.md` of a stuck planner and asked "what's going wrong here?", it
+consistently surfaces problems the planner itself never flags. This may be
+**confirmation bias** (the operator already suspects divergence when asking) or
+a **real meta-cognitive asymmetry** (an outside reader without the planner's
+in-context optimism). Section 6 proposes an experiment to disambiguate.
+
+## 2. Goals & Non-Goals
+
+**Goals**
+
+- Detect mid-session divergence early enough for the planner to course-correct.
+- Notify the planner via the existing agent-messaging mechanism, so the planner
+  can choose to adjust its strategy.
+- Notify the operator when divergence crosses a threshold the planner cannot
+  self-correct.
+- Be **optional and composable** — operators must be able to disable, tune, or
+  trigger the deeper LLM-based check on demand.
+- **Factorize** existing scattered divergence-adjacent logic into a clear
+  semantic cluster, before adding new code.
+
+**Non-Goals**
+
+- Replace existing guards. Capability, budget, approval, and emergency-stop
+  guards remain as they are — Sentinel is observational.
+- Be a security boundary. Sentinel produces signals, not denials. Hard limits
+  remain in `LoopGuard`, `PolicyEngine`, and budgets.
+- Be a learning system. Sentinel does not persist judgments across sessions
+  beyond the causal log — that is the role of memory/curator agents.
+
+## 3. Current Guard Catalog (Factorization View)
+
+A thorough survey of `autonoetic-gateway/src/` reveals **14 distinct guard
+mechanisms** today. Grouping them by _semantic domain_ rather than file
+location yields five clusters:
+
+### Cluster A — Trajectory guards (the divergence-relevant cluster)
+
+| Guard | File | Trips on |
+|---|---|---|
+| `LoopGuard::check_loop` (loops without progress) | `runtime/guard.rs:75-104` | N consecutive turns without a new tool fingerprint |
+| `LoopGuard::register_failure` (tool failure budget) | `runtime/guard.rs:127-145` | Same tool fails ≥ N times (any args) |
+| `LoopGuard::register_child_failure` (delegation budget) | `runtime/guard.rs:147-153` | ≥ N failed `workflow.wait` children |
+| `LoopGuard::is_sub_trip_warning` (80% threshold) | `runtime/guard.rs:106-125` | Approaching trip — used for R-7.18 degraded mode |
+| `budget_tracker::emit_context_pressure_high_if_warranted` | `runtime/budget_tracker.rs:34-71` | Context utilization crosses `warn_at_pct` |
+
+This cluster is **the natural home for divergence detection**. Today it is
+internally LoopGuard-shaped: mechanical, per-tool, and per-turn. It already
+emits sub-trip warnings (R-7.18) — they just are not aggregated into a
+"session health" signal.
+
+### Cluster B — Resource budgets
+
+| Guard | File |
+|---|---|
+| `SessionBudget::check_pre_llm` | `runtime/session_budget.rs` |
+| `RootSessionBudget::check_pre_llm` | `runtime/root_session_budget.rs` |
+| `enforce_cost_catalog_preflight` | `runtime/budget_tracker.rs:156-200` |
+
+These two budget structs have **parallel shapes** (`max_llm_rounds`,
+`max_llm_tokens`, `max_wall_clock_secs`, `max_session_price_usd`,
+`max_tool_invocations`) and parallel hooks (`check_pre_llm` /
+`record_llm_completion`). They could share a `BudgetEnvelope` trait
+without semantic loss. _Factorization opportunity F-1._
+
+### Cluster C — Policy / capability denials
+
+| Guard | File |
+|---|---|
+| `PolicyEngine::can_exec_shell_detailed` | `policy.rs:1-510` |
+| `SecurityAnalyzer` (destructive, privilege, escape, injection) | `policy.rs` |
+| `network_policy::validate_request` | `runtime/network_policy.rs` |
+| `promotion::record` severity gate | `runtime/tools/promotion.rs:177-223` |
+
+These are **rejection-time** guards — they deny the operation outright. Out
+of scope for Sentinel.
+
+### Cluster D — Gate / approval / continuation
+
+Already factorized into `GateService` (`runtime/human_gate.rs`) — see
+`human-gate-unification-plan.md`. Out of scope.
+
+### Cluster E — Emergency / lifecycle / retention
+
+| Guard | File |
+|---|---|
+| `emergency_stop_root_session` | `execution.rs:841-1187` |
+| `active_execution_registry` (PID/abort tracking) | `runtime/active_execution_registry.rs` |
+| `reconcile_stale_active_executions` | `scheduler/gateway_store/migrate.rs:686-695` |
+| `RetentionConfig` (execution_traces, causal_events) | various |
+| `runtime_lock` drift check | `runtime_lock.rs` |
+| `constitution` signature verification | `docs/constitution-signing.md` |
+
+Out of scope, except that emergency stop is the **escalation target** when
+Sentinel fires its most severe judgment.
+
+### Factorization Opportunities Identified
+
+| ID | Opportunity | Effort |
+|---|---|---|
+| **F-1** | Unify `SessionBudget` + `RootSessionBudget` behind a single `BudgetEnvelope` trait (today they share 80% of code) | S |
+| **F-2** | Promote LoopGuard's `is_sub_trip_warning` into a richer `TrajectoryHealth` state machine that the new Sentinel consumes | M |
+| **F-3** | Add a `divergence.*` causal event family with consistent shape (severity, signal_type, evidence_ref) instead of ad-hoc fields on existing events | S |
+| **F-4** | Unify retention TTLs into a single `RetentionConfig` enum so future Sentinel records share the lifecycle | S |
+| **F-5** | Consider moving `progress_budget_tools` from `LoopGuardConfig` into a future `TrajectoryConfig` block (cluster A's container) | S |
+
+F-2 and F-3 are **prerequisites** for Sentinel itself and ship in Phase 1.
+F-1, F-4, F-5 are independent housekeeping and may be deferred.
+
+## 4. Proposed Architecture
+
+The Sentinel is implemented in **two layers** that the operator can enable
+independently:
+
+### Layer 1 — Deterministic Trajectory Monitor (in-gateway, always-on)
+
+Lives in `autonoetic-gateway/src/runtime/trajectory_monitor.rs` (new file).
+Hooks the existing causal event stream and the LoopGuard sub-trip warnings.
+It is rule-based, cheap, and has no LLM cost.
+
+**Inputs**
+
+- LoopGuard state snapshots (per-turn)
+- `causal_events` writes (subscribes to `tool.*`, `turn.*`, `error.*`)
+- Live digest stall metrics (lines/turn rate over a sliding window)
+- Tool error type distribution (via `execution_traces`)
+
+**Signals computed per session**
+
+| Signal | Definition | Default threshold |
+|---|---|---|
+| `loop_pressure` | `loop_guard.current_loops / max_loops` | warn ≥ 0.8 |
+| `failure_pressure` | max over tools of `failures / max_tool_failures` | warn ≥ 0.8 |
+| `child_failure_pressure` | `child_failures / max_child_failures` | warn ≥ 0.66 |
+| `digest_stall` | turns since last new causal event category | warn ≥ 5 |
+| `repetition_entropy` | Shannon entropy of last-N tool fingerprints (low = repetitive) | warn ≤ 1.2 |
+| `error_burst` | error events in last-N turns | warn ≥ 5 |
+| `context_pressure` | already exists in `budget_tracker.rs` | warn ≥ 0.8 |
+
+A simple **weighted aggregate** produces a `TrajectoryHealth` enum:
+
+```rust
+enum TrajectoryHealth {
+    Healthy,
+    Watching { signals: Vec<DivergenceSignal> },   // ≥1 warn signal
+    Diverging { signals: Vec<DivergenceSignal> },  // ≥2 warn signals or ≥1 critical
+    Critical { signals: Vec<DivergenceSignal> },   // approaching trip (95%+)
+}
+```
+
+**Actions taken (configurable per level)**
+
+| Level | Action |
+|---|---|
+| `Healthy` | nothing |
+| `Watching` | emit `divergence.observed` causal event (no further action) |
+| `Diverging` | emit `divergence.detected` event + `agent.message` to root planner with the signals as evidence + (optional) trigger LLM watchdog (Layer 2) |
+| `Critical` | all of `Diverging` actions + operator notification via existing user_interactions channel |
+
+**Why this layer first**
+
+- The symptoms operators name (loops, repeated errors, weird repetition) are
+  mechanically detectable from existing data.
+- Zero LLM cost. Zero new failure modes (no hallucinations).
+- It's **falsifiable**: thresholds either fire on real divergence or they don't.
+- It builds the substrate (the `divergence.*` event family, the
+  `TrajectoryHealth` snapshot) that Layer 2 needs.
+
+### Layer 2 — LLM Watchdog Agent (optional, triggerable)
+
+A new specialist agent under `agents/specialists/watchdog/` (or similar). It is
+explicitly **not** wired into every session. It runs only when:
+
+1. The operator triggers it manually via a CLI command (`autonoetic watchdog
+   <session_id>`).
+2. Layer 1 reaches `Diverging` or `Critical` **and** the gateway config has
+   `watchdog.auto_invoke_on_diverging = true` (default: false).
+3. A scheduled health-check fires for long-running sessions
+   (`watchdog.scheduled_review_every_n_turns`, default: disabled).
+
+**Capabilities**
+
+- `digest.query` — read the live digest of the target session
+- `execution.search` — query causal events
+- `agent.message` — send a message to the root planner
+- `user_interaction.escalate` — escalate to the operator
+
+It has **no execution capabilities**. It cannot kill processes, edit code, or
+modify session state. Pure observer.
+
+**Prompt skeleton**
+
+> You are reviewing a live agent session for signs of divergence: loops,
+> repeated failed strategies, drilling into the wrong sub-problem, declared
+> "success" on the wrong axis, or any other pattern a fresh reader would
+> immediately notice but the in-context planner has missed. You have the live
+> digest, causal events, and trajectory health signals already computed by the
+> deterministic monitor. **Default to silence** — only speak if you find a
+> concrete issue with concrete evidence. If you do, send a brief, specific
+> message to the planner. If the divergence is severe and the planner has
+> already been warned, escalate to the operator.
+
+**Why this is its own agent and not a function call**
+
+- It needs LLM judgment, not deterministic rules, by hypothesis.
+- It must be **observable** in the causal chain (its calls and decisions are
+  audit events).
+- It runs in its own session/budget — its own divergence cannot infect the
+  target session's budget.
+- It can be evolved/improved as a Skill like any other agent.
+
+**Why it must be optional**
+
+- LLM cost per invocation is non-trivial (reads the whole digest).
+- Operator's hypothesis (digest readers catch things planners miss) is not
+  yet validated — see §6.
+- Adding an always-on LLM observer to every session would meaningfully
+  change the cost profile of the runtime.
+
+## 5. Rollout Phases
+
+| Phase | Scope | Deliverable |
+|---|---|---|
+| **P0** | Factorization F-2, F-3 | `TrajectoryHealth` enum, `divergence.*` causal event family, no behavior change yet |
+| **P1** | Layer 1 deterministic monitor | `trajectory_monitor.rs`, signal computation, `Watching`/`Diverging`/`Critical` levels emit events |
+| **P2** | Layer 1 messaging | Planner receives `agent.message` on `Diverging`; operator notification on `Critical` |
+| **P3** | Layer 2 watchdog agent | New agent bundle, manual CLI trigger only |
+| **P4** | Layer 2 auto-invoke | Optional config flag to invoke watchdog from Layer 1 escalations |
+| **P5** | Tuning | Threshold calibration from real session corpus; F-1, F-4, F-5 housekeeping |
+
+Each phase is independently shippable and provides value on its own.
+
+## 6. Validating the "Digest-Reader Bias" Hypothesis
+
+Before building Layer 2, run a **falsifiable experiment** on archived
+sessions to test whether outside readers really do catch divergence the
+planner misses, or whether the operator is biased by knowing the answer in
+advance.
+
+**Method**
+
+1. Collect 20 archived sessions from `~/.autonoetic/sessions/`: 10 known
+   to have diverged (operator-flagged), 10 known to have succeeded.
+2. Strip outcome from each — present only the digest and causal events.
+3. Run the watchdog prompt blind on all 20. Record its judgment per session.
+4. Compute: true-positive rate, false-positive rate, precision, recall.
+5. Compare against Layer 1 deterministic signals alone on the same corpus.
+
+**Success criteria for proceeding to P3**
+
+- Watchdog true-positive rate must be **strictly higher** than Layer 1 alone
+  on the same corpus, by enough to justify the per-invocation cost.
+- Watchdog false-positive rate on healthy sessions must be **≤ 10%** —
+  noisy false alarms erode planner trust.
+
+If the experiment fails, P3+ is dropped and Layer 1 is enough.
+
+## 7. Open Questions
+
+1. **Should the planner be able to disable Sentinel messages for a turn?**
+   (E.g., "I know I look stuck but I'm working through a known-slow phase.")
+   Argues for a `sentinel.suppress(turns=N)` tool with audit logging.
+2. **What is the right TTL for `divergence.*` causal events?**
+   Probably same as other causal events (90d), but worth confirming for
+   privacy.
+3. **Does Layer 2 need to read execution_traces (stdout/stderr) or only the
+   digest?** Reading traces is much more expensive but might be necessary
+   for some divergence types.
+4. **Should F-1 (BudgetEnvelope unification) block P0?** Probably not —
+   keep them independent.
+5. **Constitutional alignment**: which rule numbers govern Sentinel's
+   behavior? It is observational, so likely a new R-7.x family rather than
+   extending R-3.x policy rules.
+
+## 8. References
+
+- `docs/design/human-gate-unification-plan.md` — the precedent factorization
+  effort this design follows
+- `autonoetic-gateway/src/runtime/guard.rs` — LoopGuard, the closest existing
+  cousin
+- `autonoetic-gateway/src/runtime/budget_tracker.rs` — context pressure
+  warning, a partial existing example of trajectory monitoring
+- `autonoetic-gateway/src/runtime/post_session_digest.rs` — post-session
+  analysis (Sentinel is its in-session counterpart)
+- `docs/agent-learning.md` — `digest.query`, `execution.search` APIs the
+  watchdog will use
+- `docs/separation-of-powers.md` — why the watchdog has no execution
+  capabilities

--- a/docs/design/self-improvement-loop-design.md
+++ b/docs/design/self-improvement-loop-design.md
@@ -1,0 +1,353 @@
+# Self-Improvement Loop — Design
+
+> Status: **Draft (2026-05-20)** — feedback wanted before implementation.
+> Tracking issue: [#244](https://github.com/mandubian/autonoetic/issues/244).
+> Phase issues: P0 [#245](https://github.com/mandubian/autonoetic/issues/245),
+> P1 [#246](https://github.com/mandubian/autonoetic/issues/246),
+> P2 [#247](https://github.com/mandubian/autonoetic/issues/247),
+> P3 [#248](https://github.com/mandubian/autonoetic/issues/248),
+> P4 [#249](https://github.com/mandubian/autonoetic/issues/249),
+> P5 [#250](https://github.com/mandubian/autonoetic/issues/250),
+> P6 [#251](https://github.com/mandubian/autonoetic/issues/251),
+> P7 [#252](https://github.com/mandubian/autonoetic/issues/252).
+> Related: [`divergence-sentinel-design.md`](./divergence-sentinel-design.md) (in-session
+> divergence detection; this doc is its post-session counterpart).
+
+## 1. Problem Statement
+
+Today's improvement loop is **operator-driven and manual**:
+
+1. Operator runs a task; the session finishes (well or poorly).
+2. Operator asks Claude to read the digest and identify what went wrong.
+3. Operator + Claude diagnose: missing skill step, broken agent prompt, missing
+   gateway primitive, oversized prompt, wrong routing, etc.
+4. Operator edits skills or files a code change.
+5. Operator re-runs the task and hopes it's better.
+
+The mechanics for most of this exist in Autonoetic already — but they are
+**disconnected**. There is no command that takes a finished session and walks
+it through `analyze → propose → validate → approve → deploy → monitor`.
+
+The operator wants this loop to be **concrete and partly automatic**, with two
+target axes:
+
+- **Logical correctness** — "register to service X" failed because of a missing
+  OAuth callback step.
+- **Efficiency** — a session burned 47k tokens and 23 turns when a tighter
+  agent could have done it in 12k tokens and 8 turns.
+
+And explicitly **not yet** fully autonomous — operator approval gates every
+deploy until the system has earned trust.
+
+## 2. What Already Exists (Bigger Than I Expected)
+
+A thorough infrastructure survey shows **the closed loop is ~70% built**. The
+table below maps closed-loop stages to the production code that already
+implements them:
+
+| Stage | Existing component | File / location | Status |
+|---|---|---|---|
+| **Detect — bad session signals** | `LoopGuard` sub-trip, budget breach, error_burst, divergence sentinel (planned #238) | `runtime/guard.rs`, `runtime/session_budget.rs` | ✅ Production |
+| **Detect — cross-session patterns** | `memory-curator.default` agent (scores per-agent perf; flags systemic gaps) | `agents/evolution/memory-curator.default/SKILL.md` | ✅ Production |
+| **Detect — orchestration chassis** | `evolution-orchestrator.default` (cron-driven: analyses sessions, triggers curator + steward, surfaces admin proposals) | `agents/evolution/evolution-orchestrator.default/SKILL.md` | ✅ Production |
+| **Diagnose — narrative** | Auto `post_session_digest` (LLM narrative + structured memory extraction) | `runtime/post_session_digest.rs` | ✅ Production |
+| **Diagnose — agent-level** | `evolution-steward.default` (classifies root cause: instructions-level / code-level / systemic) | `agents/evolution/evolution-steward.default/SKILL.md` | ✅ Production |
+| **Propose — agent / skill change** | `agent-factory.default` (coder + auditor + evaluator pipeline) | `agents/evolution/agent-factory.default/` | ✅ Production |
+| **Propose — revision storage** | `agent_revision_create`, immutable + content-addressed + Ed25519 signed | `runtime/tools/agent_revision.rs` | ✅ Production |
+| **Validate — eval suite** | `eval_suite_publish/run/compare/report` (with self-evaluation ownership invariant) | `runtime/tools/evaluation.rs` | ✅ Schemas; compare logic TBD |
+| **Validate — sealed replay** | `autonoetic eval sealed --artifact-ref <ar> --fixture-set <fs>` + recording mode | `runtime/sealed_network.rs`, `runtime/sealed_network_proxy.rs` | ✅ Production |
+| **Approve — promotion gate** | `promotion.record` with severity gating; auditor + evaluator pass required for `full` mode | `runtime/tools/promotion.rs` | ✅ Production |
+| **Deploy — alias swap** | `agent_revision_promote` (atomic alias update; multiple revisions coexist) | `runtime/tools/agent_revision.rs` | ✅ Production |
+| **Rollback** | `agent_revision_rollback` | `runtime/tools/agent_revision.rs` | ✅ Production |
+| **Monitor — cost & traces** | `session_cost_usd`, `execution_traces`, `causal_events` | various | ✅ Production |
+| **Install** | `specialized_builder.default` | `agents/evolution/specialized_builder.default/` | ✅ Production |
+
+The chassis is already there. The user can already do **most** of this by
+chatting with the evolution-orchestrator. What is missing is **the connective
+tissue that makes it concrete and operator-fronted**.
+
+## 3. What's Actually Missing (The Real Gap)
+
+Five concrete gaps, in priority order:
+
+### G1 — A/B replay orchestration (the keystone)
+
+There is no tool today that takes a recorded task and runs it against **two
+agent revisions in parallel**, returning a comparison report. Today you can:
+
+- Spawn one session with `revision_id` pinned (✅)
+- Replay a sealed evaluator against fixtures (✅)
+- Run two `agent_spawn` calls manually (✅)
+
+But there is **no built-in primitive that does**: `(task, revision_A,
+revision_B) → comparison_report` with controlled inputs, controlled fixtures,
+and shared evaluation criteria. Without this, every "is variant B actually
+better?" question falls back to "deploy and hope," which is exactly the
+behavior the operator wants to escape.
+
+### G2 — Multi-axis outcome grading
+
+`execution_traces` records cost and exit codes. `memory-curator` scores
+agents post-hoc. But there is **no canonical answer** to "did this session
+succeed at its task?" beyond what the curator infers from extracted memory
+or what the operator marked manually.
+
+For self-improvement, we need a structured `SessionOutcome`:
+
+```rust
+struct SessionOutcome {
+    task_goal: Option<String>,          // declared up front, optional
+    completion: Completion,              // Achieved | PartiallyAchieved | Failed | Aborted
+    cost_usd: f64,                       // already tracked
+    tokens: TokenBreakdown,              // already tracked
+    turns: u32,                          // already trivially derivable
+    wall_clock_secs: u64,                // already tracked
+    quality_score: Option<QualityScore>, // optional — from an external judge agent
+    operator_rating: Option<OperatorRating>,  // optional — explicit thumbs
+    grader: GraderProvenance,            // who graded this, with what evidence
+}
+```
+
+The grader must **not be the agent that ran the session** (self-bias drift,
+already a constitutional invariant on eval suites — `evaluated_targets`
+cannot include the publishing agent).
+
+### G3 — Code-issue proposer (operator-implements path)
+
+The operator wants the loop to be able to **propose** code changes, not just
+agent/skill changes. The proposed path: a specialist agent reads a failed
+session, identifies that the cause is in gateway code (e.g., "tool result
+schema lost the `Location` header on 3xx redirects"), and **files a
+well-scoped GitHub issue** with evidence (session ID, causal events,
+suggested fix area). The operator implements the fix on their own time.
+
+This is **bounded**: the proposer only opens issues, never edits code, never
+auto-merges. It is a focused agent with `github.issue.create` and
+`execution.search` capabilities and nothing else.
+
+### G4 — Eval compare statistical logic
+
+`eval_compare` is registered as a tool but the comparison logic is currently
+a stub. We need real statistical reasoning: is the observed delta
+significant? How many replays do we need? Are we within budget?
+
+For Phase 1, **bootstrap confidence intervals** over N replays (N typically
+3–10) are sufficient — no need for parametric tests. The output is a
+recommendation (`prefer_a` / `prefer_b` / `inconclusive`) with the CI as
+evidence.
+
+### G5 — Operator-fronted CLI
+
+There is no `autonoetic improve` command. The user wants something like:
+
+```bash
+autonoetic improve --session <session_id>
+# or
+autonoetic improve --last 20-sessions --agent planner.default
+```
+
+…that drives the loop end-to-end and reports back. Internally it just
+delegates to `evolution-orchestrator`, but with operator-mode behavior
+(interactive prompts, proposed changes shown inline, approval gates).
+
+## 4. The Closed Loop, Concretely
+
+```mermaid
+flowchart LR
+    A[Operator: 'autonoetic improve'] --> B[Detect: select sessions]
+    B --> C[Diagnose: post-session digests + curator]
+    C --> D{Root cause?}
+    D -->|Skill/agent prompt| E[Propose: agent-factory builds revision]
+    D -->|Logical step missing| E
+    D -->|Code-level| F[Propose: file GitHub issue → operator]
+    D -->|Systemic / routing| G[Propose: admin proposal]
+    E --> H[Validate: A/B replay on fixtures + held-out tasks]
+    H --> I[Eval compare: bootstrap CI]
+    I --> J{Better on all axes?}
+    J -->|Yes| K[Operator approves]
+    J -->|Inconclusive| L[More replays or drop]
+    J -->|Worse| M[Reject + record reason]
+    K --> N[Deploy: agent_revision_promote]
+    N --> O[Monitor: next N sessions]
+    O --> P{Regression?}
+    P -->|Yes| Q[agent_revision_rollback]
+    P -->|No| R[Done]
+```
+
+### The "logical fix" example (operator's first case)
+
+> Session 41a3 tried to register to service X and failed because the OAuth
+> callback step was missing from the planner's skill.
+
+1. **Detect**: session ended with `completion=Failed`; curator flagged
+   `planner.default` for `failure_mode=workflow_incomplete`.
+2. **Diagnose**: post-session digest narrative + curator decision journal
+   point at missing OAuth callback step.
+3. **Propose**: `evolution-steward` decides this is instructions-level. It
+   spawns `agent-factory` with context: "add OAuth callback handling step to
+   register workflow." Agent-factory produces revision `planner.default@v17`.
+4. **Validate**: A/B replay the failed session and 3 other registration tasks
+   on v16 (ground) vs v17 (beta). Replay uses recorded fixtures for the
+   external OAuth provider.
+5. **Eval compare**: v17 succeeds on 4/4, v16 succeeds on 1/4. Cost delta
+   negligible. Recommendation: `prefer_b`.
+6. **Operator approves**: sees diff, approves via interactive prompt or via
+   `admin.proposal` queue.
+7. **Deploy**: `agent_revision_promote v17`. Old `v16` retained for rollback.
+8. **Monitor**: next 5 registration sessions are watched; if regression,
+   automatic rollback proposal surfaces.
+
+### The "efficiency fix" example (operator's second case)
+
+> The planner used 47k tokens and 23 turns for a task a tighter version
+> should solve in 12k / 8 turns.
+
+1. **Detect**: not a failure, but `evolution-orchestrator` flags the session
+   as "outlier cost" — token usage > 90th percentile for this agent over the
+   last 30 days.
+2. **Diagnose**: curator analyzes which turns burned tokens. Identifies
+   verbose system prompt and redundant re-summarization steps.
+3. **Propose**: agent-factory produces `planner.default@v18-beta` with a
+   condensed prompt and a `summarize_only_at_milestones` flag.
+4. **Validate**: A/B replay 10 archived planner sessions on v17 (current)
+   vs v18-beta. **Cost-only metrics are not enough** — also measure
+   completion rate. A v18 that succeeds 60% of the time at half the cost is
+   strictly worse than v17 at 95%.
+5. **Eval compare**: v18-beta uses 0.55× tokens at 0.94× success.
+   Bootstrap CI on completion is too wide. Recommendation: `inconclusive`,
+   needs more replays.
+6. **Operator decision**: run more replays, or accept the cost-vs-success
+   tradeoff, or drop.
+7. **Deploy / rollback**: same path as above.
+
+## 5. Reward Hacking Defenses
+
+This is the section the operator was right to flag. Without these, "cheaper
+sessions" becomes the objective and quality erodes silently.
+
+### D1 — Multi-axis grading is mandatory
+
+A variant cannot be promoted on a single metric. The minimum bar is
+**completion AND cost AND quality**. If the variant wins on cost but the
+quality judge cannot confirm it matches on completion, it is **not better** —
+it is differently bad. Encoded in `eval_compare` as a multi-objective
+decision: variant B is preferred only if it Pareto-dominates A or is within
+configured tolerance on all axes.
+
+### D2 — The judge cannot be the proposer
+
+Already a constitutional invariant on eval suites: the publishing agent
+cannot appear in `evaluated_targets`. Extend this to the improvement loop:
+the agent that proposed the revision cannot grade it. Quality scoring is
+delegated to an independent specialist (e.g. an evaluator with no skin in
+the proposal).
+
+### D3 — Held-out tasks
+
+The variant must succeed on tasks it was not optimized against. If we
+proposed v18 from 5 specific session failures, validate also on a sample of
+sessions outside those 5. Configurable: `validation.holdout_ratio` (default
+0.3).
+
+### D4 — Cost-cut Pareto floor
+
+A variant whose cost reduction comes from completion reduction is rejected
+mechanically. Equivalently: if `completion_rate(B) < completion_rate(A) -
+tolerance`, the variant is rejected regardless of cost savings.
+
+### D5 — Operator final approval, always (Phase 1)
+
+Until the loop has run enough cycles for the operator to trust its
+judgments, **every promote requires operator approval**. This is enforced
+by routing all `agent_revision_promote` calls through the existing
+admin-proposal queue with explicit operator approval. Path to relax this in
+§7 (Progressive Automation).
+
+### D6 — Rollback bound to monitoring
+
+After deploy, the next N sessions are monitored. If completion rate or cost
+regresses by > 15% relative to ground, an automatic `rollback proposal` is
+queued for operator approval. This is **not auto-rollback** — operator
+decides. But the proposal is automatic.
+
+## 6. Rollout Phases
+
+| Phase | Deliverable | Why this order |
+|---|---|---|
+| **P0** | `SessionOutcome` structured grading (G2) — schema + grader agent + storage | Everything downstream needs this; cheapest of the gaps |
+| **P1** | `eval_compare` statistical logic (G4) — bootstrap CI, multi-axis decisions | Needed by validation; only the comparison routine is new code |
+| **P2** | A/B replay orchestrator (G1) — `improvement_orchestrator` agent + tool that does `(task, rev_A, rev_B) → comparison` | The keystone gap |
+| **P3** | `autonoetic improve` CLI (G5) — operator-fronted entry point | Makes the loop concrete |
+| **P4** | Skill-level evolution end-to-end (use P0–P3 for prompts only) | Lowest-risk first deploy of the loop |
+| **P5** | Agent-level evolution (capabilities, routing, sub-agents) | Higher blast radius; needs P4 to bake in |
+| **P6** | Code-issue proposer agent (G3) | Adds the code-level axis; bounded scope |
+| **P7** | Progressive automation: skip operator approval on small-blast-radius improvements with multi-cycle clean record | See §7 |
+
+Each phase is independently valuable. P0 alone unlocks better dashboards.
+P1 alone unlocks honest A/B reports. P2 alone unlocks operator-driven
+deliberate testing.
+
+## 7. Progressive Automation (The Path to Less Manual)
+
+The operator wants to start operator-triggered and **allow more automation
+later, progressively**. The progression has three gradations, each unlocked
+by accumulated track record:
+
+| Level | Trigger | Approval | When to unlock |
+|---|---|---|---|
+| **L1: Operator-triggered, operator-approved** | `autonoetic improve` | Every deploy | Default, always available |
+| **L2: Auto-triggered, operator-approved** | `evolution-orchestrator` cron run | Every deploy still requires operator | After 10 successful L1 cycles with no regressions for an agent |
+| **L3: Auto-triggered, auto-approved (bounded)** | Cron run | Auto-approval ONLY for: skill-only changes, multi-axis pass, held-out validated, blast radius score < threshold | After 20 successful L2 cycles per agent + explicit operator opt-in per agent |
+
+L3 is **opt-in per agent** and never automatic for agents with code-execution
+or sandbox-escape-adjacent capabilities. Constitutional rules apply.
+
+## 8. Relationship to the Divergence Sentinel (#238)
+
+The two designs are **complementary halves**:
+
+- **Sentinel** = in-session, real-time, detects divergence mid-flight, notifies
+  planner or operator while the session is still running.
+- **Self-improvement** = post-session, batch, detects systemic patterns
+  across many sessions and proposes durable changes.
+
+Concretely, the sentinel's `divergence.detected` causal events are **inputs
+to the curator**, which uses them as evidence when scoring agents. A
+high-divergence agent over many sessions is a candidate for improvement.
+
+## 9. Open Questions
+
+1. **Replay fidelity for non-fixtured external calls.** Sealed fixtures cover
+   recorded calls. Tasks involving novel real-world side effects (sending a
+   message, signing up to a service) cannot be replayed safely. Should
+   replay refuse such tasks, or use a mock provider, or operator-gate?
+2. **How many replays for a confidence interval the operator trusts?**
+   3 is cheap and weak; 10 is expensive and strong. Default proposal: 5,
+   configurable.
+3. **Held-out task pool: how curated?** Auto-sample from archived sessions
+   tagged with the same agent? Operator-curated golden set?
+4. **Quality-judge agent: separate per agent type, or one universal judge?**
+   Universal is simpler but may miss domain-specific criteria.
+5. **Cost ceiling per `autonoetic improve` invocation.** Replays add up. We
+   should declare a per-invocation budget (default proposal: $1) and
+   short-circuit cleanly.
+6. **What about the planner itself proposing improvements to itself?** The
+   ownership invariant on eval suites forbids self-evaluation. Should it also
+   forbid self-proposal? Probably yes for L3 auto-approval, possibly OK for
+   L1/L2 with operator review.
+
+## 10. References
+
+- `docs/design/divergence-sentinel-design.md` — sister design (in-session)
+- `docs/design/cognitive-capsule-standardization.md` — capsule format used
+  for replay determinism (Phase 4 is the last piece for full replay)
+- `docs/design/sealed-network-evaluation-plan.md` — fixture replay
+  infrastructure
+- `docs/design/sealed-evaluator-replay-design.md` — sealed evaluator CLI
+- `agents/evolution/` — existing pipeline (curator, steward, factory,
+  builder, orchestrator, adapter)
+- `autonoetic-gateway/src/runtime/tools/agent_revision.rs` — revision API
+- `autonoetic-gateway/src/runtime/tools/evaluation.rs` — eval suite API
+- `autonoetic-gateway/src/runtime/tools/promotion.rs` — promotion gating
+- `docs/separation-of-powers.md` — constitutional context for what may /
+  may not be auto-modified


### PR DESCRIPTION
Cherry-picks an older local commit (\`3485afc\`, 2026-05-20) that never made it to remote \`main\`. The two design docs are referenced by tracking issues #238 and #244 and by the PRs that implemented their phases (#253–#259, all merged), but the docs themselves were never pushed.

## What's in this PR

- \`docs/design/divergence-sentinel-design.md\` (319 lines) — design for the in-session divergence sentinel (Layer 1 deterministic monitor + Layer 2 optional LLM watchdog). Tracking: #238.
- \`docs/design/self-improvement-loop-design.md\` (350 lines) — design for the operator-fronted closed self-improvement loop (\`SessionOutcome\` grading, \`eval_compare\` stats, A/B replay orchestrator, \`autonoetic improve\` CLI, code-issue proposer). Tracking: #244.

Both docs follow the existing design-doc pattern in \`docs/design/\` (factorization survey, phased rollout, reward-hacking defenses, linked GitHub tracking + phase issues).

## Why now

The docs were committed locally on 2026-05-20 but never pushed; subsequent \`main\` activity (PRs #258, #259, plus 8 unrelated commits) made local \`main\` diverge. This PR brings the docs to remote \`main\` cleanly via a fresh cherry-pick rather than a rebase. Pure file additions — no conflicts possible.

## Test plan

- [ ] Reviewer confirms the design docs are consistent with the merged P0-P4 work (PRs #253, #254, #255, #256, #257, #258, #259)
- [ ] No code changes; no test runs needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)