### PR TITLE
feat(improve): P6 code-issue-proposer agent and github.issue.create tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 htmlcov/
 .venv-constitution/
 .venv-lock/
+.claude/

--- a/agents/evolution/code-issue-proposer.default/SKILL.md
+++ b/agents/evolution/code-issue-proposer.default/SKILL.md
@@ -76,8 +76,8 @@ This agent is strictly bounded to the following capabilities, enforced at the ga
 **This agent NEVER:**
 - Edits code or opens pull requests
 - Spawns child agents
-- Executes shell commands
-- Makes network requests outside the GitHub API
+- Has CodeExecution capability (cannot run arbitrary shell commands)
+- Makes network requests outside the configured GitHub API scope
 
 Any expansion of this capability set requires a constitutional amendment through the R++2 gate.
 
@@ -109,6 +109,4 @@ Any expansion of this capability set requires a constitutional amendment through
 3. Identify the failing tool call or schema mismatch
 ```
 
-## Rate Limiting
 
-Issue creation is limited to 5 per day per operator. This is enforced at the gateway level (configurable via `limits.max_daily_issues`).

--- a/agents/evolution/code-issue-proposer.default/SKILL.md
+++ b/agents/evolution/code-issue-proposer.default/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "code-issue-proposer.default"
+description: "Analyzes failed sessions with code-level root causes and files scoped GitHub issues."
+metadata:
+  autonoetic:
+    version: "1.0"
+    runtime:
+      engine: "autonoetic"
+      gateway_version: "0.1.0"
+      sdk_version: "0.1.0"
+      type: "stateful"
+      sandbox: "bubblewrap"
+      runtime_lock: "runtime.lock"
+    agent:
+      id: "code-issue-proposer.default"
+      name: "Code Issue Proposer Default"
+      description: >
+        Takes a failed session, reads causal events and digest, identifies
+        gateway-code-level root cause, and files a well-scoped GitHub issue
+        via github.issue.create. Never edits code, never opens PRs.
+    llm_config:
+      provider: "openrouter"
+      model: "google/gemini-3-flash-preview"
+      temperature: 0.1
+    capabilities:
+      - type: "ReadAccess"
+        scopes: ["digest.*"]
+      - type: "SandboxFunctions"
+        allowed:
+          - "execution.search"
+          - "digest.query"
+      - type: "GithubIssueCreate"
+        patterns: ["*"]
+    limits:
+      max_session_price_usd: 0.05
+    validation: "soft"
+    io:
+      trigger: "Manual via 'autonoetic improve --session <id> --propose-code-fix' or delegated by evolution-steward on code_level classification."
+      returns:
+        type: object
+        required: ["ok", "issue_url"]
+        properties:
+          ok:
+            type: boolean
+          issue_url:
+            type: string
+          session_id:
+            type: string
+---
+
+# Code-Issue Proposer
+
+## Purpose
+
+File well-scoped GitHub issues for code-level problems found in failed agent sessions.
+
+## Workflow
+
+1. Receive a session ID and outcome (via trigger_sessions context or CLI flag).
+2. Read causal events via `execution.search` — focus on tool errors, denied actions, and contract violations.
+3. Read the session digest via `digest.query` for the full execution trace.
+4. Identify the root cause — is it a code bug (script error, missing error handling, schema mismatch) vs a prompt-level issue?
+5. If code-level: compose a GitHub issue with evidence, session ID, and suggested fix area.
+6. Call `github.issue.create` to file the issue.
+7. Return the issue URL.
+
+## Bounded Capabilities (Constitutional Invariant)
+
+This agent is strictly bounded to the following capabilities, enforced at the gateway level:
+
+- **ReadAccess** — read session digests and causal events
+- **SandboxFunctions: execution.search** — search causal events
+- **SandboxFunctions: digest.query** — read session digests
+- **GithubIssueCreate** — create GitHub issues only
+
+**This agent NEVER:**
+- Edits code or opens pull requests
+- Spawns child agents
+- Executes shell commands
+- Makes network requests outside the GitHub API
+
+Any expansion of this capability set requires a constitutional amendment through the R++2 gate.
+
+## Issue Body Format
+
+```markdown
+## Session `<session_id>`
+
+**Agent:** `<agent_id>`
+**Goal:** `<task_goal>`
+**Status:** failed/ungraded
+**Turns:** N
+**Cost:** $X.XXXX
+
+### Evidence
+<from grader evidence_summary, if available>
+
+### Tool Failures / Denials
+| Action | Status | Reason |
+|--------|--------|--------|
+| `<tool_name>` | ERROR | <reason> |
+
+### Suggested Fix Area
+<description of the likely code area that needs fixing>
+
+### Reproduction
+1. `autonoetic session trace <session_id>`
+2. Review the outcome digest
+3. Identify the failing tool call or schema mismatch
+```
+
+## Rate Limiting
+
+Issue creation is limited to 5 per day per operator. This is enforced at the gateway level (configurable via `limits.max_daily_issues`).

--- a/autonoetic-gateway/src/policy.rs
+++ b/autonoetic-gateway/src/policy.rs
@@ -786,6 +786,20 @@ impl PolicyEngine {
         PolicyDecision::deny("R-1.1")
     }
 
+    pub fn can_create_github_issue(&self, repo: &str) -> PolicyDecision {
+        for cap in &self.manifest.capabilities {
+            if let Capability::GithubIssueCreate { patterns } = cap {
+                for pattern in patterns {
+                    let prefix = pattern.trim_end_matches('*');
+                    if repo.is_empty() || repo.starts_with(prefix) {
+                        return PolicyDecision::allow("R-1.1");
+                    }
+                }
+            }
+        }
+        PolicyDecision::deny("R-1.1")
+    }
+
     pub fn can_audit_reasoning(&self, target_agent_id: &str) -> PolicyDecision {
         for cap in &self.manifest.capabilities {
             if let Capability::ReasoningAudit { targets } = cap {

--- a/autonoetic-gateway/src/policy.rs
+++ b/autonoetic-gateway/src/policy.rs
@@ -790,8 +790,14 @@ impl PolicyEngine {
         for cap in &self.manifest.capabilities {
             if let Capability::GithubIssueCreate { patterns } = cap {
                 for pattern in patterns {
-                    let prefix = pattern.trim_end_matches('*');
-                    if repo.is_empty() || repo.starts_with(prefix) {
+                    if pattern == "*" {
+                        return PolicyDecision::allow("R-1.1");
+                    }
+                    if let Some(prefix) = pattern.strip_suffix('*') {
+                        if repo.starts_with(prefix) {
+                            return PolicyDecision::allow("R-1.1");
+                        }
+                    } else if repo == pattern {
                         return PolicyDecision::allow("R-1.1");
                     }
                 }
@@ -1106,5 +1112,55 @@ mod tests {
             .security_analysis
             .expect("security analysis should be present");
         assert!(analysis.threats.contains(&SecurityThreat::Destructive));
+    }
+
+    #[test]
+    fn test_can_create_github_issue_wildcard_allows_any_repo() {
+        let manifest = manifest_with_caps(vec![Capability::GithubIssueCreate {
+            patterns: vec!["*".to_string()],
+        }]);
+        let policy = PolicyEngine::new(manifest);
+        assert!(policy.can_create_github_issue("mandubian/autonoetic").is_allowed());
+        assert!(policy.can_create_github_issue("other/repo").is_allowed());
+    }
+
+    #[test]
+    fn test_can_create_github_issue_exact_match() {
+        let manifest = manifest_with_caps(vec![Capability::GithubIssueCreate {
+            patterns: vec!["mandubian/autonoetic".to_string()],
+        }]);
+        let policy = PolicyEngine::new(manifest);
+        assert!(policy.can_create_github_issue("mandubian/autonoetic").is_allowed());
+        assert!(!policy.can_create_github_issue("mandubian/autonoetic-evil").is_allowed());
+        assert!(!policy.can_create_github_issue("other/repo").is_allowed());
+    }
+
+    #[test]
+    fn test_can_create_github_issue_prefix_wildcard() {
+        let manifest = manifest_with_caps(vec![Capability::GithubIssueCreate {
+            patterns: vec!["mandubian/*".to_string()],
+        }]);
+        let policy = PolicyEngine::new(manifest);
+        assert!(policy.can_create_github_issue("mandubian/autonoetic").is_allowed());
+        assert!(policy.can_create_github_issue("mandubian/other").is_allowed());
+        assert!(!policy.can_create_github_issue("other/repo").is_allowed());
+    }
+
+    #[test]
+    fn test_can_create_github_issue_denied_without_capability() {
+        let manifest = manifest_with_caps(vec![Capability::ReadAccess {
+            scopes: vec!["*".to_string()],
+        }]);
+        let policy = PolicyEngine::new(manifest);
+        assert!(!policy.can_create_github_issue("mandubian/autonoetic").is_allowed());
+    }
+
+    #[test]
+    fn test_can_create_github_issue_empty_repo_denied_without_wildcard() {
+        let manifest = manifest_with_caps(vec![Capability::GithubIssueCreate {
+            patterns: vec!["mandubian/autonoetic".to_string()],
+        }]);
+        let policy = PolicyEngine::new(manifest);
+        assert!(!policy.can_create_github_issue("").is_allowed());
     }
 }

--- a/autonoetic-gateway/src/runtime/analysis/mod.rs
+++ b/autonoetic-gateway/src/runtime/analysis/mod.rs
@@ -140,6 +140,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::SkillInstall { .. } => "SkillInstall",
         Capability::ConstitutionalProposal { .. } => "ConstitutionalProposal",
         Capability::ReasoningAudit { .. } => "ReasoningAudit",
+        Capability::GithubIssueCreate { .. } => "GithubIssueCreate",
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow",
         Capability::SecurityRedTeam => "SecurityRedTeam",
     }

--- a/autonoetic-gateway/src/runtime/capability_inference.rs
+++ b/autonoetic-gateway/src/runtime/capability_inference.rs
@@ -267,6 +267,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::SkillInstall { .. } => "SkillInstall",
         Capability::ConstitutionalProposal { .. } => "ConstitutionalProposal",
         Capability::ReasoningAudit { .. } => "ReasoningAudit",
+        Capability::GithubIssueCreate { .. } => "GithubIssueCreate",
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow",
         Capability::SecurityRedTeam => "SecurityRedTeam",
     }

--- a/autonoetic-gateway/src/runtime/state_attestation.rs
+++ b/autonoetic-gateway/src/runtime/state_attestation.rs
@@ -244,6 +244,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::SkillInstall { .. } => "SkillInstall",
         Capability::ConstitutionalProposal { .. } => "ConstitutionalProposal",
         Capability::ReasoningAudit { .. } => "ReasoningAudit",
+        Capability::GithubIssueCreate { .. } => "GithubIssueCreate",
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow",
         Capability::SecurityRedTeam => "SecurityRedTeam",
     }

--- a/autonoetic-gateway/src/runtime/tools/github_issue.rs
+++ b/autonoetic-gateway/src/runtime/tools/github_issue.rs
@@ -18,8 +18,8 @@ struct GithubIssueCreateArgs {
     body: String,
     #[serde(default)]
     labels: Option<String>,
-    #[serde(default)]
-    repo: Option<String>,
+    /// Target repo in "owner/repo" format — required for policy scoping.
+    repo: String,
 }
 
 pub struct GithubIssueCreateTool;
@@ -60,10 +60,10 @@ impl NativeTool for GithubIssueCreateTool {
                     },
                     "repo": {
                         "type": "string",
-                        "description": "Repository to file in (default: current gh remote)"
+                        "description": "Target repo in \"owner/repo\" format"
                     }
                 },
-                "required": ["title", "body"],
+                "required": ["title", "body", "repo"],
                 "additionalProperties": false
             }),
         }
@@ -71,7 +71,7 @@ impl NativeTool for GithubIssueCreateTool {
 
     fn execute(
         &self,
-        manifest: &AgentManifest,
+        _manifest: &AgentManifest,
         policy: &PolicyEngine,
         _agent_dir: &Path,
         _gateway_dir: Option<&Path>,
@@ -85,12 +85,11 @@ impl NativeTool for GithubIssueCreateTool {
         let args: GithubIssueCreateArgs = serde_json::from_str(arguments_json)
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
-        let repo = args.repo.as_deref().unwrap_or("");
-        let decision = policy.can_create_github_issue(repo);
+        let decision = policy.can_create_github_issue(&args.repo);
         if !decision.is_allowed() {
             return Err(anyhow::anyhow!(
                 "GithubIssueCreate capability denied for repo '{}': missing required capability",
-                repo
+                args.repo
             ));
         }
 
@@ -98,15 +97,11 @@ impl NativeTool for GithubIssueCreateTool {
         cmd.arg("issue").arg("create");
         cmd.arg("--title").arg(&args.title);
         cmd.arg("--body").arg(&args.body);
+        cmd.arg("--repo").arg(&args.repo);
 
         if let Some(labels) = &args.labels {
             if !labels.trim().is_empty() {
                 cmd.arg("--label").arg(labels);
-            }
-        }
-        if let Some(repo) = &args.repo {
-            if !repo.trim().is_empty() {
-                cmd.arg("--repo").arg(repo);
             }
         }
 

--- a/autonoetic-gateway/src/runtime/tools/github_issue.rs
+++ b/autonoetic-gateway/src/runtime/tools/github_issue.rs
@@ -1,0 +1,133 @@
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::tools::NativeTool;
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
+use serde::Deserialize;
+use std::path::Path;
+use std::sync::Arc;
+
+pub fn register_tools(registry: &mut crate::runtime::tools::NativeToolRegistry) {
+    registry.register(Box::new(GithubIssueCreateTool));
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubIssueCreateArgs {
+    title: String,
+    body: String,
+    #[serde(default)]
+    labels: Option<String>,
+    #[serde(default)]
+    repo: Option<String>,
+}
+
+pub struct GithubIssueCreateTool;
+
+impl NativeTool for GithubIssueCreateTool {
+    fn name(&self) -> &'static str {
+        "github.issue.create"
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        manifest
+            .capabilities
+            .iter()
+            .any(|cap| matches!(cap, Capability::GithubIssueCreate { .. }))
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Create a GitHub issue. Requires `gh` CLI to be installed and authenticated. \
+                          The code-issue-proposer agent uses this to file scoped code-level issues \
+                          from failed sessions."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Issue title"
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Issue body in Markdown"
+                    },
+                    "labels": {
+                        "type": "string",
+                        "description": "Comma-separated labels (optional)"
+                    },
+                    "repo": {
+                        "type": "string",
+                        "description": "Repository to file in (default: current gh remote)"
+                    }
+                },
+                "required": ["title", "body"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&autonoetic_types::config::GatewayConfig>,
+        _gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        let args: GithubIssueCreateArgs = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let repo = args.repo.as_deref().unwrap_or("");
+        let decision = policy.can_create_github_issue(repo);
+        if !decision.is_allowed() {
+            return Err(anyhow::anyhow!(
+                "GithubIssueCreate capability denied for repo '{}': missing required capability",
+                repo
+            ));
+        }
+
+        let mut cmd = std::process::Command::new("gh");
+        cmd.arg("issue").arg("create");
+        cmd.arg("--title").arg(&args.title);
+        cmd.arg("--body").arg(&args.body);
+
+        if let Some(labels) = &args.labels {
+            if !labels.trim().is_empty() {
+                cmd.arg("--label").arg(labels);
+            }
+        }
+        if let Some(repo) = &args.repo {
+            if !repo.trim().is_empty() {
+                cmd.arg("--repo").arg(repo);
+            }
+        }
+
+        let output = cmd
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to execute `gh issue create`: {} — is `gh` installed?", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!(
+                "`gh issue create` failed (exit {}): {}",
+                output.status.code().unwrap_or(-1),
+                stderr.trim()
+            ));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(serde_json::json!({
+            "ok": true,
+            "url": stdout,
+        })
+        .to_string())
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -608,6 +608,7 @@ pub(crate) fn capability_type_name(cap: &Capability) -> String {
         Capability::BudgetNoPriceAvailableAllow => {
             "budget.no_price_available.allow".to_string()
         }
+        Capability::GithubIssueCreate { .. } => "GithubIssueCreate".to_string(),
         Capability::SecurityRedTeam => "SecurityRedTeam".to_string(),
     }
 }
@@ -962,6 +963,7 @@ pub mod digest;
 pub mod evaluation;
 pub mod execution;
 pub mod federation;
+pub mod github_issue;
 pub mod improvement;
 pub mod knowledge;
 pub mod observability;
@@ -1015,6 +1017,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::observability::register_tools(&mut registry);
     crate::runtime::tools::federation::register_tools(&mut registry);
     crate::runtime::tools::improvement::register_tools(&mut registry);
+    crate::runtime::tools::github_issue::register_tools(&mut registry);
     crate::runtime::tools::promotion::register_tools(&mut registry);
     crate::runtime::tools::scheduler::register_tools(&mut registry);
     crate::runtime::tools::skill::register_tools(&mut registry);

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -149,6 +149,14 @@ pub enum Capability {
     #[serde(rename = "budget.no_price_available.allow")]
     BudgetNoPriceAvailableAllow,
 
+    /// Create GitHub issues via `github.issue.create`.
+    /// The `patterns` field restricts which repos can be targeted.
+    /// Use ["*"] for any repo, or specific patterns like "owner/repo".
+    GithubIssueCreate {
+        #[serde(default = "default_patterns_all")]
+        patterns: Vec<String>,
+    },
+
     /// Submit adversarial attack-pattern proposals via `attack_pattern_propose`.
     /// Granted exclusively to the system-tier red-team agent. Intentionally
     /// separate from `Evaluation` — the red-team agent must NOT also author eval
@@ -257,6 +265,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::SkillInstall { .. } => "SkillInstall".to_string(),
         Capability::ConstitutionalProposal { .. } => "ConstitutionalProposal".to_string(),
         Capability::ReasoningAudit { .. } => "ReasoningAudit".to_string(),
+        Capability::GithubIssueCreate { .. } => "GithubIssueCreate".to_string(),
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow".to_string(),
         Capability::SecurityRedTeam => "SecurityRedTeam".to_string(),
     }
@@ -320,6 +329,10 @@ fn capability_broadening(
         (Capability::ReasoningAudit { targets: a }, Capability::ReasoningAudit { targets: b }) => {
             scope_broadening(capability_type, a, b)
         }
+        (
+            Capability::GithubIssueCreate { patterns: a },
+            Capability::GithubIssueCreate { patterns: b },
+        ) => scope_broadening(capability_type, a, b),
         (
             Capability::CodeExecution {
                 patterns: ap,

--- a/autonoetic/src/cli/improve.rs
+++ b/autonoetic/src/cli/improve.rs
@@ -44,6 +44,10 @@ pub struct ImproveRunArgs {
     /// If true, refuse to deploy — output the comparison report path instead.
     #[arg(long)]
     pub no_prompt: bool,
+    /// File a GitHub issue with code-level findings from failed sessions.
+    /// Requires `gh` CLI installed and authenticated. Used in conjunction with --session.
+    #[arg(long)]
+    pub propose_code_fix: bool,
 }
 
 pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> anyhow::Result<()> {
@@ -55,6 +59,7 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
             let agent = args.agent.as_deref();
             let dry_run = args.dry_run;
             let no_prompt = args.no_prompt;
+            let propose_code_fix = args.propose_code_fix;
             let loaded_config = autonoetic_gateway::config::load_config(config_path)?;
             let gateway_dir = loaded_config.agents_dir.join(".gateway");
             let store = Arc::new(GatewayStore::open(&gateway_dir).context(
@@ -82,6 +87,11 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
             if dry_run {
                 eprintln!("[dry-run] Stopping before propose/validate as requested.");
                 return Ok(());
+            }
+
+            // 3b. Code-fix proposal path — files a GitHub issue instead of proposing a revision
+            if propose_code_fix {
+                return handle_propose_code_fix(&loaded_config, &store, &gateway_dir, &session_ids, &outcomes, no_prompt).await;
             }
 
             // 4. Determine agent to improve from the first outcome
@@ -447,6 +457,182 @@ fn propose_improvement(
         .with_context(|| format!("Failed to copy runtime.lock to {:?}", dst_dir))?;
 
     Ok(short_id)
+}
+
+/// File a GitHub issue with code-level findings from one or more failed sessions.
+/// Requires `gh` CLI to be installed and authenticated.
+async fn handle_propose_code_fix(
+    config: &autonoetic_types::config::GatewayConfig,
+    store: &Arc<GatewayStore>,
+    gateway_dir: &Path,
+    _session_ids: &[String],
+    outcomes: &[(String, autonoetic_types::session_outcome::SessionOutcome)],
+    _no_prompt: bool,
+) -> anyhow::Result<()> {
+    use autonoetic_gateway::runtime::tools::github_issue::GithubIssueCreateTool;
+    use autonoetic_types::causal_chain::CausalEventRecord;
+
+    let target_agent = outcomes
+        .first()
+        .map(|(_, o)| o.source_agent_id.clone())
+        .unwrap_or_default();
+
+    for (sid, outcome) in outcomes {
+        // Skip passed sessions unless no_prompt (for now, skip all passed)
+        if outcome.judged_success() == Some(true) {
+            eprintln!("[skip] Session {} passed — no issue filed.", sid);
+            continue;
+        }
+
+        // Gather causal events for this session
+        let causal_events: Vec<CausalEventRecord> = store
+            .search_causal_events(Some(sid), None, 100)
+            .with_context(|| format!("Failed to read causal events for session '{}'", sid))?;
+
+        let tool_failures: Vec<&CausalEventRecord> = causal_events
+            .iter()
+            .filter(|e| e.status == "ERROR" || e.status == "DENIED")
+            .collect();
+
+        // Build issue body
+        let mut body = String::new();
+
+        body.push_str(&format!(
+            "## Session `{}`\n\n**Agent:** {}  \n**Goal:** {}  \n**Status:** {}  \n**Turns:** {}  \n**Cost:** ${:.4}\n\n",
+            sid,
+            outcome.source_agent_id,
+            outcome.task_goal.as_deref().unwrap_or("(no goal)"),
+            match outcome.judged_success() {
+                Some(true) => "passed",
+                Some(false) => "failed",
+                None => "ungraded",
+            },
+            outcome.turns,
+            outcome.cost_usd,
+        ));
+
+        if let Some(ref grader) = outcome.grader {
+            if let Some(ref summary) = grader.evidence_summary {
+                body.push_str(&format!("**Evidence:** {}\n\n", summary));
+            }
+        }
+
+        if !tool_failures.is_empty() {
+            body.push_str("### Tool Failures / Denials\n\n");
+            body.push_str("| Action | Status | Reason |\n");
+            body.push_str("|--------|--------|--------|\n");
+            for ev in tool_failures.iter().take(10) {
+                let reason = ev.reason.as_deref().unwrap_or("(none)");
+                body.push_str(&format!("| `{}` | {} | {} |\n", ev.action, ev.status, reason));
+            }
+            body.push('\n');
+        }
+
+        body.push_str("### Suggested Fix Area\n\n");
+        body.push_str("_This issue was auto-filed by the code-issue-proposer. Review the causal event log ");
+        body.push_str("and digest to identify the root cause in gateway code._\n\n");
+
+        body.push_str("#### Reproduction\n");
+        body.push_str(&format!("1. Run `autonoetic session trace {}`\n", sid));
+        body.push_str(&format!("2. Review the outcome digest at session `{}`\n", sid));
+        body.push_str("3. Identify the failing tool call or schema mismatch\n");
+
+        // File the issue via github.issue.create tool
+        let manifest = AgentManifest {
+            version: "1.0".to_string(),
+            runtime: RuntimeDeclaration {
+                engine: "autonoetic".to_string(),
+                gateway_version: "0.1.0".to_string(),
+                sdk_version: "0.1.0".to_string(),
+                runtime_type: "stateful".to_string(),
+                sandbox: "bubblewrap".to_string(),
+                runtime_lock: "runtime.lock".to_string(),
+            },
+            agent: AgentIdentity {
+                id: "autonoetic-cli".to_string(),
+                name: "Autonoetic CLI".to_string(),
+                description: "CLI code-issue-proposer".to_string(),
+            },
+            capabilities: vec![Capability::GithubIssueCreate {
+                patterns: vec!["*".into()],
+            }],
+            llm_config: None,
+            limits: None,
+            background: None,
+            disclosure: None,
+            io: None,
+            middleware: None,
+            execution_mode: Default::default(),
+            script_entry: None,
+            script_input_mode: Default::default(),
+            gateway_url: None,
+            gateway_token: None,
+            allowed_tool_tiers: vec![],
+            agentskills_import: None,
+            compression: None,
+            sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+        };
+        let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+        let tool = GithubIssueCreateTool;
+
+        let title = format!(
+            "[code-issue-proposer] Session {} — {}",
+            sid,
+            outcome.task_goal.as_deref().unwrap_or("code-level issue")
+        );
+
+        let tool_args = serde_json::json!({
+            "title": title,
+            "body": body,
+            "labels": "code-issue-proposer",
+        });
+
+        let result = tool
+            .execute(
+                &manifest,
+                &policy,
+                Path::new("/tmp"),
+                Some(gateway_dir),
+                &tool_args.to_string(),
+                Some(sid),
+                None,
+                Some(config),
+                Some(store.clone()),
+                None,
+            )
+            .with_context(|| format!("Failed to file GitHub issue for session '{}'", sid))?;
+
+        let parsed: serde_json::Value = serde_json::from_str(&result)
+            .with_context(|| format!("Failed to parse tool output: {}", result))?;
+
+        let url = parsed["url"].as_str().unwrap_or("(unknown)");
+        eprintln!("Filed issue for session `{}`: {}", sid, url);
+
+        // Emit causal event for audit trail
+        let _ = store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+            event_id: uuid::Uuid::new_v4().to_string(),
+            agent_id: target_agent.clone(),
+            session_id: sid.to_string(),
+            turn_id: None,
+            event_seq: chrono::Utc::now().timestamp_millis().max(0) as u64,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            category: "tool".to_string(),
+            action: "code_issue_proposed".to_string(),
+            status: "SUCCESS".to_string(),
+            enforced_rules: autonoetic_types::causal_chain::default_enforced_rules(),
+            target: Some(url.to_string()),
+            payload: Some(serde_json::json!({
+                "session_id": sid,
+                "agent_id": target_agent,
+                "issue_url": url,
+            }).to_string()),
+            payload_ref: None,
+            evidence_ref: None,
+            reason: Some("Auto-filed by code-issue-proposer via CLI".to_string()),
+        });
+    }
+
+    Ok(())
 }
 
 fn run_ab_replay(

--- a/autonoetic/src/cli/improve.rs
+++ b/autonoetic/src/cli/improve.rs
@@ -2,6 +2,35 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
+/// Escape pipe `|` and newline characters for Markdown table cells.
+fn escape_md_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ").replace('\r', " ")
+}
+
+/// Guess the GitHub `owner/repo` from the git remote origin URL.
+/// Supports both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git`.
+fn guess_github_repo() -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // git@github.com:owner/repo.git  →  owner/repo
+    // https://github.com/owner/repo.git  →  owner/repo
+    if let Some(path) = url.split("github.com").nth(1) {
+        let path = path.trim_start_matches(':').trim_start_matches('/');
+        let path = path.strip_suffix(".git").unwrap_or(path);
+        let path = path.strip_suffix('/').unwrap_or(path);
+        if let Some((owner, repo)) = path.split_once('/') {
+            return Some(format!("{}/{}", owner, repo.trim_end_matches('/')));
+        }
+    }
+    None
+}
+
 use anyhow::Context;
 use autonoetic_gateway::runtime::tools::improvement::AbReplayTool;
 use autonoetic_gateway::runtime::tools::NativeTool;
@@ -477,8 +506,46 @@ async fn handle_propose_code_fix(
         .map(|(_, o)| o.source_agent_id.clone())
         .unwrap_or_default();
 
+    // Build shared manifest, policy, and tool once (constant across sessions)
+    let manifest = AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "autonoetic-cli".to_string(),
+            name: "Autonoetic CLI".to_string(),
+            description: "CLI code-issue-proposer".to_string(),
+        },
+        capabilities: vec![Capability::GithubIssueCreate {
+            patterns: vec!["*".into()],
+        }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    };
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let tool = GithubIssueCreateTool;
+
     for (sid, outcome) in outcomes {
-        // Skip passed sessions unless no_prompt (for now, skip all passed)
+        // Skip passed sessions
         if outcome.judged_success() == Some(true) {
             eprintln!("[skip] Session {} passed — no issue filed.", sid);
             continue;
@@ -513,7 +580,7 @@ async fn handle_propose_code_fix(
 
         if let Some(ref grader) = outcome.grader {
             if let Some(ref summary) = grader.evidence_summary {
-                body.push_str(&format!("**Evidence:** {}\n\n", summary));
+                body.push_str(&format!("**Evidence:** {}\n\n", escape_md_cell(summary)));
             }
         }
 
@@ -522,7 +589,7 @@ async fn handle_propose_code_fix(
             body.push_str("| Action | Status | Reason |\n");
             body.push_str("|--------|--------|--------|\n");
             for ev in tool_failures.iter().take(10) {
-                let reason = ev.reason.as_deref().unwrap_or("(none)");
+                let reason = ev.reason.as_deref().map(escape_md_cell).unwrap_or_else(|| "(none)".to_string());
                 body.push_str(&format!("| `{}` | {} | {} |\n", ev.action, ev.status, reason));
             }
             body.push('\n');
@@ -537,54 +604,20 @@ async fn handle_propose_code_fix(
         body.push_str(&format!("2. Review the outcome digest at session `{}`\n", sid));
         body.push_str("3. Identify the failing tool call or schema mismatch\n");
 
-        // File the issue via github.issue.create tool
-        let manifest = AgentManifest {
-            version: "1.0".to_string(),
-            runtime: RuntimeDeclaration {
-                engine: "autonoetic".to_string(),
-                gateway_version: "0.1.0".to_string(),
-                sdk_version: "0.1.0".to_string(),
-                runtime_type: "stateful".to_string(),
-                sandbox: "bubblewrap".to_string(),
-                runtime_lock: "runtime.lock".to_string(),
-            },
-            agent: AgentIdentity {
-                id: "autonoetic-cli".to_string(),
-                name: "Autonoetic CLI".to_string(),
-                description: "CLI code-issue-proposer".to_string(),
-            },
-            capabilities: vec![Capability::GithubIssueCreate {
-                patterns: vec!["*".into()],
-            }],
-            llm_config: None,
-            limits: None,
-            background: None,
-            disclosure: None,
-            io: None,
-            middleware: None,
-            execution_mode: Default::default(),
-            script_entry: None,
-            script_input_mode: Default::default(),
-            gateway_url: None,
-            gateway_token: None,
-            allowed_tool_tiers: vec![],
-            agentskills_import: None,
-            compression: None,
-            sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
-        };
-        let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
-        let tool = GithubIssueCreateTool;
-
         let title = format!(
             "[code-issue-proposer] Session {} — {}",
             sid,
             outcome.task_goal.as_deref().unwrap_or("code-level issue")
         );
 
+        let repo = guess_github_repo()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine GitHub repo from git remote — set origin or pass --repo"))?;
+
         let tool_args = serde_json::json!({
             "title": title,
             "body": body,
             "labels": "code-issue-proposer",
+            "repo": repo,
         });
 
         let result = tool
@@ -623,7 +656,7 @@ async fn handle_propose_code_fix(
             target: Some(url.to_string()),
             payload: Some(serde_json::json!({
                 "session_id": sid,
-                "agent_id": target_agent,
+                "agent_id": target_agent.clone(),
                 "issue_url": url,
             }).to_string()),
             payload_ref: None,


### PR DESCRIPTION
## Summary

Implements P6 (#251) — the code-issue-proposer agent that files scoped GitHub issues for failed sessions with code-level root causes.

### New: `GithubIssueCreate` Capability
- Added `Capability::GithubIssueCreate { patterns }` variant — patterns scope which repos can be targeted (`*` for any)
- Policy engine check: `can_create_github_issue(repo)` → rule `R-1.1`

### New: `github.issue.create` Tool
- Wraps `gh issue create` CLI — requires `gh` installed and authenticated
- Args: `title` (required), `body` (required), `labels` (optional CSV), `repo` (optional)
- Gated by `GithubIssueCreate` capability
- Returns URL of created issue

### New: CLI `--propose-code-fix` Flag
- `autonoetic improve run --session <id> --propose-code-fix`
- Reads session outcome + causal events → formats Markdown issue body → calls tool → emits `code_issue_proposed` causal event
- Skips sessions with `judged_success() == true`

### New: `code-issue-proposer.default` Agent
- Strictly bounded capabilities: `ReadAccess` (digest.*), `SandboxFunctions` (execution.search, digest.query), `GithubIssueCreate`
- Constitutional invariant: never edits code, never opens PRs, never spawns children
- SKILL.md with full workflow description and issue body template

### Registrations
- Added `GithubIssueCreate` to all 5 `capability_type_name` match arms (analysis, capability_inference, state_attestation, tools/mod, types/capability)
- Registered `github_issue::register_tools` in `default_registry()`

Closes #251