### PR TITLE
capsule: OFP transfer + replay + headless + memory (Phase 4 of #220)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ name = "autonoetic-ofp"
 version = "0.1.0"
 dependencies = [
  "autonoetic-types",
+ "base64",
  "serde",
  "serde_json",
 ]

--- a/autonoetic-gateway/src/capsule/export.rs
+++ b/autonoetic-gateway/src/capsule/export.rs
@@ -117,6 +117,19 @@ pub fn export(req: ExportRequest, ctx: ExportContext<'_>) -> Result<ExportOutcom
             session_id,
         )? {
             Some(ckpt) => {
+                // Refuse to bundle a checkpoint that belongs to a
+                // different agent than the revision we're exporting —
+                // otherwise the resulting capsule would carry agent A's
+                // code with agent B's session state and produce
+                // surprising restores on the receiver.
+                if ckpt.agent_id != revision.agent_id {
+                    anyhow::bail!(
+                        "Replay-mode export: checkpoint for session {:?} belongs to agent {:?}, not {:?}",
+                        session_id,
+                        ckpt.agent_id,
+                        revision.agent_id
+                    );
+                }
                 let bytes = serde_json::to_vec_pretty(&ckpt)?;
                 archive::write_entry(staging_path, crate::capsule::paths::CHECKPOINT_PATH, &bytes)?;
                 Some(crate::capsule::paths::CHECKPOINT_PATH.to_string())
@@ -395,7 +408,7 @@ fn stage_memory_snapshot(
     let serialised = serde_json::to_vec_pretty(&snapshot_json)?;
     archive::write_entry(staging, crate::capsule::paths::MEMORY_SNAPSHOT_PATH, &serialised)?;
     Ok(autonoetic_types::capsule::CapsuleMemorySnapshot {
-        entry_count: entries.len(),
+        entry_count: entries.len() as u64,
         scopes: scopes.into_iter().collect(),
         content_handle: crate::capsule::paths::MEMORY_SNAPSHOT_PATH.to_string(),
         redacted: true,

--- a/autonoetic-gateway/src/capsule/export.rs
+++ b/autonoetic-gateway/src/capsule/export.rs
@@ -40,6 +40,12 @@ pub struct ExportRequest {
     pub sign: Option<bool>,
     /// Output archive path. Defaults to `<agent_id>.capsule.tar.zst` in `cwd`.
     pub output_path: Option<PathBuf>,
+    /// Required for `Replay` mode: the session whose latest checkpoint
+    /// should be bundled. Ignored for other modes.
+    pub session_id: Option<String>,
+    /// Required for `Headless` mode: the root session whose scheduled
+    /// jobs should be bundled. Ignored for other modes.
+    pub root_session_id: Option<String>,
 }
 
 impl ExportRequest {
@@ -51,6 +57,8 @@ impl ExportRequest {
             include_memory: None,
             sign: None,
             output_path: None,
+            session_id: None,
+            root_session_id: None,
         }
     }
 }
@@ -91,17 +99,59 @@ pub fn export(req: ExportRequest, ctx: ExportContext<'_>) -> Result<ExportOutcom
     let included_skills = collect_skill_names(&revision_dir);
 
     let memory_snapshot = if req.include_memory.unwrap_or(cfg.include_memory_by_default) {
-        Some(stage_memory_snapshot(staging_path, &revision.agent_id)?)
+        Some(stage_memory_snapshot(
+            staging_path,
+            &revision.agent_id,
+            ctx.gateway_store.as_ref(),
+        )?)
     } else {
         None
     };
 
     let checkpoint_handle = if req.mode == CapsuleMode::Replay {
-        // Phase 2 records the path the importer should look for. Phase 4
-        // wires the actual checkpoint capture / restore.
-        Some(crate::capsule::paths::CHECKPOINT_PATH.to_string())
+        let session_id = req.session_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("Replay-mode export requires session_id in ExportRequest")
+        })?;
+        match crate::runtime::checkpoint::load_latest_checkpoint(
+            ctx.gateway_config,
+            session_id,
+        )? {
+            Some(ckpt) => {
+                let bytes = serde_json::to_vec_pretty(&ckpt)?;
+                archive::write_entry(staging_path, crate::capsule::paths::CHECKPOINT_PATH, &bytes)?;
+                Some(crate::capsule::paths::CHECKPOINT_PATH.to_string())
+            }
+            None => anyhow::bail!(
+                "Replay-mode export: no checkpoint found for session {}",
+                session_id
+            ),
+        }
     } else {
         None
+    };
+
+    let scheduled_jobs = if req.mode == CapsuleMode::Headless {
+        let root = req.root_session_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("Headless-mode export requires root_session_id in ExportRequest")
+        })?;
+        ctx.gateway_store
+            .list_scheduled_jobs_for_root(root)?
+            .into_iter()
+            .map(|j| autonoetic_types::capsule::CapsuleScheduledJob {
+                job_id: j.job_id,
+                owner_agent_id: j.owner_agent_id,
+                root_session_id: j.root_session_id,
+                target_agent_id: j.target_agent_id,
+                target_revision_id: j.target_revision_id,
+                message: j.message,
+                metadata_json: j.metadata_json,
+                cron_expr: j.cron_expr,
+                timezone: j.timezone,
+                created_at: j.created_at,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
     };
 
     let capsule_id = compute_capsule_id(&revision.revision_id, req.mode);
@@ -134,12 +184,17 @@ pub fn export(req: ExportRequest, ctx: ExportContext<'_>) -> Result<ExportOutcom
         },
         requires_agents: vec![],
         requires_skills: vec![],
+        scheduled_jobs,
+        platform: Some(autonoetic_types::capsule::CapsulePlatform {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+        }),
     };
 
-    // Hermetic layer embedding (LayerStore archive copy + platform
-    // descriptor) lands in Phase 4 once the revision-to-layer-closure
-    // helper is in place. For now thin and hermetic exports differ only
-    // in the mode field and the importer's compatibility checks.
+    // Hermetic layer embedding via LayerStore is a follow-up — Phase 4
+    // ships the export-side platform descriptor and the scheduled-jobs
+    // bundle; the layer-closure traversal helper will land alongside the
+    // OFP receive-side handler in a separate PR.
 
     if signed {
         let key = GatewayIdentityKey::load_or_generate(ctx.gateway_dir)
@@ -316,23 +371,32 @@ fn collect_skill_names(revision_dir: &Path) -> Vec<String> {
 }
 
 fn stage_memory_snapshot(
-    _staging: &Path,
-    _agent_id: &str,
+    staging: &Path,
+    agent_id: &str,
+    store: &GatewayStore,
 ) -> Result<autonoetic_types::capsule::CapsuleMemorySnapshot> {
-    // Phase 2 records the snapshot placeholder file so importers can
-    // dedup; full agent-scoped memory enumeration lands with Phase 4
-    // (memory dedup + conflict policy). The redaction round-trip is
-    // demonstrated by the unit test below.
+    // Enumerate memories owned by this agent (any scope), then run each
+    // one through the redaction pipeline. The receiving gateway may
+    // re-key these (see [`crate::capsule::import`]).
+    let ids = store.memory_list_ids_owned_by(agent_id)?;
+    let mut entries: Vec<serde_json::Value> = Vec::with_capacity(ids.len());
+    let mut scopes: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for id in &ids {
+        if let Some(obj) = store.memory_get_unrestricted(id)? {
+            scopes.insert(obj.scope.clone());
+            let serialised = serde_json::to_value(&obj)?;
+            entries.push(redact_json_value(&serialised));
+        }
+    }
     let snapshot_json = serde_json::json!({
-        "entries": [],
-        "scopes": ["memory", "user_profile"],
+        "entries": entries,
+        "scopes": scopes.iter().cloned().collect::<Vec<_>>(),
     });
-    let redacted = redact_json_value(&snapshot_json);
-    let serialised = serde_json::to_vec_pretty(&redacted)?;
-    archive::write_entry(_staging, crate::capsule::paths::MEMORY_SNAPSHOT_PATH, &serialised)?;
+    let serialised = serde_json::to_vec_pretty(&snapshot_json)?;
+    archive::write_entry(staging, crate::capsule::paths::MEMORY_SNAPSHOT_PATH, &serialised)?;
     Ok(autonoetic_types::capsule::CapsuleMemorySnapshot {
-        entry_count: 0,
-        scopes: vec!["memory".to_string(), "user_profile".to_string()],
+        entry_count: entries.len(),
+        scopes: scopes.into_iter().collect(),
         content_handle: crate::capsule::paths::MEMORY_SNAPSHOT_PATH.to_string(),
         redacted: true,
     })

--- a/autonoetic-gateway/src/capsule/import.rs
+++ b/autonoetic-gateway/src/capsule/import.rs
@@ -25,7 +25,7 @@ use crate::scheduler::gateway_store::GatewayStore;
 
 const CAPSULE_FORMAT_MAJOR_SUPPORTED: u64 = 1;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ImportRequest {
     pub archive_path: PathBuf,
     /// Require a present + verified signature.
@@ -37,6 +37,37 @@ pub struct ImportRequest {
     /// Override the trust domain stamped on the imported revision.
     /// Defaults to `"local"`.
     pub trust_domain_override: Option<String>,
+    /// Conflict policy for memory entries that already exist locally.
+    pub memory_conflict_policy: MemoryConflictPolicy,
+}
+
+impl Default for ImportRequest {
+    fn default() -> Self {
+        Self {
+            archive_path: PathBuf::new(),
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::default(),
+        }
+    }
+}
+
+/// What to do when the incoming capsule carries a memory entry whose
+/// `memory_id` already exists on the receiving gateway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryConflictPolicy {
+    /// Keep the local copy; skip the imported one (default — safest).
+    KeepLocal,
+    /// Overwrite the local copy with the imported one.
+    OverwriteLocal,
+}
+
+impl Default for MemoryConflictPolicy {
+    fn default() -> Self {
+        MemoryConflictPolicy::KeepLocal
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -49,6 +80,16 @@ pub struct ImportOutcome {
     pub dry_run: bool,
     pub dedup_savings_bytes: u64,
     pub created_revision: bool,
+    /// Number of memory entries actually persisted (post-conflict-policy).
+    pub memory_entries_imported: usize,
+    /// Number of memory entries skipped because a local copy existed and
+    /// the policy was `KeepLocal`.
+    pub memory_entries_skipped: usize,
+    /// Number of scheduled jobs recreated on this gateway (Headless mode).
+    pub scheduled_jobs_recreated: usize,
+    /// True when a session checkpoint from the capsule was restored
+    /// into the gateway's checkpoint store (Replay mode).
+    pub checkpoint_restored: bool,
 }
 
 pub struct ImportContext<'a> {
@@ -112,6 +153,28 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
         .clone()
         .unwrap_or_else(|| "local".to_string());
 
+    // Platform compatibility: refuse cross-platform layer imports when
+    // the trust domain is anything other than `"local"`. Within the same
+    // trust boundary we trust the operator's judgment (mostly so dev
+    // workflows on macOS hosts can pull capsules built in Linux CI).
+    if trust_domain != "local" {
+        if let Some(p) = &manifest.platform {
+            let local_os = std::env::consts::OS;
+            let local_arch = std::env::consts::ARCH;
+            if p.os != local_os || p.arch != local_arch {
+                anyhow::bail!(
+                    "capsule was built for {}/{} but this gateway is {}/{}; \
+                     refusing import in trust_domain={} (override --trust-domain local to bypass)",
+                    p.os,
+                    p.arch,
+                    local_os,
+                    local_arch,
+                    trust_domain
+                );
+            }
+        }
+    }
+
     let agent_dir = extract.path().join("agent");
     let file_map = read_agent_files(&agent_dir)?;
     let (dedup_savings, _content_handles) =
@@ -127,6 +190,10 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
             dry_run: true,
             dedup_savings_bytes: dedup_savings,
             created_revision: false,
+            memory_entries_imported: 0,
+            memory_entries_skipped: 0,
+            scheduled_jobs_recreated: 0,
+            checkpoint_restored: false,
         });
     }
 
@@ -184,6 +251,25 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
         bind_alias(ctx.gateway_store, &agent_id, &revision_id)?;
     }
 
+    let (memory_imported, memory_skipped) = import_memory_snapshot(
+        ctx.gateway_store,
+        extract.path(),
+        manifest.memory_snapshot.as_ref(),
+        req.memory_conflict_policy,
+    )?;
+
+    let scheduled_jobs_recreated = if matches!(manifest.mode, autonoetic_types::capsule::CapsuleMode::Headless) {
+        recreate_scheduled_jobs(ctx.gateway_store, &manifest.scheduled_jobs)?
+    } else {
+        0
+    };
+
+    let checkpoint_restored = if matches!(manifest.mode, autonoetic_types::capsule::CapsuleMode::Replay) {
+        restore_checkpoint(ctx.gateway_config, extract.path(), &manifest)?
+    } else {
+        false
+    };
+
     emit_import_event(
         ctx.gateway_store,
         &manifest.capsule_id,
@@ -202,7 +288,115 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
         dry_run: false,
         dedup_savings_bytes: dedup_savings,
         created_revision: !revision_existed,
+        memory_entries_imported: memory_imported,
+        memory_entries_skipped: memory_skipped,
+        scheduled_jobs_recreated,
+        checkpoint_restored,
     })
+}
+
+fn import_memory_snapshot(
+    store: &Arc<GatewayStore>,
+    extract_root: &Path,
+    snapshot: Option<&autonoetic_types::capsule::CapsuleMemorySnapshot>,
+    policy: MemoryConflictPolicy,
+) -> Result<(usize, usize)> {
+    let Some(snapshot) = snapshot else {
+        return Ok((0, 0));
+    };
+    let path = extract_root.join(&snapshot.content_handle);
+    if !path.is_file() {
+        return Ok((0, 0));
+    }
+    let bytes = std::fs::read(&path)?;
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let entries = match parsed.get("entries").and_then(|v| v.as_array()) {
+        Some(arr) => arr.clone(),
+        None => return Ok((0, 0)),
+    };
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    for entry in entries {
+        let obj: autonoetic_types::memory::MemoryObject = match serde_json::from_value(entry) {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::warn!(
+                    target: "capsule",
+                    error = %e,
+                    "skipping malformed memory entry"
+                );
+                continue;
+            }
+        };
+        let existing = store.memory_get_unrestricted(&obj.memory_id)?;
+        match (existing, policy) {
+            (Some(_), MemoryConflictPolicy::KeepLocal) => skipped += 1,
+            (_, _) => {
+                store.memory_upsert(&obj)?;
+                imported += 1;
+            }
+        }
+    }
+    Ok((imported, skipped))
+}
+
+fn recreate_scheduled_jobs(
+    store: &Arc<GatewayStore>,
+    jobs: &[autonoetic_types::capsule::CapsuleScheduledJob],
+) -> Result<usize> {
+    let mut created = 0;
+    for j in jobs {
+        let now = Utc::now().to_rfc3339();
+        let new_id = format!("job_capsule_{}_{}", j.job_id, uuid::Uuid::new_v4());
+        let job = autonoetic_types::scheduled_job::ScheduledJob {
+            job_id: new_id,
+            owner_agent_id: j.owner_agent_id.clone(),
+            root_session_id: j.root_session_id.clone(),
+            target_agent_id: j.target_agent_id.clone(),
+            target_revision_id: j.target_revision_id.clone(),
+            message: j.message.clone(),
+            metadata_json: j.metadata_json.clone(),
+            cron_expr: j.cron_expr.clone(),
+            timezone: j.timezone.clone(),
+            next_run_at: now.clone(),
+            last_run_at: None,
+            status: autonoetic_types::scheduled_job::ScheduledJobStatus::Active,
+            created_at: now.clone(),
+            updated_at: now,
+            last_error: None,
+            generation: 0,
+        };
+        match store.create_scheduled_job(&job) {
+            Ok(()) => created += 1,
+            Err(e) => {
+                tracing::warn!(
+                    target: "capsule",
+                    error = %e,
+                    job_id = %j.job_id,
+                    "failed to re-create scheduled job; continuing"
+                );
+            }
+        }
+    }
+    Ok(created)
+}
+
+fn restore_checkpoint(
+    config: &GatewayConfig,
+    extract_root: &Path,
+    manifest: &CapsuleManifest,
+) -> Result<bool> {
+    let Some(rel) = &manifest.checkpoint_handle else {
+        return Ok(false);
+    };
+    let path = extract_root.join(rel);
+    if !path.is_file() {
+        return Ok(false);
+    }
+    let bytes = std::fs::read(&path)?;
+    let ckpt: crate::runtime::checkpoint::SessionCheckpoint = serde_json::from_slice(&bytes)?;
+    crate::runtime::checkpoint::save_checkpoint(config, &ckpt)?;
+    Ok(true)
 }
 
 fn read_agent_files(agent_dir: &Path) -> Result<BTreeMap<String, Vec<u8>>> {

--- a/autonoetic-gateway/src/capsule/import.rs
+++ b/autonoetic-gateway/src/capsule/import.rs
@@ -256,6 +256,7 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
         extract.path(),
         manifest.memory_snapshot.as_ref(),
         req.memory_conflict_policy,
+        &manifest.agent_id,
     )?;
 
     let scheduled_jobs_recreated = if matches!(manifest.mode, autonoetic_types::capsule::CapsuleMode::Headless) {
@@ -295,15 +296,58 @@ pub fn import(req: ImportRequest, ctx: ImportContext<'_>) -> Result<ImportOutcom
     })
 }
 
+/// Reject manifest-supplied relative paths that could read outside the
+/// extracted capsule directory. Same rules as the tar entry guard:
+/// non-empty, no absolute prefix, no `..` segments, no Windows-style
+/// drive letters or backslashes.
+fn validate_archive_relative_path(p: &str, label: &str) -> Result<()> {
+    if p.is_empty() {
+        anyhow::bail!("capsule manifest has empty {}", label);
+    }
+    if p.starts_with('/') || p.contains('\\') {
+        anyhow::bail!(
+            "capsule manifest {} {:?} is absolute or contains backslashes",
+            label,
+            p
+        );
+    }
+    let path = std::path::Path::new(p);
+    for component in path.components() {
+        use std::path::Component;
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                anyhow::bail!(
+                    "capsule manifest {} {:?} contains an absolute prefix",
+                    label,
+                    p
+                );
+            }
+            Component::ParentDir => {
+                anyhow::bail!(
+                    "capsule manifest {} {:?} contains parent-dir segment",
+                    label,
+                    p
+                );
+            }
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+    Ok(())
+}
+
 fn import_memory_snapshot(
     store: &Arc<GatewayStore>,
     extract_root: &Path,
     snapshot: Option<&autonoetic_types::capsule::CapsuleMemorySnapshot>,
     policy: MemoryConflictPolicy,
+    expected_agent_id: &str,
 ) -> Result<(usize, usize)> {
     let Some(snapshot) = snapshot else {
         return Ok((0, 0));
     };
+    // The handle comes from the (potentially untrusted) manifest. Refuse
+    // anything that could escape the extracted capsule directory.
+    validate_archive_relative_path(&snapshot.content_handle, "memory content_handle")?;
     let path = extract_root.join(&snapshot.content_handle);
     if !path.is_file() {
         return Ok((0, 0));
@@ -328,6 +372,20 @@ fn import_memory_snapshot(
                 continue;
             }
         };
+        // Refuse memory entries that claim a different owner — a
+        // tampered/unsigned capsule must not be able to inject
+        // arbitrary memories for unrelated agents into the receiver.
+        if obj.owner_agent_id != expected_agent_id {
+            tracing::warn!(
+                target: "capsule",
+                memory_id = %obj.memory_id,
+                claimed_owner = %obj.owner_agent_id,
+                expected_owner = %expected_agent_id,
+                "skipping memory entry whose owner_agent_id does not match the capsule's agent_id"
+            );
+            skipped += 1;
+            continue;
+        }
         let existing = store.memory_get_unrestricted(&obj.memory_id)?;
         match (existing, policy) {
             (Some(_), MemoryConflictPolicy::KeepLocal) => skipped += 1,
@@ -389,12 +447,24 @@ fn restore_checkpoint(
     let Some(rel) = &manifest.checkpoint_handle else {
         return Ok(false);
     };
+    // The checkpoint path is operator-trusted only when signed; even
+    // then, guard against absolute / parent-dir segments before joining.
+    validate_archive_relative_path(rel, "checkpoint_handle")?;
     let path = extract_root.join(rel);
     if !path.is_file() {
         return Ok(false);
     }
     let bytes = std::fs::read(&path)?;
     let ckpt: crate::runtime::checkpoint::SessionCheckpoint = serde_json::from_slice(&bytes)?;
+    // A tampered/unsigned capsule could otherwise inject a checkpoint
+    // for an unrelated agent into the receiver's checkpoint store.
+    if ckpt.agent_id != manifest.agent_id {
+        anyhow::bail!(
+            "Replay-mode checkpoint agent_id {:?} does not match manifest agent_id {:?}",
+            ckpt.agent_id,
+            manifest.agent_id
+        );
+    }
     crate::runtime::checkpoint::save_checkpoint(config, &ckpt)?;
     Ok(true)
 }

--- a/autonoetic-gateway/src/capsule/mod.rs
+++ b/autonoetic-gateway/src/capsule/mod.rs
@@ -13,10 +13,10 @@
 //!   digest + Ed25519 signature checks
 //! - [`archive::pack`] / [`archive::unpack`] — low-level archive helpers
 //!
-//! Phase 2 ships the thin-mode happy path end-to-end (export → import → new
-//! revision record). Hermetic-layer embedding, memory-merge conflict
-//! policy, and Replay-mode session resume layer on top of these surfaces
-//! in Phase 4.
+//! Phase 2 shipped the thin-mode happy path. Phase 4 adds Replay-mode
+//! checkpoint bundle/restore, Headless-mode scheduled-job bundle/recreate,
+//! real memory-snapshot enumeration with a conflict policy, and a
+//! platform compatibility refusal that fires in non-`local` trust domains.
 
 pub mod archive;
 pub mod export;
@@ -24,7 +24,7 @@ pub mod import;
 pub mod verify;
 
 pub use export::{export, ExportContext, ExportOutcome, ExportRequest};
-pub use import::{import, ImportContext, ImportOutcome, ImportRequest};
+pub use import::{import, ImportContext, ImportOutcome, ImportRequest, MemoryConflictPolicy};
 
 /// Canonical relative paths inside the capsule archive.
 pub mod paths {

--- a/autonoetic-gateway/src/capsule/verify.rs
+++ b/autonoetic-gateway/src/capsule/verify.rs
@@ -158,6 +158,8 @@ mod tests {
             },
             requires_agents: vec![],
             requires_skills: vec![],
+            scheduled_jobs: vec![],
+            platform: None,
         }
     }
 

--- a/autonoetic-gateway/src/runtime/tools/capsule.rs
+++ b/autonoetic-gateway/src/runtime/tools/capsule.rs
@@ -47,6 +47,12 @@ struct CapsuleExportArgs {
     sign: Option<bool>,
     #[serde(default)]
     output: Option<PathBuf>,
+    /// Required when `mode == "replay"`.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// Required when `mode == "headless"`.
+    #[serde(default)]
+    root_session_id: Option<String>,
 }
 
 fn default_mode_string() -> String {
@@ -139,6 +145,8 @@ impl NativeTool for CapsuleExportTool {
                 include_memory: args.include_memory,
                 sign: args.sign,
                 output_path: args.output,
+                session_id: args.session_id,
+                root_session_id: args.root_session_id,
             },
             ExportContext {
                 gateway_dir,
@@ -239,6 +247,7 @@ impl NativeTool for CapsuleImportTool {
                 activate: args.activate,
                 dry_run: args.dry_run,
                 trust_domain_override: args.trust_domain,
+                ..Default::default()
             },
             ImportContext {
                 gateway_dir,

--- a/autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs
+++ b/autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs
@@ -483,3 +483,254 @@ fn platform_mismatch_refused_when_trust_domain_not_local() {
     .expect("local trust domain bypasses platform check");
     assert!(ok.created_revision);
 }
+
+#[test]
+fn import_refuses_memory_entry_with_mismatched_owner() {
+    let f = fixture("own.agent", "rev_sha256:own-001");
+    let now = "2026-05-28T00:00:00Z".to_string();
+    // Seed one legitimate memory owned by the agent, plus one owned by
+    // a different agent (which a tampered capsule could try to inject).
+    for (id, owner) in [("good-1", "own.agent"), ("evil-2", "other.agent")] {
+        let obj = MemoryObject {
+            memory_id: id.to_string(),
+            scope: "memory".to_string(),
+            owner_agent_id: owner.to_string(),
+            writer_agent_id: owner.to_string(),
+            source_type: Default::default(),
+            source_ref: "test".to_string(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            content: "x".to_string(),
+            content_hash: "sha256:0".to_string(),
+            confidence: None,
+            tags: vec![],
+            lineage: vec![],
+            visibility: MemoryVisibility::default(),
+            expires_at: None,
+            revision_id: None,
+            binding_session_id: None,
+            alias_ref: None,
+            quarantine_reason: None,
+        };
+        f.store.memory_upsert(&obj).unwrap();
+    }
+
+    // Override `memory_list_ids_owned_by` semantics by exporting (which
+    // only lists `owner_agent_id == agent_id`)…but to force the bad
+    // entry into the bundle we hand-rewrite memory_snapshot.json after
+    // unpacking the archive. This simulates a tampered capsule.
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("own.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "own.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: Some(true),
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    // Tamper: inject an extra entry owned by `other.agent`.
+    let work = tempdir().unwrap();
+    autonoetic_gateway::capsule::archive::unpack(&archive, work.path(), 16 * 1024 * 1024).unwrap();
+    let snapshot_path = work.path().join("memory/memory_snapshot.json");
+    let mut snapshot: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&snapshot_path).unwrap()).unwrap();
+    let injected = serde_json::json!({
+        "memory_id": "evil-2",
+        "scope": "memory",
+        "owner_agent_id": "other.agent",
+        "writer_agent_id": "other.agent",
+        "source_type": "agent_write",
+        "source_ref": "tampered",
+        "created_at": "2026-05-28T00:00:00Z",
+        "updated_at": "2026-05-28T00:00:00Z",
+        "content": "evil",
+        "content_hash": "sha256:0",
+        "tags": [],
+        "lineage": [],
+        "visibility": "private",
+        "expires_at": null,
+        "revision_id": null,
+        "binding_session_id": null,
+        "alias_ref": null,
+        "quarantine_reason": null,
+    });
+    snapshot["entries"]
+        .as_array_mut()
+        .unwrap()
+        .push(injected);
+    std::fs::write(&snapshot_path, serde_json::to_vec_pretty(&snapshot).unwrap()).unwrap();
+    autonoetic_gateway::capsule::archive::pack(work.path(), &archive).unwrap();
+
+    let r = fresh_fixture();
+    let outcome = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect("import");
+    // The legitimate entry should be imported; the tampered entry must
+    // be skipped (not silently injected into the receiver's store).
+    assert_eq!(outcome.memory_entries_imported, 1);
+    assert!(outcome.memory_entries_skipped >= 1);
+    assert!(
+        r.store.memory_get_unrestricted("good-1").unwrap().is_some(),
+        "good-1 should be imported"
+    );
+    assert!(
+        r.store.memory_get_unrestricted("evil-2").unwrap().is_none(),
+        "evil-2 must NOT be imported despite being in the archive"
+    );
+}
+
+#[test]
+fn replay_export_refuses_checkpoint_for_other_agent() {
+    let f = fixture("replay.agent", "rev_sha256:replay-001");
+    // Save a checkpoint whose agent_id is somebody else's.
+    let ckpt = SessionCheckpoint {
+        history: vec![Message::system("test")],
+        turn_counter: 1,
+        session_state: Default::default(),
+        loop_guard_state: LoopGuardState {
+            max_loops_without_progress: 10,
+            max_tool_failures: 5,
+            max_consecutive_same_progress: 2,
+            max_child_failures: 3,
+            current_loops: 0,
+            tool_failure_counts: std::collections::HashMap::new(),
+            last_progress_fingerprint: None,
+            consecutive_progress_count: 0,
+            child_failure_count: 0,
+            ..Default::default()
+        },
+        agent_id: "different.agent".to_string(),
+        session_id: "x-session".to_string(),
+        turn_id: "t01".to_string(),
+        workflow_id: None,
+        task_id: None,
+        runtime_lock_hash: None,
+        llm_config_snapshot: None,
+        tool_registry_version: None,
+        yield_reason: YieldReason::Hibernation,
+        content_store_refs: vec![],
+        created_at: "2026-05-28T00:00:00Z".to_string(),
+        pending_tool_state: None,
+        llm_rounds_consumed: 1,
+        tool_invocations_consumed: 0,
+        tokens_consumed: 0,
+        estimated_cost_usd: 0.0,
+        compression_metadata: None,
+        capsule_state: None,
+        assistant_message: None,
+        pending_action: None,
+        suspended_at: None,
+    };
+    save_checkpoint(&f.config, &ckpt).unwrap();
+
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("rep.capsule.tar.zst");
+    let err = export(
+        ExportRequest {
+            agent_id: "replay.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Replay,
+            include_memory: Some(false),
+            sign: Some(false),
+            output_path: Some(archive),
+            session_id: Some("x-session".to_string()),
+            root_session_id: None,
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect_err("export must refuse a checkpoint owned by a different agent");
+    assert!(
+        err.to_string().contains("different.agent"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn import_refuses_traversal_in_memory_content_handle() {
+    let f = fixture("trav.agent", "rev_sha256:trav-001");
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("trav.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "trav.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: Some(true),
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    // Tamper: rewrite the manifest's memory_snapshot.content_handle to
+    // an absolute path.
+    let work = tempdir().unwrap();
+    autonoetic_gateway::capsule::archive::unpack(&archive, work.path(), 16 * 1024 * 1024).unwrap();
+    let manifest_path = work.path().join("capsule.json");
+    let mut m: autonoetic_types::capsule::CapsuleManifest =
+        serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    if let Some(ref mut snap) = m.memory_snapshot {
+        snap.content_handle = "/etc/passwd".to_string();
+    }
+    std::fs::write(&manifest_path, serde_json::to_vec_pretty(&m).unwrap()).unwrap();
+    autonoetic_gateway::capsule::archive::pack(work.path(), &archive).unwrap();
+
+    let r = fresh_fixture();
+    let err = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect_err("absolute content_handle must be refused");
+    assert!(
+        err.to_string().contains("memory content_handle")
+            || err.to_string().contains("absolute"),
+        "unexpected error: {err}"
+    );
+}

--- a/autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs
+++ b/autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs
@@ -1,0 +1,485 @@
+//! Phase 4 integration tests — Replay mode, Headless mode, memory
+//! import dedup, and platform-mismatch refusal.
+
+use autonoetic_gateway::capsule::{export, import, ExportContext, ImportContext, ExportRequest, ImportRequest};
+use autonoetic_gateway::capsule::import::MemoryConflictPolicy;
+use autonoetic_gateway::llm::Message;
+use autonoetic_gateway::runtime::checkpoint::{
+    list_checkpoints, save_checkpoint, SessionCheckpoint, YieldReason,
+};
+use autonoetic_gateway::runtime::guard::LoopGuardState;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent_revision::{
+    AgentAliasRecord, AgentRevisionRecord, AgentRevisionStatus,
+};
+use autonoetic_types::capsule::{CapsuleMode, CapsulePlatform};
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::memory::{MemoryObject, MemoryVisibility};
+use autonoetic_types::scheduled_job::{ScheduledJob, ScheduledJobStatus};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    config: GatewayConfig,
+    store: Arc<GatewayStore>,
+    gateway_dir: std::path::PathBuf,
+}
+
+fn fixture(agent_id: &str, revision_id: &str) -> Fixture {
+    let temp = tempdir().unwrap();
+    let agents_dir = temp.path().join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let rev_dir = gateway_dir
+        .join("revisions")
+        .join("agents")
+        .join(agent_id)
+        .join(revision_id);
+    std::fs::create_dir_all(&rev_dir).unwrap();
+    std::fs::write(rev_dir.join("SKILL.md"), "# agent\n").unwrap();
+    std::fs::write(rev_dir.join("runtime.lock"), "agents: []\n").unwrap();
+
+    let rev = AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: agent_id.to_string(),
+        base_revision_id: None,
+        artifact_id: None,
+        content_digest: format!("sha256:{}", "x".repeat(64)),
+        runtime_lock_hash: format!("sha256:{}", "y".repeat(64)),
+        manifest_hash: format!("sha256:{}", "z".repeat(64)),
+        created_at: "2026-05-28T00:00:00Z".to_string(),
+        created_by_type: "user".to_string(),
+        created_by_id: "test".to_string(),
+        source_kind: "artifact".to_string(),
+        source_ref: None,
+        origin_node_id: "node-A".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Ready,
+        metadata_json: serde_json::Value::Null,
+        short_id: "abcd1234".to_string(),
+        signature: None,
+        signer_id: None,
+    };
+    store.insert_agent_revision(&rev).unwrap();
+    let alias = AgentAliasRecord {
+        alias_id: agent_id.to_string(),
+        agent_id: agent_id.to_string(),
+        revision_id: revision_id.to_string(),
+        updated_at: "2026-05-28T00:00:00Z".to_string(),
+        updated_by_type: "user".to_string(),
+        updated_by_id: "test".to_string(),
+        reason: None,
+    };
+    store.upsert_agent_alias(&alias).unwrap();
+
+    let config = GatewayConfig {
+        agents_dir,
+        ..Default::default()
+    };
+
+    Fixture {
+        _temp: temp,
+        config,
+        store,
+        gateway_dir,
+    }
+}
+
+fn fresh_fixture() -> Fixture {
+    let temp = tempdir().unwrap();
+    let agents_dir = temp.path().join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let config = GatewayConfig {
+        agents_dir,
+        ..Default::default()
+    };
+    Fixture {
+        _temp: temp,
+        config,
+        store,
+        gateway_dir,
+    }
+}
+
+#[test]
+fn memory_export_then_import_roundtrip_with_conflict_policy() {
+    let f = fixture("mem.agent", "rev_sha256:mem-001");
+    // Seed two memories owned by the agent.
+    for (id, content) in [("mem-1", "fact one"), ("mem-2", "fact two")] {
+        let now = "2026-05-28T00:00:00Z".to_string();
+        let obj = MemoryObject {
+            memory_id: id.to_string(),
+            scope: "memory".to_string(),
+            owner_agent_id: "mem.agent".to_string(),
+            writer_agent_id: "mem.agent".to_string(),
+            source_type: Default::default(),
+            source_ref: "test".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+            content: content.to_string(),
+            content_hash: "sha256:0".to_string(),
+            confidence: None,
+            tags: vec![],
+            lineage: vec![],
+            visibility: MemoryVisibility::default(),
+            expires_at: None,
+            revision_id: None,
+            binding_session_id: None,
+            alias_ref: None,
+            quarantine_reason: None,
+        };
+        f.store.memory_upsert(&obj).unwrap();
+    }
+
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("mem.capsule.tar.zst");
+    let outcome = export(
+        ExportRequest {
+            agent_id: "mem.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: Some(true),
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+    let _ = outcome;
+
+    // Fresh receiver — first import lays both entries down.
+    let r = fresh_fixture();
+    let first = import(
+        ImportRequest {
+            archive_path: archive.clone(),
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect("first import");
+    assert_eq!(first.memory_entries_imported, 2);
+    assert_eq!(first.memory_entries_skipped, 0);
+    assert!(r.store.memory_get_unrestricted("mem-1").unwrap().is_some());
+
+    // Second import with KeepLocal must skip both (already exist).
+    let second = import(
+        ImportRequest {
+            archive_path: archive.clone(),
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect("second import");
+    assert_eq!(second.memory_entries_imported, 0);
+    assert_eq!(second.memory_entries_skipped, 2);
+
+    // Third import with OverwriteLocal must replace both.
+    let third = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::OverwriteLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect("third import");
+    assert_eq!(third.memory_entries_imported, 2);
+    assert_eq!(third.memory_entries_skipped, 0);
+}
+
+#[test]
+fn replay_mode_bundles_checkpoint_and_import_lays_it_down() {
+    let f = fixture("rep.agent", "rev_sha256:rep-001");
+    // Persist a synthetic checkpoint for a session.
+    let ckpt = SessionCheckpoint {
+        history: vec![Message::system("test")],
+        turn_counter: 7,
+        session_state: Default::default(),
+        loop_guard_state: LoopGuardState {
+            max_loops_without_progress: 10,
+            max_tool_failures: 5,
+            max_consecutive_same_progress: 2,
+            max_child_failures: 3,
+            current_loops: 1,
+            tool_failure_counts: std::collections::HashMap::new(),
+            last_progress_fingerprint: None,
+            consecutive_progress_count: 0,
+            child_failure_count: 0,
+            ..Default::default()
+        },
+        agent_id: "rep.agent".to_string(),
+        session_id: "sess-1".to_string(),
+        turn_id: "t007".to_string(),
+        workflow_id: None,
+        task_id: None,
+        runtime_lock_hash: Some("abc".to_string()),
+        llm_config_snapshot: None,
+        tool_registry_version: None,
+        yield_reason: YieldReason::Hibernation,
+        content_store_refs: vec![],
+        created_at: "2026-05-28T00:00:00Z".to_string(),
+        pending_tool_state: None,
+        llm_rounds_consumed: 1,
+        tool_invocations_consumed: 0,
+        tokens_consumed: 100,
+        estimated_cost_usd: 0.001,
+        compression_metadata: None,
+        capsule_state: None,
+        assistant_message: None,
+        pending_action: None,
+        suspended_at: None,
+    };
+    save_checkpoint(&f.config, &ckpt).unwrap();
+
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("rep.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "rep.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Replay,
+            include_memory: Some(false),
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+            session_id: Some("sess-1".to_string()),
+            root_session_id: None,
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    let r = fresh_fixture();
+    let outcome = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect("import");
+    assert!(
+        outcome.checkpoint_restored,
+        "checkpoint should be restored on Replay-mode import"
+    );
+
+    // The receiver should now have a checkpoint at the same session_id +
+    // turn_id ready for the scheduler to resume.
+    let entries = list_checkpoints(&r.config, "sess-1").unwrap();
+    assert!(
+        entries.iter().any(|p| p.contains("t007")),
+        "expected a t007 checkpoint, got {:?}",
+        entries
+    );
+}
+
+#[test]
+fn headless_mode_bundles_and_recreates_scheduled_jobs() {
+    let f = fixture("hl.agent", "rev_sha256:hl-001");
+    let now = "2026-05-28T00:00:00Z".to_string();
+    let job = ScheduledJob {
+        job_id: "job-orig-001".to_string(),
+        owner_agent_id: "hl.agent".to_string(),
+        root_session_id: "root-1".to_string(),
+        target_agent_id: "hl.agent".to_string(),
+        target_revision_id: "rev_sha256:hl-001".to_string(),
+        message: "tick".to_string(),
+        metadata_json: None,
+        cron_expr: "0 * * * *".to_string(),
+        timezone: "UTC".to_string(),
+        next_run_at: now.clone(),
+        last_run_at: None,
+        status: ScheduledJobStatus::Active,
+        created_at: now.clone(),
+        updated_at: now,
+        last_error: None,
+        generation: 0,
+    };
+    f.store.create_scheduled_job(&job).unwrap();
+
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("hl.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "hl.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Headless,
+            include_memory: Some(false),
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: Some("root-1".to_string()),
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    let r = fresh_fixture();
+    let outcome = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None,
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect("import");
+    assert_eq!(outcome.scheduled_jobs_recreated, 1);
+
+    // The new job exists with a different (capsule-prefixed) job_id but
+    // the same cron and owner.
+    let owned = r
+        .store
+        .list_scheduled_jobs_for_owner("hl.agent", None, None)
+        .unwrap();
+    assert_eq!(owned.len(), 1);
+    let new_job = &owned[0];
+    assert!(
+        new_job.job_id.starts_with("job_capsule_job-orig-001_"),
+        "unexpected job_id: {}",
+        new_job.job_id
+    );
+    assert_eq!(new_job.cron_expr, "0 * * * *");
+    assert_eq!(new_job.target_agent_id, "hl.agent");
+}
+
+#[test]
+fn platform_mismatch_refused_when_trust_domain_not_local() {
+    let f = fixture("plat.agent", "rev_sha256:plat-001");
+
+    let out_dir = tempdir().unwrap();
+    let archive = out_dir.path().join("plat.capsule.tar.zst");
+    export(
+        ExportRequest {
+            agent_id: "plat.agent".to_string(),
+            revision_id: None,
+            mode: CapsuleMode::Thin,
+            include_memory: Some(false),
+            sign: Some(false),
+            output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
+        },
+        ExportContext {
+            gateway_dir: &f.gateway_dir,
+            gateway_config: &f.config,
+            gateway_store: &f.store,
+        },
+    )
+    .expect("export");
+
+    // Manually tamper the platform in the embedded manifest to look
+    // hostile. The signature was disabled so digest mismatch is moot.
+    let work = tempdir().unwrap();
+    autonoetic_gateway::capsule::archive::unpack(&archive, work.path(), 16 * 1024 * 1024).unwrap();
+    let manifest_path = work.path().join("capsule.json");
+    let mut m: autonoetic_types::capsule::CapsuleManifest =
+        serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    m.platform = Some(CapsulePlatform {
+        os: "alien-os".to_string(),
+        arch: "made-up-arch".to_string(),
+    });
+    std::fs::write(&manifest_path, serde_json::to_vec_pretty(&m).unwrap()).unwrap();
+    autonoetic_gateway::capsule::archive::pack(work.path(), &archive).unwrap();
+
+    let r = fresh_fixture();
+    // trust_domain "foreign" + mismatched platform should refuse.
+    let err = import(
+        ImportRequest {
+            archive_path: archive.clone(),
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: Some("foreign".to_string()),
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r.gateway_dir,
+            gateway_config: &r.config,
+            gateway_store: &r.store,
+        },
+    )
+    .expect_err("platform mismatch in foreign trust domain must refuse");
+    assert!(
+        err.to_string().contains("built for alien-os/made-up-arch"),
+        "{}",
+        err
+    );
+
+    // Same archive in trust_domain "local" should succeed (bypass for
+    // operator-controlled imports).
+    let r2 = fresh_fixture();
+    let ok = import(
+        ImportRequest {
+            archive_path: archive,
+            verify_signature: false,
+            dry_run: false,
+            activate: false,
+            trust_domain_override: None, // defaults to "local"
+            memory_conflict_policy: MemoryConflictPolicy::KeepLocal,
+        },
+        ImportContext {
+            gateway_dir: &r2.gateway_dir,
+            gateway_config: &r2.config,
+            gateway_store: &r2.store,
+        },
+    )
+    .expect("local trust domain bypasses platform check");
+    assert!(ok.created_revision);
+}

--- a/autonoetic-gateway/tests/capsule_pipeline_integration.rs
+++ b/autonoetic-gateway/tests/capsule_pipeline_integration.rs
@@ -110,6 +110,8 @@ fn export_then_import_creates_revision_with_capsule_import_source_kind() {
             include_memory: None,
             sign: Some(true),
             output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
         },
         autonoetic_gateway::capsule::ExportContext {
             gateway_dir: &f.gateway_dir,
@@ -153,6 +155,7 @@ fn export_then_import_creates_revision_with_capsule_import_source_kind() {
             dry_run: false,
             activate: true,
             trust_domain_override: None,
+            memory_conflict_policy: Default::default(),
         },
         autonoetic_gateway::capsule::ImportContext {
             gateway_dir: &f2.gateway_dir,
@@ -207,6 +210,8 @@ fn import_dry_run_does_not_persist_revision() {
             include_memory: None,
             sign: Some(false),
             output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
         },
         autonoetic_gateway::capsule::ExportContext {
             gateway_dir: &f.gateway_dir,
@@ -242,6 +247,7 @@ fn import_dry_run_does_not_persist_revision() {
             dry_run: true,
             activate: false,
             trust_domain_override: None,
+            memory_conflict_policy: Default::default(),
         },
         autonoetic_gateway::capsule::ImportContext {
             gateway_dir: &f2.gateway_dir,
@@ -269,6 +275,8 @@ fn tampered_archive_fails_verify_signature() {
             include_memory: None,
             sign: Some(true),
             output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
         },
         autonoetic_gateway::capsule::ExportContext {
             gateway_dir: &f.gateway_dir,
@@ -317,6 +325,7 @@ fn tampered_archive_fails_verify_signature() {
             dry_run: false,
             activate: false,
             trust_domain_override: None,
+            memory_conflict_policy: Default::default(),
         },
         autonoetic_gateway::capsule::ImportContext {
             gateway_dir: &f2.gateway_dir,
@@ -345,6 +354,8 @@ fn import_refuses_archive_exceeding_size_cap() {
             include_memory: None,
             sign: Some(false),
             output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
         },
         autonoetic_gateway::capsule::ExportContext {
             gateway_dir: &f.gateway_dir,
@@ -363,6 +374,7 @@ fn import_refuses_archive_exceeding_size_cap() {
             dry_run: true,
             activate: false,
             trust_domain_override: None,
+            memory_conflict_policy: Default::default(),
         },
         autonoetic_gateway::capsule::ImportContext {
             gateway_dir: &f.gateway_dir,
@@ -391,6 +403,8 @@ fn second_import_is_dedup_noop_for_existing_revision() {
             include_memory: None,
             sign: Some(false),
             output_path: Some(archive.clone()),
+            session_id: None,
+            root_session_id: None,
         },
         autonoetic_gateway::capsule::ExportContext {
             gateway_dir: &f.gateway_dir,
@@ -425,6 +439,7 @@ fn second_import_is_dedup_noop_for_existing_revision() {
             dry_run: false,
             activate: false,
             trust_domain_override: None,
+            memory_conflict_policy: Default::default(),
         },
         autonoetic_gateway::capsule::ImportContext {
             gateway_dir: &f2.gateway_dir,
@@ -442,6 +457,7 @@ fn second_import_is_dedup_noop_for_existing_revision() {
             dry_run: false,
             activate: false,
             trust_domain_override: None,
+            memory_conflict_policy: Default::default(),
         },
         autonoetic_gateway::capsule::ImportContext {
             gateway_dir: &f2.gateway_dir,

--- a/autonoetic-ofp/Cargo.toml
+++ b/autonoetic-ofp/Cargo.toml
@@ -8,3 +8,4 @@ license.workspace = true
 autonoetic-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+base64 = "0.22.1"

--- a/autonoetic-ofp/src/wire.rs
+++ b/autonoetic-ofp/src/wire.rs
@@ -110,6 +110,43 @@ pub enum WireRequest {
     /// Ping to check if the peer is alive.
     #[serde(rename = "ping")]
     Ping,
+
+    /// Offer a Cognitive Capsule for transfer to the peer.
+    /// The peer responds with `CapsuleAccept` (or `Error`), and the
+    /// originator then streams chunks via `CapsuleData` followed by
+    /// `CapsuleComplete`. Requires the `capsule_transfer` extension to
+    /// be advertised by both peers at handshake time.
+    #[serde(rename = "capsule_offer")]
+    CapsuleOffer {
+        /// ID of the capsule being offered.
+        capsule_id: String,
+        /// SHA-256 of the canonical manifest JSON (with the `signature`
+        /// field cleared). Lets the receiver verify the eventual
+        /// `capsule.json` matches what was advertised.
+        manifest_digest: String,
+        /// Total archive size in bytes.
+        size_bytes: u64,
+    },
+
+    /// Stream a chunk of capsule archive bytes. `chunk_index` is zero-based
+    /// and monotonically increasing within a single offer.
+    #[serde(rename = "capsule_data")]
+    CapsuleData {
+        capsule_id: String,
+        chunk_index: u32,
+        /// Raw archive bytes (base64-encoded inside JSON).
+        #[serde(with = "base64_bytes")]
+        data: Vec<u8>,
+    },
+
+    /// Signal end of stream. The receiver computes a SHA-256 over the
+    /// reassembled bytes and verifies it matches `digest`.
+    #[serde(rename = "capsule_complete")]
+    CapsuleComplete {
+        capsule_id: String,
+        /// SHA-256 hex of the reassembled archive bytes.
+        digest: String,
+    },
 }
 
 /// Response messages.
@@ -184,7 +221,53 @@ pub enum WireResponse {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         peer_event_ref: Option<PeerEventRef>,
     },
+
+    /// Accept a previously-received `CapsuleOffer` — the originator may
+    /// now begin streaming `CapsuleData` chunks.
+    #[serde(rename = "capsule_accept")]
+    CapsuleAccept { capsule_id: String },
+
+    /// Acknowledge a completed capsule transfer with the import outcome.
+    #[serde(rename = "capsule_ack")]
+    CapsuleAck {
+        capsule_id: String,
+        /// Whether the import was successful on the receiver.
+        imported: bool,
+        /// Optional error reason when `imported = false`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        /// Revision ID created on the receiver (when imported).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        revision_id: Option<String>,
+    },
 }
+
+/// Base64 helper for the `Vec<u8>` payload of [`WireRequest::CapsuleData`].
+mod base64_bytes {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        STANDARD.decode(s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Name of the OFP extension that gates the `capsule_transfer` family.
+/// Both peers must advertise this string in their handshake to enable
+/// `CapsuleOffer` / `CapsuleAccept` / `CapsuleData` / `CapsuleComplete`
+/// / `CapsuleAck`.
+pub const CAPSULE_TRANSFER_EXTENSION: &str = "capsule_transfer";
 
 /// Notification messages (one-way, no response).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -296,6 +379,95 @@ mod tests {
         assert_eq!(len as usize, bytes.len() - 4);
         let decoded = decode_message(&bytes[4..]).unwrap();
         assert_eq!(decoded.id, "msg-1");
+    }
+
+    #[test]
+    fn capsule_offer_request_roundtrip() {
+        let msg = WireMessage {
+            id: "cap-offer-1".to_string(),
+            signature: None,
+            seq_num: None,
+            kind: WireMessageKind::Request(WireRequest::CapsuleOffer {
+                capsule_id: "cap_sha256:abc".to_string(),
+                manifest_digest: "deadbeef".to_string(),
+                size_bytes: 1024,
+            }),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("capsule_offer"));
+        let decoded: WireMessage = serde_json::from_str(&json).unwrap();
+        match decoded.kind {
+            WireMessageKind::Request(WireRequest::CapsuleOffer {
+                capsule_id,
+                manifest_digest,
+                size_bytes,
+            }) => {
+                assert_eq!(capsule_id, "cap_sha256:abc");
+                assert_eq!(manifest_digest, "deadbeef");
+                assert_eq!(size_bytes, 1024);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn capsule_data_base64_roundtrip() {
+        let payload = vec![1u8, 2, 3, 4, 5];
+        let msg = WireMessage {
+            id: "cap-data-1".to_string(),
+            signature: None,
+            seq_num: None,
+            kind: WireMessageKind::Request(WireRequest::CapsuleData {
+                capsule_id: "cap_sha256:abc".to_string(),
+                chunk_index: 0,
+                data: payload.clone(),
+            }),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: WireMessage = serde_json::from_str(&json).unwrap();
+        match decoded.kind {
+            WireMessageKind::Request(WireRequest::CapsuleData {
+                data, chunk_index, ..
+            }) => {
+                assert_eq!(data, payload);
+                assert_eq!(chunk_index, 0);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn capsule_ack_response_roundtrip() {
+        let msg = WireMessage {
+            id: "cap-ack-1".to_string(),
+            signature: None,
+            seq_num: None,
+            kind: WireMessageKind::Response(WireResponse::CapsuleAck {
+                capsule_id: "cap_x".to_string(),
+                imported: true,
+                reason: None,
+                revision_id: Some("rev_sha256:xyz".to_string()),
+            }),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("capsule_ack"));
+        let decoded: WireMessage = serde_json::from_str(&json).unwrap();
+        match decoded.kind {
+            WireMessageKind::Response(WireResponse::CapsuleAck {
+                imported,
+                revision_id,
+                ..
+            }) => {
+                assert!(imported);
+                assert_eq!(revision_id.as_deref(), Some("rev_sha256:xyz"));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn capsule_transfer_extension_name_is_stable() {
+        assert_eq!(CAPSULE_TRANSFER_EXTENSION, "capsule_transfer");
     }
 
     #[test]

--- a/autonoetic-types/src/capsule.rs
+++ b/autonoetic-types/src/capsule.rs
@@ -210,6 +210,38 @@ pub struct CapsuleManifest {
     /// Skill names this capsule depends on but does not bundle.
     #[serde(default)]
     pub requires_skills: Vec<String>,
+
+    // --- Mode-specific extras ---
+    /// Scheduled job definitions bundled into Headless-mode capsules. On
+    /// import the receiving gateway recreates these jobs via the
+    /// scheduler (subject to local config caps).
+    #[serde(default)]
+    pub scheduled_jobs: Vec<CapsuleScheduledJob>,
+    /// Build platform of the originating gateway. Importers compare
+    /// against the local platform when `trust_domain` is not `"local"`
+    /// to refuse incompatible layer bundles.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<CapsulePlatform>,
+}
+
+/// A scheduled job definition bundled in a Headless-mode capsule.
+///
+/// Mirrors the gateway's `autonoetic_types::scheduled_job::ScheduledJob`
+/// shape so the importer can `INSERT` directly. Job IDs are remapped on
+/// import to avoid collisions with the receiver's existing jobs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapsuleScheduledJob {
+    pub job_id: String,
+    pub owner_agent_id: String,
+    pub root_session_id: String,
+    pub target_agent_id: String,
+    pub target_revision_id: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_json: Option<String>,
+    pub cron_expr: String,
+    pub timezone: String,
+    pub created_at: String,
 }
 
 fn default_format_version() -> String {
@@ -309,6 +341,11 @@ mod tests {
             },
             requires_agents: vec!["lead".to_string()],
             requires_skills: vec!["researcher".to_string()],
+            scheduled_jobs: vec![],
+            platform: Some(CapsulePlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+            }),
         }
     }
 

--- a/autonoetic/src/cli/capsule.rs
+++ b/autonoetic/src/cli/capsule.rs
@@ -8,7 +8,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use autonoetic_gateway::capsule::{self, ExportRequest, ImportRequest};
+use autonoetic_gateway::capsule::{self, ExportRequest, ImportRequest, MemoryConflictPolicy};
 use autonoetic_gateway::config::load_config;
 use autonoetic_gateway::execution::gateway_root_dir;
 use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
@@ -38,6 +38,8 @@ pub fn handle_export(
     include_memory: Option<bool>,
     sign: Option<bool>,
     output: Option<&Path>,
+    session_id: Option<&str>,
+    root_session_id: Option<&str>,
     json: bool,
 ) -> anyhow::Result<()> {
     let config = load_config(config_path)?;
@@ -55,6 +57,8 @@ pub fn handle_export(
         include_memory,
         sign,
         output_path: output.map(|p| p.to_path_buf()),
+        session_id: session_id.map(|s| s.to_string()),
+        root_session_id: root_session_id.map(|s| s.to_string()),
     };
     let outcome = capsule::export(
         req,
@@ -94,11 +98,21 @@ pub fn handle_import(
     activate: bool,
     dry_run: bool,
     trust_domain: Option<&str>,
+    memory_conflict: &str,
     json: bool,
 ) -> anyhow::Result<()> {
     let config = load_config(config_path)?;
     let gateway_dir = gateway_root_dir(&config);
     let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let memory_conflict_policy = match memory_conflict.to_ascii_lowercase().as_str() {
+        "keep-local" | "keep_local" => MemoryConflictPolicy::KeepLocal,
+        "overwrite-local" | "overwrite_local" => MemoryConflictPolicy::OverwriteLocal,
+        other => anyhow::bail!(
+            "unknown --memory-conflict value '{}' (expected: keep-local | overwrite-local)",
+            other
+        ),
+    };
 
     let req = ImportRequest {
         archive_path: archive.to_path_buf(),
@@ -106,6 +120,7 @@ pub fn handle_import(
         activate,
         dry_run,
         trust_domain_override: trust_domain.map(|s| s.to_string()),
+        memory_conflict_policy,
     };
     let outcome = capsule::import(
         req,

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -210,6 +210,12 @@ pub enum CapsuleCommands {
         /// Output archive path (default: <agent_id>.capsule.tar.zst).
         #[arg(long)]
         output: Option<std::path::PathBuf>,
+        /// Session whose latest checkpoint to bundle (required for `--mode replay`).
+        #[arg(long)]
+        session_id: Option<String>,
+        /// Root session whose scheduled jobs to bundle (required for `--mode headless`).
+        #[arg(long)]
+        root_session_id: Option<String>,
         /// Emit machine-readable JSON output.
         #[arg(long)]
         json: bool,
@@ -230,6 +236,10 @@ pub enum CapsuleCommands {
         /// Override trust domain stamped on the imported revision.
         #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(["local", "partner", "foreign"]))]
         trust_domain: Option<String>,
+        /// Memory conflict policy when an entry already exists locally:
+        /// `keep-local` (default, skip) or `overwrite-local`.
+        #[arg(long, default_value = "keep-local")]
+        memory_conflict: String,
         /// Emit machine-readable JSON output.
         #[arg(long)]
         json: bool,

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -647,6 +647,8 @@ async fn main() -> anyhow::Result<()> {
                 include_memory,
                 sign,
                 output,
+                session_id,
+                root_session_id,
                 json,
             } => {
                 cli::capsule::handle_export(
@@ -657,6 +659,8 @@ async fn main() -> anyhow::Result<()> {
                     *include_memory,
                     *sign,
                     output.as_deref(),
+                    session_id.as_deref(),
+                    root_session_id.as_deref(),
                     *json,
                 )?;
             }
@@ -666,6 +670,7 @@ async fn main() -> anyhow::Result<()> {
                 activate,
                 dry_run,
                 trust_domain,
+                memory_conflict,
                 json,
             } => {
                 cli::capsule::handle_import(
@@ -675,6 +680,7 @@ async fn main() -> anyhow::Result<()> {
                     *activate,
                     *dry_run,
                     trust_domain.as_deref(),
+                    memory_conflict,
                     *json,
                 )?;
             }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -516,8 +516,12 @@ autonoetic capsule export <agent_id> \
   [--sign[=true|false]]                    # sign with the gateway key;
                                            # omit to defer to config.capsule.auto_sign
   [--output <path>]                        # default: <agent_id>.capsule.tar.zst
+  [--session-id <id>]                      # required for --mode replay
+  [--root-session-id <id>]                 # required for --mode headless
   [--json]
 ```
+
+Replay mode bundles the latest `SessionCheckpoint` for `--session-id`; Headless mode bundles all scheduled jobs under `--root-session-id`. Importers recreate jobs with prefixed IDs and lay the checkpoint into the receiving gateway's `.gateway/checkpoints/` so the scheduler resume path can pick it up.
 
 ### `autonoetic capsule import`
 
@@ -528,7 +532,8 @@ autonoetic capsule import <path> \
   [--verify-signature]                     # require + verify a trusted signature
   [--activate]                             # bind the alias to the imported revision
   [--dry-run]                              # validate only
-  [--trust-domain local|partner|foreign]   # constrained set; clap rejects other values
+  [--trust-domain local|partner|foreign]   # constrained set; clap rejects other values; platform compatibility only enforced when != local
+  [--memory-conflict keep-local|overwrite-local]   # default: keep-local
   [--json]
 ```
 

--- a/docs/design/cognitive-capsule-implementation-plan.md
+++ b/docs/design/cognitive-capsule-implementation-plan.md
@@ -1,0 +1,373 @@
+# Cognitive Capsule Standardization — Phased Implementation Plan
+
+**Umbrella**: [#220](https://github.com/mandubian/autonoetic/issues/220)
+**Companion design doc**: [`cognitive-capsule-standardization.md`](cognitive-capsule-standardization.md)
+
+This document records the phased implementation strategy that landed the
+Cognitive Capsule standardization umbrella. The companion design doc
+covers the *what* and *why*; this one covers the *how* — what was split
+out per phase, what was reused from existing infrastructure, and where
+each surface lives in the tree.
+
+## Status
+
+| Phase | Issue | PR | Surface |
+|---|---|---|---|
+| 1 — Schema & Core Types | [#222](https://github.com/mandubian/autonoetic/issues/222) | [#280](https://github.com/mandubian/autonoetic/pull/280) | `autonoetic-types` |
+| 2 — Export / Import Pipeline | [#223](https://github.com/mandubian/autonoetic/issues/223) | [#281](https://github.com/mandubian/autonoetic/pull/281) | `autonoetic-gateway::capsule` |
+| 3 — CLI & Gateway Tools | [#224](https://github.com/mandubian/autonoetic/issues/224) | [#282](https://github.com/mandubian/autonoetic/pull/282) | `autonoetic::cli::capsule`, `runtime::tools::capsule` |
+| 4 — Federation & Advanced Modes | [#225](https://github.com/mandubian/autonoetic/issues/225) | [#283](https://github.com/mandubian/autonoetic/pull/283) | `autonoetic-ofp::wire`, gateway Replay / Headless / memory glue |
+
+PRs are stacked: each targets the previous phase's branch and
+auto-retargets to `main` as the predecessor merges. The umbrella stays
+open until all four merge.
+
+## Context
+
+Issue [#220](https://github.com/mandubian/autonoetic/issues/220) promotes
+the existing minimal `CapsuleManifest` (in
+`autonoetic-types/src/capsule.rs`) into a first-class portable agent
+format. Before this work the codebase had only the bones —
+`CapsuleMode { Thin, Hermetic }`, `IncludedArtifact`,
+`CapsuleGatewayRuntime` — with no pipeline, no signature, no CLI, no
+agent tools, no federation transport.
+
+## Reusable infrastructure (zero changes needed)
+
+The companion design doc identifies these building blocks. The capsule
+pipeline composes them rather than reinventing storage, signing, or
+redaction.
+
+| Component | Path | Used for |
+|---|---|---|
+| `AgentRevisionRecord`, `AgentRef`, `short_id()` | `autonoetic-types/src/agent_revision.rs` | Immutable revision pinning |
+| `RuntimeLock`, `LockedLayerMount`, `LockedArtifact` | `autonoetic-types/src/runtime_lock.rs` | Execution closure |
+| `LayerStore`, `LayerManifest`, `CapturedLayer` | `autonoetic-types/src/layer.rs` + gateway store | Layer dedup/import |
+| `ArtifactBundle`, `ArtifactHandle`, `ArtifactKind` | `autonoetic-types/src/artifact.rs` | Artifact closure |
+| `redact_json_value`, `redact_embedded_secrets`, `is_sensitive_key` | `autonoetic-types/src/redaction.rs` | Secret scrubbing |
+| `ContentStore` (SHA-256, dedup) | `autonoetic-gateway/src/runtime/content_store.rs` | Blob storage |
+| `SessionCheckpoint`, `save_checkpoint`, `load_latest_checkpoint` | `autonoetic-gateway/src/runtime/checkpoint.rs` | Replay mode |
+| `GatewayIdentityKey` (Ed25519 sign / fingerprint) | `autonoetic-gateway/src/runtime/crypto.rs` | Capsule signing |
+| Causal events + `causal_events` SQLite mirror | gateway runtime | `capsule.export` / `capsule.import` audit |
+| Scheduled jobs store | `autonoetic-gateway/src/scheduler/gateway_store/scheduled_jobs.rs` | Headless mode |
+| Memory store (`memory_list_ids_owned_by`, `memory_get_unrestricted`, `memory_upsert`) | `autonoetic-gateway/src/scheduler/gateway_store/memory.rs` | Memory snapshot |
+
+---
+
+## Phase 1 — Schema & Core Types ([#222](https://github.com/mandubian/autonoetic/issues/222))
+
+**Branch**: `capsule/phase-1-schema`
+**Surface**: `autonoetic-types` only. Touches gateway only via exhaustive
+match arms for the new `Capability` variant.
+
+### Files modified
+
+- `autonoetic-types/src/capsule.rs` — full rewrite of the manifest module:
+  - `CapsuleMode` gains `Replay` and `Headless` variants
+  - Helpers `is_hermetic()`, `needs_checkpoint()` on `CapsuleMode`
+  - New structs: `CapsuleSignature`, `CapsuleMemorySnapshot`, `CapsuleProvenance`, `CapsulePlatform`, `CapsuleLayerRef`
+  - `CapsuleManifest` gains: `format_version` (const `CAPSULE_FORMAT_VERSION = "1.0.0"`), `revision_id`, `revision_short_id`, `content_digest`, `included_layers`, `included_skills`, `memory_snapshot`, `checkpoint_handle`, `signature`, `provenance`, `requires_agents`, `requires_skills`
+  - All new fields use `#[serde(default)]` / `skip_serializing_if = "Option::is_none"` so older capsules still parse (forward compat)
+  - Methods `format_major_version() -> Option<u64>` and `layer_embedded_path()`
+- `autonoetic-types/src/capability.rs`:
+  - New `Capability::CapsuleExport` variant (unit; no payload — capsule pipelines self-describe scope via mode/include flags)
+  - Update `capability_type_name`, `all_capability_kind_names`, and the exhaustiveness pin test
+- `autonoetic-types/src/config.rs`:
+  - New `CapsuleConfig` struct: `trusted_signers: HashMap<String,String>`, `default_mode: String`, `max_capsule_size_bytes: u64`, `auto_sign: bool`, `include_memory_by_default: bool`
+  - Wire `pub capsule: CapsuleConfig` into `GatewayConfig` with `#[serde(default)]`
+- `autonoetic-gateway/src/runtime/analysis/mod.rs`, `runtime/capability_inference.rs`, `runtime/state_attestation.rs`, `runtime/tools/mod.rs`:
+  - Add `Capability::CapsuleExport => "CapsuleExport"` arm to each local `capability_type_name` match (4 sites; compiler-enforced via E0004)
+- `config/config-template.yaml` — commented `capsule:` block under retention
+- `docs/config-reference.md` — appended "Cognitive Capsules" subsection mirroring the retention/sentinel sections
+
+### Verification
+
+```bash
+cargo test -p autonoetic-types --lib capsule        # 11 new unit tests
+cargo test -p autonoetic-types --lib capability     # 9 capability tests
+cargo build --workspace
+```
+
+---
+
+## Phase 2 — Export / Import Pipeline ([#223](https://github.com/mandubian/autonoetic/issues/223))
+
+**Branch**: `capsule/phase-2-pipeline`
+**Surface**: `autonoetic-gateway` — new module `capsule/`.
+
+### Module layout (in `autonoetic-gateway/src/capsule/`)
+
+```
+mod.rs       — public re-exports: ExportRequest, ExportOutcome,
+               ImportRequest, ImportOutcome, MemoryConflictPolicy,
+               ExportContext, ImportContext
+archive.rs   — tar.zst pack/unpack with size cap from
+               CapsuleConfig.max_capsule_size_bytes + path-traversal
+               guard (rejects absolute paths and `..` segments)
+verify.rs    — canonical-JSON digest (signature field cleared during
+               canonicalisation), Ed25519 sign_manifest /
+               verify_signature, SignatureStatus
+export.rs    — pipeline: resolve → collect → scrub → manifest → digest
+               → sign → archive → event
+import.rs    — pipeline: extract → parse → verify → compat → dedup →
+               revision → memory → event
+```
+
+Wired into `autonoetic-gateway/src/lib.rs` (`pub mod capsule;`).
+
+### Export pipeline (`export.rs`)
+
+1. Resolve agent + revision selector via existing `GatewayStore::get_agent_revision` / `get_agent_alias`.
+2. Copy SKILL.md, runtime.lock, and the rest of the revision directory under `agent/` in a tempdir.
+3. Apply `redact_embedded_secrets()` per text file; record per-file redactions.
+4. (Phase 4) Hermetic mode embeds layer archives; Replay mode bundles the latest `SessionCheckpoint`; Headless mode bundles scheduled jobs.
+5. Build `CapsuleManifest`; populate `provenance` from gateway `node_id`, crate version, `"local"`.
+6. If `signed`: load `GatewayIdentityKey` and sign the canonical JSON (signature field cleared during canonicalisation, mirroring `state_attestation`).
+7. Write `capsule.json` to staging.
+8. `archive::pack` the staging dir into `tar.zst`.
+9. Enforce `cfg.max_capsule_size_bytes` on the resulting archive.
+10. Emit a `capsule.export` causal event (`category = "capsule"`, `action = "export"`, payload `{capsule_id, revision_id, mode, size_bytes, signed}`).
+
+### Import pipeline (`import.rs`)
+
+1. Stat the archive; refuse if larger than `max_capsule_size_bytes`.
+2. Extract into a tempdir via `archive::unpack`, which also enforces the
+   size cap on the *decompressed* total.
+3. Parse `capsule.json`; refuse `format_major_version` > current.
+4. Verify signature against `cfg.trusted_signers` when
+   `verify_signature` is true; refuse `Mismatch` /
+   `UntrustedSigner` / `MissingRequired` outcomes.
+5. (Phase 4) Platform compat: refuse when `trust_domain != "local"`
+   and `CapsulePlatform` mismatches the local one.
+6. Walk `agent/` and dedup blobs into `ContentStore`; track
+   `dedup_savings_bytes`.
+7. Materialise the revision directory at
+   `.gateway/revisions/agents/<agent>/<rev>/`.
+8. Insert `AgentRevisionRecord` with `source_kind = "capsule_import"` and
+   `source_ref = capsule_id`.
+9. If `--activate`: upsert the agent alias to point at the new revision.
+10. (Phase 4) Memory + checkpoint + scheduled-jobs side effects.
+11. Emit a `capsule.import` causal event.
+
+### Tests
+
+`autonoetic-gateway/tests/capsule_pipeline_integration.rs` covers:
+
+- thin export → import roundtrip creates a `capsule_import` revision
+- `SKILL.md` containing `sk-…` is scrubbed before the archive is written
+- `--dry-run` leaves the receiver untouched
+- tampered manifest fails signature verification
+- archive over `max_capsule_size_bytes` is refused before extraction
+- second import is a no-op for an already-present revision (non-decreasing dedup)
+
+Unit tests live in each submodule (`archive`, `export`, `import`,
+`verify`): 14 in total.
+
+---
+
+## Phase 3 — CLI & Gateway Tools ([#224](https://github.com/mandubian/autonoetic/issues/224))
+
+**Branch**: `capsule/phase-3-cli`
+**Surface**: `autonoetic` (CLI) + `autonoetic-gateway` (agent tools, policy).
+
+### CLI (`autonoetic/src/cli/capsule.rs`)
+
+Subcommands plumbed through clap, dispatched from `autonoetic/src/main.rs`:
+
+```
+autonoetic capsule export <agent_id>
+  [--mode thin|hermetic|replay|headless] [--revision <rev_id>]
+  [--include-memory] [--sign] [--output <path>]
+  [--session-id <id>]          # required for --mode replay
+  [--root-session-id <id>]     # required for --mode headless
+  [--json]
+
+autonoetic capsule import <path>
+  [--verify-signature] [--activate] [--dry-run]
+  [--trust-domain local|partner|foreign]
+  [--memory-conflict keep-local|overwrite-local]
+  [--json]
+
+autonoetic capsule verify <path>  [--json]
+autonoetic capsule inspect <path> [--json]
+```
+
+Each subcommand loads `config.yaml` via `autonoetic_gateway::config::load_config`, opens the `GatewayStore`, and delegates to `autonoetic_gateway::capsule::{export, import, verify}`.
+
+`verify` prints a structured report (manifest schema, canonical digest,
+signature status, redactions, provenance). `inspect` prints the
+`capsule.json` summary.
+
+### Agent tools (`autonoetic-gateway/src/runtime/tools/capsule.rs`)
+
+```
+capsule.export(agent_id, mode?, include_memory?, sign?, output?,
+               revision?, session_id?, root_session_id?)
+  → { capsule_path, capsule_id, mode, signed, size_bytes,
+      manifest_digest, redactions }
+
+capsule.import(archive, verify_signature?, activate?, dry_run?,
+               trust_domain?)
+  → { capsule_id, agent_id, revision_id, signature_status,
+      created_revision, dedup_savings_bytes, … }
+```
+
+Both gated by `Capability::CapsuleExport`. Registered in
+`runtime/tools/mod.rs::default_registry`.
+
+### Policy
+
+`PolicyEngine::can_use_capsule()` in `autonoetic-gateway/src/policy.rs`:
+pattern-matches the `CapsuleExport` variant, returns `allow("R-1.1")` or
+`deny("R-1.1")`. Tool execution checks this gate before unpacking
+arguments.
+
+### Tests
+
+- `autonoetic-gateway/tests/capsule_tools_integration.rs` — capability gate (tool unavailable without `CapsuleExport`) + tool definition schema check
+- `autonoetic/tests/capsule_cli_e2e.rs` — drives the actual binary end-to-end through export → inspect → verify → import --dry-run
+- `docs/CLI.md` — new "Capsule Commands" section
+
+---
+
+## Phase 4 — Federation & Advanced Modes ([#225](https://github.com/mandubian/autonoetic/issues/225))
+
+**Branch**: `capsule/phase-4-federation`
+**Surface**: `autonoetic-ofp` (wire protocol), `autonoetic-gateway`
+(transfer handlers, Replay / Headless / memory glue).
+
+### OFP `capsule_transfer` extension (`autonoetic-ofp/src/wire.rs`)
+
+New `WireRequest` variants:
+
+```
+CapsuleOffer    { capsule_id, manifest_digest, size_bytes }
+CapsuleData     { capsule_id, chunk_index, data }   # base64 in JSON
+CapsuleComplete { capsule_id, digest }
+```
+
+New `WireResponse` variants:
+
+```
+CapsuleAccept   { capsule_id }
+CapsuleAck      { capsule_id, imported, reason, revision_id }
+```
+
+Plus the extension name constant
+`CAPSULE_TRANSFER_EXTENSION = "capsule_transfer"` for handshake-time
+negotiation. `autonoetic-ofp` picks up `base64 = "0.22"` for the
+`CapsuleData.data` chunk encoding.
+
+The receive-side dispatcher (`autonoetic-gateway/src/server/ofp.rs`) is
+**deferred to a follow-up PR**. Until that lands, the existing
+wildcard arm returns `WireResponse::Error { code: 501 }` for the new
+variants. The wire schema is stable, so federation glue can be added
+incrementally without re-opening the protocol.
+
+### Schema additions (forward-compat)
+
+In `autonoetic-types/src/capsule.rs`:
+
+- `CapsuleManifest.scheduled_jobs: Vec<CapsuleScheduledJob>` — populated in Headless mode
+- `CapsuleManifest.platform: Option<CapsulePlatform>` — stamped on every export
+
+Both `#[serde(default)]`, so older capsules still parse.
+
+### Replay mode
+
+- Export takes a required `session_id` and bundles the latest
+  `SessionCheckpoint` via `load_latest_checkpoint`, writing it to
+  `checkpoint/checkpoint.json` and setting `checkpoint_handle`.
+- Import deserialises the checkpoint and calls `save_checkpoint`, laying
+  the file into the receiver's `.gateway/checkpoints/<session>/` tree.
+  The scheduler's existing resume path picks it up on the next tick;
+  no new JSON-RPC verb is needed.
+
+### Headless mode
+
+- Export takes a required `root_session_id` and bundles every row from
+  `GatewayStore::list_scheduled_jobs_for_root` into `scheduled_jobs`.
+- Import iterates `manifest.scheduled_jobs` and inserts each via
+  `GatewayStore::create_scheduled_job`, prefixing the new `job_id`
+  with `job_capsule_<original>_<uuid>` to avoid collisions with the
+  receiver's pre-existing jobs.
+
+### Memory snapshot (made real)
+
+Phase 2 stubbed the snapshot; Phase 4 makes it real:
+
+- Export: `memory_list_ids_owned_by` → loop `memory_get_unrestricted`
+  → `redact_json_value` per entry → write `memory/memory_snapshot.json`.
+- Import: walk entries, deserialise each `MemoryObject`, consult the
+  conflict policy:
+
+  ```
+  enum MemoryConflictPolicy { KeepLocal, OverwriteLocal }   # default KeepLocal
+  ```
+
+  `KeepLocal` (the default) skips when a `memory_id` already exists
+  locally; `OverwriteLocal` upserts unconditionally. The import outcome
+  reports `memory_entries_imported` and `memory_entries_skipped`.
+
+### Platform compatibility hard-fail
+
+When `trust_domain != "local"` and the embedded `CapsulePlatform`
+mismatches `std::env::consts::OS` / `ARCH`, the import is refused
+before any persistence. Within the `"local"` trust domain the operator
+explicitly bypasses the check (so dev workflows on macOS can pull
+capsules built in Linux CI).
+
+### Tests
+
+- `autonoetic-ofp` unit tests — wire roundtrip for `CapsuleOffer`,
+  `CapsuleData` (base64), `CapsuleAck`, plus the extension-name pin
+- `autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs`:
+  - Replay export → import → checkpoint laid down at the receiver
+  - Headless export → import → scheduled job recreated with prefixed ID
+  - Memory KeepLocal vs OverwriteLocal policy behaviour
+  - Platform mismatch refused in `foreign` trust domain, accepted in `local`
+
+---
+
+## Verification across all phases
+
+After each phase merges:
+
+```bash
+cargo build --workspace
+cargo test --workspace
+cargo run -p autonoetic -- capsule export <fixture> --mode hermetic --sign   # Phase 3+
+cargo run -p autonoetic -- capsule verify <archive>
+cargo run -p autonoetic -- capsule import <archive> --activate --verify-signature
+```
+
+Causal-chain audit:
+
+```bash
+cargo run -p autonoetic -- trace list | grep capsule_export
+cargo run -p autonoetic -- trace list | grep capsule_import
+```
+
+## Decisions confirmed during implementation
+
+1. **`CapsuleConfig.auto_sign = true` default** — mirrors revision auto-signing; operators can override per-export via `--sign=false`.
+2. **`dedup_savings_bytes` surfaced both in the causal event and the import outcome** — helps operators see the value in CLI output as well as audit history.
+3. **Memory conflict policy default = `KeepLocal`** — avoids capsule imports silently overwriting curated knowledge on the receiver.
+4. **OFP receive-side dispatcher deferred** — Phase 4 ships the wire schema and import glue; wiring the dispatcher (with HMAC + sequence-number integration) is a follow-up since the existing 501 fallback covers unknown variants safely.
+
+## Deltas from the original plan
+
+- The Phase 4 OFP **receive-side handler** in `server/ofp.rs` was
+  intentionally deferred to a follow-up PR — the wire types alone are a
+  stable surface and the existing wildcard error fallback covers any
+  unknown variant.
+- Memory conflict policy ships with two values (`KeepLocal`,
+  `OverwriteLocal`) instead of the originally-sketched three; the
+  `merge_into_namespaced_scope` policy was not necessary for the cases
+  the test fixtures exercise and would have required schema-level
+  decisions about scope namespacing that did not have a clear use case.
+- Replay-mode session resume **does not** require a one-shot operator
+  approval at this stage. The capsule pipeline only restores the
+  checkpoint file; the scheduler's existing resume path retains its
+  own approval/yield-reason gating, which already handles the
+  cross-gateway case.

--- a/docs/design/cognitive-capsule-standardization.md
+++ b/docs/design/cognitive-capsule-standardization.md
@@ -1,6 +1,7 @@
 # Cognitive Capsule Standardization — Design Plan
 
 **Concept origin**: `docs/design/concepts.md` (line 41)
+**Phased implementation plan**: [`cognitive-capsule-implementation-plan.md`](cognitive-capsule-implementation-plan.md)
 **Archived plan reference**: `docs/archived/plan_extended.md` Phase 13 (concepts only — code paths no longer match)
 
 ## Background


### PR DESCRIPTION
## Summary

Phase 4 of the [Cognitive Capsule Standardization umbrella (#220)](https://github.com/mandubian/autonoetic/issues/220). **Stacked on #282 (Phase 3)** — will retarget to `main` once Phase 3 merges.

### OFP `capsule_transfer` wire extension (`autonoetic-ofp`)

- New `WireRequest` variants: `CapsuleOffer { capsule_id, manifest_digest, size_bytes }`, `CapsuleData { capsule_id, chunk_index, data }` (base64-encoded bytes), `CapsuleComplete { capsule_id, digest }`
- New `WireResponse` variants: `CapsuleAccept { capsule_id }`, `CapsuleAck { capsule_id, imported, reason, revision_id }`
- New extension name constant `CAPSULE_TRANSFER_EXTENSION = "capsule_transfer"` for handshake negotiation
- Roundtrip tests for all three new variants + base64 encoding

### Schema additions (forward-compat — all `#[serde(default)]`)

- `CapsuleManifest.scheduled_jobs: Vec<CapsuleScheduledJob>` for Headless mode
- `CapsuleManifest.platform: Option<CapsulePlatform>` stamped on every export

### Export pipeline

- **Replay mode**: requires `session_id`, bundles latest `SessionCheckpoint` via `load_latest_checkpoint`
- **Headless mode**: requires `root_session_id`, bundles all `ScheduledJob` rows via `list_scheduled_jobs_for_root`
- **Real memory snapshot**: `memory_list_ids_owned_by` + `memory_get_unrestricted`, each entry passed through `redact_json_value`
- Every export stamps the current `CapsulePlatform`

### Import pipeline

- `MemoryConflictPolicy::{KeepLocal, OverwriteLocal}` (default `KeepLocal`); outcome reports imported vs skipped counts
- `recreate_scheduled_jobs` prefixes the new `job_id` with `job_capsule_<original>_` to avoid collisions
- `restore_checkpoint` writes the bundled checkpoint into the receiver's `.gateway/checkpoints/` so the scheduler resume path can pick it up
- Platform compatibility hard-fail: refused when `trust_domain != "local"` and the embedded `CapsulePlatform` mismatches

### CLI

- `capsule export` gains `--session-id` (Replay) and `--root-session-id` (Headless)
- `capsule import` gains `--memory-conflict {keep-local | overwrite-local}`

## What's deferred to a follow-up

The OFP receive-side dispatcher (`autonoetic-gateway/src/server/ofp.rs`) is not yet wired to call `capsule::import` when a `CapsuleData` stream completes. Until that lands, the existing wildcard arm returns `WireResponse::Error { code: 501 }` for the new variants. The wire types are stable, so federation-side glue can be added incrementally without re-opening the protocol.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p autonoetic-ofp` — 6/6 pass (3 new capsule wire tests + existing handshake + roundtrip)
- [x] `cargo test -p autonoetic-gateway --test capsule_phase4_advanced_modes` — 4/4 pass:
  - Replay export → import → checkpoint laid down at receiver
  - Headless export → import → scheduled job recreated with prefixed ID
  - Memory KeepLocal vs OverwriteLocal policy behaviour
  - Platform mismatch refused in `foreign` trust domain, accepted in `local`
- [x] Phase 2 + Phase 3 integration tests still pass

Closes #225. Depends on #224 (Phase 3 / #282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)