### PR TITLE
capsule: export/import pipeline (Phase 2 of #220)

### DIFF
--- a/autonoetic-gateway/Cargo.toml
+++ b/autonoetic-gateway/Cargo.toml
@@ -40,6 +40,7 @@ regex = "1.11.2"
 libc = "0.2"
 tar = "0.4"
 zstd = "0.13"
+tempfile = "3.26.0"
 aes-gcm = "0.10.3"
 rand = "0.8"
 
@@ -48,6 +49,5 @@ name = "mock-moltbook"
 path = "src/bin/mock_moltbook.rs"
 
 [dev-dependencies]
-tempfile = "3.26.0"
 serial_test = "3.0"
 proptest = "1.11.0"

--- a/autonoetic-gateway/src/capsule/archive.rs
+++ b/autonoetic-gateway/src/capsule/archive.rs
@@ -1,0 +1,177 @@
+//! tar.zst archive helpers for capsules.
+//!
+//! Capsules are packed as `tar.zst` archives with this directory layout
+//! (see design doc, section "Capsule Archive Structure"):
+//!
+//! ```text
+//! capsule_<id>/
+//! ├── capsule.json
+//! ├── agent/
+//! │   ├── SKILL.md
+//! │   ├── runtime.lock
+//! │   └── files/
+//! ├── artifacts/   (hermetic only)
+//! ├── layers/      (hermetic only)
+//! ├── memory/      (opt-in)
+//! └── checkpoint/  (replay only)
+//! ```
+//!
+//! Pack takes a staging directory + an output path; unpack takes an
+//! archive path + a target directory. Importers MUST provide an extracted
+//! byte-size cap so a malicious archive cannot fill the filesystem.
+
+use anyhow::{Context, Result};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+use tar::{Archive as TarArchive, Builder as TarBuilder};
+use zstd::{Decoder as ZstdDecoder, Encoder as ZstdEncoder};
+
+const ZSTD_LEVEL: i32 = 3;
+
+/// Pack `source_dir` as a tar.zst archive at `output_path`. Existing
+/// files at `output_path` are overwritten.
+pub fn pack(source_dir: &Path, output_path: &Path) -> Result<()> {
+    let f = File::create(output_path)
+        .with_context(|| format!("creating capsule archive at {}", output_path.display()))?;
+    let writer = BufWriter::new(f);
+    let encoder = ZstdEncoder::new(writer, ZSTD_LEVEL)?;
+    let mut tar_builder = TarBuilder::new(encoder);
+    tar_builder
+        .append_dir_all(".", source_dir)
+        .with_context(|| format!("tarring {}", source_dir.display()))?;
+    let encoder = tar_builder.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+/// Unpack a tar.zst archive into `target_dir`.
+///
+/// Refuses if the cumulative uncompressed size exceeds `max_extract_bytes`
+/// (resource-exhaustion guard). Refuses path traversal (entries whose tar
+/// header path escapes `target_dir`).
+pub fn unpack(archive_path: &Path, target_dir: &Path, max_extract_bytes: u64) -> Result<u64> {
+    std::fs::create_dir_all(target_dir)
+        .with_context(|| format!("creating extract dir {}", target_dir.display()))?;
+    let file = File::open(archive_path)
+        .with_context(|| format!("opening capsule archive {}", archive_path.display()))?;
+    let reader = BufReader::new(file);
+    let decoder = ZstdDecoder::new(reader)?;
+    let mut archive = TarArchive::new(decoder);
+    archive.set_preserve_permissions(false);
+    archive.set_overwrite(true);
+
+    let target_canonical = target_dir
+        .canonicalize()
+        .with_context(|| format!("canonicalising target {}", target_dir.display()))?;
+
+    let mut total: u64 = 0;
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let header_size = entry.header().size().unwrap_or(0);
+        total = total
+            .checked_add(header_size)
+            .ok_or_else(|| anyhow::anyhow!("capsule size overflow"))?;
+        if total > max_extract_bytes {
+            anyhow::bail!(
+                "capsule extraction exceeds max size {} bytes",
+                max_extract_bytes
+            );
+        }
+        // Defend against path traversal: reject absolute paths or any
+        // `..` segment. Components like `.` and the bare archive root
+        // (`./`) are harmless and pass through.
+        let path = entry.path()?.into_owned();
+        for component in path.components() {
+            use std::path::Component;
+            match component {
+                Component::Prefix(_) | Component::RootDir => {
+                    anyhow::bail!(
+                        "capsule entry has absolute path: {}",
+                        path.display()
+                    );
+                }
+                Component::ParentDir => {
+                    anyhow::bail!(
+                        "capsule entry contains parent-dir segment: {}",
+                        path.display()
+                    );
+                }
+                Component::CurDir | Component::Normal(_) => {}
+            }
+        }
+        entry.unpack_in(&target_canonical)?;
+    }
+    Ok(total)
+}
+
+/// Read the raw bytes of a file within an extracted capsule directory.
+pub fn read_entry(capsule_root: &Path, relative: &str) -> Result<Vec<u8>> {
+    let mut f = File::open(capsule_root.join(relative))
+        .with_context(|| format!("opening capsule entry {}", relative))?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+/// Write bytes to a file within a staging capsule directory, creating
+/// parent directories as needed.
+pub fn write_entry(staging_root: &Path, relative: &str, bytes: &[u8]) -> Result<()> {
+    let p = staging_root.join(relative);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let f = File::create(&p)
+        .with_context(|| format!("creating capsule entry {}", p.display()))?;
+    let mut w = BufWriter::new(f);
+    w.write_all(bytes)?;
+    w.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn pack_then_unpack_roundtrips_files() {
+        let src = tempdir().unwrap();
+        std::fs::create_dir_all(src.path().join("agent")).unwrap();
+        std::fs::write(src.path().join("agent/SKILL.md"), b"# hi\n").unwrap();
+        std::fs::write(src.path().join("capsule.json"), b"{}").unwrap();
+
+        let out = tempdir().unwrap();
+        let archive = out.path().join("c.tar.zst");
+        pack(src.path(), &archive).unwrap();
+        assert!(archive.exists());
+
+        let extract = tempdir().unwrap();
+        let total = unpack(&archive, extract.path(), 64 * 1024).unwrap();
+        assert!(total > 0);
+        let skill = std::fs::read(extract.path().join("agent/SKILL.md")).unwrap();
+        assert_eq!(skill, b"# hi\n");
+        let manifest = std::fs::read(extract.path().join("capsule.json")).unwrap();
+        assert_eq!(manifest, b"{}");
+    }
+
+    #[test]
+    fn unpack_refuses_when_total_exceeds_cap() {
+        let src = tempdir().unwrap();
+        std::fs::write(src.path().join("big.bin"), vec![0u8; 4096]).unwrap();
+        let out = tempdir().unwrap();
+        let archive = out.path().join("c.tar.zst");
+        pack(src.path(), &archive).unwrap();
+        let extract = tempdir().unwrap();
+        let err = unpack(&archive, extract.path(), 1024).expect_err("cap should trip");
+        assert!(err.to_string().contains("max size"), "{err}");
+    }
+
+    #[test]
+    fn write_then_read_entry_roundtrip() {
+        let staging = tempdir().unwrap();
+        write_entry(staging.path(), "a/b/c.txt", b"hello").unwrap();
+        let bytes = read_entry(staging.path(), "a/b/c.txt").unwrap();
+        assert_eq!(bytes, b"hello");
+    }
+}

--- a/autonoetic-gateway/src/capsule/archive.rs
+++ b/autonoetic-gateway/src/capsule/archive.rs
@@ -78,9 +78,17 @@ pub fn unpack(archive_path: &Path, target_dir: &Path, max_extract_bytes: u64) ->
                 max_extract_bytes
             );
         }
-        // Defend against path traversal: reject absolute paths or any
-        // `..` segment. Components like `.` and the bare archive root
-        // (`./`) are harmless and pass through.
+        // Defend against tar-archive abuse:
+        //
+        // 1. Path traversal — reject absolute paths and any `..`
+        //    segment. `.` and the bare archive root (`./`) are
+        //    harmless and pass through.
+        // 2. Entry type — only regular files and directories are
+        //    materialised. Symlinks, hardlinks, character/block
+        //    devices, FIFOs, and other "interesting" tar entry types
+        //    can be used to write outside the target dir at extract
+        //    time or to create unsafe nodes on the host. They are
+        //    refused outright.
         let path = entry.path()?.into_owned();
         for component in path.components() {
             use std::path::Component;
@@ -99,6 +107,14 @@ pub fn unpack(archive_path: &Path, target_dir: &Path, max_extract_bytes: u64) ->
                 }
                 Component::CurDir | Component::Normal(_) => {}
             }
+        }
+        let entry_type = entry.header().entry_type();
+        if !(entry_type.is_file() || entry_type.is_dir()) {
+            anyhow::bail!(
+                "capsule entry has unsupported type {:?}: {} (only regular files and directories are allowed; symlinks, hardlinks, and special files are refused)",
+                entry_type,
+                path.display()
+            );
         }
         entry.unpack_in(&target_canonical)?;
     }
@@ -173,5 +189,44 @@ mod tests {
         write_entry(staging.path(), "a/b/c.txt", b"hello").unwrap();
         let bytes = read_entry(staging.path(), "a/b/c.txt").unwrap();
         assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn unpack_refuses_symlink_entries() {
+        use std::io::Write;
+        use tar::{EntryType, Header};
+        // Hand-craft a tar.zst archive containing a single symlink
+        // entry pointing at `/etc/passwd`. `pack` would have followed
+        // symlinks at archive time, so we have to build the header
+        // ourselves to exercise the unpack-side refusal.
+        let mut tar_bytes: Vec<u8> = Vec::new();
+        {
+            let mut tar_builder = TarBuilder::new(&mut tar_bytes);
+            let mut header = Header::new_gnu();
+            header.set_path("evil").unwrap();
+            header.set_entry_type(EntryType::Symlink);
+            header.set_link_name("/etc/passwd").unwrap();
+            header.set_size(0);
+            header.set_mode(0o777);
+            header.set_cksum();
+            tar_builder.append(&header, &[][..]).unwrap();
+            tar_builder.finish().unwrap();
+        }
+        let mut compressed: Vec<u8> = Vec::new();
+        {
+            let mut encoder = ZstdEncoder::new(&mut compressed, 3).unwrap();
+            encoder.write_all(&tar_bytes).unwrap();
+            encoder.finish().unwrap();
+        }
+        let out = tempdir().unwrap();
+        let archive = out.path().join("c.tar.zst");
+        std::fs::write(&archive, &compressed).unwrap();
+        let extract = tempdir().unwrap();
+        let err = unpack(&archive, extract.path(), 64 * 1024)
+            .expect_err("symlink entries must be refused");
+        assert!(
+            err.to_string().contains("unsupported type"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/autonoetic-gateway/src/capsule/export.rs
+++ b/autonoetic-gateway/src/capsule/export.rs
@@ -104,7 +104,7 @@ pub fn export(req: ExportRequest, ctx: ExportContext<'_>) -> Result<ExportOutcom
         None
     };
 
-    let capsule_id = compute_capsule_id(&revision.revision_id);
+    let capsule_id = compute_capsule_id(&revision.revision_id, req.mode);
     let signed = req.sign.unwrap_or(cfg.auto_sign);
 
     let mut manifest = CapsuleManifest {
@@ -250,8 +250,13 @@ fn copy_dir_redacted(
     Ok(())
 }
 
+/// Cap on file size for the UTF-8 fallback scrubbing path. We don't want
+/// to slurp huge binary-ish files through the regex pipeline.
+const REDACTION_UTF8_FALLBACK_SIZE_LIMIT: usize = 1024 * 1024;
+
 fn redact_file_if_text(filename: &str, bytes: Vec<u8>) -> (Vec<u8>, bool) {
-    let is_text_extension = filename
+    // First branch: a recognised text extension — always try to scrub.
+    let has_text_extension = filename
         .rsplit_once('.')
         .map(|(_, ext)| {
             matches!(
@@ -260,8 +265,38 @@ fn redact_file_if_text(filename: &str, bytes: Vec<u8>) -> (Vec<u8>, bool) {
             )
         })
         .unwrap_or(false);
-    if !is_text_extension {
-        return (bytes, false);
+    // Second branch: recognised extensionless configuration filenames
+    // that often carry secrets (`.env`, `Dockerfile`, `Makefile`, etc.).
+    let basename = filename
+        .rsplit_once('/')
+        .map(|(_, b)| b)
+        .unwrap_or(filename);
+    let is_known_textual_basename = matches!(
+        basename,
+        ".env"
+            | "Dockerfile"
+            | "Makefile"
+            | "LICENSE"
+            | "Containerfile"
+            | "Procfile"
+            | ".bashrc"
+            | ".zshrc"
+    ) || basename.starts_with(".env.");
+    let try_redact = has_text_extension || is_known_textual_basename;
+    if !try_redact {
+        // Fall back to UTF-8 detection for anything else, but only up
+        // to a size cap to keep the regex pipeline bounded.
+        if bytes.len() > REDACTION_UTF8_FALLBACK_SIZE_LIMIT {
+            return (bytes, false);
+        }
+        let Ok(text) = std::str::from_utf8(&bytes) else {
+            return (bytes, false);
+        };
+        let redacted = redact_embedded_secrets(text);
+        if redacted == text {
+            return (bytes, false);
+        }
+        return (redacted.into_bytes(), true);
     }
     let Ok(text) = std::str::from_utf8(&bytes) else {
         return (bytes, false);
@@ -303,11 +338,18 @@ fn stage_memory_snapshot(
     })
 }
 
-fn compute_capsule_id(revision_id: &str) -> String {
+/// Content-derived capsule ID: SHA-256 over (revision_id, mode).
+///
+/// Deterministic so that two exports of the same revision in the same
+/// mode produce the same `capsule_id` — necessary for dedup and stable
+/// provenance chains (see `docs/design/cognitive-capsule-standardization.md`).
+/// Timestamp salting is intentionally avoided.
+fn compute_capsule_id(revision_id: &str, mode: CapsuleMode) -> String {
     use sha2::{Digest, Sha256};
-    let salt = format!("{}-{}", revision_id, Utc::now().to_rfc3339());
     let mut hasher = Sha256::new();
-    hasher.update(salt.as_bytes());
+    hasher.update(revision_id.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(mode_str(mode).as_bytes());
     let hex = format!("{:x}", hasher.finalize());
     format!("cap_sha256:{}", &hex[..16])
 }
@@ -385,9 +427,20 @@ mod tests {
 
     #[test]
     fn compute_capsule_id_format() {
-        let id = compute_capsule_id("rev_sha256:abc");
+        let id = compute_capsule_id("rev_sha256:abc", CapsuleMode::Thin);
         assert!(id.starts_with("cap_sha256:"));
         assert_eq!(id.len(), "cap_sha256:".len() + 16);
+    }
+
+    #[test]
+    fn compute_capsule_id_is_deterministic_and_mode_sensitive() {
+        let a = compute_capsule_id("rev_sha256:abc", CapsuleMode::Thin);
+        let b = compute_capsule_id("rev_sha256:abc", CapsuleMode::Thin);
+        let c = compute_capsule_id("rev_sha256:abc", CapsuleMode::Hermetic);
+        let d = compute_capsule_id("rev_sha256:xyz", CapsuleMode::Thin);
+        assert_eq!(a, b, "same inputs must yield same capsule_id");
+        assert_ne!(a, c, "mode change must yield a different capsule_id");
+        assert_ne!(a, d, "revision change must yield a different capsule_id");
     }
 
     #[test]

--- a/autonoetic-gateway/src/capsule/export.rs
+++ b/autonoetic-gateway/src/capsule/export.rs
@@ -1,0 +1,400 @@
+//! Capsule export pipeline.
+//!
+//! Given an `AgentRevisionRecord` and a target archive path, stages the
+//! revision's files into a tempdir, applies redaction, builds the
+//! [`CapsuleManifest`], optionally signs it, packs as `tar.zst`, and
+//! emits a `capsule.export` causal event.
+//!
+//! Hermetic / Replay / Headless modes layer additional content
+//! (embedded layers, session checkpoint, scheduled jobs) on top of the
+//! shared thin-mode body. Phases 2 ships the thin and hermetic paths
+//! end-to-end; replay/headless leave the right hooks (`checkpoint_handle`,
+//! scheduled-job collection) for Phase 4 to fill in.
+
+use anyhow::{Context, Result};
+use autonoetic_types::capsule::{
+    CapsuleManifest, CapsuleMode, CapsuleProvenance, CAPSULE_FORMAT_VERSION,
+};
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::redaction::{redact_embedded_secrets, redact_json_value};
+use chrono::Utc;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::capsule::archive;
+use crate::capsule::verify;
+use crate::runtime::crypto::GatewayIdentityKey;
+use crate::scheduler::gateway_store::GatewayStore;
+
+/// Inputs to the export pipeline.
+#[derive(Debug, Clone)]
+pub struct ExportRequest {
+    pub agent_id: String,
+    /// Specific revision selector. `None` resolves the current alias.
+    pub revision_id: Option<String>,
+    pub mode: CapsuleMode,
+    /// When `true`, include a redacted memory snapshot. If unset, falls
+    /// back to `CapsuleConfig::include_memory_by_default`.
+    pub include_memory: Option<bool>,
+    /// Force or skip signing. `None` defers to `CapsuleConfig::auto_sign`.
+    pub sign: Option<bool>,
+    /// Output archive path. Defaults to `<agent_id>.capsule.tar.zst` in `cwd`.
+    pub output_path: Option<PathBuf>,
+}
+
+impl ExportRequest {
+    pub fn new(agent_id: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: None,
+            sign: None,
+            output_path: None,
+        }
+    }
+}
+
+/// Result of a successful export.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ExportOutcome {
+    pub capsule_id: String,
+    pub capsule_path: PathBuf,
+    pub revision_id: String,
+    pub mode: String,
+    pub signed: bool,
+    pub size_bytes: u64,
+    pub manifest_digest: String,
+    pub redactions: Vec<String>,
+}
+
+/// Inputs required to run the export pipeline. Carries handles, not raw
+/// state, so callers can plug in their existing gateway containers.
+pub struct ExportContext<'a> {
+    pub gateway_dir: &'a Path,
+    pub gateway_config: &'a GatewayConfig,
+    pub gateway_store: &'a Arc<GatewayStore>,
+}
+
+/// Run the export pipeline. Returns the [`ExportOutcome`] and emits a
+/// `capsule.export` causal event keyed to the agent.
+pub fn export(req: ExportRequest, ctx: ExportContext<'_>) -> Result<ExportOutcome> {
+    let cfg = &ctx.gateway_config.capsule;
+    let revision = resolve_revision(&req, ctx.gateway_store.as_ref())?;
+    let revision_dir = revision_dir(ctx.gateway_dir, &revision.agent_id, &revision.revision_id);
+
+    let staging = tempfile::tempdir().context("creating capsule staging dir")?;
+    let staging_path = staging.path();
+
+    let redactions = stage_revision_files(&revision_dir, staging_path)?;
+
+    let included_skills = collect_skill_names(&revision_dir);
+
+    let memory_snapshot = if req.include_memory.unwrap_or(cfg.include_memory_by_default) {
+        Some(stage_memory_snapshot(staging_path, &revision.agent_id)?)
+    } else {
+        None
+    };
+
+    let checkpoint_handle = if req.mode == CapsuleMode::Replay {
+        // Phase 2 records the path the importer should look for. Phase 4
+        // wires the actual checkpoint capture / restore.
+        Some(crate::capsule::paths::CHECKPOINT_PATH.to_string())
+    } else {
+        None
+    };
+
+    let capsule_id = compute_capsule_id(&revision.revision_id);
+    let signed = req.sign.unwrap_or(cfg.auto_sign);
+
+    let mut manifest = CapsuleManifest {
+        capsule_id: capsule_id.clone(),
+        format_version: CAPSULE_FORMAT_VERSION.to_string(),
+        mode: req.mode,
+        created_at: Utc::now().to_rfc3339(),
+        agent_id: revision.agent_id.clone(),
+        revision_id: revision.revision_id.clone(),
+        revision_short_id: revision.short_id.clone(),
+        content_digest: revision.content_digest.clone(),
+        entrypoint: crate::capsule::paths::SKILL_REL.to_string(),
+        runtime_lock: crate::capsule::paths::RUNTIME_LOCK_REL.to_string(),
+        included_artifacts: vec![],
+        included_layers: vec![],
+        included_skills,
+        gateway_runtime: None,
+        memory_snapshot,
+        checkpoint_handle,
+        redactions: redactions.clone(),
+        signature: None,
+        provenance: CapsuleProvenance {
+            origin_node_id: ctx.gateway_config.node_id.clone(),
+            gateway_version: env!("CARGO_PKG_VERSION").to_string(),
+            trust_domain: "local".to_string(),
+            parent_capsule_id: None,
+        },
+        requires_agents: vec![],
+        requires_skills: vec![],
+    };
+
+    // Hermetic layer embedding (LayerStore archive copy + platform
+    // descriptor) lands in Phase 4 once the revision-to-layer-closure
+    // helper is in place. For now thin and hermetic exports differ only
+    // in the mode field and the importer's compatibility checks.
+
+    if signed {
+        let key = GatewayIdentityKey::load_or_generate(ctx.gateway_dir)
+            .context("loading gateway identity key to sign capsule")?;
+        manifest.signature = Some(verify::sign_manifest(&manifest, &key)?);
+    }
+
+    let manifest_digest = verify::manifest_digest(&manifest)?;
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
+    archive::write_entry(staging_path, "capsule.json", &manifest_bytes)?;
+
+    let output_path = req.output_path.clone().unwrap_or_else(|| {
+        PathBuf::from(format!("{}.capsule.tar.zst", revision.agent_id))
+    });
+    archive::pack(staging_path, &output_path)?;
+
+    let size_bytes = std::fs::metadata(&output_path)?.len();
+    if size_bytes > cfg.max_capsule_size_bytes {
+        anyhow::bail!(
+            "capsule archive size {} exceeds configured max {} (set capsule.max_capsule_size_bytes higher to allow)",
+            size_bytes,
+            cfg.max_capsule_size_bytes
+        );
+    }
+
+    emit_export_event(
+        ctx.gateway_store,
+        &capsule_id,
+        &revision.agent_id,
+        &revision.revision_id,
+        &manifest.mode,
+        size_bytes,
+        signed,
+    )?;
+
+    Ok(ExportOutcome {
+        capsule_id,
+        capsule_path: output_path,
+        revision_id: revision.revision_id,
+        mode: mode_str(manifest.mode).to_string(),
+        signed,
+        size_bytes,
+        manifest_digest,
+        redactions,
+    })
+}
+
+fn resolve_revision(
+    req: &ExportRequest,
+    store: &GatewayStore,
+) -> Result<autonoetic_types::agent_revision::AgentRevisionRecord> {
+    if let Some(rev_id) = req.revision_id.as_deref() {
+        return store
+            .get_agent_revision(rev_id)?
+            .with_context(|| format!("unknown revision: {}", rev_id));
+    }
+    let alias = store
+        .get_agent_alias(&req.agent_id)?
+        .with_context(|| format!("no alias for agent: {}", req.agent_id))?;
+    store
+        .get_agent_revision(&alias.revision_id)?
+        .with_context(|| format!("alias points to missing revision: {}", alias.revision_id))
+}
+
+fn revision_dir(gateway_dir: &Path, agent_id: &str, revision_id: &str) -> PathBuf {
+    gateway_dir
+        .join("revisions")
+        .join("agents")
+        .join(agent_id)
+        .join(revision_id)
+}
+
+fn stage_revision_files(revision_dir: &Path, staging: &Path) -> Result<Vec<String>> {
+    let agent_root = staging.join("agent");
+    std::fs::create_dir_all(&agent_root)?;
+    let mut redactions = Vec::new();
+    copy_dir_redacted(revision_dir, &agent_root, &mut redactions, "agent")?;
+    Ok(redactions)
+}
+
+fn copy_dir_redacted(
+    src: &Path,
+    dst: &Path,
+    redactions: &mut Vec<String>,
+    rel_prefix: &str,
+) -> Result<()> {
+    for entry in std::fs::read_dir(src)
+        .with_context(|| format!("reading revision dir {}", src.display()))?
+    {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy().to_string();
+        let dst_path = dst.join(&name);
+        let rel = format!("{}/{}", rel_prefix, name_str);
+        if file_type.is_dir() {
+            std::fs::create_dir_all(&dst_path)?;
+            copy_dir_redacted(&entry.path(), &dst_path, redactions, &rel)?;
+        } else if file_type.is_file() {
+            let bytes = std::fs::read(entry.path())?;
+            let (out_bytes, redacted) = redact_file_if_text(&name_str, bytes);
+            if redacted {
+                redactions.push(rel);
+            }
+            std::fs::write(&dst_path, out_bytes)?;
+        }
+    }
+    Ok(())
+}
+
+fn redact_file_if_text(filename: &str, bytes: Vec<u8>) -> (Vec<u8>, bool) {
+    let is_text_extension = filename
+        .rsplit_once('.')
+        .map(|(_, ext)| {
+            matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "md" | "txt" | "lock" | "json" | "yaml" | "yml" | "toml" | "py" | "sh" | "ts" | "js" | "rs"
+            )
+        })
+        .unwrap_or(false);
+    if !is_text_extension {
+        return (bytes, false);
+    }
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return (bytes, false);
+    };
+    let redacted = redact_embedded_secrets(text);
+    let changed = redacted != text;
+    (redacted.into_bytes(), changed)
+}
+
+fn collect_skill_names(revision_dir: &Path) -> Vec<String> {
+    let skill_path = revision_dir.join("SKILL.md");
+    if skill_path.is_file() {
+        vec!["SKILL.md".to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn stage_memory_snapshot(
+    _staging: &Path,
+    _agent_id: &str,
+) -> Result<autonoetic_types::capsule::CapsuleMemorySnapshot> {
+    // Phase 2 records the snapshot placeholder file so importers can
+    // dedup; full agent-scoped memory enumeration lands with Phase 4
+    // (memory dedup + conflict policy). The redaction round-trip is
+    // demonstrated by the unit test below.
+    let snapshot_json = serde_json::json!({
+        "entries": [],
+        "scopes": ["memory", "user_profile"],
+    });
+    let redacted = redact_json_value(&snapshot_json);
+    let serialised = serde_json::to_vec_pretty(&redacted)?;
+    archive::write_entry(_staging, crate::capsule::paths::MEMORY_SNAPSHOT_PATH, &serialised)?;
+    Ok(autonoetic_types::capsule::CapsuleMemorySnapshot {
+        entry_count: 0,
+        scopes: vec!["memory".to_string(), "user_profile".to_string()],
+        content_handle: crate::capsule::paths::MEMORY_SNAPSHOT_PATH.to_string(),
+        redacted: true,
+    })
+}
+
+fn compute_capsule_id(revision_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let salt = format!("{}-{}", revision_id, Utc::now().to_rfc3339());
+    let mut hasher = Sha256::new();
+    hasher.update(salt.as_bytes());
+    let hex = format!("{:x}", hasher.finalize());
+    format!("cap_sha256:{}", &hex[..16])
+}
+
+fn mode_str(mode: CapsuleMode) -> &'static str {
+    match mode {
+        CapsuleMode::Thin => "thin",
+        CapsuleMode::Hermetic => "hermetic",
+        CapsuleMode::Replay => "replay",
+        CapsuleMode::Headless => "headless",
+    }
+}
+
+fn emit_export_event(
+    store: &GatewayStore,
+    capsule_id: &str,
+    agent_id: &str,
+    revision_id: &str,
+    mode: &CapsuleMode,
+    size_bytes: u64,
+    signed: bool,
+) -> Result<()> {
+    let payload = serde_json::json!({
+        "capsule_id": capsule_id,
+        "revision_id": revision_id,
+        "mode": mode_str(*mode),
+        "size_bytes": size_bytes,
+        "signed": signed,
+    });
+    let event = autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: agent_id.to_string(),
+        session_id: "gateway".to_string(),
+        turn_id: None,
+        event_seq: 0,
+        timestamp: Utc::now().to_rfc3339(),
+        category: "capsule".to_string(),
+        action: "export".to_string(),
+        status: "SUCCESS".to_string(),
+        enforced_rules: autonoetic_types::causal_chain::default_enforced_rules(),
+        target: Some(format!("{}@{}", agent_id, revision_id)),
+        payload: Some(payload.to_string()),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    };
+    store.create_causal_event(&event)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_file_if_text_masks_text_secrets() {
+        let bytes = b"OPENAI_API_KEY=sk-abc123secret\n".to_vec();
+        let (out, changed) = redact_file_if_text("SKILL.md", bytes.clone());
+        assert!(changed);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(
+            !out_str.contains("sk-abc123secret"),
+            "secret should be masked: {}",
+            out_str
+        );
+    }
+
+    #[test]
+    fn redact_file_if_text_passes_binary_unchanged() {
+        let bytes = b"\x7fELF\x02\x01".to_vec();
+        let (out, changed) = redact_file_if_text("binary.so", bytes.clone());
+        assert!(!changed);
+        assert_eq!(out, bytes);
+    }
+
+    #[test]
+    fn compute_capsule_id_format() {
+        let id = compute_capsule_id("rev_sha256:abc");
+        assert!(id.starts_with("cap_sha256:"));
+        assert_eq!(id.len(), "cap_sha256:".len() + 16);
+    }
+
+    #[test]
+    fn mode_str_covers_all_variants() {
+        assert_eq!(mode_str(CapsuleMode::Thin), "thin");
+        assert_eq!(mode_str(CapsuleMode::Hermetic), "hermetic");
+        assert_eq!(mode_str(CapsuleMode::Replay), "replay");
+        assert_eq!(mode_str(CapsuleMode::Headless), "headless");
+    }
+}

--- a/autonoetic-gateway/src/capsule/import.rs
+++ b/autonoetic-gateway/src/capsule/import.rs
@@ -100,6 +100,13 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
 
     let revision_id = manifest.revision_id.clone();
     let agent_id = manifest.agent_id.clone();
+    // Both fields are interpolated into filesystem paths under
+    // `.gateway/revisions/agents/<agent_id>/<revision_id>/`. They
+    // come from an untrusted capsule manifest, so refuse anything
+    // that could break out of that directory or include directory
+    // separators.
+    validate_path_component(&agent_id, "agent_id")?;
+    validate_path_component(&revision_id, "revision_id")?;
     let trust_domain = req
         .trust_domain_override
         .clone()
@@ -344,6 +351,44 @@ fn emit_import_event(
     Ok(())
 }
 
+/// Refuse manifest-supplied strings that would let an attacker steer
+/// the import pipeline outside the per-agent / per-revision directory
+/// or assemble unexpected paths. Allowed characters are intentionally
+/// narrow (alphanumeric, `_`, `-`, `.`, and `:` for the
+/// `rev_sha256:abcd…` convention); the value also must not be empty
+/// or contain `..` segments.
+fn validate_path_component(value: &str, label: &str) -> anyhow::Result<()> {
+    if value.is_empty() {
+        anyhow::bail!("capsule manifest has empty {}", label);
+    }
+    if value.contains("..") {
+        anyhow::bail!(
+            "capsule manifest {} {:?} contains parent-dir segment",
+            label,
+            value
+        );
+    }
+    if value.contains('/') || value.contains('\\') {
+        anyhow::bail!(
+            "capsule manifest {} {:?} contains a path separator",
+            label,
+            value
+        );
+    }
+    for ch in value.chars() {
+        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':');
+        if !ok {
+            anyhow::bail!(
+                "capsule manifest {} {:?} contains unsupported character {:?}",
+                label,
+                value,
+                ch
+            );
+        }
+    }
+    Ok(())
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
@@ -373,5 +418,24 @@ mod tests {
             sha256_hex(b"hello"),
             "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
+    }
+
+    #[test]
+    fn validate_path_component_accepts_canonical_ids() {
+        assert!(validate_path_component("planner.default", "agent_id").is_ok());
+        assert!(
+            validate_path_component("rev_sha256:abcdef1234567890", "revision_id").is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_path_component_rejects_traversal_and_separators() {
+        for bad in ["", "..", "../etc", "foo/bar", "foo\\bar", "foo bar", "foo;bar"] {
+            assert!(
+                validate_path_component(bad, "agent_id").is_err(),
+                "{:?} should be rejected",
+                bad
+            );
+        }
     }
 }

--- a/autonoetic-gateway/src/capsule/import.rs
+++ b/autonoetic-gateway/src/capsule/import.rs
@@ -1,0 +1,377 @@
+//! Capsule import pipeline.
+//!
+//! Extracts a `tar.zst` capsule into a tempdir, parses `capsule.json`,
+//! verifies the signature against the configured trust store, materialises
+//! the revision directory under `.gateway/revisions/agents/<agent>/<rev>/`,
+//! inserts a fresh `AgentRevisionRecord` with
+//! `source_kind = "capsule_import"`, and emits a `capsule.import` causal
+//! event.
+//!
+//! Phase 2 ships the thin-mode happy path end-to-end. Hermetic-layer
+//! dedup, memory merge with conflict policy, and replay-mode session
+//! resume layer on top in Phase 4.
+
+use anyhow::{Context, Result};
+use autonoetic_types::capsule::CapsuleManifest;
+use autonoetic_types::config::GatewayConfig;
+use chrono::Utc;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::capsule::archive;
+use crate::capsule::verify::{verify_signature, SignatureStatus};
+use crate::scheduler::gateway_store::GatewayStore;
+
+const CAPSULE_FORMAT_MAJOR_SUPPORTED: u64 = 1;
+
+#[derive(Debug, Clone, Default)]
+pub struct ImportRequest {
+    pub archive_path: PathBuf,
+    /// Require a present + verified signature.
+    pub verify_signature: bool,
+    /// Run validation only; do not persist anything.
+    pub dry_run: bool,
+    /// When true, after importing the revision rebind the alias.
+    pub activate: bool,
+    /// Override the trust domain stamped on the imported revision.
+    /// Defaults to `"local"`.
+    pub trust_domain_override: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImportOutcome {
+    pub capsule_id: String,
+    pub agent_id: String,
+    pub revision_id: String,
+    pub revision_short_id: String,
+    pub signature_status: String,
+    pub dry_run: bool,
+    pub dedup_savings_bytes: u64,
+    pub created_revision: bool,
+}
+
+pub struct ImportContext<'a> {
+    pub gateway_dir: &'a Path,
+    pub gateway_config: &'a GatewayConfig,
+    pub gateway_store: &'a Arc<GatewayStore>,
+}
+
+pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcome> {
+    let cfg = &ctx.gateway_config.capsule;
+    let archive_size = std::fs::metadata(&req.archive_path)
+        .with_context(|| format!("stat capsule archive {}", req.archive_path.display()))?
+        .len();
+    if archive_size > cfg.max_capsule_size_bytes {
+        anyhow::bail!(
+            "capsule archive size {} exceeds configured max {}",
+            archive_size,
+            cfg.max_capsule_size_bytes
+        );
+    }
+
+    let extract = tempfile::tempdir().context("creating capsule extract tempdir")?;
+    archive::unpack(&req.archive_path, extract.path(), cfg.max_capsule_size_bytes)?;
+
+    let manifest_bytes = archive::read_entry(extract.path(), "capsule.json")
+        .context("reading capsule.json from extracted archive")?;
+    let manifest: CapsuleManifest = serde_json::from_slice(&manifest_bytes)
+        .context("parsing capsule.json")?;
+
+    if let Some(major) = manifest.format_major_version() {
+        if major > CAPSULE_FORMAT_MAJOR_SUPPORTED {
+            anyhow::bail!(
+                "unsupported capsule format_version {} (this gateway supports {}.x)",
+                manifest.format_version,
+                CAPSULE_FORMAT_MAJOR_SUPPORTED
+            );
+        }
+    } else {
+        anyhow::bail!(
+            "capsule.json has malformed format_version: {}",
+            manifest.format_version
+        );
+    }
+
+    let sig_status = verify_signature(&manifest, cfg, req.verify_signature)?;
+    if req.verify_signature && !sig_status.is_ok() {
+        anyhow::bail!("signature verification failed: {:?}", sig_status);
+    }
+
+    let revision_id = manifest.revision_id.clone();
+    let agent_id = manifest.agent_id.clone();
+    let trust_domain = req
+        .trust_domain_override
+        .clone()
+        .unwrap_or_else(|| "local".to_string());
+
+    let agent_dir = extract.path().join("agent");
+    let file_map = read_agent_files(&agent_dir)?;
+    let (dedup_savings, _content_handles) =
+        stage_blobs_into_content_store(ctx.gateway_dir, &file_map)?;
+
+    if req.dry_run {
+        return Ok(ImportOutcome {
+            capsule_id: manifest.capsule_id,
+            agent_id,
+            revision_id,
+            revision_short_id: manifest.revision_short_id,
+            signature_status: format!("{:?}", sig_status),
+            dry_run: true,
+            dedup_savings_bytes: dedup_savings,
+            created_revision: false,
+        });
+    }
+
+    let revision_existed = ctx
+        .gateway_store
+        .get_agent_revision(&revision_id)?
+        .is_some();
+
+    if !revision_existed {
+        materialize_revision_dir(ctx.gateway_dir, &agent_id, &revision_id, &file_map)?;
+        let now = Utc::now().to_rfc3339();
+        let runtime_lock_hash = file_map
+            .get("runtime.lock")
+            .map(|bytes| format!("sha256:{}", sha256_hex(bytes)))
+            .unwrap_or_else(|| String::new());
+        let manifest_hash = file_map
+            .get("SKILL.md")
+            .map(|bytes| format!("sha256:{}", sha256_hex(bytes)))
+            .unwrap_or_else(|| String::new());
+
+        let rev = autonoetic_types::agent_revision::AgentRevisionRecord {
+            revision_id: revision_id.clone(),
+            agent_id: agent_id.clone(),
+            base_revision_id: None,
+            artifact_id: None,
+            content_digest: manifest.content_digest.clone(),
+            runtime_lock_hash,
+            manifest_hash,
+            created_at: now,
+            created_by_type: "system".to_string(),
+            created_by_id: "capsule.import".to_string(),
+            source_kind: "capsule_import".to_string(),
+            source_ref: Some(manifest.capsule_id.clone()),
+            origin_node_id: manifest.provenance.origin_node_id.clone(),
+            trust_domain: trust_domain.clone(),
+            status: autonoetic_types::agent_revision::AgentRevisionStatus::Candidate,
+            metadata_json: serde_json::json!({
+                "capsule": {
+                    "capsule_id": manifest.capsule_id,
+                    "format_version": manifest.format_version,
+                    "mode": manifest.mode,
+                    "provenance": manifest.provenance,
+                    "signature_status": format!("{:?}", sig_status),
+                    "redactions": manifest.redactions,
+                }
+            }),
+            short_id: manifest.revision_short_id.clone(),
+            signature: manifest.signature.as_ref().map(|s| s.signature.clone()),
+            signer_id: manifest.signature.as_ref().map(|s| s.signer_id.clone()),
+        };
+        ctx.gateway_store.insert_agent_revision(&rev)?;
+    }
+
+    if req.activate {
+        bind_alias(ctx.gateway_store, &agent_id, &revision_id)?;
+    }
+
+    emit_import_event(
+        ctx.gateway_store,
+        &manifest.capsule_id,
+        &agent_id,
+        &revision_id,
+        dedup_savings,
+        &sig_status,
+    )?;
+
+    Ok(ImportOutcome {
+        capsule_id: manifest.capsule_id,
+        agent_id,
+        revision_id,
+        revision_short_id: manifest.revision_short_id,
+        signature_status: format!("{:?}", sig_status),
+        dry_run: false,
+        dedup_savings_bytes: dedup_savings,
+        created_revision: !revision_existed,
+    })
+}
+
+fn read_agent_files(agent_dir: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    let mut map = BTreeMap::new();
+    if !agent_dir.exists() {
+        return Ok(map);
+    }
+    walk(agent_dir, agent_dir, &mut map)?;
+    Ok(map)
+}
+
+fn walk(
+    base: &Path,
+    cur: &Path,
+    map: &mut BTreeMap<String, Vec<u8>>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(cur)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(base)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        if file_type.is_dir() {
+            walk(base, &path, map)?;
+        } else if file_type.is_file() {
+            map.insert(rel, std::fs::read(&path)?);
+        }
+    }
+    Ok(())
+}
+
+fn stage_blobs_into_content_store(
+    gateway_dir: &Path,
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<(u64, Vec<String>)> {
+    let store = crate::runtime::content_store::ContentStore::new(gateway_dir)?;
+    let mut dedup_savings: u64 = 0;
+    let mut handles = Vec::new();
+    for bytes in files.values() {
+        let handle = crate::runtime::content_store::ContentStore::compute_handle(bytes);
+        if store.exists(&handle) {
+            dedup_savings = dedup_savings.saturating_add(bytes.len() as u64);
+        }
+        store.write(bytes)?;
+        handles.push(handle);
+    }
+    Ok((dedup_savings, handles))
+}
+
+fn materialize_revision_dir(
+    gateway_dir: &Path,
+    agent_id: &str,
+    revision_id: &str,
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<PathBuf> {
+    let rev_dir = gateway_dir
+        .join("revisions")
+        .join("agents")
+        .join(agent_id)
+        .join(revision_id);
+    if rev_dir.exists() {
+        return Ok(rev_dir);
+    }
+    if let Some(parent) = rev_dir.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = rev_dir
+        .parent()
+        .unwrap()
+        .join(format!(".tmp-{}-{}", revision_id, uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp)?;
+    for (rel, bytes) in files {
+        let dst = tmp.join(rel);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&dst, bytes)?;
+    }
+    match std::fs::rename(&tmp, &rev_dir) {
+        Ok(()) => Ok(rev_dir),
+        Err(_) if rev_dir.exists() => {
+            let _ = std::fs::remove_dir_all(&tmp);
+            Ok(rev_dir)
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&tmp);
+            Err(e.into())
+        }
+    }
+}
+
+fn bind_alias(
+    store: &Arc<GatewayStore>,
+    agent_id: &str,
+    revision_id: &str,
+) -> Result<()> {
+    let now = Utc::now().to_rfc3339();
+    let alias = autonoetic_types::agent_revision::AgentAliasRecord {
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: revision_id.to_string(),
+        updated_at: now,
+        updated_by_type: "system".to_string(),
+        updated_by_id: "capsule.import".to_string(),
+        reason: Some("capsule import --activate".to_string()),
+    };
+    store.upsert_agent_alias(&alias)?;
+    Ok(())
+}
+
+fn emit_import_event(
+    store: &Arc<GatewayStore>,
+    capsule_id: &str,
+    agent_id: &str,
+    revision_id: &str,
+    dedup_savings: u64,
+    sig_status: &SignatureStatus,
+) -> Result<()> {
+    let payload = serde_json::json!({
+        "capsule_id": capsule_id,
+        "revision_id": revision_id,
+        "dedup_savings_bytes": dedup_savings,
+        "signature_status": format!("{:?}", sig_status),
+    });
+    let event = autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: agent_id.to_string(),
+        session_id: "gateway".to_string(),
+        turn_id: None,
+        event_seq: 0,
+        timestamp: Utc::now().to_rfc3339(),
+        category: "capsule".to_string(),
+        action: "import".to_string(),
+        status: "SUCCESS".to_string(),
+        enforced_rules: autonoetic_types::causal_chain::default_enforced_rules(),
+        target: Some(format!("{}@{}", agent_id, revision_id)),
+        payload: Some(payload.to_string()),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: None,
+    };
+    store.create_causal_event(&event)?;
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("{:x}", h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walk_collects_relative_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("nested")).unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"A").unwrap();
+        std::fs::write(dir.path().join("nested/b.txt"), b"B").unwrap();
+        let mut map = BTreeMap::new();
+        walk(dir.path(), dir.path(), &mut map).unwrap();
+        assert_eq!(map.get("a.txt"), Some(&b"A".to_vec()));
+        assert_eq!(map.get("nested/b.txt"), Some(&b"B".to_vec()));
+    }
+
+    #[test]
+    fn sha256_hex_is_stable() {
+        assert_eq!(
+            sha256_hex(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+}

--- a/autonoetic-gateway/src/capsule/mod.rs
+++ b/autonoetic-gateway/src/capsule/mod.rs
@@ -1,0 +1,36 @@
+//! Cognitive Capsule export/import pipelines.
+//!
+//! A Cognitive Capsule is a portable, signed, revision-pinned snapshot of
+//! an agent — see `docs/design/cognitive-capsule-standardization.md`. The
+//! schema lives in `autonoetic-types/src/capsule.rs`; this module holds
+//! the gateway-side pipelines that produce and consume those archives.
+//!
+//! Surface:
+//!
+//! - [`export::export`] — package a revision into a `tar.zst` archive
+//! - [`import::import`] — extract an archive and create a new revision
+//! - [`verify::manifest_digest`] / [`verify::verify_signature`] — canonical
+//!   digest + Ed25519 signature checks
+//! - [`archive::pack`] / [`archive::unpack`] — low-level archive helpers
+//!
+//! Phase 2 ships the thin-mode happy path end-to-end (export → import → new
+//! revision record). Hermetic-layer embedding, memory-merge conflict
+//! policy, and Replay-mode session resume layer on top of these surfaces
+//! in Phase 4.
+
+pub mod archive;
+pub mod export;
+pub mod import;
+pub mod verify;
+
+pub use export::{export, ExportContext, ExportOutcome, ExportRequest};
+pub use import::{import, ImportContext, ImportOutcome, ImportRequest};
+
+/// Canonical relative paths inside the capsule archive.
+pub mod paths {
+    pub const CAPSULE_JSON: &str = "capsule.json";
+    pub const SKILL_REL: &str = "SKILL.md";
+    pub const RUNTIME_LOCK_REL: &str = "runtime.lock";
+    pub const MEMORY_SNAPSHOT_PATH: &str = "memory/memory_snapshot.json";
+    pub const CHECKPOINT_PATH: &str = "checkpoint/checkpoint.json";
+}

--- a/autonoetic-gateway/src/capsule/verify.rs
+++ b/autonoetic-gateway/src/capsule/verify.rs
@@ -1,0 +1,247 @@
+//! Capsule digest + signature canonicalisation and verification.
+//!
+//! The capsule digest is SHA-256 over the **canonical JSON** of the manifest
+//! with the `signature` field cleared to `None`. This makes signing
+//! idempotent (signing twice produces the same input bytes) and lets the
+//! verifier recompute the digest deterministically.
+//!
+//! `serde_json` emits keys in struct definition order for our concrete
+//! `CapsuleManifest` (no `Value` round-trip), which is stable across builds
+//! — the same canonicalisation choice the `state_attestation` module uses.
+
+use anyhow::{Context, Result};
+use autonoetic_types::capsule::{CapsuleManifest, CapsuleSignature};
+use autonoetic_types::config::CapsuleConfig;
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+/// Compute the canonical JSON bytes used for digest + signing. The
+/// `signature` field is cleared in the copy before serialisation so that
+/// a signed manifest's digest matches the unsigned one.
+pub fn canonical_bytes(manifest: &CapsuleManifest) -> Result<Vec<u8>> {
+    let mut canonical = manifest.clone();
+    canonical.signature = None;
+    serde_json::to_vec(&canonical)
+        .context("serialising capsule manifest for canonicalisation")
+}
+
+/// SHA-256 hex digest over [`canonical_bytes`].
+pub fn manifest_digest(manifest: &CapsuleManifest) -> Result<String> {
+    let bytes = canonical_bytes(manifest)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Outcome of [`verify_signature`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignatureStatus {
+    /// No signature present and `require_signature` was false.
+    Absent,
+    /// Signature present and verified successfully against the trusted-signer registry.
+    Verified,
+    /// Signature present but the `signer_id` is not in
+    /// `CapsuleConfig::trusted_signers`.
+    UntrustedSigner,
+    /// Signature present but cryptographic verification failed.
+    Mismatch,
+    /// Signature present but malformed (wrong length, bad base64, etc.).
+    Malformed,
+    /// Signature absent and `require_signature` was true.
+    MissingRequired,
+}
+
+impl SignatureStatus {
+    /// Returns true when the status represents a successful trust decision
+    /// (either no signature was required or the signature verified).
+    pub fn is_ok(&self) -> bool {
+        matches!(self, SignatureStatus::Absent | SignatureStatus::Verified)
+    }
+}
+
+/// Verify `manifest.signature` against the provided trust store.
+///
+/// When `require_signature` is true and the manifest carries no
+/// signature, the result is [`SignatureStatus::MissingRequired`].
+pub fn verify_signature(
+    manifest: &CapsuleManifest,
+    config: &CapsuleConfig,
+    require_signature: bool,
+) -> Result<SignatureStatus> {
+    let Some(sig) = manifest.signature.as_ref() else {
+        return Ok(if require_signature {
+            SignatureStatus::MissingRequired
+        } else {
+            SignatureStatus::Absent
+        });
+    };
+
+    if sig.algorithm != "ed25519" {
+        return Ok(SignatureStatus::Malformed);
+    }
+    let Some(pub_b64) = config.trusted_signers.get(&sig.signer_id) else {
+        return Ok(SignatureStatus::UntrustedSigner);
+    };
+    let pub_bytes = match B64.decode(pub_b64) {
+        Ok(b) if b.len() == 32 => b,
+        _ => return Ok(SignatureStatus::Malformed),
+    };
+    let mut pub_arr = [0u8; 32];
+    pub_arr.copy_from_slice(&pub_bytes);
+    let vk = match VerifyingKey::from_bytes(&pub_arr) {
+        Ok(v) => v,
+        Err(_) => return Ok(SignatureStatus::Malformed),
+    };
+    let sig_bytes = match B64.decode(&sig.signature) {
+        Ok(b) if b.len() == 64 => b,
+        _ => return Ok(SignatureStatus::Malformed),
+    };
+    let mut sig_arr = [0u8; 64];
+    sig_arr.copy_from_slice(&sig_bytes);
+    let signature = Signature::from_bytes(&sig_arr);
+
+    let canonical = canonical_bytes(manifest)?;
+    Ok(if vk.verify(&canonical, &signature).is_ok() {
+        SignatureStatus::Verified
+    } else {
+        SignatureStatus::Mismatch
+    })
+}
+
+/// Build a [`CapsuleSignature`] using the gateway's identity key. The
+/// caller is responsible for setting `manifest.signature = Some(...)`
+/// before persistence.
+pub fn sign_manifest(
+    manifest: &CapsuleManifest,
+    key: &crate::runtime::crypto::GatewayIdentityKey,
+) -> Result<CapsuleSignature> {
+    let canonical = canonical_bytes(manifest)?;
+    let signature = key.sign(&canonical);
+    Ok(CapsuleSignature {
+        algorithm: "ed25519".to_string(),
+        signer_id: format!("gateway:{}", key.fingerprint()),
+        signature,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::capsule::{CapsuleMode, CapsuleProvenance};
+
+    fn empty_manifest() -> CapsuleManifest {
+        CapsuleManifest {
+            capsule_id: "cap_test".to_string(),
+            format_version: autonoetic_types::capsule::CAPSULE_FORMAT_VERSION.to_string(),
+            mode: CapsuleMode::Thin,
+            created_at: "2026-05-28T00:00:00Z".to_string(),
+            agent_id: "a".to_string(),
+            revision_id: "rev".to_string(),
+            revision_short_id: "rv".to_string(),
+            content_digest: "d".to_string(),
+            entrypoint: "SKILL.md".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+            included_artifacts: vec![],
+            included_layers: vec![],
+            included_skills: vec![],
+            gateway_runtime: None,
+            memory_snapshot: None,
+            checkpoint_handle: None,
+            redactions: vec![],
+            signature: None,
+            provenance: CapsuleProvenance {
+                origin_node_id: "n".to_string(),
+                gateway_version: "v".to_string(),
+                trust_domain: "local".to_string(),
+                parent_capsule_id: None,
+            },
+            requires_agents: vec![],
+            requires_skills: vec![],
+        }
+    }
+
+    #[test]
+    fn canonical_bytes_ignores_signature_field() {
+        let mut m1 = empty_manifest();
+        let mut m2 = empty_manifest();
+        m2.signature = Some(CapsuleSignature {
+            algorithm: "ed25519".to_string(),
+            signer_id: "gateway:abc".to_string(),
+            signature: "AAAA".to_string(),
+        });
+        assert_eq!(canonical_bytes(&m1).unwrap(), canonical_bytes(&m2).unwrap());
+        assert_eq!(manifest_digest(&m1).unwrap(), manifest_digest(&m2).unwrap());
+        m1.agent_id = "different".to_string();
+        assert_ne!(manifest_digest(&m1).unwrap(), manifest_digest(&m2).unwrap());
+    }
+
+    #[test]
+    fn verify_absent_signature_returns_absent_or_missing() {
+        let m = empty_manifest();
+        let cfg = CapsuleConfig::default();
+        assert_eq!(verify_signature(&m, &cfg, false).unwrap(), SignatureStatus::Absent);
+        assert_eq!(
+            verify_signature(&m, &cfg, true).unwrap(),
+            SignatureStatus::MissingRequired
+        );
+    }
+
+    #[test]
+    fn untrusted_signer_returns_untrusted_signer() {
+        let mut m = empty_manifest();
+        m.signature = Some(CapsuleSignature {
+            algorithm: "ed25519".to_string(),
+            signer_id: "gateway:unknown".to_string(),
+            signature: B64.encode([0u8; 64]),
+        });
+        let cfg = CapsuleConfig::default();
+        assert_eq!(
+            verify_signature(&m, &cfg, false).unwrap(),
+            SignatureStatus::UntrustedSigner
+        );
+    }
+
+    #[test]
+    fn malformed_signature_returns_malformed() {
+        let mut m = empty_manifest();
+        m.signature = Some(CapsuleSignature {
+            algorithm: "ed25519".to_string(),
+            signer_id: "gateway:any".to_string(),
+            signature: "not_base64!".to_string(),
+        });
+        let mut cfg = CapsuleConfig::default();
+        cfg.trusted_signers
+            .insert("gateway:any".to_string(), B64.encode([0u8; 32]));
+        assert_eq!(
+            verify_signature(&m, &cfg, false).unwrap(),
+            SignatureStatus::Malformed
+        );
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip_with_gateway_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let key = crate::runtime::crypto::GatewayIdentityKey::load_or_generate(temp.path()).unwrap();
+        let mut m = empty_manifest();
+        let sig = sign_manifest(&m, &key).unwrap();
+        m.signature = Some(sig);
+
+        let mut cfg = CapsuleConfig::default();
+        cfg.trusted_signers.insert(
+            format!("gateway:{}", key.fingerprint()),
+            B64.encode(key.public_key_bytes()),
+        );
+        assert_eq!(
+            verify_signature(&m, &cfg, true).unwrap(),
+            SignatureStatus::Verified
+        );
+
+        // Tamper with the manifest after signing — verification must fail.
+        m.agent_id = "tampered".to_string();
+        assert_eq!(
+            verify_signature(&m, &cfg, true).unwrap(),
+            SignatureStatus::Mismatch
+        );
+    }
+}

--- a/autonoetic-gateway/src/lib.rs
+++ b/autonoetic-gateway/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod agent;
 pub mod artifact_store;
 pub mod bootstrap;
+pub mod capsule;
 pub mod causal_chain;
 pub mod config;
 pub mod constitution_digest;

--- a/autonoetic-gateway/tests/capsule_pipeline_integration.rs
+++ b/autonoetic-gateway/tests/capsule_pipeline_integration.rs
@@ -1,0 +1,458 @@
+//! Integration tests for the capsule export/import pipeline.
+
+use autonoetic_gateway::capsule::{export, import, ExportRequest, ImportRequest};
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent_revision::{
+    AgentAliasRecord, AgentRevisionRecord, AgentRevisionStatus,
+};
+use autonoetic_types::capsule::CapsuleMode;
+use autonoetic_types::config::GatewayConfig;
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    config: GatewayConfig,
+    store: Arc<GatewayStore>,
+    gateway_dir: std::path::PathBuf,
+}
+
+fn seed_revision_files(gateway_dir: &std::path::Path, agent_id: &str, revision_id: &str) {
+    let rev_dir = gateway_dir
+        .join("revisions")
+        .join("agents")
+        .join(agent_id)
+        .join(revision_id);
+    std::fs::create_dir_all(&rev_dir).unwrap();
+    std::fs::write(
+        rev_dir.join("SKILL.md"),
+        "# test agent\nSecret: OPENAI_API_KEY=sk-abc123\n",
+    )
+    .unwrap();
+    std::fs::write(rev_dir.join("runtime.lock"), "agents: []\n").unwrap();
+}
+
+fn make_fixture(agent_id: &str, revision_id: &str) -> Fixture {
+    let temp = tempdir().unwrap();
+    let agents_dir = temp.path().join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    seed_revision_files(&gateway_dir, agent_id, revision_id);
+
+    let rev = AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: agent_id.to_string(),
+        base_revision_id: None,
+        artifact_id: None,
+        content_digest: format!("sha256:{}", "x".repeat(64)),
+        runtime_lock_hash: format!("sha256:{}", "y".repeat(64)),
+        manifest_hash: format!("sha256:{}", "z".repeat(64)),
+        created_at: "2026-05-28T00:00:00Z".to_string(),
+        created_by_type: "user".to_string(),
+        created_by_id: "test".to_string(),
+        source_kind: "artifact".to_string(),
+        source_ref: Some("art_test".to_string()),
+        origin_node_id: "node-A".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Ready,
+        metadata_json: serde_json::Value::Null,
+        short_id: "abcd1234".to_string(),
+        signature: None,
+        signer_id: None,
+    };
+    store.insert_agent_revision(&rev).unwrap();
+    let alias = AgentAliasRecord {
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: revision_id.to_string(),
+        updated_at: "2026-05-28T00:00:00Z".to_string(),
+        updated_by_type: "user".to_string(),
+        updated_by_id: "test".to_string(),
+        reason: None,
+    };
+    store.upsert_agent_alias(&alias).unwrap();
+
+    let mut config = GatewayConfig {
+        agents_dir,
+        ..Default::default()
+    };
+    // Seed trusted signer for the gateway key so signed import verifies.
+    let key =
+        autonoetic_gateway::runtime::crypto::GatewayIdentityKey::load_or_generate(&gateway_dir)
+            .unwrap();
+    config.capsule.trusted_signers.insert(
+        format!("gateway:{}", key.fingerprint()),
+        B64.encode(key.public_key_bytes()),
+    );
+
+    Fixture {
+        _temp: temp,
+        config,
+        store,
+        gateway_dir,
+    }
+}
+
+#[test]
+fn export_then_import_creates_revision_with_capsule_import_source_kind() {
+    let f = make_fixture("demo.agent", "rev_sha256:cap-rt-001");
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("agent.capsule.tar.zst");
+
+    let outcome = export(
+        ExportRequest {
+            agent_id: "demo.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: None,
+            sign: Some(true),
+            output_path: Some(archive.clone()),
+        },
+        autonoetic_gateway::capsule::ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+    assert_eq!(outcome.mode, "thin");
+    assert!(outcome.signed);
+    assert!(outcome.size_bytes > 0);
+    assert!(outcome.capsule_path.exists());
+
+    // Import into a fresh gateway.
+    let f2 = {
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let gateway_dir = agents_dir.join(".gateway");
+        std::fs::create_dir_all(&gateway_dir).unwrap();
+        let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+        let mut config = GatewayConfig {
+            agents_dir,
+            ..Default::default()
+        };
+        config
+            .capsule
+            .trusted_signers
+            .extend(f.config.capsule.trusted_signers.clone());
+        Fixture {
+            _temp: temp,
+            config,
+            store,
+            gateway_dir,
+        }
+    };
+
+    let imp = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: true,
+            dry_run: false,
+            activate: true,
+            trust_domain_override: None,
+        },
+        autonoetic_gateway::capsule::ImportContext {
+            gateway_dir: &f2.gateway_dir,
+            gateway_config: &f2.config,
+            gateway_store: &f2.store,
+        },
+    )
+    .expect("import");
+    assert!(imp.created_revision);
+    assert_eq!(imp.agent_id, "demo.agent");
+    assert_eq!(imp.signature_status, "Verified");
+
+    // The new gateway should now have the revision with source_kind = capsule_import.
+    let rev = f2
+        .store
+        .get_agent_revision(&imp.revision_id)
+        .unwrap()
+        .expect("revision persisted");
+    assert_eq!(rev.source_kind, "capsule_import");
+    assert_eq!(rev.source_ref.as_deref(), Some(outcome.capsule_id.as_str()));
+
+    // Alias bound to the new revision (because --activate).
+    let alias = f2.store.get_agent_alias("demo.agent").unwrap().unwrap();
+    assert_eq!(alias.revision_id, imp.revision_id);
+
+    // The exported SKILL.md must NOT contain the raw secret value.
+    let rev_dir = f2
+        .gateway_dir
+        .join("revisions")
+        .join("agents")
+        .join("demo.agent")
+        .join(&imp.revision_id);
+    let skill = std::fs::read_to_string(rev_dir.join("SKILL.md")).unwrap();
+    assert!(
+        !skill.contains("sk-abc123"),
+        "scrubbing failed; SKILL.md still contains secret: {}",
+        skill
+    );
+}
+
+#[test]
+fn import_dry_run_does_not_persist_revision() {
+    let f = make_fixture("demo.agent", "rev_sha256:cap-dr-002");
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("agent.capsule.tar.zst");
+
+    let outcome = export(
+        ExportRequest {
+            agent_id: "demo.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: None,
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+        },
+        autonoetic_gateway::capsule::ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+    let _ = outcome;
+
+    let f2 = {
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let gateway_dir = agents_dir.join(".gateway");
+        std::fs::create_dir_all(&gateway_dir).unwrap();
+        let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+        let config = GatewayConfig {
+            agents_dir,
+            ..Default::default()
+        };
+        Fixture {
+            _temp: temp,
+            config,
+            store,
+            gateway_dir,
+        }
+    };
+
+    let imp = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: true,
+            activate: false,
+            trust_domain_override: None,
+        },
+        autonoetic_gateway::capsule::ImportContext {
+            gateway_dir: &f2.gateway_dir,
+            gateway_config: &f2.config,
+            gateway_store: &f2.store,
+        },
+    )
+    .expect("import");
+    assert!(imp.dry_run);
+    assert!(!imp.created_revision);
+    assert!(f2.store.get_agent_revision(&imp.revision_id).unwrap().is_none());
+}
+
+#[test]
+fn tampered_archive_fails_verify_signature() {
+    let f = make_fixture("demo.agent", "rev_sha256:cap-tamper-003");
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("agent.capsule.tar.zst");
+
+    export(
+        ExportRequest {
+            agent_id: "demo.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: None,
+            sign: Some(true),
+            output_path: Some(archive.clone()),
+        },
+        autonoetic_gateway::capsule::ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    // Tamper: rewrite the manifest inside the archive.
+    let work = tempdir().unwrap();
+    autonoetic_gateway::capsule::archive::unpack(&archive, work.path(), 1024 * 1024).unwrap();
+    let manifest_path = work.path().join("capsule.json");
+    let mut m: autonoetic_types::capsule::CapsuleManifest =
+        serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    m.agent_id = "evil.agent".to_string();
+    std::fs::write(&manifest_path, serde_json::to_vec_pretty(&m).unwrap()).unwrap();
+    autonoetic_gateway::capsule::archive::pack(work.path(), &archive).unwrap();
+
+    let f2 = {
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let gateway_dir = agents_dir.join(".gateway");
+        std::fs::create_dir_all(&gateway_dir).unwrap();
+        let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+        let mut config = GatewayConfig {
+            agents_dir,
+            ..Default::default()
+        };
+        config
+            .capsule
+            .trusted_signers
+            .extend(f.config.capsule.trusted_signers.clone());
+        Fixture {
+            _temp: temp,
+            config,
+            store,
+            gateway_dir,
+        }
+    };
+
+    let err = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: true,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+        },
+        autonoetic_gateway::capsule::ImportContext {
+            gateway_dir: &f2.gateway_dir,
+            gateway_config: &f2.config,
+            gateway_store: &f2.store,
+        },
+    )
+    .expect_err("tampered capsule must fail verify");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Mismatch") || msg.contains("signature"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn import_refuses_archive_exceeding_size_cap() {
+    let f = make_fixture("demo.agent", "rev_sha256:cap-size-004");
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("agent.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "demo.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: None,
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+        },
+        autonoetic_gateway::capsule::ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    let mut config = f.config.clone();
+    config.capsule.max_capsule_size_bytes = 16;
+    let err = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: true,
+            activate: false,
+            trust_domain_override: None,
+        },
+        autonoetic_gateway::capsule::ImportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect_err("oversize archive must be refused");
+    assert!(
+        err.to_string().contains("exceeds configured max"),
+        "{}",
+        err
+    );
+}
+
+#[test]
+fn second_import_is_dedup_noop_for_existing_revision() {
+    let f = make_fixture("demo.agent", "rev_sha256:cap-dedup-005");
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("agent.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "demo.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: None,
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+        },
+        autonoetic_gateway::capsule::ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    let f2 = {
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let gateway_dir = agents_dir.join(".gateway");
+        std::fs::create_dir_all(&gateway_dir).unwrap();
+        let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+        let config = GatewayConfig {
+            agents_dir,
+            ..Default::default()
+        };
+        Fixture {
+            _temp: temp,
+            config,
+            store,
+            gateway_dir,
+        }
+    };
+
+    let first = import(
+        ImportRequest {
+            archive_path: archive.clone(),
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+        },
+        autonoetic_gateway::capsule::ImportContext {
+            gateway_dir: &f2.gateway_dir,
+            gateway_config: &f2.config,
+            gateway_store: &f2.store,
+        },
+    )
+    .expect("first import");
+    assert!(first.created_revision);
+
+    let second = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+        },
+        autonoetic_gateway::capsule::ImportContext {
+            gateway_dir: &f2.gateway_dir,
+            gateway_config: &f2.config,
+            gateway_store: &f2.store,
+        },
+    )
+    .expect("second import");
+    assert!(!second.created_revision, "second import must not duplicate");
+    assert!(
+        second.dedup_savings_bytes >= first.dedup_savings_bytes,
+        "second import should report at least as much dedup as the first"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [Cognitive Capsule Standardization umbrella (#220)](https://github.com/mandubian/autonoetic/issues/220). **Stacked on #280 (Phase 1)** — once Phase 1 merges, this PR will retarget to `main`.

New module `autonoetic-gateway/src/capsule/` ships the thin-mode export/import pipeline end-to-end:

- **archive.rs** — `tar.zst` pack/unpack with a size cap + path-traversal guard (rejects absolute paths and `..` segments; the `./` archive root passes through).
- **verify.rs** — canonical JSON digest (signature field cleared during canonicalisation, mirroring `state_attestation`), Ed25519 sign/verify against `capsule.trusted_signers` from config, exhaustive `SignatureStatus` (`Verified` / `UntrustedSigner` / `Mismatch` / `Malformed` / `MissingRequired` / `Absent`).
- **export.rs** — resolves `AgentRevisionRecord` by `agent_id` or explicit `revision_id`, copies the revision dir into staging with per-file text redaction (`redact_embedded_secrets()`), builds `CapsuleManifest`, optionally signs with `GatewayIdentityKey`, packs tar.zst, enforces `max_capsule_size_bytes`, and emits a `capsule.export` causal event.
- **import.rs** — extracts archive into a tempdir, parses manifest, rejects unsupported `format_version`, verifies signature when requested, dedups blobs into `ContentStore`, materialises the revision dir, inserts `AgentRevisionRecord` with `source_kind = "capsule_import"` + `source_ref = capsule_id`, optionally rebinds the alias on `--activate`, and emits a `capsule.import` causal event. Supports `dry_run`.

`tempfile` is promoted from dev-deps to runtime deps (the import pipeline needs it for the extract tempdir).

## What ships in Phase 2 vs later

- ✅ Thin-mode export + import roundtrip
- ✅ Ed25519 signing + verification against the trusted-signer registry
- ✅ Text-file secret scrubbing on export
- ✅ Size cap + traversal guard on import
- ✅ `capsule.export` / `capsule.import` causal events
- ⏳ Hermetic-mode layer embedding (Phase 4)
- ⏳ Memory snapshot enumeration / merge with conflict policy (Phase 4)
- ⏳ Replay-mode checkpoint capture + resume (Phase 4)
- ⏳ Cross-gateway OFP transfer (Phase 4)
- ⏳ CLI surface + agent-initiated tools (Phase 3)

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p autonoetic-gateway --test capsule_pipeline_integration` — 5/5 pass
- [x] `cargo test -p autonoetic-gateway --lib capsule::archive capsule::export capsule::import capsule::verify` — 14/14 pass
- [x] `export → tamper → import` test confirms signature mismatch is detected
- [x] `archive size > max_capsule_size_bytes` is refused before extraction
- [x] Second import of the same archive is a no-op for the revision and reports non-decreasing dedup savings

Closes #223. Depends on #222 (Phase 1 / #280).

🤖 Generated with [Claude Code](https://claude.com/claude-code)