### PR TITLE
Make workflow.wait signal-driven instead of poll-by-default (#288 PR A)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/workflow.rs
+++ b/autonoetic-gateway/src/runtime/tools/workflow.rs
@@ -5,8 +5,8 @@ use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
 use autonoetic_types::agent::{AgentManifest, ToolTier};
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
-use serde::de::{self, DeserializeOwned};
 use serde::Deserialize;
+use serde::de;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -336,7 +336,7 @@ impl NativeTool for WorkflowWaitTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Wait for async tasks to complete. Pass task_ids from agent.spawn(async=true). Returns structured status for each task. Succeeded tasks include an 'output' field with 'implicit_artifact_id' (e.g., 'impl_task-abc123') plus 'named_outputs' and 'artifacts'. Use content.read with named_outputs[*].ref (preferred) or with implicit_artifact_id to inspect full payload. With timeout_secs=0 (default), returns current status immediately. With timeout_secs>0, polls until all tasks finish or timeout expires. When task_ids is empty or omitted, waits for all tasks in the current workflow.".to_string(),
+            description: "Suspends until watched task_ids reach terminal state (Succeeded, Failed, Cancelled, Aborted). Pass task_ids from agent.spawn(async=true). Returns structured status for each task. Succeeded tasks include an 'output' field with 'implicit_artifact_id' (e.g., 'impl_task-abc123') plus 'named_outputs' and 'artifacts'. Use content.read with named_outputs[*].ref (preferred) or with implicit_artifact_id to inspect full payload. By default, blocks for up to default_workflow_wait_secs (configurable, default 30s), waking immediately on child-state transitions. Pass timeout_secs=0 to probe current status without waiting. When task_ids is empty or omitted, waits for all tasks in the current workflow.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -353,13 +353,7 @@ impl NativeTool for WorkflowWaitTool {
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 300,
-                        "description": "Max seconds to wait. 0 = check once and return (default). >0 = poll until all tasks finish or timeout."
-                    },
-                    "poll_interval_secs": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 30,
-                        "description": "Seconds between status polls when blocking. Default: 2."
+                        "description": "Max seconds to block. Omit to use default_workflow_wait_secs (default 30s). 0 = probe once and return immediately (no blocking)."
                     }
                 },
                 "additionalProperties": false
@@ -388,8 +382,6 @@ impl NativeTool for WorkflowWaitTool {
             workflow_id: Option<String>,
             #[serde(default)]
             timeout_secs: Option<u64>,
-            #[serde(default)]
-            poll_interval_secs: Option<u64>,
         }
 
         let args: Args = serde_json::from_str(arguments_json)
@@ -428,8 +420,10 @@ impl NativeTool for WorkflowWaitTool {
 
         anyhow::ensure!(!task_ids.is_empty(), "no tasks found in workflow '{}'", workflow_id);
 
-        let timeout_secs = args.timeout_secs.unwrap_or(0).min(300);
-        let poll_interval_secs = args.poll_interval_secs.unwrap_or(2).clamp(1, 30);
+        let timeout_secs = args
+            .timeout_secs
+            .unwrap_or(gw_config.default_workflow_wait_secs)
+            .min(300);
 
         // Non-blocking mode: check once and return
         if timeout_secs == 0 {
@@ -472,10 +466,16 @@ impl NativeTool for WorkflowWaitTool {
             .map_err(Into::into);
         }
 
-        // Blocking mode: poll until join satisfied or timeout
+        // Blocking mode: wait for signal-driven wake or deadline
         let task_ids_clone = task_ids.clone();
         let wf_id = workflow_id.clone();
         let gw_config_arc = std::sync::Arc::new(gw_config.clone());
+        let notify = gateway_store
+            .as_ref()
+            .map(|s| {
+                let sid = session_id.unwrap_or(&manifest.agent.id);
+                s.task_notify.get_or_create(sid)
+            });
 
         let (
             tasks_status,
@@ -488,13 +488,13 @@ impl NativeTool for WorkflowWaitTool {
         ) = if let Ok(handle) = tokio::runtime::Handle::try_current() {
             tokio::task::block_in_place(|| {
                 handle.block_on(async {
-                    poll_until_join(
+                    signal_driven_wait(
                         gw_config_arc.as_ref(),
                         gateway_store.as_deref(),
                         &wf_id,
                         &task_ids_clone,
                         timeout_secs,
-                        poll_interval_secs,
+                        notify.as_ref(),
                         _gateway_dir,
                         session_id,
                     )
@@ -503,13 +503,13 @@ impl NativeTool for WorkflowWaitTool {
             })
         } else {
             tokio::runtime::Runtime::new()?.block_on(async {
-                poll_until_join(
+                signal_driven_wait(
                     gw_config_arc.as_ref(),
                     gateway_store.as_deref(),
                     &wf_id,
                     &task_ids_clone,
                     timeout_secs,
-                    poll_interval_secs,
+                    notify.as_ref(),
                     _gateway_dir,
                     session_id,
                 )
@@ -543,14 +543,15 @@ impl NativeTool for WorkflowWaitTool {
 }
 
 const STALL_GRACE_SECS: i64 = 30;
+const FALLBACK_POLL_SECS: u64 = 5;
 
-async fn poll_until_join(
+async fn signal_driven_wait(
     config: &GatewayConfig,
     store: Option<&crate::scheduler::gateway_store::GatewayStore>,
     workflow_id: &str,
     task_ids: &[String],
     timeout_secs: u64,
-    poll_interval_secs: u64,
+    notify: Option<&std::sync::Arc<tokio::sync::Notify>>,
     gateway_dir: Option<&Path>,
     session_id: Option<&str>,
 ) -> (
@@ -562,8 +563,9 @@ async fn poll_until_join(
     usize,
     Vec<serde_json::Value>,
 ) {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
-    let mut waited_secs = 0u64;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    let start = std::time::Instant::now();
+    let mut last_waited_report = 0u64;
 
     loop {
         let (tasks_status, all_done, any_failed, any_not_found, failed_task_count, failure_summary) =
@@ -575,6 +577,8 @@ async fn poll_until_join(
                 gateway_dir,
                 session_id,
             );
+        let waited_secs = start.elapsed().as_secs();
+
         if all_done {
             return (
                 tasks_status,
@@ -598,9 +602,8 @@ async fn poll_until_join(
             );
         }
 
-        // Stall detection: if a Running task has no transcript after STALL_GRACE_SECS,
-        // return early so the caller can take action instead of burning the full timeout.
-        if waited_secs >= STALL_GRACE_SECS as u64 {
+        if waited_secs >= STALL_GRACE_SECS as u64 && waited_secs != last_waited_report {
+            last_waited_report = waited_secs;
             if let Some(gw_store) = store {
                 let mut stall_detected = false;
                 let mut enriched_status = tasks_status.clone();
@@ -636,8 +639,7 @@ async fn poll_until_join(
             }
         }
 
-        let now = std::time::Instant::now();
-        if now >= deadline {
+        if tokio::time::Instant::now() >= deadline {
             return (
                 tasks_status,
                 false,
@@ -649,9 +651,19 @@ async fn poll_until_join(
             );
         }
 
-        let remaining = (deadline - now).as_secs().min(poll_interval_secs).max(1);
-        waited_secs += remaining;
-        tokio::time::sleep(std::time::Duration::from_secs(remaining)).await;
+        let fallback = tokio::time::sleep(std::time::Duration::from_secs(FALLBACK_POLL_SECS));
+        tokio::pin!(fallback);
+
+        if let Some(n) = notify {
+            let notified = n.notified();
+            tokio::pin!(notified);
+            tokio::select! {
+                _ = &mut notified => {}
+                _ = &mut fallback => {}
+            }
+        } else {
+            fallback.await;
+        }
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/workflow.rs
+++ b/autonoetic-gateway/src/runtime/tools/workflow.rs
@@ -470,12 +470,10 @@ impl NativeTool for WorkflowWaitTool {
         let task_ids_clone = task_ids.clone();
         let wf_id = workflow_id.clone();
         let gw_config_arc = std::sync::Arc::new(gw_config.clone());
-        let notify = gateway_store
-            .as_ref()
-            .map(|s| {
-                let sid = session_id.unwrap_or(&manifest.agent.id);
-                s.task_notify.get_or_create(sid)
-            });
+        let notify = match (gateway_store.as_ref(), session_id) {
+            (Some(s), Some(sid)) => Some(s.task_notify.get_or_create(sid)),
+            _ => None,
+        };
 
         let (
             tasks_status,

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -30,6 +30,7 @@ pub mod runner;
 pub mod signal;
 pub mod store;
 pub mod system_agents;
+pub mod task_notify;
 pub mod auto_learning_jobs;
 pub mod overflow_classifier;
 pub mod single_flight;

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -112,6 +112,7 @@ pub struct GatewayStore {
     /// Weak ref avoids an `Arc` cycle with [`crate::scheduler::hooks::HookExecutor`], which may
     /// hold an `Arc<GatewayStore>` for other hooks.
     policy_hook_executor: Mutex<Option<Weak<crate::scheduler::hooks::HookExecutor>>>,
+    pub task_notify: crate::scheduler::task_notify::TaskNotifyRegistry,
 }
 
 impl GatewayStore {
@@ -135,6 +136,7 @@ impl GatewayStore {
             approval_flood_cap: std::sync::atomic::AtomicUsize::new(0),
             escalation_flood_cap: std::sync::atomic::AtomicUsize::new(0),
             policy_hook_executor: Mutex::new(None),
+            task_notify: crate::scheduler::task_notify::TaskNotifyRegistry::new(),
         };
         {
             let mut conn = store.conn.lock().unwrap();

--- a/autonoetic-gateway/src/scheduler/signal.rs
+++ b/autonoetic-gateway/src/scheduler/signal.rs
@@ -304,6 +304,9 @@ pub fn send_child_state_notification(
         timestamp: chrono::Utc::now().to_rfc3339(),
     };
     write_signal(store, target_session_id, &signal_id, &signal)?;
+    if let Some(s) = store {
+        s.task_notify.notify_session(target_session_id);
+    }
     Ok(())
 }
 

--- a/autonoetic-gateway/src/scheduler/task_notify.rs
+++ b/autonoetic-gateway/src/scheduler/task_notify.rs
@@ -23,6 +23,7 @@ impl TaskNotifyRegistry {
         let map = self.notifiers.lock().expect("task_notify mutex poisoned");
         if let Some(notify) = map.get(session_id) {
             notify.notify_waiters();
+            notify.notify_one();
         }
     }
 }

--- a/autonoetic-gateway/src/scheduler/task_notify.rs
+++ b/autonoetic-gateway/src/scheduler/task_notify.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub struct TaskNotifyRegistry {
+    notifiers: Mutex<HashMap<String, Arc<tokio::sync::Notify>>>,
+}
+
+impl TaskNotifyRegistry {
+    pub fn new() -> Self {
+        Self {
+            notifiers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn get_or_create(&self, session_id: &str) -> Arc<tokio::sync::Notify> {
+        let mut map = self.notifiers.lock().expect("task_notify mutex poisoned");
+        map.entry(session_id.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Notify::new()))
+            .clone()
+    }
+
+    pub fn notify_session(&self, session_id: &str) {
+        let map = self.notifiers.lock().expect("task_notify mutex poisoned");
+        if let Some(notify) = map.get(session_id) {
+            notify.notify_waiters();
+        }
+    }
+}
+
+impl Default for TaskNotifyRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/autonoetic-gateway/tests/workflow_wait_signal_driven.rs
+++ b/autonoetic-gateway/tests/workflow_wait_signal_driven.rs
@@ -1,0 +1,410 @@
+//! Signal-driven workflow.wait integration tests (issue #288).
+//!
+//! Verifies that `workflow.wait` wakes on child-state transitions via the
+//! TaskNotifyRegistry rather than relying on polling.
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::scheduler::workflow_store::{self, save_task_run, save_workflow_run};
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::workflow::{TaskRun, TaskRunStatus, WorkflowRun, WorkflowRunStatus};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn planner_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "planner.default".to_string(),
+            name: "planner.default".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![Capability::AgentSpawn {
+            max_children: 4,
+            max_spawn_depth: 0,
+        }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn setup() -> anyhow::Result<(tempfile::TempDir, GatewayConfig, Arc<GatewayStore>)> {
+    let temp = tempdir()?;
+    let agents_dir = temp.path().join("agents");
+    let parent_dir = agents_dir.join("planner.default");
+    std::fs::create_dir_all(&parent_dir)?;
+    let config = GatewayConfig {
+        agents_dir,
+        default_workflow_wait_secs: 10,
+        ..GatewayConfig::default()
+    };
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+    Ok((temp, config, store))
+}
+
+fn seed_two_tasks(
+    config: &GatewayConfig,
+    store: &GatewayStore,
+    workflow_id: &str,
+    root_session_id: &str,
+    task_a: &str,
+    task_b: &str,
+) -> anyhow::Result<()> {
+    let workflow = WorkflowRun {
+        workflow_id: workflow_id.to_string(),
+        root_session_id: root_session_id.to_string(),
+        lead_agent_id: "planner.default".to_string(),
+        status: WorkflowRunStatus::WaitingChildren,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        active_task_ids: vec![],
+        queued_task_ids: vec![],
+        join_policy: Default::default(),
+        join_task_ids: vec![task_a.to_string(), task_b.to_string()],
+    };
+    save_workflow_run(config, Some(store), &workflow)?;
+
+    for tid in [task_a, task_b] {
+        let task = TaskRun {
+            task_id: tid.to_string(),
+            workflow_id: workflow_id.to_string(),
+            agent_id: "exec-agent".to_string(),
+            session_id: format!("{root_session_id}/{tid}"),
+            parent_session_id: root_session_id.to_string(),
+            status: TaskRunStatus::Running,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            source_agent_id: Some("planner.default".to_string()),
+            result_summary: None,
+            join_group: None,
+            message: Some("test task".to_string()),
+            metadata: None,
+            retry_count: 0,
+            last_failure_class: None,
+            retry_policy: None,
+            side_effect_state: None,
+            dedupe_key: None,
+        };
+        save_task_run(config, Some(store), &task)?;
+    }
+    Ok(())
+}
+
+/// Legacy probe: timeout_secs=0 returns immediately with current status.
+#[test]
+fn timeout_zero_returns_immediately() -> anyhow::Result<()> {
+    let (_temp, config, store) = setup()?;
+    let workflow_id = "wf-probe";
+    let root_session_id = "root-probe";
+    let task_id = "task-probe";
+
+    seed_two_tasks(&config, &store, workflow_id, root_session_id, task_id, "task-probe-b")?;
+
+    let manifest = planner_manifest();
+    let _policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let parent_dir = config.agents_dir.join("planner.default");
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let args = serde_json::json!({
+        "workflow_id": workflow_id,
+        "task_ids": [task_id],
+        "timeout_secs": 0
+    });
+
+    let start = std::time::Instant::now();
+    let result = registry.execute(
+        "workflow_wait",
+        &manifest,
+        &_policy,
+        &parent_dir,
+        Some(&gateway_dir),
+        &serde_json::to_string(&args)?,
+        Some(root_session_id),
+        Some("turn-probe"),
+        Some(&config),
+        Some(store.clone()),
+        None,
+    )?;
+    let elapsed = start.elapsed();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result)?;
+    assert_eq!(parsed["ok"].as_bool(), Some(true));
+    assert_eq!(parsed["join_satisfied"].as_bool(), Some(false));
+    assert_eq!(parsed["waited_secs"].as_u64(), Some(0));
+    assert!(elapsed < std::time::Duration::from_millis(500));
+    Ok(())
+}
+
+/// Signal-driven wake: transitioning a task wakes workflow.wait within
+/// milliseconds, not after a multi-second poll cycle.
+#[tokio::test]
+async fn signal_wakes_wait_within_100ms() -> anyhow::Result<()> {
+    let (_temp, config, store) = setup()?;
+    let workflow_id = "wf-signal";
+    let root_session_id = "root-signal";
+    let task_a = "task-sig-a";
+    let task_b = "task-sig-b";
+
+    seed_two_tasks(&config, &store, workflow_id, root_session_id, task_a, task_b)?;
+
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = Arc::new(default_registry());
+    let parent_dir = config.agents_dir.join("planner.default");
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+
+    let args = serde_json::json!({
+        "workflow_id": workflow_id,
+        "task_ids": [task_a, task_b],
+        "timeout_secs": 30
+    });
+    let args_str = serde_json::to_string(&args)?;
+    let config_clone = config.clone();
+    let store_clone = store.clone();
+    let manifest_clone = manifest.clone();
+
+    let wait_handle = tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let result = registry.execute(
+            "workflow_wait",
+            &manifest_clone,
+            &PolicyEngine::new(manifest_clone.clone()),
+            &parent_dir,
+            Some(&gateway_dir),
+            &args_str,
+            Some(root_session_id),
+            Some("turn-signal"),
+            Some(&config_clone),
+            Some(store_clone),
+            None,
+        );
+        (start.elapsed(), result)
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    workflow_store::update_task_run_status(
+        &config,
+        Some(store.as_ref()),
+        workflow_id,
+        task_a,
+        TaskRunStatus::Succeeded,
+        Some("done".to_string()),
+        None,
+        None,
+    )?;
+
+    workflow_store::update_task_run_status(
+        &config,
+        Some(store.as_ref()),
+        workflow_id,
+        task_b,
+        TaskRunStatus::Succeeded,
+        Some("done".to_string()),
+        None,
+        None,
+    )?;
+
+    let (elapsed, result) = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        wait_handle,
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("workflow.wait timed out"))??;
+
+    let result = result?;
+    let parsed: serde_json::Value = serde_json::from_str(&result)?;
+    assert_eq!(parsed["ok"].as_bool(), Some(true));
+    assert_eq!(parsed["join_satisfied"].as_bool(), Some(true));
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "expected sub-2s wake, got {:?}",
+        elapsed
+    );
+
+    Ok(())
+}
+
+/// Deadline path: with a short timeout and no transitions, workflow.wait
+/// returns at the deadline with tasks still running.
+#[tokio::test]
+async fn deadline_returns_with_tasks_still_running() -> anyhow::Result<()> {
+    let (_temp, config, store) = setup()?;
+    let workflow_id = "wf-deadline";
+    let root_session_id = "root-deadline";
+    let task_a = "task-dl-a";
+    let task_b = "task-dl-b";
+
+    seed_two_tasks(&config, &store, workflow_id, root_session_id, task_a, task_b)?;
+
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = Arc::new(default_registry());
+    let parent_dir = config.agents_dir.join("planner.default");
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+
+    let args = serde_json::json!({
+        "workflow_id": workflow_id,
+        "task_ids": [task_a, task_b],
+        "timeout_secs": 2
+    });
+    let args_str = serde_json::to_string(&args)?;
+
+    let wait_handle = tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let result = registry.execute(
+            "workflow_wait",
+            &manifest,
+            &policy,
+            &parent_dir,
+            Some(&gateway_dir),
+            &args_str,
+            Some(root_session_id),
+            Some("turn-deadline"),
+            Some(&config),
+            Some(store),
+            None,
+        );
+        (start.elapsed(), result)
+    });
+
+    let (elapsed, result) = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        wait_handle,
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("workflow.wait timed out"))??;
+
+    let result = result?;
+    let parsed: serde_json::Value = serde_json::from_str(&result)?;
+    assert_eq!(parsed["ok"].as_bool(), Some(true));
+    assert_eq!(parsed["join_satisfied"].as_bool(), Some(false));
+    assert!(
+        elapsed >= std::time::Duration::from_secs(1),
+        "expected at least 1s wait, got {:?}",
+        elapsed
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(8),
+        "expected sub-8s wait (signal fallback), got {:?}",
+        elapsed
+    );
+
+    Ok(())
+}
+
+/// Sequential transitions: both tasks transition one at a time with a delay,
+/// and the total wait is bounded by signal response time, not polling interval.
+#[tokio::test]
+async fn sequential_transitions_both_complete_fast() -> anyhow::Result<()> {
+    let (_temp, config, store) = setup()?;
+    let workflow_id = "wf-seq";
+    let root_session_id = "root-seq";
+    let task_a = "task-seq-a";
+    let task_b = "task-seq-b";
+
+    seed_two_tasks(&config, &store, workflow_id, root_session_id, task_a, task_b)?;
+
+    let manifest = planner_manifest();
+    let registry = Arc::new(default_registry());
+    let parent_dir = config.agents_dir.join("planner.default");
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+
+    let args = serde_json::json!({
+        "workflow_id": workflow_id,
+        "task_ids": [task_a, task_b],
+        "timeout_secs": 30
+    });
+    let args_str = serde_json::to_string(&args)?;
+    let config_clone = config.clone();
+    let store_clone = store.clone();
+    let manifest_clone = manifest.clone();
+
+    let wait_handle = tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let result = registry.execute(
+            "workflow_wait",
+            &manifest_clone,
+            &PolicyEngine::new(manifest_clone.clone()),
+            &parent_dir,
+            Some(&gateway_dir),
+            &args_str,
+            Some(root_session_id),
+            Some("turn-seq"),
+            Some(&config_clone),
+            Some(store_clone),
+            None,
+        );
+        (start.elapsed(), result)
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    workflow_store::update_task_run_status(
+        &config,
+        Some(store.as_ref()),
+        workflow_id,
+        task_a,
+        TaskRunStatus::Succeeded,
+        Some("done a".to_string()),
+        None,
+        None,
+    )?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    workflow_store::update_task_run_status(
+        &config,
+        Some(store.as_ref()),
+        workflow_id,
+        task_b,
+        TaskRunStatus::Succeeded,
+        Some("done b".to_string()),
+        None,
+        None,
+    )?;
+
+    let (elapsed, result) = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        wait_handle,
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("workflow.wait timed out"))??;
+
+    let result = result?;
+    let parsed: serde_json::Value = serde_json::from_str(&result)?;
+    assert_eq!(parsed["ok"].as_bool(), Some(true));
+    assert_eq!(parsed["join_satisfied"].as_bool(), Some(true));
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "expected sub-2s wake, got {:?}",
+        elapsed
+    );
+
+    Ok(())
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1098,6 +1098,13 @@ pub struct GatewayConfig {
     #[serde(default = "default_signal_delivery_timeout_secs")]
     pub signal_delivery_timeout_secs: u64,
 
+    /// Default blocking timeout for `workflow.wait` when the caller omits
+    /// `timeout_secs`. The tool blocks until all watched task_ids reach a
+    /// terminal state or this deadline elapses. Set to 0 to restore the
+    /// legacy immediate-return behaviour. Default: 30.
+    #[serde(default = "default_workflow_wait_secs")]
+    pub default_workflow_wait_secs: u64,
+
     #[serde(default)]
     pub hooks: Vec<crate::hooks::HookConfig>,
 
@@ -2015,6 +2022,10 @@ fn default_signal_delivery_timeout_secs() -> u64 {
     60
 }
 
+fn default_workflow_wait_secs() -> u64 {
+    30
+}
+
 fn default_evidence_mode() -> String {
     "full".to_string()
 }
@@ -2465,6 +2476,7 @@ impl Default for GatewayConfig {
             approval_levels: ApprovalLevelConfig::default(),
             context_compression: ContextCompressionConfig::default(),
             signal_delivery_timeout_secs: default_signal_delivery_timeout_secs(),
+            default_workflow_wait_secs: default_workflow_wait_secs(),
             hooks: Vec::new(),
             scheduled_jobs: ScheduledJobsConfig::default(),
             promotion_governor: PromotionGovernorConfig::default(),

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -123,6 +123,12 @@ approval_timeout_secs: 3600
 # + tool calls). Default: 60.
 # signal_delivery_timeout_secs: 60
 
+# Default blocking timeout (seconds) for workflow.wait when the agent omits
+# timeout_secs. The tool blocks until all watched task_ids reach terminal
+# state or this deadline elapses. Set to 0 to restore legacy immediate-return.
+# Default: 30.
+# default_workflow_wait_secs: 30
+
 # ── Hooks ──────────────────────────────────────────────────────────────
 # Reactive bindings from gateway events to actions.
 # Available events: session.closed, session.suspended, approval.resolved,


### PR DESCRIPTION
## Summary

- **TaskNotifyRegistry**: in-memory `tokio::sync::Notify` keyed by session ID, stored on `GatewayStore`. `send_child_state_notification` pings it on every call; `workflow.wait` subscribes via cancel-safe `tokio::select!`.
- **Default blocking**: `workflow.wait` now blocks for up to `default_workflow_wait_secs` (configurable, default 30s) instead of returning immediately. Pass `timeout_secs=0` for the legacy probe behaviour.
- **Signal-driven wait**: replaced the sleep-poll loop (`poll_until_join`) with `signal_driven_wait` that wakes on `Notify::notified()` with a 5s fallback poll safety net.
- **Tool schema**: description now leads with "Suspends until watched task_ids reach terminal state", framing polling as the exotic case.

Part of #288 (PR A — gateway behaviour only; agent SKILL.md and docs updates follow in PR B).

## Test plan

- [x] `timeout_zero_returns_immediately` — legacy probe preserved
- [x] `signal_wakes_wait_within_100ms` — 2 tasks transition, wait wakes in <2s
- [x] `sequential_transitions_both_complete_fast` — tasks complete one at a time
- [x] `deadline_returns_with_tasks_still_running` — short timeout expires with tasks pending
- [x] Existing `constitution_right_ri_0_14` tests still pass
- [x] `cargo build` clean