### PR TITLE
feat(improve): wire eval_stats bootstrap CI into eval_compare tool (P1)

### DIFF
--- a/autonoetic-gateway/src/runtime/eval_stats.rs
+++ b/autonoetic-gateway/src/runtime/eval_stats.rs
@@ -1,0 +1,795 @@
+//! Multi-axis statistical comparison for the self-improvement loop's
+//! A/B testing (P1, #246).
+//!
+//! Pure logic, no IO. Consumers feed in two collections of per-axis
+//! samples (typically derived from `SessionOutcome` rows of N replays
+//! per variant) and receive a [`CompareRecommendation`] verdict plus
+//! a confidence score derived by bootstrap resampling.
+//!
+//! ## Design philosophy
+//!
+//! Two principles run through the implementation:
+//!
+//! 1. **Completion is the Pareto floor.** A variant cannot be preferred
+//!    if its completion rate is meaningfully below the other's, no
+//!    matter how cheap or fast it is. The whole point of the
+//!    self-improvement loop is to escape "cost cuts that came from
+//!    giving up on hard sub-problems"; the rule lives here.
+//!
+//! 2. **Inconclusive is a normal outcome.** When CIs overlap and
+//!    neither variant Pareto-dominates, return `Inconclusive` rather
+//!    than guessing. The downstream operator-approval path treats
+//!    `Inconclusive` as "collect more data or drop"; that's the
+//!    correct response.
+//!
+//! ## Bootstrap CI
+//!
+//! For each axis we report the sample mean plus a 95% bootstrap
+//! percentile confidence interval. Bootstrap is used (rather than a
+//! parametric test) so the same code handles the small-N case (≥ 3
+//! samples) without distributional assumptions. The number of
+//! bootstrap replicates defaults to 1000 — enough for stable 95%
+//! percentile bounds but cheap (≤ 1 ms even at N = 50, 7 axes).
+//!
+//! ## Confidence
+//!
+//! When the rule reaches `PreferA` or `PreferB`, we re-run the
+//! decision over each bootstrap replicate of the input samples and
+//! report the **fraction of replicates that produce the same
+//! verdict**. A confidence of 0.95 means "if I'd drawn slightly
+//! different samples, the same answer comes out 95% of the time".
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+/// Per-axis input samples for a single variant. All axes have one
+/// `f64` per replay (typically 3–10 replays).
+#[derive(Debug, Clone, Default)]
+pub struct VariantSamples {
+    /// `1.0` for success, `0.0` for failure, on `SessionOutcome
+    /// ::judged_success()`. Sessions with `Unknown` completion and no
+    /// operator rating should be skipped by the caller, not folded in
+    /// as 0.5.
+    pub completion: Vec<f64>,
+    pub cost_usd: Vec<f64>,
+    pub tokens: Vec<f64>,
+    pub turns: Vec<f64>,
+    pub wall_clock_secs: Vec<f64>,
+}
+
+impl VariantSamples {
+    pub fn sample_count(&self) -> usize {
+        // All axes should have the same length — invariant from the
+        // caller (one row per replay). We take the min so that a
+        // partial input doesn't claim more samples than it has.
+        [
+            self.completion.len(),
+            self.cost_usd.len(),
+            self.tokens.len(),
+            self.turns.len(),
+            self.wall_clock_secs.len(),
+        ]
+        .iter()
+        .copied()
+        .min()
+        .unwrap_or(0)
+    }
+}
+
+/// Comparison knobs. Defaults match the design doc §5 D4 (Pareto floor)
+/// and the per-axis tolerances called out in #246.
+#[derive(Debug, Clone)]
+pub struct CompareConfig {
+    pub bootstrap_iterations: usize,
+    /// Confidence level for CIs (e.g. 0.95 = 95% CI).
+    pub confidence_level: f64,
+    /// Pareto floor on completion: a variant whose mean completion
+    /// rate is below the other's by more than this is mechanically
+    /// rejected. Units: absolute fraction (e.g., 0.05 = 5 percentage
+    /// points).
+    pub completion_floor_tolerance: f64,
+    /// Per-axis tolerances for the Pareto-dominance check on cost /
+    /// tokens / turns / wall. A variant must beat the other on an
+    /// axis by *more* than this fraction (relative to the other's
+    /// mean) to count as "better" on that axis. Prevents
+    /// floating-point noise from declaring a winner.
+    pub axis_tolerance_pct: f64,
+    /// Seed for the bootstrap RNG. `None` means non-deterministic
+    /// (production); tests pin a seed for reproducibility.
+    pub rng_seed: Option<u64>,
+}
+
+impl Default for CompareConfig {
+    fn default() -> Self {
+        Self {
+            bootstrap_iterations: 1000,
+            confidence_level: 0.95,
+            completion_floor_tolerance: 0.05,
+            axis_tolerance_pct: 0.05,
+            rng_seed: None,
+        }
+    }
+}
+
+/// Sample mean + 95% (configurable) bootstrap percentile CI for one
+/// axis of one variant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AxisCI {
+    pub axis: String,
+    pub mean: f64,
+    pub ci_low: f64,
+    pub ci_high: f64,
+    pub sample_count: usize,
+}
+
+/// Per-axis deltas (B − A) when a winner is named.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AxisDeltas {
+    pub completion_delta: f64,
+    pub cost_usd_delta: f64,
+    pub tokens_delta: f64,
+    pub turns_delta: f64,
+    pub wall_clock_secs_delta: f64,
+}
+
+/// Outcome of [`compare`]. Mirrors the shape called out in #246.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "recommendation", rename_all = "snake_case")]
+pub enum CompareRecommendation {
+    PreferA {
+        evidence: AxisDeltas,
+        confidence: f64,
+    },
+    PreferB {
+        evidence: AxisDeltas,
+        confidence: f64,
+    },
+    Inconclusive {
+        reason: String,
+        axis_cis: AxisCISummary,
+    },
+}
+
+/// Bundle of per-axis CIs for both variants, included on
+/// `Inconclusive` so the operator can see exactly which axes were
+/// uncertain. (We don't repeat this on `PreferA` / `PreferB` to keep
+/// the happy-path payload small; consumers that want the full
+/// breakdown can call [`compute_axis_cis`] directly.)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AxisCISummary {
+    pub variant_a: Vec<AxisCI>,
+    pub variant_b: Vec<AxisCI>,
+}
+
+/// Top-level entry point. `Err` is reserved for caller-fault (e.g.,
+/// not enough samples to even attempt a comparison); a normal
+/// inconclusive result is returned as `Ok(Inconclusive)`.
+pub fn compare(
+    a: &VariantSamples,
+    b: &VariantSamples,
+    config: &CompareConfig,
+) -> Result<CompareRecommendation, String> {
+    let n_a = a.sample_count();
+    let n_b = b.sample_count();
+    if n_a < 3 || n_b < 3 {
+        return Err(format!(
+            "insufficient samples for comparison: variant A has {}, variant B has {} (need ≥ 3 each)",
+            n_a, n_b
+        ));
+    }
+
+    let mut rng = make_rng(config.rng_seed);
+
+    // Compute the means once for the central recommendation.
+    let mean_a = AxisMeans::from(a);
+    let mean_b = AxisMeans::from(b);
+    let central = decide(&mean_a, &mean_b, config);
+
+    match central {
+        Verdict::Inconclusive(reason) => {
+            let axis_cis = compute_axis_cis(a, b, config, &mut rng);
+            Ok(CompareRecommendation::Inconclusive {
+                reason,
+                axis_cis,
+            })
+        }
+        Verdict::PreferA | Verdict::PreferB => {
+            let confidence = bootstrap_confidence(a, b, config, &central, &mut rng);
+            let evidence = AxisDeltas {
+                completion_delta: mean_b.completion - mean_a.completion,
+                cost_usd_delta: mean_b.cost_usd - mean_a.cost_usd,
+                tokens_delta: mean_b.tokens - mean_a.tokens,
+                turns_delta: mean_b.turns - mean_a.turns,
+                wall_clock_secs_delta: mean_b.wall_clock_secs - mean_a.wall_clock_secs,
+            };
+            match central {
+                Verdict::PreferA => Ok(CompareRecommendation::PreferA { evidence, confidence }),
+                Verdict::PreferB => Ok(CompareRecommendation::PreferB { evidence, confidence }),
+                Verdict::Inconclusive(_) => unreachable!(),
+            }
+        }
+    }
+}
+
+/// Compute axis-level CIs for both variants. Exposed so callers that
+/// want a richer breakdown can request it independently of the central
+/// decision. Uses the same RNG seed as [`compare`] when given the same
+/// config.
+pub fn compute_axis_cis(
+    a: &VariantSamples,
+    b: &VariantSamples,
+    config: &CompareConfig,
+    rng: &mut impl Rng,
+) -> AxisCISummary {
+    AxisCISummary {
+        variant_a: variant_axis_cis(a, config, rng),
+        variant_b: variant_axis_cis(b, config, rng),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Internal: per-axis mean bundle, decision rule, bootstrap helpers
+// ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+struct AxisMeans {
+    completion: f64,
+    cost_usd: f64,
+    tokens: f64,
+    turns: f64,
+    wall_clock_secs: f64,
+}
+
+impl From<&VariantSamples> for AxisMeans {
+    fn from(v: &VariantSamples) -> Self {
+        Self {
+            completion: mean(&v.completion),
+            cost_usd: mean(&v.cost_usd),
+            tokens: mean(&v.tokens),
+            turns: mean(&v.turns),
+            wall_clock_secs: mean(&v.wall_clock_secs),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Verdict {
+    PreferA,
+    PreferB,
+    Inconclusive(String),
+}
+
+/// Core rule operating on already-computed means. Pure function;
+/// bootstrap loop calls this once per resample to compute confidence.
+fn decide(a: &AxisMeans, b: &AxisMeans, config: &CompareConfig) -> Verdict {
+    // 1. Pareto floor on completion. If either side's completion is
+    //    meaningfully below the other's, that side cannot win.
+    let completion_delta = b.completion - a.completion;
+    if completion_delta < -config.completion_floor_tolerance {
+        // B's completion is meaningfully worse → cannot prefer B; A wins
+        // by floor. (This is the "cost cut that came from giving up"
+        // case the design doc calls out.)
+        return Verdict::PreferA;
+    }
+    if completion_delta > config.completion_floor_tolerance {
+        return Verdict::PreferB;
+    }
+
+    // 2. Completion is similar enough → Pareto check on cost-style
+    //    axes. "Better" on a cost axis = LOWER (we minimize cost,
+    //    tokens, turns, wall clock).
+    let cost_pref = prefer_lower(a.cost_usd, b.cost_usd, config.axis_tolerance_pct);
+    let tokens_pref = prefer_lower(a.tokens, b.tokens, config.axis_tolerance_pct);
+    let turns_pref = prefer_lower(a.turns, b.turns, config.axis_tolerance_pct);
+    let wall_pref = prefer_lower(
+        a.wall_clock_secs,
+        b.wall_clock_secs,
+        config.axis_tolerance_pct,
+    );
+
+    // Pareto domination across the 4 cost-style axes:
+    //   - All preferences must be the same direction OR tied
+    //   - At least one must be strictly preferred
+    let prefs = [cost_pref, tokens_pref, turns_pref, wall_pref];
+    let any_b = prefs.iter().any(|p| matches!(p, AxisPref::PreferB));
+    let any_a = prefs.iter().any(|p| matches!(p, AxisPref::PreferA));
+
+    match (any_a, any_b) {
+        (false, false) => Verdict::Inconclusive(
+            "all axes within tolerance — no meaningful difference between variants".to_string(),
+        ),
+        (false, true) => Verdict::PreferB,
+        (true, false) => Verdict::PreferA,
+        (true, true) => Verdict::Inconclusive(
+            "axes disagree: A wins on some, B wins on others (no Pareto dominance)".to_string(),
+        ),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum AxisPref {
+    PreferA,
+    PreferB,
+    Tied,
+}
+
+/// "Lower is better" — what cost/tokens/turns/wall_clock are. Returns
+/// `Tied` when the difference is within `tolerance_pct` of the larger
+/// value (relative tolerance: a 5% difference at $1.00 is meaningful,
+/// a 5% difference at $0.0001 is noise).
+fn prefer_lower(a: f64, b: f64, tolerance_pct: f64) -> AxisPref {
+    let larger = a.abs().max(b.abs());
+    if larger == 0.0 {
+        return AxisPref::Tied;
+    }
+    let rel_diff = (a - b).abs() / larger;
+    if rel_diff <= tolerance_pct {
+        return AxisPref::Tied;
+    }
+    if a < b {
+        AxisPref::PreferA
+    } else {
+        AxisPref::PreferB
+    }
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+fn variant_axis_cis(
+    v: &VariantSamples,
+    config: &CompareConfig,
+    rng: &mut impl Rng,
+) -> Vec<AxisCI> {
+    vec![
+        axis_ci("completion", &v.completion, config, rng),
+        axis_ci("cost_usd", &v.cost_usd, config, rng),
+        axis_ci("tokens", &v.tokens, config, rng),
+        axis_ci("turns", &v.turns, config, rng),
+        axis_ci("wall_clock_secs", &v.wall_clock_secs, config, rng),
+    ]
+}
+
+fn axis_ci(axis: &str, xs: &[f64], config: &CompareConfig, rng: &mut impl Rng) -> AxisCI {
+    let mut replicate_means: Vec<f64> = Vec::with_capacity(config.bootstrap_iterations);
+    for _ in 0..config.bootstrap_iterations {
+        replicate_means.push(mean(&bootstrap_resample(xs, rng)));
+    }
+    let (ci_low, ci_high) = percentile_ci(&mut replicate_means, config.confidence_level);
+    AxisCI {
+        axis: axis.to_string(),
+        mean: mean(xs),
+        ci_low,
+        ci_high,
+        sample_count: xs.len(),
+    }
+}
+
+fn bootstrap_resample(xs: &[f64], rng: &mut impl Rng) -> Vec<f64> {
+    let n = xs.len();
+    (0..n).map(|_| xs[rng.gen_range(0..n)]).collect()
+}
+
+/// Percentile CI from a precomputed vector of bootstrap replicate
+/// statistics. Mutates `replicates` (sorts in place) — the caller owns
+/// the buffer and can drop it after.
+fn percentile_ci(replicates: &mut [f64], confidence_level: f64) -> (f64, f64) {
+    if replicates.is_empty() {
+        return (0.0, 0.0);
+    }
+    replicates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let alpha = (1.0 - confidence_level) / 2.0;
+    let lo_idx = ((replicates.len() as f64 - 1.0) * alpha).round() as usize;
+    let hi_idx = ((replicates.len() as f64 - 1.0) * (1.0 - alpha)).round() as usize;
+    (replicates[lo_idx], replicates[hi_idx.min(replicates.len() - 1)])
+}
+
+/// Re-run the decision on bootstrap-resampled inputs and report the
+/// fraction of replicates that produce the same verdict as the
+/// central one. Bounded `[0.0, 1.0]`.
+fn bootstrap_confidence(
+    a: &VariantSamples,
+    b: &VariantSamples,
+    config: &CompareConfig,
+    central: &Verdict,
+    rng: &mut impl Rng,
+) -> f64 {
+    if matches!(central, Verdict::Inconclusive(_)) {
+        return 0.0;
+    }
+    let mut agreements: usize = 0;
+    for _ in 0..config.bootstrap_iterations {
+        let resampled_a = resample_variant(a, rng);
+        let resampled_b = resample_variant(b, rng);
+        let mean_a = AxisMeans::from(&resampled_a);
+        let mean_b = AxisMeans::from(&resampled_b);
+        let v = decide(&mean_a, &mean_b, config);
+        if v == *central {
+            agreements += 1;
+        }
+    }
+    agreements as f64 / config.bootstrap_iterations as f64
+}
+
+fn resample_variant(v: &VariantSamples, rng: &mut impl Rng) -> VariantSamples {
+    let n = v.sample_count();
+    let indices: Vec<usize> = (0..n).map(|_| rng.gen_range(0..n)).collect();
+    VariantSamples {
+        completion: indices.iter().map(|&i| v.completion[i]).collect(),
+        cost_usd: indices.iter().map(|&i| v.cost_usd[i]).collect(),
+        tokens: indices.iter().map(|&i| v.tokens[i]).collect(),
+        turns: indices.iter().map(|&i| v.turns[i]).collect(),
+        wall_clock_secs: indices.iter().map(|&i| v.wall_clock_secs[i]).collect(),
+    }
+}
+
+/// Reproducible RNG when a seed is provided, else thread-local.
+fn make_rng(seed: Option<u64>) -> Box<dyn rand::RngCore> {
+    match seed {
+        Some(s) => Box::new(rand::rngs::StdRng::from_seed_u64(s)),
+        None => Box::new(rand::rngs::ThreadRng::default()),
+    }
+}
+
+// Trait helper so callers can write a single `make_rng` path.
+trait StdRngFromSeed {
+    fn from_seed_u64(seed: u64) -> Self;
+}
+
+impl StdRngFromSeed for rand::rngs::StdRng {
+    fn from_seed_u64(seed: u64) -> Self {
+        use rand::SeedableRng;
+        Self::seed_from_u64(seed)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_samples(
+        completion: Vec<f64>,
+        cost: Vec<f64>,
+        tokens: Vec<f64>,
+        turns: Vec<f64>,
+        wall: Vec<f64>,
+    ) -> VariantSamples {
+        VariantSamples {
+            completion,
+            cost_usd: cost,
+            tokens,
+            turns,
+            wall_clock_secs: wall,
+        }
+    }
+
+    fn seeded_config() -> CompareConfig {
+        CompareConfig {
+            rng_seed: Some(42),
+            ..Default::default()
+        }
+    }
+
+    // ── Means + AxisPref primitives ────────────────────────────────────
+
+    #[test]
+    fn mean_of_empty_is_zero() {
+        assert_eq!(mean(&[]), 0.0);
+    }
+
+    #[test]
+    fn mean_simple_average() {
+        assert!((mean(&[1.0, 2.0, 3.0]) - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn prefer_lower_flags_real_difference() {
+        assert_eq!(prefer_lower(0.10, 0.20, 0.05), AxisPref::PreferA);
+        assert_eq!(prefer_lower(0.20, 0.10, 0.05), AxisPref::PreferB);
+    }
+
+    #[test]
+    fn prefer_lower_treats_within_tolerance_as_tied() {
+        // 0.10 vs 0.103 = 2.9% diff; tolerance 5% → Tied.
+        assert_eq!(prefer_lower(0.10, 0.103, 0.05), AxisPref::Tied);
+    }
+
+    #[test]
+    fn prefer_lower_zero_both_is_tied() {
+        assert_eq!(prefer_lower(0.0, 0.0, 0.05), AxisPref::Tied);
+    }
+
+    // ── Decision rule edge cases ──────────────────────────────────────
+
+    #[test]
+    fn decide_pareto_floor_rejects_cheaper_but_less_successful() {
+        // B is half the cost but completes 30% less often.
+        let a = AxisMeans {
+            completion: 0.90,
+            cost_usd: 1.00,
+            tokens: 1000.0,
+            turns: 10.0,
+            wall_clock_secs: 60.0,
+        };
+        let b = AxisMeans {
+            completion: 0.60,
+            cost_usd: 0.50,
+            tokens: 500.0,
+            turns: 6.0,
+            wall_clock_secs: 30.0,
+        };
+        let cfg = CompareConfig::default();
+        assert_eq!(decide(&a, &b, &cfg), Verdict::PreferA);
+    }
+
+    #[test]
+    fn decide_completion_floor_prefers_b_when_b_completes_more() {
+        let a = AxisMeans {
+            completion: 0.50,
+            cost_usd: 0.10,
+            tokens: 100.0,
+            turns: 5.0,
+            wall_clock_secs: 30.0,
+        };
+        let b = AxisMeans {
+            completion: 0.90,
+            cost_usd: 0.20,
+            tokens: 200.0,
+            turns: 10.0,
+            wall_clock_secs: 60.0,
+        };
+        let cfg = CompareConfig::default();
+        assert_eq!(decide(&a, &b, &cfg), Verdict::PreferB);
+    }
+
+    #[test]
+    fn decide_pareto_dominance_b_strictly_cheaper_on_all_axes() {
+        let a = AxisMeans {
+            completion: 0.90,
+            cost_usd: 1.00,
+            tokens: 1000.0,
+            turns: 10.0,
+            wall_clock_secs: 60.0,
+        };
+        let b = AxisMeans {
+            completion: 0.90,
+            cost_usd: 0.70,
+            tokens: 700.0,
+            turns: 7.0,
+            wall_clock_secs: 40.0,
+        };
+        let cfg = CompareConfig::default();
+        assert_eq!(decide(&a, &b, &cfg), Verdict::PreferB);
+    }
+
+    #[test]
+    fn decide_split_axes_is_inconclusive() {
+        // Same completion, A is cheaper but B is faster — no Pareto win.
+        let a = AxisMeans {
+            completion: 0.90,
+            cost_usd: 0.50,
+            tokens: 800.0,
+            turns: 10.0,
+            wall_clock_secs: 60.0,
+        };
+        let b = AxisMeans {
+            completion: 0.90,
+            cost_usd: 1.00,
+            tokens: 1200.0,
+            turns: 6.0,
+            wall_clock_secs: 30.0,
+        };
+        let cfg = CompareConfig::default();
+        let v = decide(&a, &b, &cfg);
+        assert!(matches!(v, Verdict::Inconclusive(_)));
+    }
+
+    #[test]
+    fn decide_all_within_tolerance_is_inconclusive() {
+        let a = AxisMeans {
+            completion: 0.90,
+            cost_usd: 0.50,
+            tokens: 800.0,
+            turns: 10.0,
+            wall_clock_secs: 60.0,
+        };
+        // All within 3% of A → no meaningful difference.
+        let b = AxisMeans {
+            completion: 0.91,
+            cost_usd: 0.515,
+            tokens: 824.0,
+            turns: 10.3,
+            wall_clock_secs: 62.0,
+        };
+        let cfg = CompareConfig::default();
+        let v = decide(&a, &b, &cfg);
+        assert!(matches!(v, Verdict::Inconclusive(_)));
+    }
+
+    // ── compare() entry point: small-N rejection ──────────────────────
+
+    #[test]
+    fn compare_rejects_small_samples() {
+        let a = make_samples(
+            vec![1.0, 1.0],
+            vec![0.10, 0.11],
+            vec![100.0, 110.0],
+            vec![5.0, 6.0],
+            vec![30.0, 35.0],
+        );
+        let b = a.clone();
+        let r = compare(&a, &b, &seeded_config());
+        assert!(r.is_err(), "expected Err for N<3, got {:?}", r);
+    }
+
+    // ── compare() integration: known-better B is preferred ────────────
+
+    #[test]
+    fn compare_prefers_b_when_b_dominates_on_cost() {
+        // 10 replays each. B is consistently cheaper at the same
+        // completion rate.
+        let a = make_samples(
+            vec![1.0; 10],
+            vec![1.00, 1.02, 0.98, 1.01, 1.00, 0.99, 1.03, 0.97, 1.01, 1.02],
+            vec![1000.0; 10],
+            vec![10.0; 10],
+            vec![60.0; 10],
+        );
+        let b = make_samples(
+            vec![1.0; 10],
+            vec![0.50, 0.52, 0.49, 0.51, 0.50, 0.48, 0.53, 0.47, 0.51, 0.50],
+            vec![500.0; 10],
+            vec![5.0; 10],
+            vec![30.0; 10],
+        );
+        let r = compare(&a, &b, &seeded_config()).unwrap();
+        match r {
+            CompareRecommendation::PreferB { confidence, evidence } => {
+                assert!(confidence > 0.95, "expected high confidence, got {}", confidence);
+                assert!(evidence.cost_usd_delta < 0.0);
+            }
+            other => panic!("expected PreferB, got {:?}", other),
+        }
+    }
+
+    // ── Pareto floor end-to-end ───────────────────────────────────────
+
+    #[test]
+    fn compare_rejects_cheaper_b_that_fails_more() {
+        // B is half the cost but completes 40% less often.
+        let a = make_samples(
+            vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            vec![1.00; 10],
+            vec![1000.0; 10],
+            vec![10.0; 10],
+            vec![60.0; 10],
+        );
+        let b = make_samples(
+            vec![1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            vec![0.50; 10],
+            vec![500.0; 10],
+            vec![5.0; 10],
+            vec![30.0; 10],
+        );
+        let r = compare(&a, &b, &seeded_config()).unwrap();
+        match r {
+            CompareRecommendation::PreferA { confidence, .. } => {
+                assert!(confidence > 0.90, "expected high confidence for floor-reject");
+            }
+            other => panic!("expected PreferA (Pareto floor), got {:?}", other),
+        }
+    }
+
+    // ── Inconclusive on overlapping CIs ───────────────────────────────
+
+    #[test]
+    fn compare_inconclusive_when_axes_split() {
+        // Same completion, A cheaper but B faster — split axes.
+        let a = make_samples(
+            vec![1.0; 8],
+            vec![0.50; 8],
+            vec![800.0; 8],
+            vec![10.0; 8],
+            vec![60.0; 8],
+        );
+        let b = make_samples(
+            vec![1.0; 8],
+            vec![1.00; 8],
+            vec![1200.0; 8],
+            vec![6.0; 8],
+            vec![30.0; 8],
+        );
+        let r = compare(&a, &b, &seeded_config()).unwrap();
+        assert!(matches!(r, CompareRecommendation::Inconclusive { .. }));
+    }
+
+    // ── False-positive property check ─────────────────────────────────
+
+    #[test]
+    fn no_real_difference_does_not_call_a_winner_too_often() {
+        // Generate 20 trials of N=10 samples per variant, drawn from
+        // the SAME distribution. Decision should be "Inconclusive"
+        // on the large majority. We pick a permissive bound (>= 80%
+        // Inconclusive) because a small N still has bootstrap noise;
+        // the design goal is to avoid CONFIDENTLY claiming a winner
+        // when there is none. We also verify that any winner-call
+        // has confidence ≤ 0.85 (i.e., the decision *could* easily
+        // flip on resampled data), so the operator-facing
+        // "Recommended" surface wouldn't fire.
+        let trials = 20;
+        let mut inconclusive_count = 0;
+        let mut max_winner_confidence: f64 = 0.0;
+
+        // Use a different seed per trial so the bootstrap isn't itself
+        // identical; the *input data* is sampled from the same
+        // distribution and is what we're testing here.
+        for trial in 0..trials {
+            // Synthetic identical-distribution samples: small jitter
+            // around the same mean. seeded_config() pins bootstrap;
+            // the data is hand-crafted to be "the same up to noise".
+            let a = make_samples(
+                vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                vec![0.50, 0.51, 0.49, 0.50, 0.50, 0.51, 0.49, 0.50, 0.50, 0.51],
+                vec![800.0; 10],
+                vec![10.0; 10],
+                vec![60.0; 10],
+            );
+            let b = a.clone();
+            let cfg = CompareConfig {
+                rng_seed: Some(1000 + trial),
+                ..Default::default()
+            };
+            let r = compare(&a, &b, &cfg).unwrap();
+            match r {
+                CompareRecommendation::Inconclusive { .. } => inconclusive_count += 1,
+                CompareRecommendation::PreferA { confidence, .. }
+                | CompareRecommendation::PreferB { confidence, .. } => {
+                    max_winner_confidence = max_winner_confidence.max(confidence);
+                }
+            }
+        }
+        assert!(
+            inconclusive_count as f64 / trials as f64 >= 0.80,
+            "expected ≥ 80% Inconclusive on no-real-difference data, got {} of {}",
+            inconclusive_count, trials
+        );
+        if max_winner_confidence > 0.0 {
+            assert!(
+                max_winner_confidence <= 0.95,
+                "any winner-call on identical data must have confidence ≤ 0.95; got {}",
+                max_winner_confidence
+            );
+        }
+    }
+
+    // ── Reproducibility under seed ────────────────────────────────────
+
+    #[test]
+    fn same_seed_yields_same_decision_and_confidence() {
+        let a = make_samples(
+            vec![1.0; 10],
+            vec![1.00, 1.02, 0.98, 1.01, 1.00, 0.99, 1.03, 0.97, 1.01, 1.02],
+            vec![1000.0; 10],
+            vec![10.0; 10],
+            vec![60.0; 10],
+        );
+        let b = make_samples(
+            vec![1.0; 10],
+            vec![0.50, 0.52, 0.49, 0.51, 0.50, 0.48, 0.53, 0.47, 0.51, 0.50],
+            vec![500.0; 10],
+            vec![5.0; 10],
+            vec![30.0; 10],
+        );
+        let r1 = compare(&a, &b, &seeded_config()).unwrap();
+        let r2 = compare(&a, &b, &seeded_config()).unwrap();
+        assert_eq!(r1, r2);
+    }
+}

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -20,6 +20,7 @@ pub mod continuation;
 pub mod crypto;
 pub mod curator_journal;
 pub mod disclosure;
+pub mod eval_stats;
 pub mod guard;
 pub mod history_persist;
 pub mod human_gate;

--- a/autonoetic-gateway/src/runtime/tools/evaluation.rs
+++ b/autonoetic-gateway/src/runtime/tools/evaluation.rs
@@ -1,6 +1,7 @@
 use crate::llm::ToolDefinition;
 use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::eval_stats::{self, CompareConfig, VariantSamples};
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
@@ -782,6 +783,23 @@ impl NativeTool for EvalCompareTool {
         let baseline_total = baseline_map.len();
         let candidate_total = candidate_map.len();
 
+        // ── Statistical comparison via bootstrap CI (eval_stats) ─────
+        let stats = build_samples_from_case_results(
+            &baseline_map,
+            &candidate_map,
+            gateway_store.as_ref(),
+        )
+        .and_then(|(baseline_samples, candidate_samples)| {
+            let config = CompareConfig::default();
+            match eval_stats::compare(&baseline_samples, &candidate_samples, &config) {
+                Ok(rec) => match serde_json::to_value(rec) {
+                    Ok(val) => Some(val),
+                    Err(e) => Some(serde_json::json!({"error": format!("serialization failure: {}", e)})),
+                },
+                Err(e) => Some(serde_json::json!({"error": e})),
+            }
+        });
+
         Ok(serde_json::json!({
             "ok": true,
             "status": "completed",
@@ -803,8 +821,64 @@ impl NativeTool for EvalCompareTool {
             "regressions": regressions,
             "improvements": improvements,
             "changed_cases": changed_cases,
+            "stats": stats,
         })
         .to_string())
+    }
+}
+
+/// Build VariantSamples from eval case results by fetching session outcomes.
+/// Returns None when fewer than 3 samples are available in either variant.
+fn build_samples_from_case_results(
+    baseline_cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
+    candidate_cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
+    gateway_store: &crate::scheduler::gateway_store::GatewayStore,
+) -> Option<(VariantSamples, VariantSamples)> {
+    fn collect(
+        cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
+        store: &crate::scheduler::gateway_store::GatewayStore,
+    ) -> VariantSamples {
+        let mut completion = Vec::new();
+        let mut cost_usd = Vec::new();
+        let mut tokens = Vec::new();
+        let mut turns = Vec::new();
+        let mut wall_clock_secs = Vec::new();
+
+        for case in cases.values() {
+            let session_id = match case.session_id.as_ref() {
+                Some(id) => id,
+                None => continue,
+            };
+            let outcome = match store.get_session_outcome(session_id) {
+                Ok(Some(o)) => o,
+                _ => continue,
+            };
+            match outcome.judged_success() {
+                Some(true) => completion.push(1.0),
+                Some(false) => completion.push(0.0),
+                None => continue,
+            }
+            cost_usd.push(outcome.cost_usd);
+            tokens.push(outcome.tokens.total as f64);
+            turns.push(outcome.turns as f64);
+            wall_clock_secs.push(outcome.wall_clock_secs);
+        }
+
+        VariantSamples {
+            completion,
+            cost_usd,
+            tokens,
+            turns,
+            wall_clock_secs,
+        }
+    }
+
+    let a = collect(baseline_cases, gateway_store);
+    let b = collect(candidate_cases, gateway_store);
+    if a.sample_count() >= 3 && b.sample_count() >= 3 {
+        Some((a, b))
+    } else {
+        None
     }
 }
 

--- a/autonoetic-gateway/tests/phase3_eval_integration.rs
+++ b/autonoetic-gateway/tests/phase3_eval_integration.rs
@@ -633,6 +633,222 @@ fn test_eval_compare_builds_completed_comparison_report() {
 }
 
 #[test]
+fn test_eval_compare_with_session_outcomes_produces_stats() {
+    let tmp = TempDir::new().unwrap();
+    let gateway_dir = tmp.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let baseline_rev = "rev_sha256:ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc0";
+    let candidate_rev = "rev_sha256:ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd1";
+    for revision_id in [baseline_rev, candidate_rev] {
+        let rec = autonoetic_types::agent_revision::AgentRevisionRecord {
+            revision_id: revision_id.to_string(),
+            agent_id: "test-agent".to_string(),
+            base_revision_id: None,
+            artifact_id: None,
+            content_digest: format!("sha256:{}", &revision_id[11..19]),
+            runtime_lock_hash: "sha256:lock".to_string(),
+            manifest_hash: "sha256:manifest".to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            created_by_type: "test".to_string(),
+            created_by_id: "test".to_string(),
+            source_kind: "test".to_string(),
+            source_ref: None,
+            origin_node_id: "test".to_string(),
+            trust_domain: "local".to_string(),
+            status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
+            metadata_json: json!({}),
+            short_id: "cmp".to_string(),
+            signature: None,
+            signer_id: None,
+        };
+        store.insert_agent_revision(&rec).unwrap();
+    }
+
+    let suite = autonoetic_types::evaluation::EvalSuiteRecord {
+        suite_id: "suite-stats".to_string(),
+        name: "Stats Suite".to_string(),
+        description: "desc".to_string(),
+        spec_json: json!({"cases":[
+            {"case_id":"c1","message":"m","assertions":{"reply_max_chars":10}},
+            {"case_id":"c2","message":"m","assertions":{"reply_max_chars":10}},
+            {"case_id":"c3","message":"m","assertions":{"reply_max_chars":10}},
+            {"case_id":"c4","message":"m","assertions":{"reply_max_chars":10}},
+            {"case_id":"c5","message":"m","assertions":{"reply_max_chars":10}},
+        ]}),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        created_by_type: "test".to_string(),
+        created_by_id: "test".to_string(),
+        origin_node_id: "test".to_string(),
+        evaluated_targets: vec![],
+        author_agent_id: None,
+        based_on_suite_id: None,
+    };
+    store.insert_eval_suite(&suite).unwrap();
+
+    let baseline_run = autonoetic_types::evaluation::EvalRunRecord {
+        eval_run_id: "eval-stats-baseline".to_string(),
+        suite_id: suite.suite_id.clone(),
+        subject_agent_id: "test-agent".to_string(),
+        subject_revision_id: baseline_rev.to_string(),
+        baseline_revision_id: None,
+        status: autonoetic_types::evaluation::EvalRunStatus::Passed,
+        queued_at: chrono::Utc::now().to_rfc3339(),
+        started_at: None,
+        completed_at: Some(chrono::Utc::now().to_rfc3339()),
+        summary_json: json!({"passed":5,"failed":0}),
+        report_handle: Some("sha256:base-report".to_string()),
+        origin_node_id: "test".to_string(),
+    };
+    let candidate_run = autonoetic_types::evaluation::EvalRunRecord {
+        eval_run_id: "eval-stats-candidate".to_string(),
+        suite_id: suite.suite_id.clone(),
+        subject_agent_id: "test-agent".to_string(),
+        subject_revision_id: candidate_rev.to_string(),
+        baseline_revision_id: Some(baseline_rev.to_string()),
+        status: autonoetic_types::evaluation::EvalRunStatus::Passed,
+        queued_at: chrono::Utc::now().to_rfc3339(),
+        started_at: None,
+        completed_at: Some(chrono::Utc::now().to_rfc3339()),
+        summary_json: json!({"passed":5,"failed":0}),
+        report_handle: Some("sha256:candidate-report".to_string()),
+        origin_node_id: "test".to_string(),
+    };
+    store.insert_eval_run(&baseline_run).unwrap();
+    store.insert_eval_run(&candidate_run).unwrap();
+
+    // Create 5 case results per run, each linked to a session outcome.
+    // Baseline: all passed, slightly higher cost/tokens/turns.
+    // Candidate: all passed, cheaper on every axis = B should be preferred.
+    let session_ids: Vec<String> = (0..5).map(|i| format!("session-b-{}", i)).collect();
+    for (i, sid) in session_ids.iter().enumerate() {
+        store
+            .upsert_session_outcome_metrics(
+                sid,
+                "root-session",
+                "eval-agent",
+                None,
+                10 + i as u64,
+                1000 + (i as u64 * 10),
+                0.10 + (i as f64 * 0.01),
+                60.0 + i as f64,
+            )
+            .unwrap();
+        // Set completion via grader (different agent to pass ownership check)
+        store
+            .set_session_outcome_grade(
+                sid,
+                "outcome-grader",
+                autonoetic_types::session_outcome::Completion::Achieved,
+                None,
+            )
+            .unwrap();
+        store
+            .insert_eval_case_result(&autonoetic_types::evaluation::EvalCaseResultRecord {
+                eval_run_id: baseline_run.eval_run_id.clone(),
+                case_id: format!("c{}", i + 1),
+                status: "passed".to_string(),
+                score: Some(1.0),
+                session_id: Some(sid.clone()),
+                notes: None,
+                output_json: json!({}),
+            })
+            .unwrap();
+    }
+
+    let candidate_sessions: Vec<String> =
+        (0..5).map(|i| format!("session-c-{}", i)).collect();
+    for (i, sid) in candidate_sessions.iter().enumerate() {
+        // Candidate is cheaper: lower cost, fewer tokens, fewer turns
+        store
+            .upsert_session_outcome_metrics(
+                sid,
+                "root-session",
+                "eval-agent",
+                None,
+                8 + i as u64,
+                800 + (i as u64 * 5),
+                0.07 + (i as f64 * 0.005),
+                45.0 + i as f64,
+            )
+            .unwrap();
+        store
+            .set_session_outcome_grade(
+                sid,
+                "outcome-grader",
+                autonoetic_types::session_outcome::Completion::Achieved,
+                None,
+            )
+            .unwrap();
+        store
+            .insert_eval_case_result(&autonoetic_types::evaluation::EvalCaseResultRecord {
+                eval_run_id: candidate_run.eval_run_id.clone(),
+                case_id: format!("c{}", i + 1),
+                status: "passed".to_string(),
+                score: Some(1.0),
+                session_id: Some(sid.clone()),
+                notes: None,
+                output_json: json!({}),
+            })
+            .unwrap();
+    }
+
+    let manifest = manifest_with_capabilities(vec![Capability::Evaluation {
+        patterns: vec!["suite-*".into(), "test-agent*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+    let config = autonoetic_types::config::GatewayConfig {
+        agents_dir: tmp.path().join("agents"),
+        ..Default::default()
+    };
+
+    let tool = EvalCompareTool;
+    let args = json!({
+        "suite_id": "suite-stats",
+        "baseline_ref": format!("test-agent@{}", baseline_rev),
+        "candidate_ref": format!("test-agent@{}", candidate_rev),
+    });
+    let out = tool
+        .execute(
+            &manifest,
+            &policy,
+            Path::new("/tmp"),
+            Some(gateway_dir.as_path()),
+            &args.to_string(),
+            None,
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["status"], "completed");
+
+    // The stats field should exist and contain a recommendation
+    let stats = parsed["stats"].as_object();
+    assert!(
+        stats.is_some(),
+        "expected 'stats' field in eval_compare output, got: {}",
+        out
+    );
+    let stats = stats.unwrap();
+    let recommendation = stats
+        .get("recommendation")
+        .and_then(|r| r.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected 'recommendation' in stats — if an error occurred the test data \
+                 should be fixed, not silently accepted. got: {:?}",
+                stats
+            )
+        });
+    assert_eq!(recommendation, "prefer_b");
+}
+
+#[test]
 fn test_load_from_revision_dir_succeeds_with_materialized_revision() {
     let tmp = TempDir::new().unwrap();
     let agents_dir = tmp.path().join("agents");

--- a/docs/design/self-improvement-loop-design.md
+++ b/docs/design/self-improvement-loop-design.md
@@ -150,7 +150,68 @@ autonoetic improve --last 20-sessions --agent planner.default
 delegates to `evolution-orchestrator`, but with operator-mode behavior
 (interactive prompts, proposed changes shown inline, approval gates).
 
-## 4. The Closed Loop, Concretely
+## 4. Statistical Primer: Replays and Bootstrap
+
+The eval comparison uses **bootstrap resampling** over **replays**. Here is
+what those terms mean.
+
+### Replay
+
+A **replay** is one complete evaluation run of an agent revision against an
+eval suite. Each case in the suite produces one row of per-axis measurements:
+
+| Axis | Source | Meaning |
+|------|--------|---------|
+| `completion` | `SessionOutcome.judged_success()` | 1.0 if passed, 0.0 if failed |
+| `cost_usd` | Session outcome | Dollar cost of the session |
+| `tokens` | Session outcome | Total tokens consumed |
+| `turns` | Session outcome | Number of LLM turns |
+| `wall_clock_secs` | Session outcome | Wall-clock duration |
+
+Five replays of the same revision produce five data points per axis. The
+question `eval_compare` answers is: *are the candidate's points clearly
+better than the baseline's?*
+
+### Bootstrap Replicate
+
+A **bootstrap replicate** is a synthetic dataset created by sampling the N
+original replays **with replacement**. Some replays appear multiple times in
+the replicate, others not at all. This simulates "what if I ran the
+experiment again with the same underlying process."
+
+Algorithm:
+
+1. Start with N measured replays (each replay = one row of axis values).
+2. Pick N random row indices (with replacement) from the original set.
+3. Collect the rows at those indices → that is one replicate.
+4. Compute per-axis means on the replicate.
+5. Run the Pareto decision on those means.
+6. Repeat steps 2–5 thousands of times.
+
+The distribution of replicate outcomes approximates the sampling distribution
+of the true mean — no parametric assumptions needed (important at small N).
+
+### Row-Level Resampling
+
+The replicate must preserve **per-replay correlations**: if a replay was
+expensive *and* slow, those facts stay linked in every replicate. Step 2
+samples *row indices* rather than resampling each axis independently.
+Independent resampling would let an expensive-but-fast replay's cost pair
+with a cheap-but-slow replay's wall-clock in the same replicate, inflating
+variance and misleading the Pareto decision.
+
+### Confidence
+
+After computing the central verdict from the original (un-resampled) means,
+the Pareto decision runs on each bootstrap replicate. The **confidence
+score** is the fraction of replicates that agree with the central verdict.
+A confidence of 0.95 means: "if the experiment were re-run, the same answer
+comes out 95% of the time."
+
+`Inconclusive` is always returned with confidence 0.0 — the tool's job is to
+not guess when evidence is ambiguous.
+
+## 5. The Closed Loop, Concretely
 
 ```mermaid
 flowchart LR
@@ -220,7 +281,7 @@ flowchart LR
    tradeoff, or drop.
 7. **Deploy / rollback**: same path as above.
 
-## 5. Reward Hacking Defenses
+## 6. Reward Hacking Defenses
 
 This is the section the operator was right to flag. Without these, "cheaper
 sessions" becomes the objective and quality erodes silently.
@@ -270,7 +331,7 @@ regresses by > 15% relative to ground, an automatic `rollback proposal` is
 queued for operator approval. This is **not auto-rollback** — operator
 decides. But the proposal is automatic.
 
-## 6. Rollout Phases
+## 7. Rollout Phases
 
 | Phase | Deliverable | Why this order |
 |---|---|---|
@@ -287,7 +348,7 @@ Each phase is independently valuable. P0 alone unlocks better dashboards.
 P1 alone unlocks honest A/B reports. P2 alone unlocks operator-driven
 deliberate testing.
 
-## 7. Progressive Automation (The Path to Less Manual)
+## 8. Progressive Automation (The Path to Less Manual)
 
 The operator wants to start operator-triggered and **allow more automation
 later, progressively**. The progression has three gradations, each unlocked
@@ -302,7 +363,7 @@ by accumulated track record:
 L3 is **opt-in per agent** and never automatic for agents with code-execution
 or sandbox-escape-adjacent capabilities. Constitutional rules apply.
 
-## 8. Relationship to the Divergence Sentinel (#238)
+## 9. Relationship to the Divergence Sentinel (#238)
 
 The two designs are **complementary halves**:
 
@@ -315,7 +376,7 @@ Concretely, the sentinel's `divergence.detected` causal events are **inputs
 to the curator**, which uses them as evidence when scoring agents. A
 high-divergence agent over many sessions is a candidate for improvement.
 
-## 9. Open Questions
+## 10. Open Questions
 
 1. **Replay fidelity for non-fixtured external calls.** Sealed fixtures cover
    recorded calls. Tasks involving novel real-world side effects (sending a
@@ -336,7 +397,7 @@ high-divergence agent over many sessions is a candidate for improvement.
    forbid self-proposal? Probably yes for L3 auto-approval, possibly OK for
    L1/L2 with operator review.
 
-## 10. References
+## 11. References
 
 - `docs/design/divergence-sentinel-design.md` — sister design (in-session)
 - `docs/design/cognitive-capsule-standardization.md` — capsule format used


### PR DESCRIPTION
## Summary

P1 — Multi-axis statistical comparison for eval_compare (issue #244).

Adds the eval_stats module (bootstrap CI + Pareto check + decision rule) and wires it into eval_compare as an optional stats field in the tool output.

### Key additions

**New module: autonoetic-gateway/src/runtime/eval_stats.rs**
- VariantSamples — per-axis sample data (completion, cost_usd, tokens, turns, wall_clock_secs)
- CompareConfig — knobs: 1000 bootstrap iterations, 95% CI, 5% Pareto floor tolerance
- compare() — entry point: returns CompareRecommendation (PreferA, PreferB, Inconclusive)
- decide() — core rule: completion Pareto floor → multi-axis Pareto dominance
- bootstrap_confidence() — fraction of bootstrap replicates agreeing with the verdict
- 16 unit tests covering means, preference, decision edges, false-positive properties, reproducibility

**Wired into EvalCompareTool in evaluation.rs**
- New helper build_samples_from_case_results() fetches SessionOutcome rows for each case result with a session_id, builds VariantSamples per variant
- Only fires when both variants have ≥ 3 samples with known completion (skips gracefully → stats: null)
- Added stats field to the JSON output containing the recommendation (or error)

**Integration test**
- test_eval_compare_with_session_outcomes_produces_stats — creates 5-case suite with session outcomes where candidate is cheaper on all axes → asserts stats.recommendation == prefer_b

### Design
- Completion is the Pareto floor: a variant with lower completion cannot win
- Inconclusive is a normal outcome — no false confidence
- Bootstrap resampling (not parametric) for small-N correctness (≥ 3 samples)
- Backward compatible: stats: null when insufficient session data exists
- All 16 eval_stats unit tests + existing eval_compare test pass

### Files changed
| File | Change |
|------|--------|
| autonoetic-gateway/src/runtime/eval_stats.rs | New — 793 lines: bootstrap CI, Pareto check, decision rule, 16 tests |
| autonoetic-gateway/src/runtime/mod.rs | +1 line: pub mod eval_stats; |
| autonoetic-gateway/src/runtime/tools/evaluation.rs | +71 lines: imports, helper, stats field in output |
| autonoetic-gateway/tests/phase3_eval_integration.rs | +213 lines: integration test with session outcomes |