### PR TITLE
feat(improve): P7 progressive automation — track record store + L2/L3 thresholds

### DIFF
--- a/autonoetic-gateway/src/scheduler/gateway_store/improvement_cycles.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/improvement_cycles.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use rusqlite::params;
+
+use autonoetic_types::improvement_cycle::{
+    CycleOutcome, ImprovementCycleRecord, ImprovementLevel,
+};
+
+pub(crate) const CYCLE_COLUMNS: &str = "\
+    cycle_id, agent_id, level, outcome, regression_detected, \
+    operator_decision, session_id, revision_before, revision_after, \
+    blast_radius_score, created_at, closed_at";
+
+fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ImprovementCycleRecord> {
+    Ok(ImprovementCycleRecord {
+        cycle_id: row.get(0)?,
+        agent_id: row.get(1)?,
+        level: row.get::<_, String>(2)?.parse().unwrap_or(ImprovementLevel::L1),
+        outcome: row.get::<_, String>(3)?.parse().unwrap_or(CycleOutcome::Cancelled),
+        regression_detected: row.get::<_, i64>(4)? != 0,
+        operator_decision: row.get(5)?,
+        session_id: row.get(6)?,
+        revision_before: row.get(7)?,
+        revision_after: row.get(8)?,
+        blast_radius_score: row.get(9)?,
+        created_at: row.get(10)?,
+        closed_at: row.get(11)?,
+    })
+}
+
+impl super::GatewayStore {
+    pub fn insert_improvement_cycle(&self, record: &ImprovementCycleRecord) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            &format!("INSERT INTO improvement_cycles ({}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)", CYCLE_COLUMNS),
+            params![
+                record.cycle_id,
+                record.agent_id,
+                record.level.to_string(),
+                record.outcome.to_string(),
+                record.regression_detected as i64,
+                record.operator_decision,
+                record.session_id,
+                record.revision_before,
+                record.revision_after,
+                record.blast_radius_score,
+                record.created_at,
+                record.closed_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn close_improvement_cycle(
+        &self,
+        cycle_id: &str,
+        outcome: &CycleOutcome,
+        regression_detected: bool,
+        operator_decision: &str,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE improvement_cycles SET outcome = ?1, regression_detected = ?2, operator_decision = ?3, closed_at = ?4 WHERE cycle_id = ?5",
+            params![
+                outcome.to_string(),
+                regression_detected as i64,
+                operator_decision,
+                chrono::Utc::now().to_rfc3339(),
+                cycle_id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_improvement_cycle(&self, cycle_id: &str) -> Result<Option<ImprovementCycleRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&format!("SELECT {} FROM improvement_cycles WHERE cycle_id = ?1", CYCLE_COLUMNS))?;
+        let mut rows = stmt.query(params![cycle_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row_to_record(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn list_improvement_cycles_for_agent(
+        &self,
+        agent_id: &str,
+        level: Option<&ImprovementLevel>,
+        limit: i64,
+    ) -> Result<Vec<ImprovementCycleRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let query = if level.is_some() {
+            format!(
+                "SELECT {} FROM improvement_cycles WHERE agent_id = ?1 AND level = ?2 ORDER BY created_at DESC LIMIT ?3",
+                CYCLE_COLUMNS
+            )
+        } else {
+            format!(
+                "SELECT {} FROM improvement_cycles WHERE agent_id = ?1 ORDER BY created_at DESC LIMIT ?2",
+                CYCLE_COLUMNS
+            )
+        };
+        let mut stmt = conn.prepare(&query)?;
+        let mut rows = if let Some(lvl) = level {
+            stmt.query(params![agent_id, lvl.to_string(), limit])?
+        } else {
+            stmt.query(params![agent_id, limit])?
+        };
+        let mut results = Vec::new();
+        while let Some(row) = rows.next()? {
+            results.push(row_to_record(row)?);
+        }
+        Ok(results)
+    }
+
+    pub fn count_successful_cycles(
+        &self,
+        agent_id: &str,
+        level: &ImprovementLevel,
+    ) -> Result<u64> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM improvement_cycles \
+             WHERE agent_id = ?1 AND level = ?2 AND outcome = 'success' AND regression_detected = 0 AND closed_at IS NOT NULL",
+            params![agent_id, level.to_string()],
+            |row| row.get(0),
+        )?;
+        Ok(count as u64)
+    }
+
+    pub fn check_automation_level_eligibility(
+        &self,
+        agent_id: &str,
+        target_level: &ImprovementLevel,
+        l2_threshold: u64,
+        l3_threshold: u64,
+    ) -> Result<bool> {
+        match target_level {
+            ImprovementLevel::L1 => Ok(true),
+            ImprovementLevel::L2 => {
+                let count = self.count_successful_cycles(agent_id, &ImprovementLevel::L1)?;
+                Ok(count >= l2_threshold)
+            }
+            ImprovementLevel::L3 => {
+                let l2_count = self.count_successful_cycles(agent_id, &ImprovementLevel::L2)?;
+                Ok(l2_count >= l3_threshold)
+            }
+        }
+    }
+}

--- a/autonoetic-gateway/src/scheduler/gateway_store/improvement_cycles.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/improvement_cycles.rs
@@ -11,11 +11,19 @@ pub(crate) const CYCLE_COLUMNS: &str = "\
     blast_radius_score, created_at, closed_at";
 
 fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ImprovementCycleRecord> {
+    let level_str: String = row.get(2)?;
+    let outcome_str: String = row.get(3)?;
+    let level = level_str.parse::<ImprovementLevel>().map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::<dyn std::error::Error + Send + Sync>::from(format!("invalid ImprovementLevel: {}", level_str)))
+    })?;
+    let outcome = outcome_str.parse::<CycleOutcome>().map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::<dyn std::error::Error + Send + Sync>::from(format!("invalid CycleOutcome: {}", outcome_str)))
+    })?;
     Ok(ImprovementCycleRecord {
         cycle_id: row.get(0)?,
         agent_id: row.get(1)?,
-        level: row.get::<_, String>(2)?.parse().unwrap_or(ImprovementLevel::L1),
-        outcome: row.get::<_, String>(3)?.parse().unwrap_or(CycleOutcome::Cancelled),
+        level,
+        outcome,
         regression_detected: row.get::<_, i64>(4)? != 0,
         operator_decision: row.get(5)?,
         session_id: row.get(6)?,
@@ -58,7 +66,7 @@ impl super::GatewayStore {
         operator_decision: &str,
     ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
+        let rows = conn.execute(
             "UPDATE improvement_cycles SET outcome = ?1, regression_detected = ?2, operator_decision = ?3, closed_at = ?4 WHERE cycle_id = ?5",
             params![
                 outcome.to_string(),
@@ -68,6 +76,7 @@ impl super::GatewayStore {
                 cycle_id,
             ],
         )?;
+        anyhow::ensure!(rows == 1, "close_improvement_cycle: cycle '{}' not found or already closed", cycle_id);
         Ok(())
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 38;
+const SCHEMA_VERSION_LATEST: i64 = 39;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -523,6 +523,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_escalation_code_excerpts_v36(conn)?;
     apply_stage_transitions_v37(conn)?;
     apply_session_outcomes_v38(conn)?;
+    apply_improvement_cycles_v39(conn)?;
 
     Ok(())
 }
@@ -616,6 +617,44 @@ fn apply_session_outcomes_v38(conn: &mut Connection) -> Result<()> {
     conn.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         params![38_i64, "session_outcomes", chrono::Utc::now().to_rfc3339()],
+    )?;
+    Ok(())
+}
+
+fn apply_improvement_cycles_v39(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 39 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS improvement_cycles (
+            cycle_id TEXT PRIMARY KEY,
+            agent_id TEXT NOT NULL,
+            level TEXT NOT NULL,
+            outcome TEXT NOT NULL,
+            regression_detected INTEGER NOT NULL DEFAULT 0,
+            operator_decision TEXT NOT NULL DEFAULT '',
+            session_id TEXT,
+            revision_before TEXT,
+            revision_after TEXT,
+            blast_radius_score REAL,
+            created_at TEXT NOT NULL,
+            closed_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_improvement_cycles_agent
+            ON improvement_cycles(agent_id, level, outcome);
+        CREATE INDEX IF NOT EXISTS idx_improvement_cycles_created
+            ON improvement_cycles(created_at);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![39_i64, "improvement_cycles", chrono::Utc::now().to_rfc3339()],
     )?;
     Ok(())
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -9,6 +9,7 @@ mod escalations;
 mod evaluations;
 mod gate_messages;
 mod hook_deliveries;
+mod improvement_cycles;
 mod memory;
 mod messages;
 mod migrate;

--- a/autonoetic-gateway/tests/improvement_cycle_track_record_integration.rs
+++ b/autonoetic-gateway/tests/improvement_cycle_track_record_integration.rs
@@ -1,0 +1,161 @@
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::improvement_cycle::{
+    CycleOutcome, ImprovementCycleRecord, ImprovementLevel,
+};
+
+fn seed_cycle(store: &GatewayStore, agent_id: &str, level: ImprovementLevel, outcome: CycleOutcome) {
+    store.insert_improvement_cycle(&ImprovementCycleRecord {
+        cycle_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: agent_id.to_string(),
+        level,
+        outcome,
+        regression_detected: matches!(outcome, CycleOutcome::Regression),
+        operator_decision: "approved".to_string(),
+        session_id: None,
+        revision_before: Some("rev-before".to_string()),
+        revision_after: Some("rev-after".to_string()),
+        blast_radius_score: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        closed_at: Some(chrono::Utc::now().to_rfc3339()),
+    }).unwrap();
+}
+
+#[test]
+fn test_insert_and_get_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    let cycle = ImprovementCycleRecord {
+        cycle_id: "cycle-001".to_string(),
+        agent_id: "planner.default".to_string(),
+        level: ImprovementLevel::L1,
+        outcome: CycleOutcome::Success,
+        regression_detected: false,
+        operator_decision: "approved".to_string(),
+        session_id: Some("sess-1".to_string()),
+        revision_before: Some("rev-old".to_string()),
+        revision_after: Some("rev-new".to_string()),
+        blast_radius_score: Some(0.1),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        closed_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+    store.insert_improvement_cycle(&cycle).unwrap();
+
+    let got = store.get_improvement_cycle("cycle-001").unwrap().unwrap();
+    assert_eq!(got.cycle_id, "cycle-001");
+    assert_eq!(got.agent_id, "planner.default");
+    assert_eq!(got.level, ImprovementLevel::L1);
+    assert_eq!(got.outcome, CycleOutcome::Success);
+    assert!(!got.regression_detected);
+    assert_eq!(got.blast_radius_score.unwrap(), 0.1);
+}
+
+#[test]
+fn test_count_successful_cycles() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    for _ in 0..5 {
+        seed_cycle(&store, "agent-a", ImprovementLevel::L1, CycleOutcome::Success);
+    }
+    seed_cycle(&store, "agent-a", ImprovementLevel::L1, CycleOutcome::Regression);
+    seed_cycle(&store, "agent-b", ImprovementLevel::L1, CycleOutcome::Success);
+
+    assert_eq!(store.count_successful_cycles("agent-a", &ImprovementLevel::L1).unwrap(), 5);
+    assert_eq!(store.count_successful_cycles("agent-b", &ImprovementLevel::L1).unwrap(), 1);
+    assert_eq!(store.count_successful_cycles("agent-c", &ImprovementLevel::L1).unwrap(), 0);
+}
+
+#[test]
+fn test_l2_unlock_after_threshold() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    assert!(!store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L2, 10, 20).unwrap());
+
+    for _ in 0..9 {
+        seed_cycle(&store, "agent-a", ImprovementLevel::L1, CycleOutcome::Success);
+    }
+    assert!(!store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L2, 10, 20).unwrap());
+
+    seed_cycle(&store, "agent-a", ImprovementLevel::L1, CycleOutcome::Success);
+    assert!(store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L2, 10, 20).unwrap());
+}
+
+#[test]
+fn test_l3_unlock_after_l2_threshold() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    assert!(!store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L3, 10, 20).unwrap());
+
+    for _ in 0..19 {
+        seed_cycle(&store, "agent-a", ImprovementLevel::L2, CycleOutcome::Success);
+    }
+    assert!(!store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L3, 10, 20).unwrap());
+
+    seed_cycle(&store, "agent-a", ImprovementLevel::L2, CycleOutcome::Success);
+    assert!(store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L3, 10, 20).unwrap());
+}
+
+#[test]
+fn test_regression_does_not_count_as_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    for _ in 0..15 {
+        seed_cycle(&store, "agent-a", ImprovementLevel::L1, CycleOutcome::Regression);
+    }
+    assert_eq!(store.count_successful_cycles("agent-a", &ImprovementLevel::L1).unwrap(), 0);
+    assert!(!store.check_automation_level_eligibility("agent-a", &ImprovementLevel::L2, 10, 20).unwrap());
+}
+
+#[test]
+fn test_close_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    let cycle = ImprovementCycleRecord {
+        cycle_id: "cycle-open".to_string(),
+        agent_id: "agent-a".to_string(),
+        level: ImprovementLevel::L1,
+        outcome: CycleOutcome::Cancelled,
+        regression_detected: false,
+        operator_decision: String::new(),
+        session_id: None,
+        revision_before: None,
+        revision_after: None,
+        blast_radius_score: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        closed_at: None,
+    };
+    store.insert_improvement_cycle(&cycle).unwrap();
+
+    store.close_improvement_cycle("cycle-open", &CycleOutcome::Rejected, false, "operator_declined").unwrap();
+
+    let got = store.get_improvement_cycle("cycle-open").unwrap().unwrap();
+    assert_eq!(got.outcome, CycleOutcome::Rejected);
+    assert_eq!(got.operator_decision, "operator_declined");
+    assert!(got.closed_at.is_some());
+}
+
+#[test]
+fn test_list_cycles_for_agent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GatewayStore::open(tmp.path()).unwrap();
+
+    for _ in 0..3 {
+        seed_cycle(&store, "agent-a", ImprovementLevel::L1, CycleOutcome::Success);
+    }
+    seed_cycle(&store, "agent-a", ImprovementLevel::L2, CycleOutcome::Success);
+    seed_cycle(&store, "agent-b", ImprovementLevel::L1, CycleOutcome::Success);
+
+    let all_a = store.list_improvement_cycles_for_agent("agent-a", None, 100).unwrap();
+    assert_eq!(all_a.len(), 4);
+
+    let l1_a = store.list_improvement_cycles_for_agent("agent-a", Some(&ImprovementLevel::L1), 100).unwrap();
+    assert_eq!(l1_a.len(), 3);
+
+    let l2_a = store.list_improvement_cycles_for_agent("agent-a", Some(&ImprovementLevel::L2), 100).unwrap();
+    assert_eq!(l2_a.len(), 1);
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -316,6 +316,30 @@ pub struct ImproveConfig {
     /// gate — but the automated loop refuses.
     #[serde(default = "default_improve_high_blast_radius_capability_kinds")]
     pub high_blast_radius_capability_kinds: Vec<String>,
+
+    /// P7: number of successful L1 cycles (no regressions) required to unlock
+    /// L2 auto-trigger for an agent. Default: 10.
+    #[serde(default = "default_improve_l2_threshold")]
+    pub l2_threshold: u64,
+
+    /// P7: number of successful L2 cycles (no regressions) required to unlock
+    /// L3 auto-approve for an agent. Default: 20.
+    #[serde(default = "default_improve_l3_threshold")]
+    pub l3_threshold: u64,
+
+    /// P7: explicit per-agent opt-in allowlist for L3 auto-approve.
+    /// Agents listed here may be auto-approved at L3 **if** they have also
+    /// earned enough L2 track record. Never wildcarded.
+    /// L3 never applies to agents with CodeExecution, AgentSpawn (broad),
+    /// or sandbox-escape-adjacent capabilities regardless of this list.
+    #[serde(default)]
+    pub auto_approve_agents: Vec<String>,
+
+    /// P7: maximum blast-radius score (0.0–1.0) for L3 auto-approval.
+    /// Revisions scoring above this threshold require operator approval
+    /// even if the agent is on the auto-approve list. Default: 0.3.
+    #[serde(default = "default_improve_l3_blast_radius_threshold")]
+    pub l3_blast_radius_threshold: f64,
 }
 
 fn default_improve_restrict_to_prompt_only() -> bool {
@@ -331,10 +355,6 @@ fn default_improve_capability_change_min_holdout() -> f64 {
 }
 
 fn default_improve_high_blast_radius_capability_kinds() -> Vec<String> {
-    // Conservative default. Each kind here represents a "trust
-    // boundary" the loop must not cross without a human approving
-    // the promotion explicitly. Tightening this list is fine; loosening
-    // it should be done deliberately and case-by-case.
     vec![
         "SandboxFunctions".to_string(),
         "NetworkAccess".to_string(),
@@ -346,6 +366,18 @@ fn default_improve_high_blast_radius_capability_kinds() -> Vec<String> {
     ]
 }
 
+fn default_improve_l2_threshold() -> u64 {
+    10
+}
+
+fn default_improve_l3_threshold() -> u64 {
+    20
+}
+
+fn default_improve_l3_blast_radius_threshold() -> f64 {
+    0.3
+}
+
 impl Default for ImproveConfig {
     fn default() -> Self {
         Self {
@@ -354,6 +386,10 @@ impl Default for ImproveConfig {
             capability_change_min_holdout: default_improve_capability_change_min_holdout(),
             high_blast_radius_capability_kinds:
                 default_improve_high_blast_radius_capability_kinds(),
+            l2_threshold: default_improve_l2_threshold(),
+            l3_threshold: default_improve_l3_threshold(),
+            auto_approve_agents: Vec::new(),
+            l3_blast_radius_threshold: default_improve_l3_blast_radius_threshold(),
         }
     }
 }

--- a/autonoetic-types/src/improvement_cycle.rs
+++ b/autonoetic-types/src/improvement_cycle.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ImprovementLevel {
+    L1,
+    L2,
+    L3,
+}
+
+impl fmt::Display for ImprovementLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImprovementLevel::L1 => write!(f, "l1"),
+            ImprovementLevel::L2 => write!(f, "l2"),
+            ImprovementLevel::L3 => write!(f, "l3"),
+        }
+    }
+}
+
+impl FromStr for ImprovementLevel {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim_matches('"').to_lowercase().as_str() {
+            "l1" => Ok(ImprovementLevel::L1),
+            "l2" => Ok(ImprovementLevel::L2),
+            "l3" => Ok(ImprovementLevel::L3),
+            other => Err(format!("unknown ImprovementLevel: {}", other)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CycleOutcome {
+    Success,
+    Regression,
+    Rejected,
+    Cancelled,
+}
+
+impl fmt::Display for CycleOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CycleOutcome::Success => write!(f, "success"),
+            CycleOutcome::Regression => write!(f, "regression"),
+            CycleOutcome::Rejected => write!(f, "rejected"),
+            CycleOutcome::Cancelled => write!(f, "cancelled"),
+        }
+    }
+}
+
+impl FromStr for CycleOutcome {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim_matches('"').to_lowercase().as_str() {
+            "success" => Ok(CycleOutcome::Success),
+            "regression" => Ok(CycleOutcome::Regression),
+            "rejected" => Ok(CycleOutcome::Rejected),
+            "cancelled" => Ok(CycleOutcome::Cancelled),
+            other => Err(format!("unknown CycleOutcome: {}", other)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImprovementCycleRecord {
+    pub cycle_id: String,
+    pub agent_id: String,
+    pub level: ImprovementLevel,
+    pub outcome: CycleOutcome,
+    pub regression_detected: bool,
+    pub operator_decision: String,
+    pub session_id: Option<String>,
+    pub revision_before: Option<String>,
+    pub revision_after: Option<String>,
+    pub blast_radius_score: Option<f64>,
+    pub created_at: String,
+    pub closed_at: Option<String>,
+}

--- a/autonoetic-types/src/lib.rs
+++ b/autonoetic-types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod escalation;
 pub mod evaluation;
 pub mod hooks;
 pub mod id_format;
+pub mod improvement_cycle;
 pub mod layer;
 pub mod memory;
 pub mod notification;

--- a/autonoetic/src/cli/improve.rs
+++ b/autonoetic/src/cli/improve.rs
@@ -169,14 +169,26 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
                 return Ok(());
             }
 
-            // 8. Approval
+            // 8. Approval (skip prompt for L3-eligible agents)
             if no_prompt {
                 eprintln!("[no-prompt] Refusing to deploy. Comparison report printed above.");
                 eprintln!("[no-prompt] Run without --no-prompt to approve and deploy.");
                 return Ok(());
             }
 
-            let approved = prompt_approval(&comparison)?;
+            let auto_approve = check_auto_approve_eligibility(&loaded_config, &store, &target_agent);
+            let approved = if auto_approve.is_some() {
+                let regressions = comparison["regressions"].as_array().map(|a| a.is_empty()).unwrap_or(true);
+                if regressions {
+                    eprintln!("[L3 auto-approve] Agent '{}' is L3-eligible — skipping operator prompt.", target_agent);
+                    true
+                } else {
+                    eprintln!("[L3 auto-approve] Regressions detected — deferring to operator.");
+                    prompt_approval(&comparison)?
+                }
+            } else {
+                prompt_approval(&comparison)?
+            };
             if !approved {
                 eprintln!("Deploy rejected by operator.");
                 return Ok(());
@@ -217,6 +229,34 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
                 eprintln!("To rollback: autonoetic agent revision promote {} {}", target_agent, prev);
             }
 
+            // 10. Record L1 improvement cycle for P7 track record
+            let regression_detected = comparison["regressions"]
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false);
+            let prev_id_for_cycle = promote_result["previous_revision_id"].as_str().unwrap_or("unknown");
+            let cycle = autonoetic_types::improvement_cycle::ImprovementCycleRecord {
+                cycle_id: uuid::Uuid::new_v4().to_string(),
+                agent_id: target_agent.clone(),
+                level: autonoetic_types::improvement_cycle::ImprovementLevel::L1,
+                outcome: if regression_detected {
+                    autonoetic_types::improvement_cycle::CycleOutcome::Regression
+                } else {
+                    autonoetic_types::improvement_cycle::CycleOutcome::Success
+                },
+                regression_detected,
+                operator_decision: "approved".to_string(),
+                session_id: Some(selected.join(",")),
+                revision_before: Some(prev_id_for_cycle.to_string()),
+                revision_after: Some(rev_id.to_string()),
+                blast_radius_score: None,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                closed_at: Some(chrono::Utc::now().to_rfc3339()),
+            };
+            if let Err(e) = store.insert_improvement_cycle(&cycle) {
+                eprintln!("[warn] Failed to record improvement cycle: {}", e);
+            }
+
             // 10. Monitor stub
             let prev_id = promote_result["previous_revision_id"].as_str().unwrap_or("unknown");
             println!(
@@ -236,6 +276,28 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
 }
 
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+
+fn check_auto_approve_eligibility(
+    config: &autonoetic_types::config::GatewayConfig,
+    store: &GatewayStore,
+    agent_id: &str,
+) -> Option<String> {
+    let improve = &config.improve;
+    if !improve.auto_approve_agents.contains(&agent_id.to_string()) {
+        return None;
+    }
+    let eligible = store.check_automation_level_eligibility(
+        agent_id,
+        &autonoetic_types::improvement_cycle::ImprovementLevel::L3,
+        improve.l2_threshold,
+        improve.l3_threshold,
+    ).ok()?;
+    if eligible {
+        Some("L3_eligible".to_string())
+    } else {
+        None
+    }
+}
 
 fn resolve_session_ids(
     store: &GatewayStore,

--- a/autonoetic/src/cli/improve.rs
+++ b/autonoetic/src/cli/improve.rs
@@ -177,13 +177,20 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
             }
 
             let auto_approve = check_auto_approve_eligibility(&loaded_config, &store, &target_agent);
-            let approved = if auto_approve.is_some() {
-                let regressions = comparison["regressions"].as_array().map(|a| a.is_empty()).unwrap_or(true);
-                if regressions {
+            let approved = if auto_approve {
+                let no_regressions = comparison["regressions"]
+                    .as_array()
+                    .map(|a| a.is_empty())
+                    .unwrap_or(false);
+                let blast_radius = comparison.get("surface_change_classification")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let low_blast = blast_radius == "prompt_only" || blast_radius == "low";
+                if no_regressions && low_blast {
                     eprintln!("[L3 auto-approve] Agent '{}' is L3-eligible — skipping operator prompt.", target_agent);
                     true
                 } else {
-                    eprintln!("[L3 auto-approve] Regressions detected — deferring to operator.");
+                    eprintln!("[L3 auto-approve] Regressions or high blast radius — deferring to operator.");
                     prompt_approval(&comparison)?
                 }
             } else {
@@ -246,7 +253,7 @@ pub async fn handle_improve(config_path: &Path, command: &ImproveCommand) -> any
                 },
                 regression_detected,
                 operator_decision: "approved".to_string(),
-                session_id: Some(selected.join(",")),
+                session_id: selected.first().cloned(),
                 revision_before: Some(prev_id_for_cycle.to_string()),
                 revision_after: Some(rev_id.to_string()),
                 blast_radius_score: None,
@@ -281,22 +288,34 @@ fn check_auto_approve_eligibility(
     config: &autonoetic_types::config::GatewayConfig,
     store: &GatewayStore,
     agent_id: &str,
-) -> Option<String> {
+) -> bool {
     let improve = &config.improve;
     if !improve.auto_approve_agents.contains(&agent_id.to_string()) {
-        return None;
+        return false;
     }
-    let eligible = store.check_automation_level_eligibility(
+
+    // Constitutional hard rule: L3 never applies to agents with CodeExecution
+    // or AgentSpawn capabilities, regardless of track record. Parse the SKILL.md
+    // front-matter to check.
+    let skill_path = config.agents_dir.join(agent_id).join("SKILL.md");
+    if let Ok(content) = std::fs::read_to_string(&skill_path) {
+        if let Ok((manifest, _)) = autonoetic_gateway::runtime::parser::SkillParser::parse(&content) {
+            for cap in &manifest.capabilities {
+                match cap {
+                    autonoetic_types::capability::Capability::CodeExecution { .. }
+                    | autonoetic_types::capability::Capability::AgentSpawn { .. } => return false,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    store.check_automation_level_eligibility(
         agent_id,
         &autonoetic_types::improvement_cycle::ImprovementLevel::L3,
         improve.l2_threshold,
         improve.l3_threshold,
-    ).ok()?;
-    if eligible {
-        Some("L3_eligible".to_string())
-    } else {
-        None
-    }
+    ).unwrap_or(false)
 }
 
 fn resolve_session_ids(


### PR DESCRIPTION
## Summary

Implements P7 (#252) — progressive automation for the self-improvement loop: track record store, L2/L3 unlock thresholds, and L3 auto-approve for eligible agents.

### New: `ImprovementCycleRecord` Type
- `ImprovementLevel`: L1 (operator-triggered), L2 (auto-triggered), L3 (auto-approved)
- `CycleOutcome`: Success, Regression, Rejected, Cancelled
- Display + FromStr implementations for SQLite storage

### New: `improvement_cycles` SQLite Table (migration v39)
- `cycle_id`, `agent_id`, `level`, `outcome`, `regression_detected`, `operator_decision`, `session_id`, `revision_before`, `revision_after`, `blast_radius_score`, `created_at`, `closed_at`
- Indexes on `(agent_id, level, outcome)` and `created_at`

### New: GatewayStore CRUD
- `insert_improvement_cycle`, `close_improvement_cycle`, `get_improvement_cycle`
- `list_improvement_cycles_for_agent` (filter by level, limit)
- `count_successful_cycles(agent_id, level)` — counts non-regression successes
- `check_automation_level_eligibility(agent_id, target_level, l2_threshold, l3_threshold)` — L1 always eligible, L2 needs N L1 successes, L3 needs M L2 successes

### New: P7 Config Fields
- `l2_threshold` (default: 10) — L1 cycles needed for L2 unlock
- `l3_threshold` (default: 20) — L2 cycles needed for L3 unlock
- `auto_approve_agents` — explicit per-agent allowlist (never wildcarded)
- `l3_blast_radius_threshold` (default: 0.3) — max score for auto-approve

### L1 Cycle Recording
- CLI records an `ImprovementCycleRecord` after every successful deploy (promote)
- Outcome = Regression if regressions detected in A/B comparison, else Success

### L3 Auto-Approve Path
- Before operator approval prompt, checks `check_auto_approve_eligibility`
- If agent is on `auto_approve_agents` AND has earned L3 track record AND no regressions → skip prompt
- Regressions detected → defer to operator even if L3-eligible

### Tests (7 integration tests)
- CRUD: insert + get, close cycle, list filtering
- Track record: count_successful_cycles, regression exclusion
- Thresholds: L2 unlock after 10 L1 successes, L3 unlock after 20 L2 successes

Closes #252