### PR TITLE
capsule: CLI + agent tools (Phase 3 of #220)

### DIFF
--- a/autonoetic-gateway/src/policy.rs
+++ b/autonoetic-gateway/src/policy.rs
@@ -806,6 +806,19 @@ impl PolicyEngine {
         PolicyDecision::deny("R-1.1")
     }
 
+    /// Gate `capsule.export` / `capsule.import` on the `CapsuleExport`
+    /// capability. The capability has no scope payload — granting it is
+    /// itself the trust boundary, mirroring `EmergencyStop` /
+    /// `SecurityRedTeam`.
+    pub fn can_use_capsule(&self) -> PolicyDecision {
+        for cap in &self.manifest.capabilities {
+            if matches!(cap, Capability::CapsuleExport) {
+                return PolicyDecision::allow("R-1.1");
+            }
+        }
+        PolicyDecision::deny("R-1.1")
+    }
+
     pub fn can_audit_reasoning(&self, target_agent_id: &str) -> PolicyDecision {
         for cap in &self.manifest.capabilities {
             if let Capability::ReasoningAudit { targets } = cap {

--- a/autonoetic-gateway/src/runtime/tools/capsule.rs
+++ b/autonoetic-gateway/src/runtime/tools/capsule.rs
@@ -1,0 +1,251 @@
+//! Agent-initiated capsule tools: `capsule.export` / `capsule.import`.
+//!
+//! Both gated by [`Capability::CapsuleExport`].
+
+use crate::capsule::{export, import, ExportContext, ExportRequest, ImportContext, ImportRequest};
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::tools::NativeTool;
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
+use autonoetic_types::capsule::CapsuleMode;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub fn register_tools(registry: &mut crate::runtime::tools::NativeToolRegistry) {
+    registry.register(Box::new(CapsuleExportTool));
+    registry.register(Box::new(CapsuleImportTool));
+}
+
+fn parse_mode(s: &str) -> anyhow::Result<CapsuleMode> {
+    match s.to_ascii_lowercase().as_str() {
+        "thin" => Ok(CapsuleMode::Thin),
+        "hermetic" => Ok(CapsuleMode::Hermetic),
+        "replay" => Ok(CapsuleMode::Replay),
+        "headless" => Ok(CapsuleMode::Headless),
+        other => anyhow::bail!(
+            "unknown capsule mode '{}' (expected: thin | hermetic | replay | headless)",
+            other
+        ),
+    }
+}
+
+// --- Export ---------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct CapsuleExportArgs {
+    agent_id: String,
+    #[serde(default = "default_mode_string")]
+    mode: String,
+    #[serde(default)]
+    revision: Option<String>,
+    #[serde(default)]
+    include_memory: Option<bool>,
+    #[serde(default)]
+    sign: Option<bool>,
+    #[serde(default)]
+    output: Option<PathBuf>,
+}
+
+fn default_mode_string() -> String {
+    "thin".to_string()
+}
+
+pub struct CapsuleExportTool;
+
+impl NativeTool for CapsuleExportTool {
+    fn name(&self) -> &'static str {
+        "capsule.export"
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        manifest
+            .capabilities
+            .iter()
+            .any(|cap| matches!(cap, Capability::CapsuleExport))
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Export an agent revision as a Cognitive Capsule archive. \
+                          Requires the CapsuleExport capability."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "agent_id": { "type": "string" },
+                    "mode": { "type": "string", "enum": ["thin", "hermetic", "replay", "headless"] },
+                    "revision": { "type": ["string", "null"] },
+                    "include_memory": { "type": ["boolean", "null"] },
+                    "sign": { "type": ["boolean", "null"] },
+                    "output": { "type": ["string", "null"] }
+                },
+                "required": ["agent_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        policy: &PolicyEngine,
+        _agent_dir: &Path,
+        gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&autonoetic_types::config::GatewayConfig>,
+        gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        let decision = policy.can_use_capsule();
+        if !decision.is_allowed() {
+            return Err(anyhow::anyhow!(
+                "CapsuleExport capability is required to invoke '{}'",
+                self.name()
+            ));
+        }
+        let args: CapsuleExportArgs = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+        let config = config.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} requires a gateway config in scope",
+                self.name()
+            )
+        })?;
+        let store = gateway_store.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} requires the gateway store in scope",
+                self.name()
+            )
+        })?;
+        let gateway_dir = gateway_dir.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} requires the gateway_dir in scope",
+                self.name()
+            )
+        })?;
+
+        let mode = parse_mode(&args.mode)?;
+        let outcome = export(
+            ExportRequest {
+                agent_id: args.agent_id,
+                revision_id: args.revision,
+                mode,
+                include_memory: args.include_memory,
+                sign: args.sign,
+                output_path: args.output,
+            },
+            ExportContext {
+                gateway_dir,
+                gateway_config: config,
+                gateway_store: &store,
+            },
+        )?;
+        Ok(serde_json::to_string(&outcome)?)
+    }
+}
+
+// --- Import ---------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct CapsuleImportArgs {
+    archive: PathBuf,
+    #[serde(default)]
+    verify_signature: bool,
+    #[serde(default)]
+    activate: bool,
+    #[serde(default)]
+    dry_run: bool,
+    #[serde(default)]
+    trust_domain: Option<String>,
+}
+
+pub struct CapsuleImportTool;
+
+impl NativeTool for CapsuleImportTool {
+    fn name(&self) -> &'static str {
+        "capsule.import"
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        manifest
+            .capabilities
+            .iter()
+            .any(|cap| matches!(cap, Capability::CapsuleExport))
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Import a Cognitive Capsule archive on this gateway. \
+                          Requires the CapsuleExport capability."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "archive": { "type": "string" },
+                    "verify_signature": { "type": "boolean" },
+                    "activate": { "type": "boolean" },
+                    "dry_run": { "type": "boolean" },
+                    "trust_domain": { "type": ["string", "null"] }
+                },
+                "required": ["archive"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        policy: &PolicyEngine,
+        _agent_dir: &Path,
+        gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&autonoetic_types::config::GatewayConfig>,
+        gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        let decision = policy.can_use_capsule();
+        if !decision.is_allowed() {
+            return Err(anyhow::anyhow!(
+                "CapsuleExport capability is required to invoke '{}'",
+                self.name()
+            ));
+        }
+        let args: CapsuleImportArgs = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+        let config = config.ok_or_else(|| {
+            anyhow::anyhow!("{} requires a gateway config in scope", self.name())
+        })?;
+        let store = gateway_store.ok_or_else(|| {
+            anyhow::anyhow!("{} requires the gateway store in scope", self.name())
+        })?;
+        let gateway_dir = gateway_dir.ok_or_else(|| {
+            anyhow::anyhow!("{} requires the gateway_dir in scope", self.name())
+        })?;
+
+        let outcome = import(
+            ImportRequest {
+                archive_path: args.archive,
+                verify_signature: args.verify_signature,
+                activate: args.activate,
+                dry_run: args.dry_run,
+                trust_domain_override: args.trust_domain,
+            },
+            ImportContext {
+                gateway_dir,
+                gateway_config: config,
+                gateway_store: &store,
+            },
+        )?;
+        Ok(serde_json::to_string(&outcome)?)
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -957,6 +957,7 @@ pub mod approval;
 pub mod artifact;
 pub mod artifact_exec;
 pub mod artifact_prepare;
+pub mod capsule;
 pub mod constitution;
 pub mod content;
 pub mod credential;
@@ -1023,6 +1024,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::scheduler::register_tools(&mut registry);
     crate::runtime::tools::skill::register_tools(&mut registry);
     crate::runtime::tools::admin_proposal::register_tools(&mut registry);
+    crate::runtime::tools::capsule::register_tools(&mut registry);
     crate::runtime::tools::constitution::register_tools(&mut registry);
     crate::runtime::tools::security_redteam::register_tools(&mut registry);
     crate::runtime::tools::sentinel::register_tools(&mut registry);

--- a/autonoetic-gateway/tests/capsule_tools_integration.rs
+++ b/autonoetic-gateway/tests/capsule_tools_integration.rs
@@ -1,0 +1,78 @@
+//! Integration tests for the agent-initiated `capsule.export` /
+//! `capsule.import` tools. Verifies the `CapsuleExport` capability gate.
+
+use autonoetic_gateway::runtime::tools::capsule::{CapsuleExportTool, CapsuleImportTool};
+use autonoetic_gateway::runtime::tools::NativeTool;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+
+fn manifest_with(caps: Vec<Capability>) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "test".to_string(),
+            name: "test".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: caps,
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+#[test]
+fn tool_unavailable_without_capability() {
+    let no_cap = manifest_with(vec![Capability::CodeExecution {
+        patterns: vec!["*".to_string()],
+        commands: vec![],
+    }]);
+    assert!(!CapsuleExportTool.is_available(&no_cap));
+    assert!(!CapsuleImportTool.is_available(&no_cap));
+}
+
+#[test]
+fn tool_available_with_capsule_export_capability() {
+    let with_cap = manifest_with(vec![Capability::CapsuleExport]);
+    assert!(CapsuleExportTool.is_available(&with_cap));
+    assert!(CapsuleImportTool.is_available(&with_cap));
+}
+
+#[test]
+fn tool_definitions_advertise_required_fields() {
+    let exp = CapsuleExportTool.definition();
+    assert_eq!(exp.name, "capsule.export");
+    let required = exp.input_schema["required"].as_array().unwrap();
+    assert!(
+        required.iter().any(|v| v == "agent_id"),
+        "agent_id must be required"
+    );
+
+    let imp = CapsuleImportTool.definition();
+    assert_eq!(imp.name, "capsule.import");
+    let required = imp.input_schema["required"].as_array().unwrap();
+    assert!(
+        required.iter().any(|v| v == "archive"),
+        "archive must be required"
+    );
+}

--- a/autonoetic/Cargo.toml
+++ b/autonoetic/Cargo.toml
@@ -29,9 +29,9 @@ unicode-width = "0.2"
 arboard = "3.4"
 rpassword = "7.3"
 chrono = "0.4"
+tempfile = "3.26.0"
 
 [dev-dependencies]
-tempfile = "3.26.0"
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 secrecy = "0.10.3"
 serial_test = "3"

--- a/autonoetic/src/cli/capsule.rs
+++ b/autonoetic/src/cli/capsule.rs
@@ -29,13 +29,14 @@ pub fn parse_mode(s: &str) -> anyhow::Result<CapsuleMode> {
 }
 
 /// `autonoetic capsule export`.
+#[allow(clippy::too_many_arguments)]
 pub fn handle_export(
     config_path: &Path,
     agent_id: &str,
     mode: &str,
     revision: Option<&str>,
-    include_memory: bool,
-    sign: bool,
+    include_memory: Option<bool>,
+    sign: Option<bool>,
     output: Option<&Path>,
     json: bool,
 ) -> anyhow::Result<()> {
@@ -47,8 +48,12 @@ pub fn handle_export(
         agent_id: agent_id.to_string(),
         revision_id: revision.map(|s| s.to_string()),
         mode: parse_mode(mode)?,
-        include_memory: Some(include_memory),
-        sign: Some(sign),
+        // `None` lets the export pipeline defer to
+        // `config.capsule.include_memory_by_default` / `auto_sign`. The
+        // CLI only forces a value when the operator explicitly passes
+        // `--include-memory` / `--sign` (or `=false`).
+        include_memory,
+        sign,
         output_path: output.map(|p| p.to_path_buf()),
     };
     let outcome = capsule::export(
@@ -175,6 +180,17 @@ pub fn handle_verify(config_path: &Path, archive: &Path, json: bool) -> anyhow::
                 println!("    - {}", r);
             }
         }
+    }
+    // Exit non-zero on any failed-trust outcome. A signed but
+    // tampered/unverifiable capsule must not fool scripts that drive
+    // verification from CI.
+    if matches!(
+        status,
+        capsule::verify::SignatureStatus::Mismatch
+            | capsule::verify::SignatureStatus::UntrustedSigner
+            | capsule::verify::SignatureStatus::Malformed
+    ) {
+        anyhow::bail!("capsule verification failed: {:?}", status);
     }
     Ok(())
 }

--- a/autonoetic/src/cli/capsule.rs
+++ b/autonoetic/src/cli/capsule.rs
@@ -1,0 +1,289 @@
+//! `autonoetic capsule` CLI subcommands — export/import/verify/inspect.
+//!
+//! These wrap the gateway-side pipeline in `autonoetic_gateway::capsule`.
+//! Each subcommand opens the gateway store from `config.yaml`, runs the
+//! requested operation, and prints either a human-readable summary or
+//! JSON when `--json` is set.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use autonoetic_gateway::capsule::{self, ExportRequest, ImportRequest};
+use autonoetic_gateway::config::load_config;
+use autonoetic_gateway::execution::gateway_root_dir;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::capsule::{CapsuleManifest, CapsuleMode};
+
+/// Parse a `--mode` value into [`CapsuleMode`].
+pub fn parse_mode(s: &str) -> anyhow::Result<CapsuleMode> {
+    match s.to_ascii_lowercase().as_str() {
+        "thin" => Ok(CapsuleMode::Thin),
+        "hermetic" => Ok(CapsuleMode::Hermetic),
+        "replay" => Ok(CapsuleMode::Replay),
+        "headless" => Ok(CapsuleMode::Headless),
+        other => anyhow::bail!(
+            "unknown capsule mode '{}' (expected one of: thin, hermetic, replay, headless)",
+            other
+        ),
+    }
+}
+
+/// `autonoetic capsule export`.
+pub fn handle_export(
+    config_path: &Path,
+    agent_id: &str,
+    mode: &str,
+    revision: Option<&str>,
+    include_memory: bool,
+    sign: bool,
+    output: Option<&Path>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let config = load_config(config_path)?;
+    let gateway_dir = gateway_root_dir(&config);
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let req = ExportRequest {
+        agent_id: agent_id.to_string(),
+        revision_id: revision.map(|s| s.to_string()),
+        mode: parse_mode(mode)?,
+        include_memory: Some(include_memory),
+        sign: Some(sign),
+        output_path: output.map(|p| p.to_path_buf()),
+    };
+    let outcome = capsule::export(
+        req,
+        capsule::ExportContext {
+            gateway_dir: &gateway_dir,
+            gateway_config: &config,
+            gateway_store: &store,
+        },
+    )?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        println!("Capsule exported");
+        println!("  capsule_id:    {}", outcome.capsule_id);
+        println!("  revision_id:   {}", outcome.revision_id);
+        println!("  mode:          {}", outcome.mode);
+        println!("  signed:        {}", outcome.signed);
+        println!("  size_bytes:    {}", outcome.size_bytes);
+        println!("  output:        {}", outcome.capsule_path.display());
+        println!("  digest:        sha256:{}", outcome.manifest_digest);
+        if !outcome.redactions.is_empty() {
+            println!("  redacted ({}):", outcome.redactions.len());
+            for r in &outcome.redactions {
+                println!("    - {}", r);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `autonoetic capsule import`.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_import(
+    config_path: &Path,
+    archive: &Path,
+    verify_signature: bool,
+    activate: bool,
+    dry_run: bool,
+    trust_domain: Option<&str>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let config = load_config(config_path)?;
+    let gateway_dir = gateway_root_dir(&config);
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let req = ImportRequest {
+        archive_path: archive.to_path_buf(),
+        verify_signature,
+        activate,
+        dry_run,
+        trust_domain_override: trust_domain.map(|s| s.to_string()),
+    };
+    let outcome = capsule::import(
+        req,
+        capsule::ImportContext {
+            gateway_dir: &gateway_dir,
+            gateway_config: &config,
+            gateway_store: &store,
+        },
+    )?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        println!(
+            "Capsule {}",
+            if outcome.dry_run {
+                "validated (dry-run)"
+            } else if outcome.created_revision {
+                "imported"
+            } else {
+                "imported (revision already present)"
+            }
+        );
+        println!("  capsule_id:        {}", outcome.capsule_id);
+        println!("  agent_id:          {}", outcome.agent_id);
+        println!("  revision_id:       {}", outcome.revision_id);
+        println!("  revision_short_id: {}", outcome.revision_short_id);
+        println!("  signature_status:  {}", outcome.signature_status);
+        println!(
+            "  dedup_savings:     {} bytes",
+            outcome.dedup_savings_bytes
+        );
+        println!("  created_revision:  {}", outcome.created_revision);
+    }
+    Ok(())
+}
+
+/// `autonoetic capsule verify`.
+pub fn handle_verify(config_path: &Path, archive: &Path, json: bool) -> anyhow::Result<()> {
+    let config = load_config(config_path)?;
+    let manifest = read_manifest(archive, config.capsule.max_capsule_size_bytes)?;
+    let status = capsule::verify::verify_signature(&manifest, &config.capsule, false)?;
+    let digest = capsule::verify::manifest_digest(&manifest)?;
+    if json {
+        let payload = serde_json::json!({
+            "capsule_id": manifest.capsule_id,
+            "format_version": manifest.format_version,
+            "agent_id": manifest.agent_id,
+            "revision_id": manifest.revision_id,
+            "mode": manifest.mode,
+            "manifest_digest": format!("sha256:{}", digest),
+            "signature_status": format!("{:?}", status),
+            "signer_id": manifest.signature.as_ref().map(|s| s.signer_id.clone()),
+            "redactions": manifest.redactions,
+            "provenance": manifest.provenance,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!("Capsule verification report");
+        println!("  capsule_id:        {}", manifest.capsule_id);
+        println!("  format_version:    {}", manifest.format_version);
+        println!("  agent_id:          {}", manifest.agent_id);
+        println!("  revision_id:       {}", manifest.revision_id);
+        println!("  mode:              {:?}", manifest.mode);
+        println!("  manifest_digest:   sha256:{}", digest);
+        println!("  signature_status:  {:?}", status);
+        if let Some(sig) = &manifest.signature {
+            println!("  signer_id:         {}", sig.signer_id);
+        }
+        if !manifest.redactions.is_empty() {
+            println!("  redactions ({}):", manifest.redactions.len());
+            for r in &manifest.redactions {
+                println!("    - {}", r);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `autonoetic capsule inspect`.
+pub fn handle_inspect(config_path: &Path, archive: &Path, json: bool) -> anyhow::Result<()> {
+    let config = load_config(config_path)?;
+    let manifest = read_manifest(archive, config.capsule.max_capsule_size_bytes)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&manifest)?);
+    } else {
+        println!("Capsule manifest summary");
+        println!("  capsule_id:        {}", manifest.capsule_id);
+        println!("  format_version:    {}", manifest.format_version);
+        println!("  mode:              {:?}", manifest.mode);
+        println!("  agent_id:          {}", manifest.agent_id);
+        println!(
+            "  revision_id:       {}  ({})",
+            manifest.revision_id, manifest.revision_short_id
+        );
+        println!(
+            "  content_digest:    {}",
+            manifest.content_digest
+        );
+        println!("  created_at:        {}", manifest.created_at);
+        println!("  entrypoint:        {}", manifest.entrypoint);
+        println!("  runtime_lock:      {}", manifest.runtime_lock);
+        println!(
+            "  included artifacts:{}",
+            if manifest.included_artifacts.is_empty() {
+                " (none)".to_string()
+            } else {
+                format!(" {}", manifest.included_artifacts.len())
+            }
+        );
+        println!(
+            "  included layers:   {}",
+            if manifest.included_layers.is_empty() {
+                "(none)".to_string()
+            } else {
+                manifest.included_layers.len().to_string()
+            }
+        );
+        println!(
+            "  included skills:   {}",
+            if manifest.included_skills.is_empty() {
+                "(none)".to_string()
+            } else {
+                manifest.included_skills.join(", ")
+            }
+        );
+        if let Some(mem) = &manifest.memory_snapshot {
+            println!(
+                "  memory snapshot:   {} entries, redacted={}",
+                mem.entry_count, mem.redacted
+            );
+        }
+        if let Some(ckpt) = &manifest.checkpoint_handle {
+            println!("  checkpoint:        {}", ckpt);
+        }
+        println!(
+            "  signature:         {}",
+            manifest
+                .signature
+                .as_ref()
+                .map(|s| format!("{} by {}", s.algorithm, s.signer_id))
+                .unwrap_or_else(|| "none".to_string())
+        );
+        println!(
+            "  origin_node:       {} (gateway {})",
+            manifest.provenance.origin_node_id, manifest.provenance.gateway_version
+        );
+        println!("  trust_domain:      {}", manifest.provenance.trust_domain);
+        if let Some(p) = &manifest.provenance.parent_capsule_id {
+            println!("  parent_capsule:    {}", p);
+        }
+    }
+    Ok(())
+}
+
+fn read_manifest(archive: &Path, max_extract_bytes: u64) -> anyhow::Result<CapsuleManifest> {
+    let tmp = tempfile::tempdir()?;
+    capsule::archive::unpack(archive, tmp.path(), max_extract_bytes)?;
+    let bytes = capsule::archive::read_entry(tmp.path(), "capsule.json")?;
+    let manifest: CapsuleManifest = serde_json::from_slice(&bytes)?;
+    Ok(manifest)
+}
+
+#[allow(dead_code)]
+pub(crate) fn _ensure_archive_path(p: Option<&Path>, agent_id: &str) -> PathBuf {
+    p.map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from(format!("{}.capsule.tar.zst", agent_id)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mode_accepts_all_canonical_strings() {
+        assert!(matches!(parse_mode("thin").unwrap(), CapsuleMode::Thin));
+        assert!(matches!(parse_mode("Hermetic").unwrap(), CapsuleMode::Hermetic));
+        assert!(matches!(parse_mode("REPLAY").unwrap(), CapsuleMode::Replay));
+        assert!(matches!(parse_mode("headless").unwrap(), CapsuleMode::Headless));
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown() {
+        let err = parse_mode("rocket").expect_err("must reject");
+        assert!(err.to_string().contains("unknown capsule mode"));
+    }
+}

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -175,6 +175,78 @@ pub enum Commands {
     Session(SessionArgs),
     /// Run the self-improvement loop (P3): diagnose, propose, validate, deploy
     Improve(crate::cli::improve::ImproveArgs),
+    /// Export, import, verify, or inspect Cognitive Capsules
+    Capsule(CapsuleArgs),
+}
+
+#[derive(Args)]
+pub struct CapsuleArgs {
+    #[command(subcommand)]
+    pub command: CapsuleCommands,
+}
+
+#[derive(Subcommand)]
+pub enum CapsuleCommands {
+    /// Export an agent revision as a Cognitive Capsule archive.
+    Export {
+        /// Agent ID to export.
+        agent_id: String,
+        /// Capsule mode: thin | hermetic | replay | headless.
+        #[arg(long, default_value = "thin")]
+        mode: String,
+        /// Pin a specific revision (defaults to the current alias target).
+        #[arg(long)]
+        revision: Option<String>,
+        /// Include a redacted memory snapshot.
+        #[arg(long)]
+        include_memory: bool,
+        /// Sign with the gateway key (overrides config.capsule.auto_sign).
+        #[arg(long)]
+        sign: bool,
+        /// Output archive path (default: <agent_id>.capsule.tar.zst).
+        #[arg(long)]
+        output: Option<std::path::PathBuf>,
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Import a Cognitive Capsule archive on this gateway.
+    Import {
+        /// Path to the .capsule.tar.zst archive.
+        archive: std::path::PathBuf,
+        /// Require + verify a signature against capsule.trusted_signers.
+        #[arg(long)]
+        verify_signature: bool,
+        /// Bind the imported revision to its agent alias.
+        #[arg(long)]
+        activate: bool,
+        /// Validate only; do not persist any revision or memory.
+        #[arg(long)]
+        dry_run: bool,
+        /// Override trust domain stamped on the imported revision
+        /// (local | partner | foreign).
+        #[arg(long)]
+        trust_domain: Option<String>,
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Validate the manifest + signature of a capsule archive without importing.
+    Verify {
+        /// Path to the .capsule.tar.zst archive.
+        archive: std::path::PathBuf,
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print a summary of the capsule manifest.
+    Inspect {
+        /// Path to the .capsule.tar.zst archive.
+        archive: std::path::PathBuf,
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Arguments for the `session` subcommand group.

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -197,12 +197,16 @@ pub enum CapsuleCommands {
         /// Pin a specific revision (defaults to the current alias target).
         #[arg(long)]
         revision: Option<String>,
-        /// Include a redacted memory snapshot.
-        #[arg(long)]
-        include_memory: bool,
-        /// Sign with the gateway key (overrides config.capsule.auto_sign).
-        #[arg(long)]
-        sign: bool,
+        /// Include a redacted memory snapshot. When omitted, the
+        /// gateway falls back to `config.capsule.include_memory_by_default`.
+        /// Use `--include-memory=false` to force it off regardless of config.
+        #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+        include_memory: Option<bool>,
+        /// Sign with the gateway key. When omitted, the gateway falls
+        /// back to `config.capsule.auto_sign`. Use `--sign=false` to
+        /// force unsigned regardless of config.
+        #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+        sign: Option<bool>,
         /// Output archive path (default: <agent_id>.capsule.tar.zst).
         #[arg(long)]
         output: Option<std::path::PathBuf>,
@@ -223,9 +227,8 @@ pub enum CapsuleCommands {
         /// Validate only; do not persist any revision or memory.
         #[arg(long)]
         dry_run: bool,
-        /// Override trust domain stamped on the imported revision
-        /// (local | partner | foreign).
-        #[arg(long)]
+        /// Override trust domain stamped on the imported revision.
+        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(["local", "partner", "foreign"]))]
         trust_domain: Option<String>,
         /// Emit machine-readable JSON output.
         #[arg(long)]

--- a/autonoetic/src/cli/mod.rs
+++ b/autonoetic/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod capsule;
 pub mod chat;
 pub mod common;
 pub mod eval;

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -639,6 +639,52 @@ async fn main() -> anyhow::Result<()> {
         Commands::Improve(args) => {
             cli::improve::handle_improve(&config_path, &args.command).await?;
         }
+        Commands::Capsule(args) => match &args.command {
+            cli::common::CapsuleCommands::Export {
+                agent_id,
+                mode,
+                revision,
+                include_memory,
+                sign,
+                output,
+                json,
+            } => {
+                cli::capsule::handle_export(
+                    &config_path,
+                    agent_id,
+                    mode,
+                    revision.as_deref(),
+                    *include_memory,
+                    *sign,
+                    output.as_deref(),
+                    *json,
+                )?;
+            }
+            cli::common::CapsuleCommands::Import {
+                archive,
+                verify_signature,
+                activate,
+                dry_run,
+                trust_domain,
+                json,
+            } => {
+                cli::capsule::handle_import(
+                    &config_path,
+                    archive,
+                    *verify_signature,
+                    *activate,
+                    *dry_run,
+                    trust_domain.as_deref(),
+                    *json,
+                )?;
+            }
+            cli::common::CapsuleCommands::Verify { archive, json } => {
+                cli::capsule::handle_verify(&config_path, archive, *json)?;
+            }
+            cli::common::CapsuleCommands::Inspect { archive, json } => {
+                cli::capsule::handle_inspect(&config_path, archive, *json)?;
+            }
+        },
     }
 
     Ok(())

--- a/autonoetic/tests/capsule_cli_e2e.rs
+++ b/autonoetic/tests/capsule_cli_e2e.rs
@@ -95,7 +95,9 @@ fn cli_export_inspect_verify_dryrun_import_roundtrip() {
 
     let archive = tmp.join("demo.capsule.tar.zst");
 
-    // Export.
+    // Export — unsigned so verify on a fresh gateway (no
+    // `trusted_signers` configured) returns `Absent` and exits 0.
+    // Signed-capsule verification is covered separately below.
     let out = run_cli(
         config_path.to_str().unwrap(),
         &[
@@ -104,7 +106,7 @@ fn cli_export_inspect_verify_dryrun_import_roundtrip() {
             "demo.agent",
             "--mode",
             "thin",
-            "--sign",
+            "--sign=false",
             "--output",
             archive.to_str().unwrap(),
         ],
@@ -128,7 +130,7 @@ fn cli_export_inspect_verify_dryrun_import_roundtrip() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("demo.agent"), "{}", stdout);
 
-    // Verify (no signature requirement; should still succeed with Absent/Verified).
+    // Verify on an unsigned capsule: returns `Absent`, exits 0.
     let out = run_cli(
         config_path.to_str().unwrap(),
         &["capsule", "verify", archive.to_str().unwrap()],
@@ -160,6 +162,61 @@ fn cli_export_inspect_verify_dryrun_import_roundtrip() {
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("dry-run"), "{}", stdout);
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    let _ = std::fs::remove_dir_all(&other);
+}
+
+#[test]
+fn cli_verify_exits_nonzero_for_untrusted_signed_capsule() {
+    // Export a signed capsule on one gateway, then run `verify`
+    // against a different gateway whose `trusted_signers` is empty.
+    // The signer is unknown to the receiver and the CLI must exit
+    // non-zero so CI/scripts treat verification as failed.
+    let tmp = tmp_dir();
+    let agents_dir = tmp.join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let config_path = tmp.join("config.yaml");
+    let yaml = format!("agents_dir: \"{}\"\n", agents_dir.display());
+    std::fs::write(&config_path, yaml).unwrap();
+    seed_revision(&gateway_dir, "demo.agent", "rev_sha256:cap-cli-verify-002");
+    let archive = tmp.join("demo.signed.capsule.tar.zst");
+
+    let out = run_cli(
+        config_path.to_str().unwrap(),
+        &[
+            "capsule",
+            "export",
+            "demo.agent",
+            "--mode",
+            "thin",
+            "--sign",
+            "--output",
+            archive.to_str().unwrap(),
+        ],
+    );
+    assert!(out.status.success(), "export failed");
+
+    // Fresh receiver — no trusted_signers configured.
+    let other = tmp_dir();
+    let other_agents = other.join("agents");
+    let other_gateway = other_agents.join(".gateway");
+    std::fs::create_dir_all(&other_gateway).unwrap();
+    let other_cfg = other.join("config.yaml");
+    let yaml = format!("agents_dir: \"{}\"\n", other_agents.display());
+    std::fs::write(&other_cfg, yaml).unwrap();
+
+    let out = run_cli(
+        other_cfg.to_str().unwrap(),
+        &["capsule", "verify", archive.to_str().unwrap()],
+    );
+    assert!(
+        !out.status.success(),
+        "verify should exit non-zero on UntrustedSigner: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     let _ = std::fs::remove_dir_all(&tmp);
     let _ = std::fs::remove_dir_all(&other);

--- a/autonoetic/tests/capsule_cli_e2e.rs
+++ b/autonoetic/tests/capsule_cli_e2e.rs
@@ -1,0 +1,166 @@
+//! End-to-end CLI test for the `autonoetic capsule` subcommands.
+//!
+//! Seeds a revision via the gateway library, then drives the CLI binary
+//! to export → inspect → verify → import (`--dry-run`).
+
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent_revision::{
+    AgentAliasRecord, AgentRevisionRecord, AgentRevisionStatus,
+};
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::sync::Arc;
+
+fn run_cli(config_path: &str, extra: &[&str]) -> Output {
+    let bin = env!("CARGO_BIN_EXE_autonoetic");
+    let mut cmd = Command::new(bin);
+    cmd.args(["--config", config_path]);
+    cmd.args(extra);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.spawn()
+        .expect("spawn autonoetic")
+        .wait_with_output()
+        .expect("wait")
+}
+
+fn tmp_dir() -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "autonoetic-capsule-e2e-{}",
+        uuid::Uuid::new_v4().to_string()[..8].to_string()
+    ));
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn seed_revision(gateway_dir: &std::path::Path, agent_id: &str, revision_id: &str) {
+    let rev_dir = gateway_dir
+        .join("revisions")
+        .join("agents")
+        .join(agent_id)
+        .join(revision_id);
+    std::fs::create_dir_all(&rev_dir).unwrap();
+    std::fs::write(rev_dir.join("SKILL.md"), "# test agent\n").unwrap();
+    std::fs::write(rev_dir.join("runtime.lock"), "agents: []\n").unwrap();
+
+    let store = Arc::new(GatewayStore::open(gateway_dir).unwrap());
+    let rev = AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: agent_id.to_string(),
+        base_revision_id: None,
+        artifact_id: None,
+        content_digest: format!("sha256:{}", "a".repeat(64)),
+        runtime_lock_hash: format!("sha256:{}", "b".repeat(64)),
+        manifest_hash: format!("sha256:{}", "c".repeat(64)),
+        created_at: "2026-05-28T00:00:00Z".to_string(),
+        created_by_type: "user".to_string(),
+        created_by_id: "test".to_string(),
+        source_kind: "artifact".to_string(),
+        source_ref: None,
+        origin_node_id: "node-A".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Ready,
+        metadata_json: serde_json::Value::Null,
+        short_id: "abcd1234".to_string(),
+        signature: None,
+        signer_id: None,
+    };
+    store.insert_agent_revision(&rev).unwrap();
+    let alias = AgentAliasRecord {
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: revision_id.to_string(),
+        updated_at: "2026-05-28T00:00:00Z".to_string(),
+        updated_by_type: "user".to_string(),
+        updated_by_id: "test".to_string(),
+        reason: None,
+    };
+    store.upsert_agent_alias(&alias).unwrap();
+}
+
+#[test]
+fn cli_export_inspect_verify_dryrun_import_roundtrip() {
+    let tmp = tmp_dir();
+    let agents_dir = tmp.join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let config_path = tmp.join("config.yaml");
+    let yaml = format!(
+        "agents_dir: \"{}\"\nllm_presets:\n  default:\n    provider: openai\n    model: gpt-4o\nllm_preset_mapping:\n  default: default\n",
+        agents_dir.display()
+    );
+    std::fs::write(&config_path, yaml).unwrap();
+
+    seed_revision(&gateway_dir, "demo.agent", "rev_sha256:cap-cli-001");
+
+    let archive = tmp.join("demo.capsule.tar.zst");
+
+    // Export.
+    let out = run_cli(
+        config_path.to_str().unwrap(),
+        &[
+            "capsule",
+            "export",
+            "demo.agent",
+            "--mode",
+            "thin",
+            "--sign",
+            "--output",
+            archive.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "export failed: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Capsule exported"), "{}", stdout);
+    assert!(archive.exists(), "archive missing at {}", archive.display());
+
+    // Inspect.
+    let out = run_cli(
+        config_path.to_str().unwrap(),
+        &["capsule", "inspect", archive.to_str().unwrap()],
+    );
+    assert!(out.status.success(), "inspect failed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("demo.agent"), "{}", stdout);
+
+    // Verify (no signature requirement; should still succeed with Absent/Verified).
+    let out = run_cli(
+        config_path.to_str().unwrap(),
+        &["capsule", "verify", archive.to_str().unwrap()],
+    );
+    assert!(out.status.success(), "verify failed");
+
+    // Import --dry-run on a fresh gateway dir.
+    let other = tmp_dir();
+    let other_agents = other.join("agents");
+    let other_gateway = other_agents.join(".gateway");
+    std::fs::create_dir_all(&other_gateway).unwrap();
+    let other_cfg = other.join("config.yaml");
+    let yaml = format!("agents_dir: \"{}\"\n", other_agents.display());
+    std::fs::write(&other_cfg, yaml).unwrap();
+    let out = run_cli(
+        other_cfg.to_str().unwrap(),
+        &[
+            "capsule",
+            "import",
+            archive.to_str().unwrap(),
+            "--dry-run",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "import dry-run failed: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("dry-run"), "{}", stdout);
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    let _ = std::fs::remove_dir_all(&other);
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -511,8 +511,10 @@ Package an agent revision into a `.capsule.tar.zst` archive.
 autonoetic capsule export <agent_id> \
   [--mode thin|hermetic|replay|headless]   # default: thin
   [--revision <rev_id>]                    # default: current alias target
-  [--include-memory]                       # include redacted memory snapshot
-  [--sign]                                 # sign with the gateway key
+  [--include-memory[=true|false]]          # include redacted memory snapshot;
+                                           # omit to defer to config.capsule.include_memory_by_default
+  [--sign[=true|false]]                    # sign with the gateway key;
+                                           # omit to defer to config.capsule.auto_sign
   [--output <path>]                        # default: <agent_id>.capsule.tar.zst
   [--json]
 ```
@@ -526,13 +528,13 @@ autonoetic capsule import <path> \
   [--verify-signature]                     # require + verify a trusted signature
   [--activate]                             # bind the alias to the imported revision
   [--dry-run]                              # validate only
-  [--trust-domain local|partner|foreign]
+  [--trust-domain local|partner|foreign]   # constrained set; clap rejects other values
   [--json]
 ```
 
 ### `autonoetic capsule verify`
 
-Validate the manifest schema, the canonical digest, and the signature (when present) against the configured `capsule.trusted_signers`.
+Validate the manifest schema, the canonical digest, and the signature (when present) against the configured `capsule.trusted_signers`. Exits **non-zero** when the signature is `Mismatch`, `UntrustedSigner`, or `Malformed`. Unsigned capsules (`Absent`) pass.
 
 ```bash
 autonoetic capsule verify <path> [--json]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -497,6 +497,57 @@ autonoetic trace history <session_id> [--json]
 
 ---
 
+## Capsule Commands
+
+Export, import, verify, and inspect Cognitive Capsules — portable, signed, revision-pinned agent snapshots. See [`docs/design/cognitive-capsule-standardization.md`](design/cognitive-capsule-standardization.md).
+
+Agent-initiated callers can use the equivalent `capsule.export` / `capsule.import` tools, gated by the `CapsuleExport` capability.
+
+### `autonoetic capsule export`
+
+Package an agent revision into a `.capsule.tar.zst` archive.
+
+```bash
+autonoetic capsule export <agent_id> \
+  [--mode thin|hermetic|replay|headless]   # default: thin
+  [--revision <rev_id>]                    # default: current alias target
+  [--include-memory]                       # include redacted memory snapshot
+  [--sign]                                 # sign with the gateway key
+  [--output <path>]                        # default: <agent_id>.capsule.tar.zst
+  [--json]
+```
+
+### `autonoetic capsule import`
+
+Import a capsule onto this gateway. Use `--dry-run` to validate without persisting.
+
+```bash
+autonoetic capsule import <path> \
+  [--verify-signature]                     # require + verify a trusted signature
+  [--activate]                             # bind the alias to the imported revision
+  [--dry-run]                              # validate only
+  [--trust-domain local|partner|foreign]
+  [--json]
+```
+
+### `autonoetic capsule verify`
+
+Validate the manifest schema, the canonical digest, and the signature (when present) against the configured `capsule.trusted_signers`.
+
+```bash
+autonoetic capsule verify <path> [--json]
+```
+
+### `autonoetic capsule inspect`
+
+Print a summary of the `capsule.json` manifest — IDs, mode, included content, signature, provenance.
+
+```bash
+autonoetic capsule inspect <path> [--json]
+```
+
+---
+
 ## Skill Commands
 
 ### `autonoetic skill install`


### PR DESCRIPTION
## Summary

Phase 3 of the [Cognitive Capsule Standardization umbrella (#220)](https://github.com/mandubian/autonoetic/issues/220). **Stacked on #281 (Phase 2)** — will retarget to `main` once Phase 2 merges.

### CLI surface (`autonoetic capsule …`)

- `export <agent_id> [--mode] [--revision] [--include-memory] [--sign] [--output] [--json]`
- `import <path> [--verify-signature] [--activate] [--dry-run] [--trust-domain] [--json]`
- `verify <path> [--json]` — validates manifest, canonical digest, signature
- `inspect <path> [--json]` — prints manifest summary

### Agent-initiated tools (gated by `Capability::CapsuleExport`)

- `capsule.export` and `capsule.import` registered in `runtime/tools/default_registry`
- New `PolicyEngine::can_use_capsule()` enforces the capability at execute time
- Tool `is_available(manifest)` only returns true when the capability is declared, so models that lack the cap never see the tool definitions

### Docs

- New "Capsule Commands" section in `docs/CLI.md` mirroring the section style of Trace/Skill/Eval

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p autonoetic-gateway --test capsule_tools_integration` — 3/3 pass (capability gate + tool discovery)
- [x] `cargo test -p autonoetic --test capsule_cli_e2e` — 1/1 pass (drives the binary through export → inspect → verify → import --dry-run)
- [x] All Phase 2 integration tests still pass

Closes #224. Depends on #223 (Phase 2 / #281).

🤖 Generated with [Claude Code](https://claude.com/claude-code)