### PR TITLE
feat(improve): implement ab_replay tool and orchestrator agent (P2)

### DIFF
--- a/agents/specialists/improvement-orchestrator.default/SKILL.md
+++ b/agents/specialists/improvement-orchestrator.default/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: "improvement-orchestrator.default"
+description: "A/B replay orchestrator: runs a set of tasks against two agent revisions and returns a statistical comparison report."
+metadata:
+  autonoetic:
+    version: "1.0"
+    runtime:
+      engine: "autonoetic"
+      gateway_version: "0.1.0"
+      sdk_version: "0.1.0"
+      type: "stateful"
+      sandbox: "bubblewrap"
+      runtime_lock: "runtime.lock"
+    agent:
+      id: "improvement-orchestrator.default"
+      name: "Improvement Orchestrator Default"
+      description: "Wraps the improvement.ab_replay native tool to run A/B comparisons between two agent revisions. Accepts task specs, queues eval runs for both revisions, and returns a multi-axis comparison report with holdout analysis."
+    llm_config:
+      provider: "openrouter"
+      model: "google/gemini-3-flash-preview"
+      temperature: 0.1
+    capabilities:
+      - type: "Evaluation"
+      - type: "ReadAccess"
+        scopes: ["*"]
+      - type: "WriteAccess"
+        scopes: ["self.*"]
+    validation: "soft"
+    io:
+      accepts:
+        type: object
+        required: [task_specs, agent_id, revision_a, revision_b]
+        properties:
+          task_specs:
+            type: array
+            description: "Task specifications to run against both revisions"
+            items:
+              type: object
+              properties:
+                message:
+                  type: string
+                  description: "Input message to send to the agent"
+                case_id:
+                  type: string
+                  description: "Optional stable case identifier"
+                reply_contains_all:
+                  type: array
+                  items: { type: string }
+                  description: "Optional: expected substrings in agent reply"
+                reply_max_chars:
+                  type: integer
+                  description: "Optional: max allowed reply length"
+              required: [message]
+          agent_id:
+            type: string
+            description: "Agent ID to replay (e.g. planner.default)"
+          revision_a:
+            type: string
+            description: "Baseline revision ref (e.g. agent_id@rev_sha256:...)"
+          revision_b:
+            type: string
+            description: "Candidate revision ref"
+          replays_per_variant:
+            type: integer
+            default: 5
+            description: "Number of replays per variant"
+          holdout_ratio:
+            type: number
+            default: 0.3
+            description: "Fraction of tasks held out for cross-validation"
+          suite_id:
+            type: string
+            description: "Optional: use an existing eval suite instead of creating one from task_specs"
+      returns:
+        type: object
+        properties:
+          ok:
+            type: boolean
+          status:
+            type: string
+            enum: [queued, completed, cost_exceeded]
+          suite_id:
+            type: string
+          summary:
+            type: object
+            properties:
+              baseline_passed: { type: integer }
+              baseline_total: { type: integer }
+              candidate_passed: { type: integer }
+              candidate_total: { type: integer }
+              delta_passed: { type: integer }
+              regression_count: { type: integer }
+              improvement_count: { type: integer }
+          holdout:
+            type: object
+          regressions:
+            type: array
+          improvements:
+            type: array
+          stats:
+            type: object
+---
+# Improvement Orchestrator
+
+You are the A/B replay orchestrator for the self-improvement loop. You wrap the `improvement.ab_replay` native tool to compare two agent revisions on a set of tasks.
+
+## Input Contract
+
+Your input is a JSON object matching `io.accepts`. The caller passes:
+- `task_specs`: array of task definitions (each with `message` and optional assertions)
+- `agent_id`: the agent whose revisions are being compared
+- `revision_a`: baseline revision ref (e.g. `planner.default@rev_sha256:abc123`)
+- `revision_b`: candidate revision ref
+- `replays_per_variant`: how many times to replay each variant (default 5)
+- `holdout_ratio`: fraction of tasks held out for cross-validation (default 0.3)
+
+## Behavior
+
+### Step 1: Call improvement.ab_replay
+
+Pass the caller's input directly to `improvement.ab_replay`:
+
+```json
+improvement.ab_replay({
+  "task_specs": <task_specs>,
+  "agent_id": "<agent_id>",
+  "revision_a": "<revision_a>",
+  "revision_b": "<revision_b>",
+  "replays_per_variant": <n>,
+  "holdout_ratio": <ratio>,
+  "suite_id": "<suite_id or omitted>"
+})
+```
+
+### Step 2: Handle response
+
+The tool returns one of three statuses:
+
+**`"queued"`** — Eval runs were enqueued for background execution. End your turn with the `queued` response so the caller can re-invoke you later. The response includes `suite_id` and `queued_eval_run_ids`.
+
+```json
+{
+  "status": "queued",
+  "suite_id": "suite-ab-...",
+  "queued_eval_run_ids": [...],
+  "message": "Queued eval runs for A/B replay. Re-invoke with same args once the background eval runner completes."
+}
+```
+
+**`"completed"`** — Both baseline and candidate eval runs are done. Return the full comparison report directly to the caller.
+
+```json
+{
+  "status": "completed",
+  "ok": true,
+  "suite_id": "suite-ab-...",
+  "summary": {
+    "baseline_passed": <n>,
+    "baseline_total": <n>,
+    "candidate_passed": <n>,
+    "candidate_total": <n>,
+    "delta_passed": <n>,
+    "regression_count": <n>,
+    "improvement_count": <n>
+  },
+  "holdout": {
+    "total_held_out": <n>,
+    "holdout_regressions": [...]
+  },
+  "regressions": [...],
+  "improvements": [...],
+  "stats": { ... }
+}
+```
+
+**`"cost_exceeded"`** — The estimated cost exceeds the $1 ceiling. Return the error info to the caller so they can reduce scope.
+
+### Step 3: Polling (re-invocation)
+
+If you receive `queued`, end your turn and return the status to the caller. When re-invoked, call `improvement.ab_replay` again with the **exact same arguments** (including `suite_id` if present). The tool will check whether eval runs are now complete and return `completed` if so.
+
+## Output Format
+
+Return a single raw JSON object matching `io.returns`. Do not wrap JSON in markdown code fences (no ```json blocks). The exact shape depends on the status:
+
+- **queued**: pass through the tool's `queued` response fields (`status`, `suite_id`, `queued_eval_run_ids`, `message`)
+- **completed**: pass through the tool's `completed` response fields (`status`, `summary`, `holdout`, `regressions`, `improvements`, `stats`, `cost`)
+- **cost_exceeded**: pass through the tool's `cost_exceeded` response
+
+Always set `ok: true` in your response if the tool returned without error, and include the `status` field.
+
+## Interpretation Guide
+
+The comparison report has several sections:
+
+- **`summary`**: raw pass/fail counts. `delta_passed > 0` means the candidate passed more tasks.
+- **`regressions`** / **`improvements`**: case IDs where the candidate changed outcome.
+- **`holdout`**: regressions on held-out tasks (tasks not used during optimization). A candidate that regresses on holdout tasks may be overfit.
+- **`stats`**: bootstrap confidence interval comparison. Shows whether the candidate is statistically better, worse, or inconclusive on a multi-axis (completion, cost, tokens, turns, wall_clock_secs) comparison.
+
+## Safety Rules
+
+- **Do NOT create or promote revisions** — this agent is orchestrator-only. Revision management is handled by `evolution-steward.default` and `agent-factory.default`.
+- **Do NOT modify SKILL.md files or agent instructions directly** — this agent only runs comparisons.
+- **Cost ceiling is enforced by the tool** — if cost is exceeded, report it to the caller.
+- **Holdout ratio is mechanically enforced** — the tool splits tasks into train/holdout sets. Report holdout regressions prominently.

--- a/agents/specialists/improvement-orchestrator.default/SKILL.md
+++ b/agents/specialists/improvement-orchestrator.default/SKILL.md
@@ -60,10 +60,6 @@ metadata:
           revision_b:
             type: string
             description: "Candidate revision ref"
-          replays_per_variant:
-            type: integer
-            default: 5
-            description: "Number of replays per variant"
           holdout_ratio:
             type: number
             default: 0.3
@@ -111,7 +107,6 @@ Your input is a JSON object matching `io.accepts`. The caller passes:
 - `agent_id`: the agent whose revisions are being compared
 - `revision_a`: baseline revision ref (e.g. `planner.default@rev_sha256:abc123`)
 - `revision_b`: candidate revision ref
-- `replays_per_variant`: how many times to replay each variant (default 5)
 - `holdout_ratio`: fraction of tasks held out for cross-validation (default 0.3)
 
 ## Behavior
@@ -126,7 +121,6 @@ improvement.ab_replay({
   "agent_id": "<agent_id>",
   "revision_a": "<revision_a>",
   "revision_b": "<revision_b>",
-  "replays_per_variant": <n>,
   "holdout_ratio": <ratio>,
   "suite_id": "<suite_id or omitted>"
 })
@@ -173,7 +167,7 @@ The tool returns one of three statuses:
 }
 ```
 
-**`"cost_exceeded"`** — The estimated cost exceeds the $1 ceiling. Return the error info to the caller so they can reduce scope.
+**`"cost_exceeded"`** — The estimated cost exceeds the $1 ceiling. The tool returns `ok: false` as a business-logic refusal (still within `Ok`). Pass through the response fields as-is preserving `ok: false`.
 
 ### Step 3: Polling (re-invocation)
 
@@ -187,7 +181,7 @@ Return a single raw JSON object matching `io.returns`. Do not wrap JSON in markd
 - **completed**: pass through the tool's `completed` response fields (`status`, `summary`, `holdout`, `regressions`, `improvements`, `stats`, `cost`)
 - **cost_exceeded**: pass through the tool's `cost_exceeded` response
 
-Always set `ok: true` in your response if the tool returned without error, and include the `status` field.
+Pass through the `ok` field as returned by the tool. `queued` and `completed` responses have `ok: true`; `cost_exceeded` has `ok: false` (a business-logic refusal within a successful tool call — do not override it). Always include the `status` field.
 
 ## Interpretation Guide
 

--- a/autonoetic-gateway/src/runtime/tools/evaluation.rs
+++ b/autonoetic-gateway/src/runtime/tools/evaluation.rs
@@ -428,7 +428,7 @@ pub fn validate_suite_spec(spec: &EvalSuiteSpec) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn enqueue_eval_run(
+pub(crate) fn enqueue_eval_run(
     gateway_store: &crate::scheduler::gateway_store::GatewayStore,
     suite: &autonoetic_types::evaluation::EvalSuiteRecord,
     suite_id: &str,
@@ -829,7 +829,7 @@ impl NativeTool for EvalCompareTool {
 
 /// Build VariantSamples from eval case results by fetching session outcomes.
 /// Returns None when fewer than 3 samples are available in either variant.
-fn build_samples_from_case_results(
+pub(crate) fn build_samples_from_case_results(
     baseline_cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
     candidate_cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
     gateway_store: &crate::scheduler::gateway_store::GatewayStore,

--- a/autonoetic-gateway/src/runtime/tools/improvement.rs
+++ b/autonoetic-gateway/src/runtime/tools/improvement.rs
@@ -1,0 +1,451 @@
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::tools::evaluation::enqueue_eval_run;
+use crate::runtime::tools::{NativeTool, NativeToolRegistry};
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
+use autonoetic_types::tool_error::tagged;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+pub fn register_tools(registry: &mut NativeToolRegistry) {
+    registry.register(Box::new(AbReplayTool));
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskSpec {
+    message: String,
+    #[serde(default)]
+    case_id: Option<String>,
+    #[serde(default)]
+    reply_contains_all: Option<Vec<String>>,
+    #[serde(default)]
+    reply_max_chars: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AbReplayArgs {
+    task_specs: Vec<TaskSpec>,
+    agent_id: String,
+    revision_a: String,
+    revision_b: String,
+    #[serde(default = "default_replays")]
+    replays_per_variant: u32,
+    #[serde(default = "default_holdout")]
+    holdout_ratio: f64,
+    /// Optional pre-existing suite_id — skip suite creation and use this suite directly.
+    #[serde(default)]
+    suite_id: Option<String>,
+}
+
+fn default_replays() -> u32 {
+    5
+}
+fn default_holdout() -> f64 {
+    0.3
+}
+
+/// Estimated max cost per session (used for cost ceiling check).
+const ESTIMATED_MAX_COST_PER_SESSION: f64 = 0.05;
+/// Default per-invocation budget in USD.
+const DEFAULT_COST_CEILING: f64 = 1.0;
+
+pub struct AbReplayTool;
+
+impl NativeTool for AbReplayTool {
+    fn name(&self) -> &'static str {
+        "improvement.ab_replay"
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        manifest
+            .capabilities
+            .iter()
+            .any(|cap| matches!(cap, Capability::Evaluation { .. }))
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Run A/B replay: execute a set of tasks against two agent revisions \
+                          and return a statistical comparison. Queues eval runs if needed."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "task_specs": {
+                        "type": "array",
+                        "description": "Task specifications to run against both revisions",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "message": { "type": "string", "description": "Input message to send to the agent" },
+                                "case_id": { "type": "string", "description": "Optional stable case identifier" },
+                                "reply_contains_all": {
+                                    "type": "array", "items": { "type": "string" },
+                                    "description": "Optional: expected substrings in agent reply"
+                                },
+                                "reply_max_chars": {
+                                    "type": "integer",
+                                    "description": "Optional: max allowed reply length"
+                                }
+                            },
+                            "required": ["message"]
+                        }
+                    },
+                    "agent_id": { "type": "string", "description": "Agent ID to replay (e.g. planner.default)" },
+                    "revision_a": { "type": "string", "description": "Baseline revision ref (agent_id@rev_sha256:...)" },
+                    "revision_b": { "type": "string", "description": "Candidate revision ref" },
+                    "replays_per_variant": {
+                        "type": "integer", "default": 5,
+                        "description": "Number of replays per variant (used for cost estimation)"
+                    },
+                    "holdout_ratio": {
+                        "type": "number", "default": 0.3,
+                        "description": "Fraction of tasks held out for cross-validation"
+                    },
+                    "suite_id": {
+                        "type": "string",
+                        "description": "Optional: use an existing eval suite instead of creating one from task_specs"
+                    }
+                },
+                "required": ["task_specs", "agent_id", "revision_a", "revision_b"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&autonoetic_types::config::GatewayConfig>,
+        gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        let args: AbReplayArgs = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments: {}", e))?;
+
+        let Some(gateway_store) = gateway_store else {
+            return Err(anyhow::anyhow!("GatewayStore is required"));
+        };
+        let config = config.ok_or_else(|| anyhow::anyhow!("GatewayConfig is required"))?;
+        let repo = crate::agent::repository::AgentRepository::from_config(config);
+
+        // Resolve both revision refs
+        let (ref_a, rev_a) =
+            repo.resolve_agent(&args.revision_a, Some(gateway_store.as_ref()))?;
+        let (ref_b, rev_b) =
+            repo.resolve_agent(&args.revision_b, Some(gateway_store.as_ref()))?;
+        anyhow::ensure!(
+            ref_a.agent_id == ref_b.agent_id,
+            "revision_a and revision_b must resolve to the same logical agent (got '{}' and '{}')",
+            ref_a.agent_id,
+            ref_b.agent_id
+        );
+        anyhow::ensure!(
+            ref_a.agent_id == args.agent_id,
+            "agent_id '{}' does not match resolved agent '{}' from revision refs",
+            args.agent_id,
+            ref_a.agent_id
+        );
+
+        // Policy check
+        let decision = policy.can_evaluate_suite("ab-replay", &args.agent_id);
+        if !decision.is_allowed() {
+            return Err(anyhow::Error::from(
+                tagged::Tagged::permission_with_rules(
+                    anyhow::anyhow!(
+                        "Permission Denied: agent '{}' lacks Evaluation capability",
+                        manifest.agent.id
+                    ),
+                    decision.enforced_rules.iter().map(|s| s.to_string()).collect(),
+                )
+            ));
+        }
+
+        // Cost ceiling check
+        let estimated_sessions = args.task_specs.len() as f64 * args.replays_per_variant as f64 * 2.0;
+        let estimated_cost = estimated_sessions * ESTIMATED_MAX_COST_PER_SESSION;
+        if estimated_cost > DEFAULT_COST_CEILING {
+            return Ok(serde_json::json!({
+                "ok": false,
+                "status": "cost_exceeded",
+                "estimated_cost_usd": estimated_cost,
+                "max_budget_usd": DEFAULT_COST_CEILING,
+                "message": format!(
+                    "Estimated cost ${:.2} exceeds max budget ${:.2}. \
+                     Reduce task_specs count, replays_per_variant, or increase budget.",
+                    estimated_cost, DEFAULT_COST_CEILING
+                ),
+            }).to_string());
+        }
+
+        // Holdout: pick a suffix of task_specs for held-out validation
+        let n_tasks = args.task_specs.len();
+        let n_holdout = (n_tasks as f64 * args.holdout_ratio).ceil() as usize;
+        let n_train = n_tasks.saturating_sub(n_holdout);
+        let holdout_start = n_train;
+
+        // Validate that holdout doesn't cover all tasks
+        if n_holdout > 0 && n_train == 0 {
+            return Err(anyhow::anyhow!(
+                "holdout_ratio={} leaves no training tasks ({} total). \
+                 Reduce holdout_ratio or provide more tasks.",
+                args.holdout_ratio, n_tasks
+            ));
+        }
+
+        // Determine suite_id: use existing or create temporary suite
+        let suite_id = if let Some(sid) = &args.suite_id {
+            // Verify the suite exists
+            gateway_store
+                .get_eval_suite(sid)?
+                .ok_or_else(|| anyhow::anyhow!("Eval suite '{}' not found", sid))?;
+            sid.clone()
+        } else {
+            create_temp_eval_suite(
+                gateway_store.as_ref(),
+                &args.agent_id,
+                &args.task_specs,
+                &manifest.agent.id,
+            )?
+        };
+
+        // Check for existing completed runs
+        let baseline_run =
+            gateway_store.find_latest_completed_eval_run(&suite_id, &rev_a.revision_id)?;
+        let candidate_run =
+            gateway_store.find_latest_completed_eval_run(&suite_id, &rev_b.revision_id)?;
+
+        let mut queued_ids: Vec<String> = Vec::new();
+
+        if baseline_run.is_none() {
+            let suite = gateway_store.get_eval_suite(&suite_id)?.ok_or_else(|| {
+                anyhow::anyhow!("Eval suite '{}' disappeared", suite_id)
+            })?;
+            let run = enqueue_eval_run(
+                gateway_store.as_ref(),
+                &suite,
+                &suite_id,
+                &args.agent_id,
+                &rev_a.revision_id,
+                None,
+                "improvement.ab_replay",
+            )?;
+            queued_ids.push(run.eval_run_id);
+        }
+
+        if candidate_run.is_none() {
+            let suite = gateway_store.get_eval_suite(&suite_id)?.ok_or_else(|| {
+                anyhow::anyhow!("Eval suite '{}' disappeared", suite_id)
+            })?;
+            let run = enqueue_eval_run(
+                gateway_store.as_ref(),
+                &suite,
+                &suite_id,
+                &args.agent_id,
+                &rev_b.revision_id,
+                Some(rev_a.revision_id.clone()),
+                "improvement.ab_replay",
+            )?;
+            queued_ids.push(run.eval_run_id);
+        }
+
+        // If any runs were queued, return immediately
+        if !queued_ids.is_empty() {
+            return Ok(serde_json::json!({
+                "ok": true,
+                "status": "queued",
+                "suite_id": suite_id,
+                "queued_eval_run_ids": queued_ids,
+                "message": "Queued eval runs for A/B replay. Call improvement.ab_replay again with the same args \
+                            once the background eval runner completes the runs to get the comparison report.",
+            }).to_string());
+        }
+
+        // Both runs exist and are completed → build comparison
+        let baseline_run = baseline_run.expect("checked above");
+        let candidate_run = candidate_run.expect("checked above");
+
+        let baseline_cases =
+            gateway_store.list_eval_case_results(&baseline_run.eval_run_id)?;
+        let candidate_cases =
+            gateway_store.list_eval_case_results(&candidate_run.eval_run_id)?;
+
+        // Build per-variant maps
+        let mut baseline_map: HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord> =
+            HashMap::new();
+        for c in baseline_cases {
+            baseline_map.insert(c.case_id.clone(), c);
+        }
+        let mut candidate_map: HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord> =
+            HashMap::new();
+        for c in candidate_cases {
+            candidate_map.insert(c.case_id.clone(), c);
+        }
+
+        // Status-based comparison across ALL cases
+        let mut case_ids = std::collections::BTreeSet::new();
+        case_ids.extend(baseline_map.keys().cloned());
+        case_ids.extend(candidate_map.keys().cloned());
+
+        let mut regressions: Vec<String> = Vec::new();
+        let mut improvements: Vec<String> = Vec::new();
+
+        for case_id in &case_ids {
+            let base = baseline_map.get(case_id);
+            let cand = candidate_map.get(case_id);
+            let base_status = base.map(|c| c.status.as_str()).unwrap_or("missing");
+            let cand_status = cand.map(|c| c.status.as_str()).unwrap_or("missing");
+            if base_status == "passed" && cand_status != "passed" {
+                regressions.push(case_id.clone());
+            }
+            if base_status != "passed" && cand_status == "passed" {
+                improvements.push(case_id.clone());
+            }
+        }
+
+        // Statistical comparison via eval_stats
+        let stats = build_ab_stats(&baseline_map, &candidate_map, gateway_store.as_ref());
+
+        // Holdout-specific comparison
+        let holdout_cases: Vec<String> = case_ids
+            .iter()
+            .skip(holdout_start)
+            .take(n_holdout)
+            .cloned()
+            .collect();
+
+        let mut holdout_regressions: Vec<String> = Vec::new();
+        for case_id in &holdout_cases {
+            let base = baseline_map.get(case_id);
+            let cand = candidate_map.get(case_id);
+            let base_status = base.map(|c| c.status.as_str()).unwrap_or("missing");
+            let cand_status = cand.map(|c| c.status.as_str()).unwrap_or("missing");
+            if base_status == "passed" && cand_status != "passed" {
+                holdout_regressions.push(case_id.clone());
+            }
+        }
+
+        let baseline_passed = baseline_map.values().filter(|c| c.status == "passed").count();
+        let candidate_passed = candidate_map.values().filter(|c| c.status == "passed").count();
+        let baseline_total = baseline_map.len();
+        let candidate_total = candidate_map.len();
+
+        Ok(serde_json::json!({
+            "ok": true,
+            "status": "completed",
+            "suite_id": suite_id,
+            "agent_id": args.agent_id,
+            "revision_a": ref_a.to_string(),
+            "revision_b": ref_b.to_string(),
+            "baseline_eval_run_id": baseline_run.eval_run_id,
+            "candidate_eval_run_id": candidate_run.eval_run_id,
+            "summary": {
+                "baseline_passed": baseline_passed,
+                "baseline_total": baseline_total,
+                "candidate_passed": candidate_passed,
+                "candidate_total": candidate_total,
+                "delta_passed": candidate_passed as i64 - baseline_passed as i64,
+                "regression_count": regressions.len(),
+                "improvement_count": improvements.len(),
+            },
+            "holdout": {
+                "total_held_out": n_holdout,
+                "holdout_regressions": holdout_regressions,
+            },
+            "regressions": regressions,
+            "improvements": improvements,
+            "stats": stats,
+            "cost": {
+                "estimated_total_usd": estimated_cost,
+                "ceiling_usd": DEFAULT_COST_CEILING,
+            },
+        })
+        .to_string())
+    }
+}
+
+/// Create a temporary eval suite from task specs and return its suite_id.
+fn create_temp_eval_suite(
+    gateway_store: &crate::scheduler::gateway_store::GatewayStore,
+    agent_id: &str,
+    task_specs: &[TaskSpec],
+    caller_agent_id: &str,
+) -> anyhow::Result<String> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let suite_id = autonoetic_types::id_format::mint_hashed_prefixed_id(
+        "suite-ab-",
+        &format!("{}-{}", agent_id, now),
+    );
+
+    let cases: Vec<serde_json::Value> = task_specs
+        .iter()
+        .enumerate()
+        .map(|(i, spec)| {
+            let case_id = spec
+                .case_id
+                .clone()
+                .unwrap_or_else(|| format!("task-{}", i));
+            let mut assertions = serde_json::json!({});
+            if let Some(ref contains) = spec.reply_contains_all {
+                assertions["reply_contains_all"] = serde_json::json!(contains);
+            }
+            if let Some(max_chars) = spec.reply_max_chars {
+                assertions["reply_max_chars"] = serde_json::json!(max_chars);
+            }
+            serde_json::json!({
+                "case_id": case_id,
+                "message": spec.message,
+                "assertions": assertions,
+            })
+        })
+        .collect();
+
+    let spec_json = serde_json::json!({ "cases": cases });
+
+    let suite = autonoetic_types::evaluation::EvalSuiteRecord {
+        suite_id: suite_id.clone(),
+        name: format!("ab-replay-{}", agent_id),
+        description: format!("Temporary A/B replay suite for {}", agent_id),
+        spec_json,
+        created_at: now,
+        created_by_type: "tool".to_string(),
+        created_by_id: caller_agent_id.to_string(),
+        origin_node_id: "gateway".to_string(),
+        evaluated_targets: vec![agent_id.to_string()],
+        author_agent_id: Some(caller_agent_id.to_string()),
+        based_on_suite_id: None,
+    };
+
+    gateway_store.insert_eval_suite(&suite)?;
+    Ok(suite_id)
+}
+
+/// Build VariantSamples from case results and run bootstrap CI comparison.
+fn build_ab_stats(
+    baseline_cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
+    candidate_cases: &HashMap<String, autonoetic_types::evaluation::EvalCaseResultRecord>,
+    gateway_store: &crate::scheduler::gateway_store::GatewayStore,
+) -> Option<serde_json::Value> {
+    let (a, b) = crate::runtime::tools::evaluation::build_samples_from_case_results(
+        baseline_cases,
+        candidate_cases,
+        gateway_store,
+    )?;
+
+    let config = crate::runtime::eval_stats::CompareConfig::default();
+    match crate::runtime::eval_stats::compare(&a, &b, &config) {
+        Ok(rec) => serde_json::to_value(rec).ok(),
+        Err(e) => Some(serde_json::json!({"error": e})),
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/improvement.rs
+++ b/autonoetic-gateway/src/runtime/tools/improvement.rs
@@ -5,6 +5,7 @@ use crate::runtime::tools::evaluation::enqueue_eval_run;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
+use autonoetic_types::evaluation::EvalRunStatus;
 use autonoetic_types::tool_error::tagged;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -32,18 +33,12 @@ struct AbReplayArgs {
     agent_id: String,
     revision_a: String,
     revision_b: String,
-    #[serde(default = "default_replays")]
-    replays_per_variant: u32,
     #[serde(default = "default_holdout")]
     holdout_ratio: f64,
-    /// Optional pre-existing suite_id — skip suite creation and use this suite directly.
     #[serde(default)]
     suite_id: Option<String>,
 }
 
-fn default_replays() -> u32 {
-    5
-}
 fn default_holdout() -> f64 {
     0.3
 }
@@ -52,6 +47,13 @@ fn default_holdout() -> f64 {
 const ESTIMATED_MAX_COST_PER_SESSION: f64 = 0.05;
 /// Default per-invocation budget in USD.
 const DEFAULT_COST_CEILING: f64 = 1.0;
+
+fn is_terminal_status(status: &EvalRunStatus) -> bool {
+    matches!(
+        status,
+        EvalRunStatus::Passed | EvalRunStatus::Failed | EvalRunStatus::Cancelled
+    )
+}
 
 pub struct AbReplayTool;
 
@@ -99,10 +101,6 @@ impl NativeTool for AbReplayTool {
                     "agent_id": { "type": "string", "description": "Agent ID to replay (e.g. planner.default)" },
                     "revision_a": { "type": "string", "description": "Baseline revision ref (agent_id@rev_sha256:...)" },
                     "revision_b": { "type": "string", "description": "Candidate revision ref" },
-                    "replays_per_variant": {
-                        "type": "integer", "default": 5,
-                        "description": "Number of replays per variant (used for cost estimation)"
-                    },
                     "holdout_ratio": {
                         "type": "number", "default": 0.3,
                         "description": "Fraction of tasks held out for cross-validation"
@@ -158,8 +156,28 @@ impl NativeTool for AbReplayTool {
             ref_a.agent_id
         );
 
-        // Policy check
-        let decision = policy.can_evaluate_suite("ab-replay", &args.agent_id);
+        // Determine suite_id and case count for cost estimation
+        let (suite_id, case_count) = if let Some(sid) = &args.suite_id {
+            let suite = gateway_store
+                .get_eval_suite(sid)?
+                .ok_or_else(|| anyhow::anyhow!("Eval suite '{}' not found", sid))?;
+            let count = suite.spec_json["cases"]
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or(0);
+            (sid.clone(), count)
+        } else {
+            let sid = create_temp_eval_suite(
+                gateway_store.as_ref(),
+                &args.agent_id,
+                &args.task_specs,
+                &manifest.agent.id,
+            )?;
+            (sid, args.task_specs.len())
+        };
+
+        // Policy check with real suite_id
+        let decision = policy.can_evaluate_suite(&suite_id, &args.agent_id);
         if !decision.is_allowed() {
             return Err(anyhow::Error::from(
                 tagged::Tagged::permission_with_rules(
@@ -172,8 +190,8 @@ impl NativeTool for AbReplayTool {
             ));
         }
 
-        // Cost ceiling check
-        let estimated_sessions = args.task_specs.len() as f64 * args.replays_per_variant as f64 * 2.0;
+        // Cost ceiling check: 1 run per revision × 2 revisions
+        let estimated_sessions = case_count as f64 * 2.0;
         let estimated_cost = estimated_sessions * ESTIMATED_MAX_COST_PER_SESSION;
         if estimated_cost > DEFAULT_COST_CEILING {
             return Ok(serde_json::json!({
@@ -181,21 +199,32 @@ impl NativeTool for AbReplayTool {
                 "status": "cost_exceeded",
                 "estimated_cost_usd": estimated_cost,
                 "max_budget_usd": DEFAULT_COST_CEILING,
+                "case_count": case_count,
                 "message": format!(
-                    "Estimated cost ${:.2} exceeds max budget ${:.2}. \
-                     Reduce task_specs count, replays_per_variant, or increase budget.",
-                    estimated_cost, DEFAULT_COST_CEILING
+                    "Estimated cost ${:.2} exceeds max budget ${:.2} ({} cases × 2 runs × ${:.2}/session). \
+                     Reduce task count or increase budget.",
+                    estimated_cost, DEFAULT_COST_CEILING, case_count, ESTIMATED_MAX_COST_PER_SESSION
                 ),
             }).to_string());
         }
 
+        // Derive all case_ids from task_specs in order (for stable holdout)
+        let all_case_ids: Vec<String> = args
+            .task_specs
+            .iter()
+            .enumerate()
+            .map(|(i, spec)| {
+                spec.case_id
+                    .clone()
+                    .unwrap_or_else(|| format!("task-{}", i))
+            })
+            .collect();
+
         // Holdout: pick a suffix of task_specs for held-out validation
-        let n_tasks = args.task_specs.len();
+        let n_tasks = all_case_ids.len();
         let n_holdout = (n_tasks as f64 * args.holdout_ratio).ceil() as usize;
         let n_train = n_tasks.saturating_sub(n_holdout);
-        let holdout_start = n_train;
 
-        // Validate that holdout doesn't cover all tasks
         if n_holdout > 0 && n_train == 0 {
             return Err(anyhow::anyhow!(
                 "holdout_ratio={} leaves no training tasks ({} total). \
@@ -204,31 +233,44 @@ impl NativeTool for AbReplayTool {
             ));
         }
 
-        // Determine suite_id: use existing or create temporary suite
-        let suite_id = if let Some(sid) = &args.suite_id {
-            // Verify the suite exists
-            gateway_store
-                .get_eval_suite(sid)?
-                .ok_or_else(|| anyhow::anyhow!("Eval suite '{}' not found", sid))?;
-            sid.clone()
-        } else {
-            create_temp_eval_suite(
-                gateway_store.as_ref(),
-                &args.agent_id,
-                &args.task_specs,
-                &manifest.agent.id,
-            )?
-        };
+        // Check for existing runs (any status) to detect pending runs and prevent duplicate enqueues
+        let baseline_existing =
+            gateway_store.find_latest_eval_run(&suite_id, &rev_a.revision_id)?;
+        let candidate_existing =
+            gateway_store.find_latest_eval_run(&suite_id, &rev_b.revision_id)?;
 
-        // Check for existing completed runs
-        let baseline_run =
-            gateway_store.find_latest_completed_eval_run(&suite_id, &rev_a.revision_id)?;
-        let candidate_run =
-            gateway_store.find_latest_completed_eval_run(&suite_id, &rev_b.revision_id)?;
+        // If either has a non-terminal run, return queued without enqueuing
+        let has_pending = baseline_existing
+            .as_ref()
+            .is_some_and(|r| !is_terminal_status(&r.status))
+            || candidate_existing
+                .as_ref()
+                .is_some_and(|r| !is_terminal_status(&r.status));
+
+        if has_pending {
+            let pending_ids: Vec<String> = [baseline_existing.as_ref(), candidate_existing.as_ref()]
+                .into_iter()
+                .flatten()
+                .filter(|r| !is_terminal_status(&r.status))
+                .map(|r| r.eval_run_id.clone())
+                .collect();
+
+            return Ok(serde_json::json!({
+                "ok": true,
+                "status": "queued",
+                "suite_id": suite_id,
+                "queued_eval_run_ids": pending_ids,
+                "message": "Eval runs already pending. Re-invoke with same args once complete.",
+            }).to_string());
+        }
+
+        // Only completed runs are useful — enqueue missing
+        let baseline_completed = baseline_existing.filter(|r| is_terminal_status(&r.status));
+        let candidate_completed = candidate_existing.filter(|r| is_terminal_status(&r.status));
 
         let mut queued_ids: Vec<String> = Vec::new();
 
-        if baseline_run.is_none() {
+        if baseline_completed.is_none() {
             let suite = gateway_store.get_eval_suite(&suite_id)?.ok_or_else(|| {
                 anyhow::anyhow!("Eval suite '{}' disappeared", suite_id)
             })?;
@@ -244,7 +286,7 @@ impl NativeTool for AbReplayTool {
             queued_ids.push(run.eval_run_id);
         }
 
-        if candidate_run.is_none() {
+        if candidate_completed.is_none() {
             let suite = gateway_store.get_eval_suite(&suite_id)?.ok_or_else(|| {
                 anyhow::anyhow!("Eval suite '{}' disappeared", suite_id)
             })?;
@@ -273,8 +315,8 @@ impl NativeTool for AbReplayTool {
         }
 
         // Both runs exist and are completed → build comparison
-        let baseline_run = baseline_run.expect("checked above");
-        let candidate_run = candidate_run.expect("checked above");
+        let baseline_run = baseline_completed.expect("checked above");
+        let candidate_run = candidate_completed.expect("checked above");
 
         let baseline_cases =
             gateway_store.list_eval_case_results(&baseline_run.eval_run_id)?;
@@ -293,15 +335,11 @@ impl NativeTool for AbReplayTool {
             candidate_map.insert(c.case_id.clone(), c);
         }
 
-        // Status-based comparison across ALL cases
-        let mut case_ids = std::collections::BTreeSet::new();
-        case_ids.extend(baseline_map.keys().cloned());
-        case_ids.extend(candidate_map.keys().cloned());
-
+        // Status-based comparison across all case_ids (in task_specs order)
         let mut regressions: Vec<String> = Vec::new();
         let mut improvements: Vec<String> = Vec::new();
 
-        for case_id in &case_ids {
+        for case_id in &all_case_ids {
             let base = baseline_map.get(case_id);
             let cand = candidate_map.get(case_id);
             let base_status = base.map(|c| c.status.as_str()).unwrap_or("missing");
@@ -317,10 +355,10 @@ impl NativeTool for AbReplayTool {
         // Statistical comparison via eval_stats
         let stats = build_ab_stats(&baseline_map, &candidate_map, gateway_store.as_ref());
 
-        // Holdout-specific comparison
-        let holdout_cases: Vec<String> = case_ids
+        // Holdout-specific comparison (from task_specs ordering)
+        let holdout_cases: Vec<String> = all_case_ids
             .iter()
-            .skip(holdout_start)
+            .skip(n_train)
             .take(n_holdout)
             .cloned()
             .collect();
@@ -402,6 +440,10 @@ fn create_temp_eval_suite(
             }
             if let Some(max_chars) = spec.reply_max_chars {
                 assertions["reply_max_chars"] = serde_json::json!(max_chars);
+            }
+            // Default assertion to ensure meaningful pass/fail signal
+            if assertions == serde_json::json!({}) {
+                assertions["reply_max_chars"] = serde_json::json!(100000);
             }
             serde_json::json!({
                 "case_id": case_id,

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -962,6 +962,7 @@ pub mod digest;
 pub mod evaluation;
 pub mod execution;
 pub mod federation;
+pub mod improvement;
 pub mod knowledge;
 pub mod observability;
 pub mod promotion;
@@ -1013,6 +1014,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::user_profile::register_tools(&mut registry);
     crate::runtime::tools::observability::register_tools(&mut registry);
     crate::runtime::tools::federation::register_tools(&mut registry);
+    crate::runtime::tools::improvement::register_tools(&mut registry);
     crate::runtime::tools::promotion::register_tools(&mut registry);
     crate::runtime::tools::scheduler::register_tools(&mut registry);
     crate::runtime::tools::skill::register_tools(&mut registry);

--- a/autonoetic-gateway/src/scheduler/gateway_store/evaluations.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/evaluations.rs
@@ -195,6 +195,48 @@ impl GatewayStore {
         Ok(results.pop())
     }
 
+    pub fn find_latest_eval_run(
+        &self,
+        suite_id: &str,
+        subject_revision_id: &str,
+    ) -> Result<Option<EvalRunRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT eval_run_id, suite_id, subject_agent_id, subject_revision_id,
+                    baseline_revision_id, status, queued_at, started_at, completed_at,
+                    summary_json, report_handle, origin_node_id
+             FROM eval_runs
+             WHERE suite_id = ?1
+               AND subject_revision_id = ?2
+             ORDER BY COALESCE(completed_at, queued_at) DESC
+             LIMIT 1",
+        )?;
+        let row = stmt
+            .query_row(params![suite_id, subject_revision_id], |row| {
+                let status_str: String = row.get(5)?;
+                let status = parse_eval_run_status(status_str.as_str());
+                let summary_json: String = row.get(9)?;
+                let summary_json =
+                    serde_json::from_str(&summary_json).unwrap_or(serde_json::Value::Null);
+                Ok(EvalRunRecord {
+                    eval_run_id: row.get(0)?,
+                    suite_id: row.get(1)?,
+                    subject_agent_id: row.get(2)?,
+                    subject_revision_id: row.get(3)?,
+                    baseline_revision_id: row.get(4)?,
+                    status,
+                    queued_at: row.get(6)?,
+                    started_at: row.get(7)?,
+                    completed_at: row.get(8)?,
+                    summary_json,
+                    report_handle: row.get(10)?,
+                    origin_node_id: row.get(11)?,
+                })
+            })
+            .optional()?;
+        Ok(row)
+    }
+
     pub fn find_latest_completed_eval_run(
         &self,
         suite_id: &str,

--- a/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
+++ b/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
@@ -46,9 +46,6 @@ fn test_manifest(capabilities: Vec<Capability>) -> AgentManifest {
     }
 }
 
-fn open_store(tmp: &TempDir) -> Arc<GatewayStore> {
-    Arc::new(GatewayStore::open(tmp.path()).unwrap())
-}
 
 fn seed_revision(
     store: &GatewayStore,
@@ -100,10 +97,14 @@ const REV_B_ID: &str = "rev_sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 
 const TARGET_AGENT: &str = "test-agent";
 
+fn open_store(tmp: &TempDir) -> Arc<GatewayStore> {
+    Arc::new(GatewayStore::open(tmp.path()).unwrap())
+}
+
 fn setup_env(tmp: &TempDir) -> (Arc<GatewayStore>, GatewayConfig) {
     let gateway_dir = tmp.path().join(".gateway");
     std::fs::create_dir_all(&gateway_dir).unwrap();
-    let store = open_store(&tmp);
+    let store = open_store(tmp);
 
     // Seed two revisions of the same test agent
     seed_revision(&store, TARGET_AGENT, REV_A_ID).unwrap();
@@ -119,30 +120,15 @@ fn setup_env(tmp: &TempDir) -> (Arc<GatewayStore>, GatewayConfig) {
     (store, config)
 }
 
-// ─── 1. Queued path ───────────────────────────────────────────────────────
-
-#[test]
-fn test_ab_replay_queues_eval_runs() {
-    let tmp = TempDir::new().unwrap();
-    let (store, config) = setup_env(&tmp);
-
+fn execute_tool(
+    store: Arc<GatewayStore>,
+    config: GatewayConfig,
+    args: serde_json::Value,
+) -> serde_json::Value {
     let manifest = test_manifest(vec![Capability::Evaluation {
         patterns: vec!["*".into()],
     }]);
     let policy = PolicyEngine::new(manifest.clone());
-
-    let args = json!({
-        "task_specs": [
-            {"message": "do task one", "case_id": "t1"},
-            {"message": "do task two", "case_id": "t2"},
-        ],
-        "agent_id": TARGET_AGENT,
-        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
-        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
-        "replays_per_variant": 1,
-        "holdout_ratio": 0.0,
-    });
-
     let result = AbReplayTool
         .execute(
             &manifest,
@@ -157,8 +143,28 @@ fn test_ab_replay_queues_eval_runs() {
             None,
         )
         .unwrap();
+    serde_json::from_str(&result).unwrap()
+}
 
-    let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+// ─── 1. Queued path ───────────────────────────────────────────────────────
+
+#[test]
+fn test_ab_replay_queues_eval_runs() {
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.0,
+    });
+
+    let v = execute_tool(store, config, args);
     assert_eq!(v["ok"], true, "expected ok=true, got: {v}");
     assert_eq!(v["status"], "queued", "expected queued, got: {v}");
     assert!(v["suite_id"].as_str().unwrap().starts_with("suite-ab-"));
@@ -174,12 +180,7 @@ fn test_ab_replay_cost_ceiling_exceeded() {
     let tmp = TempDir::new().unwrap();
     let (store, config) = setup_env(&tmp);
 
-    let manifest = test_manifest(vec![Capability::Evaluation {
-        patterns: vec!["*".into()],
-    }]);
-    let policy = PolicyEngine::new(manifest.clone());
-
-    // 20 tasks × 1 replay × 2 variants × $0.05 = $2.00 > $1.00 ceiling
+    // 20 tasks × 2 runs × $0.05 = $2.00 > $1.00 ceiling
     let tasks: Vec<serde_json::Value> = (0..20)
         .map(|i| {
             json!({
@@ -194,30 +195,15 @@ fn test_ab_replay_cost_ceiling_exceeded() {
         "agent_id": TARGET_AGENT,
         "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
         "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
-        "replays_per_variant": 1,
         "holdout_ratio": 0.0,
     });
 
-    let result = AbReplayTool
-        .execute(
-            &manifest,
-            &policy,
-            Path::new("/tmp"),
-            None,
-            &args.to_string(),
-            None,
-            None,
-            Some(&config),
-            Some(store),
-            None,
-        )
-        .unwrap();
-
-    let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+    let v = execute_tool(store, config, args);
     assert_eq!(v["ok"], false, "expected ok=false, got: {v}");
     assert_eq!(v["status"], "cost_exceeded", "expected cost_exceeded, got: {v}");
     assert!(v["estimated_cost_usd"].as_f64().unwrap() > 1.0);
     assert_eq!(v["max_budget_usd"], 1.0);
+    assert_eq!(v["case_count"], 20);
 }
 
 // ─── 3. Missing Evaluation capability ─────────────────────────────────────
@@ -247,7 +233,6 @@ fn test_ab_replay_requires_gateway_store() {
         "agent_id": TARGET_AGENT,
         "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
         "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
-        "replays_per_variant": 1,
         "holdout_ratio": 0.0,
     });
 
@@ -280,20 +265,18 @@ fn test_ab_replay_revisions_must_be_same_agent() {
     let other_rev = "rev_sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
     seed_revision(&store, "other-agent", other_rev).unwrap();
 
-    let manifest = test_manifest(vec![Capability::Evaluation {
-        patterns: vec!["*".into()],
-    }]);
-    let policy = PolicyEngine::new(manifest.clone());
-
     let args = json!({
         "task_specs": [{"message": "hello"}],
         "agent_id": TARGET_AGENT,
         "revision_a": format!("{}@{}", "other-agent", other_rev),
         "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
-        "replays_per_variant": 1,
         "holdout_ratio": 0.0,
     });
 
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
     let result = AbReplayTool.execute(
         &manifest,
         &policy,
@@ -322,21 +305,19 @@ fn test_ab_replay_holdout_covers_all_fails() {
     let tmp = TempDir::new().unwrap();
     let (store, config) = setup_env(&tmp);
 
-    let manifest = test_manifest(vec![Capability::Evaluation {
-        patterns: vec!["*".into()],
-    }]);
-    let policy = PolicyEngine::new(manifest.clone());
-
     // 1 task, holdout_ratio=1.0 → 0 train tasks
     let args = json!({
         "task_specs": [{"message": "hello"}],
         "agent_id": TARGET_AGENT,
         "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
         "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
-        "replays_per_variant": 1,
         "holdout_ratio": 1.0,
     });
 
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
     let result = AbReplayTool.execute(
         &manifest,
         &policy,
@@ -356,4 +337,44 @@ fn test_ab_replay_holdout_covers_all_fails() {
         err.contains("holdout_ratio") || err.contains("no training"),
         "expected holdout error, got: {err}"
     );
+}
+
+// ─── 7. Re-invoke while pending returns queued (no duplicate enqueue) ─────
+
+#[test]
+fn test_ab_replay_reinvoke_while_pending_returns_queued() {
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+
+    let args = json!({
+        "task_specs": [{"message": "hello", "case_id": "t1"}],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.0,
+    });
+
+    // First call: queues the runs
+    let v1 = execute_tool(store.clone(), config.clone(), args.clone());
+    assert_eq!(v1["status"], "queued");
+    let suite_id = v1["suite_id"].as_str().unwrap().to_string();
+    let queued_ids = v1["queued_eval_run_ids"].as_array().unwrap().clone();
+
+    // Second call with the same suite_id: runs are still pending → returns queued without re-enqueuing
+    let mut args2 = args.clone();
+    args2["suite_id"] = json!(suite_id);
+    let v2 = execute_tool(store.clone(), config, args2);
+    assert_eq!(v2["status"], "queued");
+    let second_ids = v2["queued_eval_run_ids"].as_array().unwrap();
+
+    // Should return the same IDs (not new ones)
+    assert_eq!(second_ids.len(), queued_ids.len());
+    for id in &queued_ids {
+        assert!(
+            second_ids.iter().any(|i| i == id),
+            "expected pending ID {:?} to appear in {:?}",
+            id,
+            second_ids
+        );
+}
 }

--- a/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
+++ b/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
@@ -1,0 +1,359 @@
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::tools::improvement::AbReplayTool;
+use autonoetic_gateway::runtime::tools::NativeTool;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::agent_revision::{AgentAliasRecord, AgentRevisionRecord, AgentRevisionStatus};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use serde_json::json;
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn test_manifest(capabilities: Vec<Capability>) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "improvement-orchestrator".to_string(),
+            name: "improvement-orchestrator".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities,
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: Default::default(),
+    }
+}
+
+fn open_store(tmp: &TempDir) -> Arc<GatewayStore> {
+    Arc::new(GatewayStore::open(tmp.path()).unwrap())
+}
+
+fn seed_revision(
+    store: &GatewayStore,
+    agent_id: &str,
+    revision_id: &str,
+) -> anyhow::Result<()> {
+    let rec = AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: agent_id.to_string(),
+        base_revision_id: None,
+        artifact_id: None,
+        content_digest: format!("sha256:seed-{}", revision_id),
+        runtime_lock_hash: "sha256:seed-lock".to_string(),
+        manifest_hash: "sha256:seed-manifest".to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        created_by_type: "test".to_string(),
+        created_by_id: "improvement_ab_replay_test".to_string(),
+        source_kind: "test".to_string(),
+        source_ref: None,
+        origin_node_id: "gateway".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Ready,
+        metadata_json: serde_json::json!({}),
+        short_id: String::new(),
+        signature: None,
+        signer_id: None,
+    };
+    store.insert_agent_revision(&rec)?;
+    Ok(())
+}
+
+fn seed_alias(store: &GatewayStore, agent_id: &str, revision_id: &str) -> anyhow::Result<()> {
+    let alias = AgentAliasRecord {
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: revision_id.to_string(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        updated_by_type: "test".to_string(),
+        updated_by_id: "improvement_ab_replay_test".to_string(),
+        reason: Some("test seed".to_string()),
+    };
+    store.upsert_agent_alias(&alias)?;
+    Ok(())
+}
+
+/// Full revision IDs in AgentRef.parse() format.
+const REV_A_ID: &str = "rev_sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const REV_B_ID: &str = "rev_sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const TARGET_AGENT: &str = "test-agent";
+
+fn setup_env(tmp: &TempDir) -> (Arc<GatewayStore>, GatewayConfig) {
+    let gateway_dir = tmp.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = open_store(&tmp);
+
+    // Seed two revisions of the same test agent
+    seed_revision(&store, TARGET_AGENT, REV_A_ID).unwrap();
+    seed_revision(&store, TARGET_AGENT, REV_B_ID).unwrap();
+    seed_alias(&store, TARGET_AGENT, REV_B_ID).unwrap();
+
+    let config = GatewayConfig {
+        agents_dir: tmp.path().join("agents"),
+        ..Default::default()
+    };
+    std::fs::create_dir_all(&config.agents_dir).unwrap();
+
+    (store, config)
+}
+
+// ─── 1. Queued path ───────────────────────────────────────────────────────
+
+#[test]
+fn test_ab_replay_queues_eval_runs() {
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "replays_per_variant": 1,
+        "holdout_ratio": 0.0,
+    });
+
+    let result = AbReplayTool
+        .execute(
+            &manifest,
+            &policy,
+            Path::new("/tmp"),
+            None,
+            &args.to_string(),
+            None,
+            None,
+            Some(&config),
+            Some(store),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(v["ok"], true, "expected ok=true, got: {v}");
+    assert_eq!(v["status"], "queued", "expected queued, got: {v}");
+    assert!(v["suite_id"].as_str().unwrap().starts_with("suite-ab-"));
+    let ids = v["queued_eval_run_ids"].as_array().unwrap();
+    assert_eq!(ids.len(), 2, "expected 2 queued runs, got: {v}");
+    assert!(v["message"].as_str().unwrap().contains("Queued"));
+}
+
+// ─── 2. Cost ceiling exceeded ─────────────────────────────────────────────
+
+#[test]
+fn test_ab_replay_cost_ceiling_exceeded() {
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+
+    // 20 tasks × 1 replay × 2 variants × $0.05 = $2.00 > $1.00 ceiling
+    let tasks: Vec<serde_json::Value> = (0..20)
+        .map(|i| {
+            json!({
+                "message": format!("task {}", i),
+                "case_id": format!("t{}", i),
+            })
+        })
+        .collect();
+
+    let args = json!({
+        "task_specs": tasks,
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "replays_per_variant": 1,
+        "holdout_ratio": 0.0,
+    });
+
+    let result = AbReplayTool
+        .execute(
+            &manifest,
+            &policy,
+            Path::new("/tmp"),
+            None,
+            &args.to_string(),
+            None,
+            None,
+            Some(&config),
+            Some(store),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(v["ok"], false, "expected ok=false, got: {v}");
+    assert_eq!(v["status"], "cost_exceeded", "expected cost_exceeded, got: {v}");
+    assert!(v["estimated_cost_usd"].as_f64().unwrap() > 1.0);
+    assert_eq!(v["max_budget_usd"], 1.0);
+}
+
+// ─── 3. Missing Evaluation capability ─────────────────────────────────────
+
+#[test]
+fn test_ab_replay_requires_evaluation_capability() {
+    let manifest = test_manifest(vec![]);
+    assert!(!AbReplayTool.is_available(&manifest));
+
+    let eval_manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    assert!(AbReplayTool.is_available(&eval_manifest));
+}
+
+// ─── 4. Missing gateway store returns error ───────────────────────────────
+
+#[test]
+fn test_ab_replay_requires_gateway_store() {
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+
+    let args = json!({
+        "task_specs": [{"message": "hello"}],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "replays_per_variant": 1,
+        "holdout_ratio": 0.0,
+    });
+
+    let result = AbReplayTool.execute(
+        &manifest,
+        &policy,
+        Path::new("/tmp"),
+        None,
+        &args.to_string(),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("GatewayStore"), "expected GatewayStore error, got: {err}");
+}
+
+// ─── 5. Revisions must belong to same agent ───────────────────────────────
+
+#[test]
+fn test_ab_replay_revisions_must_be_same_agent() {
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+
+    // Seed a third revision for a DIFFERENT agent
+    let other_rev = "rev_sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    seed_revision(&store, "other-agent", other_rev).unwrap();
+
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+
+    let args = json!({
+        "task_specs": [{"message": "hello"}],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", "other-agent", other_rev),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "replays_per_variant": 1,
+        "holdout_ratio": 0.0,
+    });
+
+    let result = AbReplayTool.execute(
+        &manifest,
+        &policy,
+        Path::new("/tmp"),
+        None,
+        &args.to_string(),
+        None,
+        None,
+        Some(&config),
+        Some(store),
+        None,
+    );
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("same logical agent"),
+        "expected same-agent error, got: {err}"
+    );
+}
+
+// ─── 6. Holdout covers all tasks → error ──────────────────────────────────
+
+#[test]
+fn test_ab_replay_holdout_covers_all_fails() {
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+
+    let manifest = test_manifest(vec![Capability::Evaluation {
+        patterns: vec!["*".into()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+
+    // 1 task, holdout_ratio=1.0 → 0 train tasks
+    let args = json!({
+        "task_specs": [{"message": "hello"}],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "replays_per_variant": 1,
+        "holdout_ratio": 1.0,
+    });
+
+    let result = AbReplayTool.execute(
+        &manifest,
+        &policy,
+        Path::new("/tmp"),
+        None,
+        &args.to_string(),
+        None,
+        None,
+        Some(&config),
+        Some(store),
+        None,
+    );
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("holdout_ratio") || err.contains("no training"),
+        "expected holdout error, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements P2 of the self-improvement loop: `improvement.ab_replay` native tool + `improvement-orchestrator.default` agent for A/B replay orchestration. Closes gap G1 in the design doc (the keystone gap).

## Changes

- **New `improvement.ab_replay` tool** (`autonoetic-gateway/src/runtime/tools/improvement.rs`):
  - Takes `task_specs`, `agent_id`, `revision_a`, `revision_b`
  - Creates a temp eval suite from task specs (or uses an existing `suite_id`)
  - Enqueues eval runs for both revisions via the existing `enqueue_eval_run`
  - Returns `{"status": "queued", ...}` when runs are pending
  - Returns `{"status": "completed", ...}` with comparison report when runs are done
  - Statistical comparison via `eval_stats::compare` (bootstrap CI)
  - Holdout split (default 30%), reports holdout regressions separately
  - Cost ceiling (default $1), refuses if exceeded
  - Status-based regression/improvement tracking across all case IDs
  - Gated behind `Evaluation` capability; policy checks via `can_evaluate_suite`

- **Visibility changes** (`autonoetic-gateway/src/runtime/tools/evaluation.rs`):
  - `enqueue_eval_run` → `pub(crate)` (was private)
  - `build_samples_from_case_results` → `pub(crate)` (was private)

- **Registry registration** (`autonoetic-gateway/src/runtime/tools/mod.rs`):
  - Added `pub mod improvement;` + `improvement::register_tools`

- **New `improvement-orchestrator.default` agent** (`agents/specialists/improvement-orchestrator.default/SKILL.md`):
  - Reasoning agent that wraps `improvement.ab_replay`
  - Provides polling pattern (queued → re-invoke → completed)
  - Declares `Evaluation`, `ReadAccess(*)`, `WriteAccess(self.*)` capabilities
  - Full JSON Schema for input/output contracts

- **Integration tests** (`autonoetic-gateway/tests/improvement_ab_replay_integration.rs`):
  - 6 tests covering: queued path, cost ceiling, missing capability, missing GatewayStore, cross-agent rejection, holdout-all error

## Related

- Closes P2 of issue #247
- Design doc: `docs/design/self-improvement-loop-design.md` §3 (G1 gap) and §7 (P2 rollout)
- P1 (eval_stats) merged in PR #263