### PR TITLE
feat(improve): P5 — agent-level evolution via three-state surface policy

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/improvement.rs
+++ b/autonoetic-gateway/src/runtime/tools/improvement.rs
@@ -158,17 +158,31 @@ impl NativeTool for AbReplayTool {
 
         // P4/P5 surface-change gate. The three-state policy lives in
         // `evaluate_surface_change_policy`; this block applies its
-        // verdict. The policy understands:
-        //   * no delta            → Allow (proceed normally)
-        //   * delta, not opted in → Reject (P4 prompt-only behaviour)
-        //   * delta, high-blast   → Reject (never automatable)
-        //   * delta, low-blast,   → AllowWithStrictHoldout
-        //     opted in              (proceed with coerced holdout ≥
-        //                            improve.capability_change_min_holdout)
+        // verdict and threads the audit trail into the response.
+        //
+        // `policy_applied` is set to one of six values so consumers
+        // can log/inspect what happened uniformly:
+        //   * `gate_disabled`                          — restrict_to_prompt_only=false
+        //   * `not_evaluated`                          — gate enabled but no gateway_dir
+        //   * `no_delta`                               — surfaces match
+        //   * `prompt_only_violation`                  — reject (operator not opted in)
+        //   * `high_blast_radius`                      — reject (never automatable)
+        //   * `capability_change_with_strict_holdout`  — allow + maybe coerce holdout
+        //
         // See docs/design/self-improvement-loop-validation.md §8 (P5).
-        let mut policy_applied = "no_delta".to_string();
+        let mut policy_applied = if config.improve.restrict_to_prompt_only {
+            // Will be overwritten once we actually evaluate.
+            "not_evaluated".to_string()
+        } else {
+            "gate_disabled".to_string()
+        };
         let mut holdout_coerced_from: Option<f64> = None;
         if config.improve.restrict_to_prompt_only {
+            // Validate the high-blast list against the canonical set
+            // from autonoetic-types. Typos here would silently disable
+            // detection for that kind, so we surface them loudly.
+            warn_unknown_high_blast_kinds(&config.improve.high_blast_radius_capability_kinds);
+
             // The revisions live under `gateway_dir/revisions/agents/<agent>/<rev>/`.
             // Use the `gateway_dir` parameter the runtime threads in
             // (production: JSON-RPC dispatch supplies it). When absent,
@@ -186,9 +200,14 @@ impl NativeTool for AbReplayTool {
                     )?;
                     match policy {
                         SurfaceChangePolicy::Allow => {
-                            // No delta. Holdout stays as the caller asked.
+                            policy_applied = "no_delta".to_string();
                         }
                         SurfaceChangePolicy::Reject { reason, classification } => {
+                            // policy_applied mirrors `classification` so all
+                            // responses share a single audit field. The
+                            // legacy `classification` field stays for
+                            // backward compatibility with operator
+                            // tooling already keyed on it.
                             return Ok(serde_json::json!({
                                 "ok": false,
                                 "status": "surface_drift_rejected",
@@ -196,21 +215,26 @@ impl NativeTool for AbReplayTool {
                                 "revision_a": ref_a.to_string(),
                                 "revision_b": ref_b.to_string(),
                                 "reason": reason,
+                                "policy_applied": classification.clone(),
                                 "classification": classification,
                                 "guardrail": "improve.restrict_to_prompt_only",
-                                "message": format!(
+                                "message":
                                     "Refused: candidate revision's capability/tool-tier surface differs \
-                                     from baseline ({}). To allow this comparison, either \
+                                     from baseline. To allow this comparison, either \
                                      (1) set `improve.allow_capability_changes: true` and ensure the change \
                                      is not high-blast-radius, or \
-                                     (2) promote the revision manually through the R++2 capability-delta gate.",
-                                    classification
-                                ),
+                                     (2) promote the revision manually through the R++2 capability-delta gate.".to_string(),
                             }).to_string());
                         }
                         SurfaceChangePolicy::AllowWithStrictHoldout { reason } => {
                             policy_applied = "capability_change_with_strict_holdout".to_string();
-                            let min_holdout = config.improve.capability_change_min_holdout;
+                            // Clamp the configured min into a sane range
+                            // before comparing — guards against a
+                            // misconfigured `capability_change_min_holdout`
+                            // value (e.g. >1, NaN) breaking the holdout
+                            // math downstream.
+                            let min_holdout =
+                                clamp_holdout_ratio(config.improve.capability_change_min_holdout);
                             if args.holdout_ratio < min_holdout {
                                 holdout_coerced_from = Some(args.holdout_ratio);
                                 args.holdout_ratio = min_holdout;
@@ -227,6 +251,7 @@ impl NativeTool for AbReplayTool {
                     }
                 }
                 None => {
+                    // policy_applied stays "not_evaluated" — set above.
                     tracing::warn!(
                         target: "improvement",
                         agent_id = %args.agent_id,
@@ -700,6 +725,54 @@ pub(crate) fn evaluate_surface_change_policy(
     Ok(SurfaceChangePolicy::AllowWithStrictHoldout {
         reason: diff_reason,
     })
+}
+
+/// Clamp a holdout ratio into `[0.0, 1.0]`. `NaN` becomes `0.0`. Used
+/// at the use site rather than at config load so misconfiguration is
+/// neutralized at the boundary without a hard parse error (which would
+/// fail the whole gateway start). Emits an `info` log when clamping
+/// actually changed the value, so an operator who set 1.5 by mistake
+/// gets a hint.
+fn clamp_holdout_ratio(raw: f64) -> f64 {
+    let clamped = if raw.is_nan() {
+        0.0
+    } else {
+        raw.max(0.0).min(1.0)
+    };
+    if (clamped - raw).abs() > f64::EPSILON || raw.is_nan() {
+        tracing::info!(
+            target: "improvement",
+            requested = raw,
+            clamped = clamped,
+            "improve.capability_change_min_holdout out of [0.0, 1.0] — clamped"
+        );
+    }
+    clamped
+}
+
+/// Validate the operator-supplied high-blast list against the canonical
+/// capability-kind names from `autonoetic-types`. Anything unknown
+/// (typo, casing, deprecated kind) is logged at WARN level so the
+/// operator notices the silent disablement. We don't reject the config
+/// — a single typo shouldn't fail the gateway — but the warning is
+/// loud enough to surface in any reasonable log review.
+fn warn_unknown_high_blast_kinds(configured: &[String]) {
+    let known: std::collections::HashSet<&str> =
+        autonoetic_types::capability::all_capability_kind_names()
+            .iter()
+            .copied()
+            .collect();
+    for kind in configured {
+        if !known.contains(kind.as_str()) {
+            tracing::warn!(
+                target: "improvement",
+                unknown_kind = %kind,
+                "improve.high_blast_radius_capability_kinds contains an unknown capability \
+                 kind — high-blast detection will silently miss this kind. Check spelling \
+                 against autonoetic_types::capability::all_capability_kind_names()."
+            );
+        }
+    }
 }
 
 fn tool_tier_surface(manifest: &AgentManifest) -> std::collections::BTreeSet<String> {

--- a/autonoetic-gateway/src/runtime/tools/improvement.rs
+++ b/autonoetic-gateway/src/runtime/tools/improvement.rs
@@ -129,7 +129,7 @@ impl NativeTool for AbReplayTool {
         gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
-        let args: AbReplayArgs = serde_json::from_str(arguments_json)
+        let mut args: AbReplayArgs = serde_json::from_str(arguments_json)
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments: {}", e))?;
 
         let Some(gateway_store) = gateway_store else {
@@ -156,13 +156,18 @@ impl NativeTool for AbReplayTool {
             ref_a.agent_id
         );
 
-        // P4 guardrail: when `improve.restrict_to_prompt_only` is true
-        // (default), refuse to compare revisions whose declared
-        // capability or tool-tier surfaces differ. The propose step
-        // forks an identical candidate, so this only fires when the
-        // candidate's SKILL.md was hand-edited to widen its surface —
-        // exactly the case P4's prompt-only milestone excludes. See
-        // `docs/design/self-improvement-loop-validation.md`.
+        // P4/P5 surface-change gate. The three-state policy lives in
+        // `evaluate_surface_change_policy`; this block applies its
+        // verdict. The policy understands:
+        //   * no delta            → Allow (proceed normally)
+        //   * delta, not opted in → Reject (P4 prompt-only behaviour)
+        //   * delta, high-blast   → Reject (never automatable)
+        //   * delta, low-blast,   → AllowWithStrictHoldout
+        //     opted in              (proceed with coerced holdout ≥
+        //                            improve.capability_change_min_holdout)
+        // See docs/design/self-improvement-loop-validation.md §8 (P5).
+        let mut policy_applied = "no_delta".to_string();
+        let mut holdout_coerced_from: Option<f64> = None;
         if config.improve.restrict_to_prompt_only {
             // The revisions live under `gateway_dir/revisions/agents/<agent>/<rev>/`.
             // Use the `gateway_dir` parameter the runtime threads in
@@ -171,27 +176,54 @@ impl NativeTool for AbReplayTool {
             // skip, rather than silently rejecting all comparisons.
             match gateway_dir {
                 Some(gw_dir) => {
-                    if let Some(reason) = surface_drift_reason(
+                    let policy = evaluate_surface_change_policy(
                         &repo,
                         gw_dir,
                         &args.agent_id,
                         &rev_a.revision_id,
                         &rev_b.revision_id,
-                    )? {
-                        return Ok(serde_json::json!({
-                            "ok": false,
-                            "status": "surface_drift_rejected",
-                            "agent_id": args.agent_id,
-                            "revision_a": ref_a.to_string(),
-                            "revision_b": ref_b.to_string(),
-                            "reason": reason,
-                            "guardrail": "improve.restrict_to_prompt_only",
-                            "message":
-                                "Refused: candidate revision changed the agent's capability \
-                                 or tool-tier surface. Self-improvement P4 is gated on \
-                                 prompt-only changes; set `improve.restrict_to_prompt_only: \
-                                 false` once your operator-side validation cycles are done."
-                        }).to_string());
+                        &config.improve,
+                    )?;
+                    match policy {
+                        SurfaceChangePolicy::Allow => {
+                            // No delta. Holdout stays as the caller asked.
+                        }
+                        SurfaceChangePolicy::Reject { reason, classification } => {
+                            return Ok(serde_json::json!({
+                                "ok": false,
+                                "status": "surface_drift_rejected",
+                                "agent_id": args.agent_id,
+                                "revision_a": ref_a.to_string(),
+                                "revision_b": ref_b.to_string(),
+                                "reason": reason,
+                                "classification": classification,
+                                "guardrail": "improve.restrict_to_prompt_only",
+                                "message": format!(
+                                    "Refused: candidate revision's capability/tool-tier surface differs \
+                                     from baseline ({}). To allow this comparison, either \
+                                     (1) set `improve.allow_capability_changes: true` and ensure the change \
+                                     is not high-blast-radius, or \
+                                     (2) promote the revision manually through the R++2 capability-delta gate.",
+                                    classification
+                                ),
+                            }).to_string());
+                        }
+                        SurfaceChangePolicy::AllowWithStrictHoldout { reason } => {
+                            policy_applied = "capability_change_with_strict_holdout".to_string();
+                            let min_holdout = config.improve.capability_change_min_holdout;
+                            if args.holdout_ratio < min_holdout {
+                                holdout_coerced_from = Some(args.holdout_ratio);
+                                args.holdout_ratio = min_holdout;
+                                tracing::info!(
+                                    target: "improvement",
+                                    agent_id = %args.agent_id,
+                                    requested_holdout = holdout_coerced_from.unwrap_or(0.0),
+                                    coerced_to = min_holdout,
+                                    reason = %reason,
+                                    "P5: holdout coerced up for capability-change comparison"
+                                );
+                            }
+                        }
                     }
                 }
                 None => {
@@ -199,7 +231,7 @@ impl NativeTool for AbReplayTool {
                         target: "improvement",
                         agent_id = %args.agent_id,
                         "improve.restrict_to_prompt_only is enabled but no gateway_dir \
-                         was supplied to the tool — surface-drift check skipped. \
+                         was supplied to the tool — surface-change policy not evaluated. \
                          Production callers should pass gateway_dir."
                     );
                 }
@@ -309,6 +341,8 @@ impl NativeTool for AbReplayTool {
                 "ok": true,
                 "status": "queued",
                 "suite_id": suite_id,
+                "policy_applied": policy_applied,
+                "holdout_coerced_from": holdout_coerced_from,
                 "queued_eval_run_ids": pending_ids,
                 "message": "Eval runs already pending. Re-invoke with same args once complete.",
             }).to_string());
@@ -358,6 +392,8 @@ impl NativeTool for AbReplayTool {
                 "ok": true,
                 "status": "queued",
                 "suite_id": suite_id,
+                "policy_applied": policy_applied,
+                "holdout_coerced_from": holdout_coerced_from,
                 "queued_eval_run_ids": queued_ids,
                 "message": "Queued eval runs for A/B replay. Call improvement.ab_replay again with the same args \
                             once the background eval runner completes the runs to get the comparison report.",
@@ -436,6 +472,8 @@ impl NativeTool for AbReplayTool {
             "agent_id": args.agent_id,
             "revision_a": ref_a.to_string(),
             "revision_b": ref_b.to_string(),
+            "policy_applied": policy_applied,
+            "holdout_coerced_from": holdout_coerced_from,
             "baseline_eval_run_id": baseline_run.eval_run_id,
             "candidate_eval_run_id": candidate_run.eval_run_id,
             "summary": {
@@ -542,33 +580,53 @@ fn build_ab_stats(
     }
 }
 
-/// Load two revisions' on-disk manifests and check that the candidate
-/// (rev_b) has not changed the agent's privilege surface relative to
-/// the baseline (rev_a). Returns `Ok(Some(reason))` when ANY non-trivial
-/// difference exists (i.e., the guardrail should reject), `Ok(None)`
-/// when the surfaces match. Hard errors propagate via `Err` (e.g.,
-/// SKILL.md missing, parse failure).
+/// Three-state verdict from [`evaluate_surface_change_policy`]. The
+/// caller (the gate inside `AbReplayTool::execute`) either proceeds
+/// untouched, proceeds with a coerced minimum holdout, or returns a
+/// reject response to the caller.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SurfaceChangePolicy {
+    /// No capability or tool-tier delta. Proceed normally.
+    Allow,
+    /// Reject. `classification` is `"prompt_only_violation"` (operator
+    /// has not opted in) or `"high_blast_radius"` (broadens
+    /// sandbox/network/code-exec/credentials/scheduler/revision —
+    /// never automatable). `reason` carries the concrete diff for
+    /// audit.
+    Reject {
+        reason: String,
+        classification: String,
+    },
+    /// Capability delta exists, operator opted in, change is not
+    /// high-blast-radius. Proceed but enforce
+    /// `improve.capability_change_min_holdout`. `reason` carries the
+    /// diff for the audit trail.
+    AllowWithStrictHoldout { reason: String },
+}
+
+/// Evaluate the surface-change policy (P4 prompt-only gate + P5
+/// capability-change extension) for an A/B replay.
 ///
-/// "Privilege surface" for P4 = the manifest's `capabilities` block AND
-/// the `allowed_tool_tiers` list. The comparison delegates to
-/// [`autonoetic_types::capability::compute_capability_delta`], which
-/// understands parameter-level widening (e.g., `ReadAccess` scopes
-/// `["self.*"]` → `["*"]` IS a privilege widening even though the
-/// capability kind is unchanged). The earlier kind-only comparator
-/// would have let that through — that's the bug Copilot's review on
-/// PR #267 caught.
+/// Compares baseline vs candidate manifests on:
+/// 1. `capabilities` via
+///    [`autonoetic_types::capability::compute_capability_delta`] —
+///    understands parameter-level widening, not just kind add/remove
+/// 2. `allowed_tool_tiers` set equality
 ///
-/// Any of `added`, `broadened`, `narrowed`, or `removed` from the
-/// delta trips the gate. P4's intent is **prompt-only**, so even
-/// narrowing is treated as a non-prompt change — the operator should
-/// be running narrowing through a separate review path, not this one.
-fn surface_drift_reason(
+/// Then classifies the verdict:
+/// - **No delta** → `Allow`
+/// - **Delta + `!allow_capability_changes`** → `Reject(prompt_only_violation)`
+/// - **Delta + opted in + ANY add/broaden in
+///   `high_blast_radius_capability_kinds`** → `Reject(high_blast_radius)`
+/// - **Delta + opted in + low-blast** → `AllowWithStrictHoldout`
+pub(crate) fn evaluate_surface_change_policy(
     repo: &crate::agent::repository::AgentRepository,
     gateway_dir: &std::path::Path,
     agent_id: &str,
     baseline_revision_id: &str,
     candidate_revision_id: &str,
-) -> anyhow::Result<Option<String>> {
+    improve_config: &autonoetic_types::config::ImproveConfig,
+) -> anyhow::Result<SurfaceChangePolicy> {
     let loaded_baseline =
         repo.load_from_revision_dir(gateway_dir, agent_id, baseline_revision_id)?;
     let loaded_candidate =
@@ -578,32 +636,70 @@ fn surface_drift_reason(
         &loaded_baseline.manifest.capabilities,
         &loaded_candidate.manifest.capabilities,
     );
-    if !delta.added.is_empty()
-        || !delta.broadened.is_empty()
-        || !delta.narrowed.is_empty()
-        || !delta.removed.is_empty()
-    {
-        return Ok(Some(format!(
-            "capabilities changed: added={:?}, broadened={:?}, narrowed={:?}, removed={:?}",
-            delta.added,
-            delta.broadened.iter().map(|b| b.capability_type.clone()).collect::<Vec<_>>(),
-            delta.narrowed,
-            delta.removed,
-        )));
-    }
-
     let tiers_a = tool_tier_surface(&loaded_baseline.manifest);
     let tiers_b = tool_tier_surface(&loaded_candidate.manifest);
-    if tiers_a != tiers_b {
-        let added: Vec<String> = tiers_b.difference(&tiers_a).cloned().collect();
-        let removed: Vec<String> = tiers_a.difference(&tiers_b).cloned().collect();
-        return Ok(Some(format!(
-            "allowed_tool_tiers differs: added={:?}, removed={:?}",
-            added, removed
-        )));
+    let tier_delta_added: Vec<String> = tiers_b.difference(&tiers_a).cloned().collect();
+    let tier_delta_removed: Vec<String> = tiers_a.difference(&tiers_b).cloned().collect();
+    let has_capability_delta = !delta.added.is_empty()
+        || !delta.broadened.is_empty()
+        || !delta.narrowed.is_empty()
+        || !delta.removed.is_empty();
+    let has_tier_delta = !tier_delta_added.is_empty() || !tier_delta_removed.is_empty();
+
+    if !has_capability_delta && !has_tier_delta {
+        return Ok(SurfaceChangePolicy::Allow);
     }
 
-    Ok(None)
+    let broadened_kinds: Vec<String> = delta
+        .broadened
+        .iter()
+        .map(|b| b.capability_type.clone())
+        .collect();
+    let diff_reason = format!(
+        "capabilities: added={:?}, broadened={:?}, narrowed={:?}, removed={:?}; \
+         allowed_tool_tiers: added={:?}, removed={:?}",
+        delta.added, broadened_kinds, delta.narrowed, delta.removed,
+        tier_delta_added, tier_delta_removed,
+    );
+
+    if !improve_config.allow_capability_changes {
+        return Ok(SurfaceChangePolicy::Reject {
+            reason: diff_reason,
+            classification: "prompt_only_violation".to_string(),
+        });
+    }
+
+    // P5 blast-radius classifier: ADDED kinds OR BROADENED kinds in
+    // the high-blast list = reject. Removed/narrowed kinds do NOT
+    // count as high-blast (removing privileges is safe). Tool-tier
+    // changes are not blast-classified separately — they go through
+    // the strict-holdout path unless paired with a high-blast cap
+    // change, which the cap check above already catches.
+    let high_blast: &[String] = &improve_config.high_blast_radius_capability_kinds;
+    let added_high: Vec<&str> = delta
+        .added
+        .iter()
+        .filter(|kind| high_blast.iter().any(|h| h == *kind))
+        .map(|s| s.as_str())
+        .collect();
+    let broadened_high: Vec<&str> = broadened_kinds
+        .iter()
+        .filter(|kind| high_blast.iter().any(|h| h == *kind))
+        .map(|s| s.as_str())
+        .collect();
+    if !added_high.is_empty() || !broadened_high.is_empty() {
+        return Ok(SurfaceChangePolicy::Reject {
+            reason: format!(
+                "{} | high-blast kinds touched: added={:?}, broadened={:?}",
+                diff_reason, added_high, broadened_high
+            ),
+            classification: "high_blast_radius".to_string(),
+        });
+    }
+
+    Ok(SurfaceChangePolicy::AllowWithStrictHoldout {
+        reason: diff_reason,
+    })
 }
 
 fn tool_tier_surface(manifest: &AgentManifest) -> std::collections::BTreeSet<String> {

--- a/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
+++ b/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
@@ -783,3 +783,256 @@ fn test_ab_replay_prompt_only_guard_can_be_disabled() {
         v
     );
 }
+
+// ─── 10. Capability-change guardrail (P5) ──────────────────────────────────
+//
+// P5 lifts P4's prompt-only restriction selectively: when an operator opts in
+// via `improve.allow_capability_changes = true`, the gate permits comparisons
+// whose candidate has a low-blast-radius capability delta, with the holdout
+// ratio coerced up to `capability_change_min_holdout` (default 0.5). High-blast
+// changes (sandbox / network / code-exec / credential / scheduler / revision)
+// remain rejected regardless.
+
+#[test]
+fn test_ab_replay_p5_allows_low_blast_capability_change_with_strict_holdout() {
+    // Baseline: minimal Evaluation. Candidate: adds AgentMessage
+    // (low-blast — agent-to-agent communication, not a sandbox/network
+    // privilege). With allow_capability_changes=true, the gate should
+    // permit the comparison and coerce holdout up to 0.5.
+    let tmp = TempDir::new().unwrap();
+    let (store, mut config) = setup_env(&tmp);
+    let gateway_dir = tmp.path().join(".gateway");
+    config.improve.allow_capability_changes = true;
+
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_A_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]"#,
+    );
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_B_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]
+      - type: "AgentMessage"
+        patterns: ["*"]"#,
+    );
+
+    let args = json!({
+        "task_specs": (0..8).map(|i| json!({
+            "message": format!("do task {}", i),
+            "case_id": format!("t{}", i),
+        })).collect::<Vec<_>>(),
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.1, // intentionally below the 0.5 minimum
+    });
+
+    let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
+    assert_ne!(
+        v["status"], "surface_drift_rejected",
+        "low-blast capability change with opt-in must not reject; got {:?}",
+        v
+    );
+    assert_eq!(
+        v["policy_applied"], "capability_change_with_strict_holdout",
+        "expected policy_applied=capability_change_with_strict_holdout; got {:?}",
+        v["policy_applied"]
+    );
+    // Holdout was coerced from 0.1 up to the configured minimum.
+    let coerced = v["holdout_coerced_from"].as_f64();
+    assert!(
+        coerced.is_some() && (coerced.unwrap() - 0.1).abs() < 1e-9,
+        "expected holdout_coerced_from=0.1; got {:?}",
+        v["holdout_coerced_from"]
+    );
+}
+
+#[test]
+fn test_ab_replay_p5_rejects_high_blast_added_kind() {
+    // Adding CodeExecution to a candidate is high-blast-radius (it's
+    // in the default high_blast_radius_capability_kinds list). Even
+    // with allow_capability_changes=true, the gate must reject.
+    let tmp = TempDir::new().unwrap();
+    let (store, mut config) = setup_env(&tmp);
+    let gateway_dir = tmp.path().join(".gateway");
+    config.improve.allow_capability_changes = true;
+
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_A_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]"#,
+    );
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_B_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]
+      - type: "CodeExecution"
+        patterns: ["*"]"#,
+    );
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.5,
+    });
+
+    let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
+    assert_eq!(v["status"], "surface_drift_rejected", "got {:?}", v);
+    assert_eq!(v["classification"], "high_blast_radius");
+    let reason = v["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("CodeExecution"),
+        "rejection reason should cite CodeExecution: got {}",
+        reason
+    );
+}
+
+#[test]
+fn test_ab_replay_p5_rejects_high_blast_broadened_kind() {
+    // Broadening an existing high-blast capability is also rejected.
+    // Baseline has NetworkAccess scoped to one host; candidate widens
+    // to all hosts. NetworkAccess is in the default high-blast list,
+    // so this must reject regardless of the opt-in flag.
+    let tmp = TempDir::new().unwrap();
+    let (store, mut config) = setup_env(&tmp);
+    let gateway_dir = tmp.path().join(".gateway");
+    config.improve.allow_capability_changes = true;
+
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_A_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]
+      - type: "NetworkAccess"
+        hosts: ["api.example.com"]"#,
+    );
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_B_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]
+      - type: "NetworkAccess"
+        hosts: ["*"]"#,
+    );
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.5,
+    });
+
+    let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
+    assert_eq!(v["status"], "surface_drift_rejected", "got {:?}", v);
+    assert_eq!(v["classification"], "high_blast_radius");
+    let reason = v["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("NetworkAccess"),
+        "rejection reason should cite NetworkAccess: got {}",
+        reason
+    );
+}
+
+#[test]
+fn test_ab_replay_p5_opt_in_unaffected_by_no_delta() {
+    // When there's no delta, the policy is `Allow` and the gate is
+    // silent regardless of allow_capability_changes. Verifies the
+    // happy path's `policy_applied` reads `no_delta`.
+    let tmp = TempDir::new().unwrap();
+    let (store, mut config) = setup_env(&tmp);
+    let gateway_dir = tmp.path().join(".gateway");
+    config.improve.allow_capability_changes = true;
+
+    let identical_caps = r#"      - type: "Evaluation"
+        patterns: ["*"]"#;
+    write_revision_skill_md(&gateway_dir, TARGET_AGENT, REV_A_ID, identical_caps);
+    write_revision_skill_md(&gateway_dir, TARGET_AGENT, REV_B_ID, identical_caps);
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.3,
+    });
+
+    let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
+    assert_ne!(v["status"], "surface_drift_rejected", "got {:?}", v);
+    assert_eq!(v["policy_applied"], "no_delta");
+    // Holdout NOT coerced — caller's 0.3 is fine when there's no delta.
+    assert!(
+        v["holdout_coerced_from"].is_null(),
+        "no coercion expected when there's no delta; got {:?}",
+        v["holdout_coerced_from"]
+    );
+}
+
+#[test]
+fn test_ab_replay_p5_low_blast_with_high_enough_holdout_is_not_coerced() {
+    // When the caller already provides a holdout ≥ the configured
+    // minimum, no coercion happens. The capability change still goes
+    // through the strict-holdout policy, just with the caller's value.
+    let tmp = TempDir::new().unwrap();
+    let (store, mut config) = setup_env(&tmp);
+    let gateway_dir = tmp.path().join(".gateway");
+    config.improve.allow_capability_changes = true;
+
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_A_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]"#,
+    );
+    write_revision_skill_md(
+        &gateway_dir,
+        TARGET_AGENT,
+        REV_B_ID,
+        r#"      - type: "Evaluation"
+        patterns: ["*"]
+      - type: "AgentMessage"
+        patterns: ["*"]"#,
+    );
+
+    let args = json!({
+        "task_specs": (0..8).map(|i| json!({
+            "message": format!("do task {}", i),
+            "case_id": format!("t{}", i),
+        })).collect::<Vec<_>>(),
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.6, // already above the 0.5 min
+    });
+
+    let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
+    assert_eq!(v["policy_applied"], "capability_change_with_strict_holdout");
+    assert!(
+        v["holdout_coerced_from"].is_null(),
+        "caller's holdout was already above the min — no coercion; got {:?}",
+        v["holdout_coerced_from"]
+    );
+}

--- a/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
+++ b/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
@@ -635,6 +635,11 @@ fn test_ab_replay_prompt_only_guard_rejects_capability_widening() {
     assert_eq!(v["ok"], false, "guardrail should reject");
     assert_eq!(v["status"], "surface_drift_rejected");
     assert_eq!(v["guardrail"], "improve.restrict_to_prompt_only");
+    // policy_applied is set on rejects too (PR #269 audit-trail
+    // uniformity). For the "not opted in" case, the classification is
+    // `prompt_only_violation`.
+    assert_eq!(v["policy_applied"], "prompt_only_violation");
+    assert_eq!(v["classification"], "prompt_only_violation");
     let reason = v["reason"].as_str().unwrap_or("");
     assert!(
         reason.contains("CodeExecution"),
@@ -893,6 +898,9 @@ fn test_ab_replay_p5_rejects_high_blast_added_kind() {
     let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
     assert_eq!(v["status"], "surface_drift_rejected", "got {:?}", v);
     assert_eq!(v["classification"], "high_blast_radius");
+    // policy_applied now mirrors classification on rejects (PR #269
+    // review fix — uniform audit field across all responses).
+    assert_eq!(v["policy_applied"], "high_blast_radius");
     let reason = v["reason"].as_str().unwrap_or("");
     assert!(
         reason.contains("CodeExecution"),
@@ -945,6 +953,9 @@ fn test_ab_replay_p5_rejects_high_blast_broadened_kind() {
     let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
     assert_eq!(v["status"], "surface_drift_rejected", "got {:?}", v);
     assert_eq!(v["classification"], "high_blast_radius");
+    // policy_applied now mirrors classification on rejects (PR #269
+    // review fix — uniform audit field across all responses).
+    assert_eq!(v["policy_applied"], "high_blast_radius");
     let reason = v["reason"].as_str().unwrap_or("");
     assert!(
         reason.contains("NetworkAccess"),
@@ -1034,5 +1045,76 @@ fn test_ab_replay_p5_low_blast_with_high_enough_holdout_is_not_coerced() {
         v["holdout_coerced_from"].is_null(),
         "caller's holdout was already above the min — no coercion; got {:?}",
         v["holdout_coerced_from"]
+    );
+}
+
+// ─── 11. Audit-trail uniformity (PR #269 review) ──────────────────────────
+//
+// `policy_applied` must reflect what actually happened across all six
+// surface-policy states, not just the no-delta default. These tests
+// pin the two "gate skipped" branches (`gate_disabled` and
+// `not_evaluated`) that earlier silently reported `no_delta`.
+
+#[test]
+fn test_ab_replay_policy_applied_gate_disabled_when_restrict_off() {
+    // Even with a real on-disk capability widening, `policy_applied`
+    // is `gate_disabled` (not `no_delta`) when the master switch is
+    // off — the policy was never consulted.
+    let tmp = TempDir::new().unwrap();
+    let (store, mut config) = setup_env(&tmp);
+    let gateway_dir = tmp.path().join(".gateway");
+    config.improve.restrict_to_prompt_only = false;
+
+    let identical_caps = r#"      - type: "Evaluation"
+        patterns: ["*"]"#;
+    write_revision_skill_md(&gateway_dir, TARGET_AGENT, REV_A_ID, identical_caps);
+    write_revision_skill_md(&gateway_dir, TARGET_AGENT, REV_B_ID, identical_caps);
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.0,
+    });
+
+    let v = execute_tool_with_gateway_dir(store, config, &gateway_dir, args);
+    assert_eq!(
+        v["policy_applied"], "gate_disabled",
+        "expected gate_disabled when restrict_to_prompt_only=false; got {:?}",
+        v["policy_applied"]
+    );
+}
+
+#[test]
+fn test_ab_replay_policy_applied_not_evaluated_when_gateway_dir_absent() {
+    // When the gate is on but gateway_dir is None, the policy can't
+    // be evaluated. The response must say so explicitly, not pretend
+    // there was no delta.
+    let tmp = TempDir::new().unwrap();
+    let (store, config) = setup_env(&tmp);
+    // Note: existing execute_tool helper passes `None` for gateway_dir.
+    // The gate's master switch (restrict_to_prompt_only) defaults to
+    // true, so this exercises the not_evaluated branch.
+
+    let args = json!({
+        "task_specs": [
+            {"message": "do task one", "case_id": "t1"},
+            {"message": "do task two", "case_id": "t2"},
+        ],
+        "agent_id": TARGET_AGENT,
+        "revision_a": format!("{}@{}", TARGET_AGENT, REV_A_ID),
+        "revision_b": format!("{}@{}", TARGET_AGENT, REV_B_ID),
+        "holdout_ratio": 0.0,
+    });
+
+    let v = execute_tool(store, config, args);
+    assert_eq!(
+        v["policy_applied"], "not_evaluated",
+        "expected not_evaluated when gateway_dir is None; got {:?}",
+        v["policy_applied"]
     );
 }

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -244,6 +244,42 @@ fn capability_map(caps: &[Capability]) -> BTreeMap<String, Capability> {
     out
 }
 
+/// Canonical capability-kind names — every value here matches what
+/// [`capability_type_name`] would produce for that `Capability`
+/// variant. Exported so config-validation code (e.g.,
+/// `ImproveConfig::high_blast_radius_capability_kinds`) can check
+/// operator-supplied capability names against the known set rather
+/// than silently accepting typos. Keep this list in sync with
+/// [`capability_type_name`] — both are exhaustive over the
+/// `Capability` enum.
+pub fn all_capability_kind_names() -> &'static [&'static str] {
+    &[
+        "SandboxFunctions",
+        "ReadAccess",
+        "WriteAccess",
+        "NetworkAccess",
+        "AgentSpawn",
+        "AgentMessage",
+        "BackgroundReevaluation",
+        "CodeExecution",
+        "EmergencyStop",
+        "AgentRevision",
+        "Evaluation",
+        "ApprovalQueue",
+        "SchedulerSignal",
+        "CredentialAccess",
+        "UserProfileAccess",
+        "SchedulerAccess",
+        "SkillInstall",
+        "ConstitutionalProposal",
+        "ReasoningAudit",
+        "GithubIssueCreate",
+        // BudgetNoPriceAvailableAllow uses its serialized rename:
+        "budget.no_price_available.allow",
+        "SecurityRedTeam",
+    ]
+}
+
 fn capability_type_name(cap: &Capability) -> String {
     match cap {
         Capability::SandboxFunctions { .. } => "SandboxFunctions".to_string(),
@@ -595,5 +631,60 @@ mod tests {
         let d = compute_capability_delta(&prev, &curr);
         assert_eq!(d.broadened.len(), 1);
         assert!(d.has_broadening());
+    }
+
+    #[test]
+    fn all_capability_kind_names_matches_capability_type_name() {
+        // Pin: every value `capability_type_name` produces for a real
+        // `Capability` variant must appear in `all_capability_kind_names()`.
+        // Adding a new variant without updating the list (used by
+        // ImproveConfig validation) would silently let typos through;
+        // this test fails loudly instead.
+        use std::collections::HashSet;
+        let known: HashSet<&str> = all_capability_kind_names().iter().copied().collect();
+        let samples = vec![
+            Capability::SandboxFunctions { allowed: vec![] },
+            Capability::ReadAccess { scopes: vec![] },
+            Capability::WriteAccess { scopes: vec![] },
+            Capability::NetworkAccess { hosts: vec![] },
+            Capability::AgentSpawn {
+                max_children: 1,
+                max_spawn_depth: 0,
+            },
+            Capability::AgentMessage { patterns: vec![] },
+            Capability::BackgroundReevaluation {
+                min_interval_secs: 1,
+                allow_reasoning: false,
+            },
+            Capability::CodeExecution {
+                patterns: vec![],
+                commands: vec![],
+            },
+            Capability::EmergencyStop,
+            Capability::AgentRevision { patterns: vec![] },
+            Capability::Evaluation { patterns: vec![] },
+            Capability::ApprovalQueue { patterns: vec![] },
+            Capability::SchedulerSignal { patterns: vec![] },
+            Capability::CredentialAccess { services: vec![] },
+            Capability::UserProfileAccess { scopes: vec![] },
+            Capability::SchedulerAccess { patterns: vec![] },
+            Capability::SkillInstall {
+                allowed_sources: vec![],
+            },
+            Capability::ConstitutionalProposal { patterns: vec![] },
+            Capability::ReasoningAudit { targets: vec![] },
+            Capability::GithubIssueCreate { patterns: vec![] },
+            Capability::BudgetNoPriceAvailableAllow,
+            Capability::SecurityRedTeam,
+        ];
+        for cap in &samples {
+            let name = capability_type_name(cap);
+            assert!(
+                known.contains(name.as_str()),
+                "capability_type_name() returned '{}' but it's not in all_capability_kind_names() — \
+                 add it to keep ImproveConfig high-blast validation honest",
+                name
+            );
+        }
     }
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -251,40 +251,109 @@ impl Default for OutcomeGraderConfig {
     }
 }
 
-/// Self-improvement loop runtime guardrails (P4 milestone — #249).
+/// Self-improvement loop runtime guardrails. P4 (#249) shipped the
+/// prompt-only safety posture; P5 (#250) lifts it selectively for
+/// agent-level changes (capability set / routing / sub-agent topology)
+/// behind stronger defenses.
 ///
-/// Today the loop's lowest-risk target is **prompt-only** edits:
-/// changes to a SKILL.md's instructions / system prompt that do not
-/// touch the manifest's `capabilities` or `allowed_tool_tiers`. P4's
-/// acceptance is gated on running 3 end-to-end cycles with these
-/// guardrails on, then collecting operator notes.
+/// The gate at A/B replay time is now a three-state policy:
 ///
-/// `restrict_to_prompt_only` is enforced at A/B replay time. When
-/// true (the default), `improvement.ab_replay` refuses to compare two
-/// revisions whose declared capability or tool-tier surfaces differ.
-/// The propose step (`autonoetic improve`) forks an identical
-/// candidate, so the only way this gate fires is if the candidate's
-/// SKILL.md was hand-edited to widen its surface — exactly the case
-/// P4 is meant to exclude.
+/// 1. **No capability delta** → proceed normally with the
+///    caller-supplied holdout (typically 0.3).
+/// 2. **Capability delta, but operator has not opted in** → reject
+///    (this is the P4 behaviour, still the default).
+/// 3. **Capability delta + opted in + low blast radius** → proceed
+///    with a **minimum holdout of `capability_change_min_holdout`**
+///    (default 0.5). The holdout is coerced up if the caller
+///    requested a lower value, with the coercion logged in the
+///    response.
+/// 4. **Capability delta + opted in + HIGH blast radius** → reject.
+///    Changes that broaden sandbox / network / code-execution /
+///    credential / scheduler / agent-revision capabilities are never
+///    eligible for the automated path. Operators promote those
+///    through the existing R++2 constitutional gate by hand.
+///
+/// `restrict_to_prompt_only` is the master switch. When `false`, the
+/// policy short-circuits to "always allow" (no defenses). Keep it
+/// `true` unless you genuinely want every capability change to skip
+/// the gate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImproveConfig {
-    /// When true, `improvement.ab_replay` rejects revision pairs whose
-    /// declared `capabilities` or `allowed_tool_tiers` differ. Default
-    /// **true** (P4 safety posture). Set to `false` once you have a
-    /// validated baseline (P5+) and want to A/B-test capability
-    /// changes too.
+    /// When true (default), the surface-change policy above is
+    /// enforced at `improvement.ab_replay` time. Set to `false` only
+    /// after the loop has earned enough track record that you trust
+    /// it to evaluate capability changes without the safety
+    /// scaffolding — this is the "raw operator-driven path" for P7
+    /// auto-approve.
     #[serde(default = "default_improve_restrict_to_prompt_only")]
     pub restrict_to_prompt_only: bool,
+
+    /// P5: when true, the gate **allows** A/B comparisons where the
+    /// candidate has a non-empty capability delta vs the baseline,
+    /// provided the change is not high-blast-radius. Default `false`
+    /// — operators opt in per-deployment after the prompt-only loop
+    /// has banked some P4 track record.
+    #[serde(default = "default_improve_allow_capability_changes")]
+    pub allow_capability_changes: bool,
+
+    /// P5: minimum holdout ratio enforced when the comparison
+    /// involves a capability change. The tool coerces the caller's
+    /// `holdout_ratio` up to this value (and notes the coercion in
+    /// the response) rather than rejecting outright — capability
+    /// changes are inherently more likely to break tasks the
+    /// proposal wasn't optimized against, so a wider safety net is
+    /// the right default. Range: `[0.0, 1.0]`. Default `0.5`.
+    #[serde(default = "default_improve_capability_change_min_holdout")]
+    pub capability_change_min_holdout: f64,
+
+    /// P5: capability kinds whose addition or broadening is treated
+    /// as high-blast-radius and rejected even when
+    /// `allow_capability_changes` is true. The list reflects
+    /// "privileges whose widening breaks the sandbox or
+    /// reaches the network / shell / credentials / scheduler / agent
+    /// promotion". An operator who wants to push such a change still
+    /// can — by promoting the revision manually through the R++2
+    /// gate — but the automated loop refuses.
+    #[serde(default = "default_improve_high_blast_radius_capability_kinds")]
+    pub high_blast_radius_capability_kinds: Vec<String>,
 }
 
 fn default_improve_restrict_to_prompt_only() -> bool {
     true
 }
 
+fn default_improve_allow_capability_changes() -> bool {
+    false
+}
+
+fn default_improve_capability_change_min_holdout() -> f64 {
+    0.5
+}
+
+fn default_improve_high_blast_radius_capability_kinds() -> Vec<String> {
+    // Conservative default. Each kind here represents a "trust
+    // boundary" the loop must not cross without a human approving
+    // the promotion explicitly. Tightening this list is fine; loosening
+    // it should be done deliberately and case-by-case.
+    vec![
+        "SandboxFunctions".to_string(),
+        "NetworkAccess".to_string(),
+        "CodeExecution".to_string(),
+        "CredentialAccess".to_string(),
+        "EmergencyStop".to_string(),
+        "AgentRevision".to_string(),
+        "SchedulerAccess".to_string(),
+    ]
+}
+
 impl Default for ImproveConfig {
     fn default() -> Self {
         Self {
             restrict_to_prompt_only: default_improve_restrict_to_prompt_only(),
+            allow_capability_changes: default_improve_allow_capability_changes(),
+            capability_change_min_holdout: default_improve_capability_change_min_holdout(),
+            high_blast_radius_capability_kinds:
+                default_improve_high_blast_radius_capability_kinds(),
         }
     }
 }

--- a/docs/design/self-improvement-loop-validation.md
+++ b/docs/design/self-improvement-loop-validation.md
@@ -153,15 +153,81 @@ not globally."_
 A GO signs off P4 and unblocks #250 (P5 — agent-level evolution). A
 NO-GO requires filing follow-ups for whatever needs fixing first.
 
-## 8. References
+## 8. P5 — agent-level evolution cycles
+
+> Status: code shipped (#250 PR). Awaiting **2 capability-change cycles**.
+
+### 8.1 What changed
+
+P5 extends the surface-change gate from binary (allow vs reject) to a
+three-state policy:
+
+| Candidate vs baseline | Policy | Holdout |
+|---|---|---|
+| No capability or tool-tier delta | `no_delta` → proceed | caller-supplied (default 0.3) |
+| Delta, `allow_capability_changes = false` (default) | `Reject(prompt_only_violation)` | n/a |
+| Delta, **opted in**, but adds or broadens a high-blast kind (`SandboxFunctions`, `NetworkAccess`, `CodeExecution`, `CredentialAccess`, `EmergencyStop`, `AgentRevision`, `SchedulerAccess`) | `Reject(high_blast_radius)` | n/a |
+| Delta, opted in, low-blast | `capability_change_with_strict_holdout` → proceed | **coerced up to `capability_change_min_holdout` (default 0.5)** |
+
+The tool response's `policy_applied` field surfaces which branch fired
+so the operator audit trail is clear. When holdout is coerced, the
+original value lands in `holdout_coerced_from`.
+
+### 8.2 Cycle protocol (capability changes)
+
+Same as §4, with two extra steps before validate:
+
+1. Pick a real session whose weakness is **agent-level** — e.g., the
+   planner can't reach evidence because `ReadAccess` scopes are too
+   narrow, or it can't message an agent because `AgentMessage`
+   patterns exclude the target.
+2. `autonoetic improve --session <id>` — diagnosis + (identical)
+   `Candidate` revision.
+3. Edit the candidate's SKILL.md to **only** widen the capability the
+   diagnosis pointed at. **Don't bundle prompt edits** in the same
+   cycle — that defeats attribution.
+4. Set `improve.allow_capability_changes = true` in the gateway
+   config. Re-run `autonoetic improve`. The A/B replay should accept
+   the comparison and coerce the holdout up.
+5. Approve, deploy, monitor as in §4. The existing R++2 constitutional
+   gate also fires at promote time as a second defender.
+6. Fill in the row in §8.3.
+
+### 8.3 Results (operator fills in)
+
+2 cycles for P5 sign-off, on any 2 agents. Capability changes only —
+prompt edits sit in §5.
+
+| # | Date | Agent | Capability change | A/B verdict | Confidence | Deployed? | Post-deploy regression observed? |
+|---|---|---|---|---|---|---|---|
+| 1 | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| 2 | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
+### 8.4 Operator notes (P5-specific)
+
+_TBD — surface anything specific to capability changes: gate
+false-positives, holdout-coercion friction, high-blast classification
+calls that felt wrong, etc._
+
+### 8.5 Sign-off
+
+| Status | Operator | Date | Notes |
+|---|---|---|---|
+| **GO / NO-GO** | _TBD_ | _TBD_ | _TBD_ |
+
+A P5 GO unblocks #252 (P7 — progressive automation).
+
+## 9. References
 
 - `docs/design/self-improvement-loop-design.md` — full design context
-- Issue [#249](https://github.com/mandubian/autonoetic/issues/249) —
-  P4 tracking
+- Issues [#249](https://github.com/mandubian/autonoetic/issues/249)
+  (P4), [#250](https://github.com/mandubian/autonoetic/issues/250)
+  (P5)
 - `autonoetic/src/cli/improve.rs` — the CLI driving the cycles
-- `autonoetic-gateway/src/runtime/tools/improvement.rs` — the A/B
-  replay tool + this PR's `restrict_to_prompt_only` guardrail
+- `autonoetic-gateway/src/runtime/tools/improvement.rs` — A/B replay
+  tool + `evaluate_surface_change_policy`
 - `autonoetic-gateway/src/runtime/eval_stats.rs` — multi-axis
   statistical comparison
-- `autonoetic-types/src/config.rs::ImproveConfig` — the
-  `restrict_to_prompt_only` config flag
+- `autonoetic-types/src/config.rs::ImproveConfig` — four config
+  flags: `restrict_to_prompt_only`, `allow_capability_changes`,
+  `capability_change_min_holdout`, `high_blast_radius_capability_kinds`

--- a/docs/design/self-improvement-loop-validation.md
+++ b/docs/design/self-improvement-loop-validation.md
@@ -155,7 +155,8 @@ NO-GO requires filing follow-ups for whatever needs fixing first.
 
 ## 8. P5 — agent-level evolution cycles
 
-> Status: code shipped (#250 PR). Awaiting **2 capability-change cycles**.
+> Status: code shipped, awaiting **2 capability-change cycles + sign-off**.
+> Tracking issue: [#250](https://github.com/mandubian/autonoetic/issues/250).
 
 ### 8.1 What changed
 


### PR DESCRIPTION
Part of #244 — Self-Improvement Loop. Adds the code prerequisites for #250 (P5). **Does not close #250** — that's gated on 2 operator-side capability-change cycles + sign-off.

## Why

P4's \`improve.restrict_to_prompt_only\` rejects ALL capability deltas. P5 selectively opens that for **low-blast-radius** changes when the operator opts in, with stronger defenses than the prompt-only path. High-blast changes stay locked to the manual R++2 path.

## What's in this PR

### 1. \`ImproveConfig\` extension (autonoetic-types/src/config.rs)

Three new fields:

| Field | Default | Meaning |
|---|---|---|
| \`allow_capability_changes\` | \`false\` | Operator opt-in for the P5 path |
| \`capability_change_min_holdout\` | \`0.5\` | Floor for holdout ratio when the gate permits a capability change |
| \`high_blast_radius_capability_kinds\` | 7-kind list | Adds/broadens of these are NEVER eligible for the automated loop |

### 2. Three-state \`SurfaceChangePolicy\` (improvement.rs)

| Candidate vs baseline | Policy | Holdout |
|---|---|---|
| No delta | \`Allow\` → proceed | caller's |
| Delta, not opted in | \`Reject(prompt_only_violation)\` | n/a |
| Delta, opted in, **high-blast** add/broaden | \`Reject(high_blast_radius)\` | n/a |
| Delta, opted in, low-blast | \`AllowWithStrictHoldout\` → proceed | **coerced up to min** |

Tool response now carries \`policy_applied\` and \`holdout_coerced_from\` in both queued and completed payloads.

### 3. Tests — **17 integration (12 P4 + 5 new P5)**

P5 tests cover:
- Low-blast change (\`AgentMessage\`) accepted, holdout coerced from 0.1 → 0.5
- High-blast **added** kind (\`CodeExecution\`) rejected with \`classification = high_blast_radius\`
- High-blast **broadened** kind (\`NetworkAccess { hosts }\` widened to \`[\"*\"]\`) rejected — pins parameter-widening detection for high-blast kinds
- Opt-in has no effect when there's no delta
- Caller-supplied holdout ≥ min is NOT coerced (no unnecessary widening)

All 12 existing P4 tests still pass.

### 4. Validation doc updates (\`self-improvement-loop-validation.md\`)

New §8 documenting the three-state policy + cycle protocol + result rows + operator notes + sign-off. §8.3–§8.5 explicitly left empty for the operator to fill in after running the 2 cycles.

## High-blast list (default)

7 capability kinds: \`SandboxFunctions\`, \`NetworkAccess\`, \`CodeExecution\`, \`CredentialAccess\`, \`EmergencyStop\`, \`AgentRevision\`, \`SchedulerAccess\`. The list is config-overridable, but tightening is encouraged; loosening should be a deliberate per-deployment decision.

## What this PR does NOT do

- **Run the 2 cycles.** Operator-side; needs real session diagnoses, real candidate edits, real LLM cost.
- **Close #250.** The milestone closes when §8.3–§8.5 of the validation doc are filled in and the operator signs off.
- **Touch R++2 promote-time gate.** Already exists; acts as second defender at promote time after the P5 replay-time gate.

## Test plan

- [ ] CI green on \`cargo build --workspace\` (clean locally)
- [ ] CI green on \`cargo test -p autonoetic-gateway --test improvement_ab_replay_integration\` (17/17 locally)
- [ ] Reviewer confirms the high-blast list matches the design intent (sandbox/network/exec/credentials/scheduler/agent-revision)
- [ ] After merge: operator opts \`improve.allow_capability_changes = true\` for a test deployment, runs 2 cycles, fills in \`self-improvement-loop-validation.md\` §8

🤖 Generated with [Claude Code](https://claude.com/claude-code)