### PR TITLE
agents/docs: prefer Ri-0.14 wake-up over workflow.wait polling (#288 PR B)

### DIFF
--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -109,8 +109,9 @@ Auto-detect: if `intended_capabilities` contains only `CredentialAccess`, `Netwo
 
 **IMPORTANT**: To delegate to a sub-agent, always use `agent_spawn` (NOT `workflow.spawn` — that tool does not exist).
 - `agent_spawn` with `async=true` — enqueues a sub-agent and returns a `task_id`
-- `workflow_wait` with `task_ids=[<task_id>]` — blocks until the sub-agent completes
-- `workflow_state` — check current workflow status on resumption
+- **Then end your turn.** Do not call `workflow_wait` to block. After spawning, reply with a short status line and stop. The gateway suspends you as `WaitingForChild` and **wakes you automatically** when the sub-agent reaches a terminal state or hits a gate (constitutional right Ri-0.14). On wake, the child's typed state is already in your turn-start context. This pipeline is strictly sequential, so each step is: spawn the stage owner → end turn → resume on wake → spawn the next stage.
+- `workflow_state` — on resume, the one call that gives mechanical `reuse_guards` truth (which stages already completed). Call it once per resume, never in a loop.
+- `workflow_wait` — **inspection / recovery only.** Use `workflow_wait(timeout_secs=0)` for a one-shot status snapshot, or `workflow_wait(task_ids=[...])` to actively probe a task you already suspect is stuck. Never use it as the normal coordination mechanism — the wake-up does that for you.
 
 Do not use write tools to produce the primary output of design, implementation, evaluation, audit, packaging, or installation stages. Spawn the stage owner instead. If that owner is unavailable or fails, report the failed stage rather than completing it yourself.
 
@@ -132,7 +133,7 @@ Do NOT rewrite code, regenerate multiple draft payload files, or rebuild equival
 
 ### Step 1: Architect (if design_needed or complex structure)
 
-Call `agent_spawn` with `agent_id="architect.default"`, `async=true`, passing the purpose and intended capabilities. Then call `workflow_wait` with the returned `task_id` to wait for completion.
+Call `agent_spawn` with `agent_id="architect.default"`, `async=true`, passing the purpose and intended capabilities. Then end your turn — you resume automatically when it completes (Ri-0.14).
 
 Skip this step for reasoning-only and simple single-file code agents.
 
@@ -189,7 +190,7 @@ Install a new reasoning agent called '<agent_id>':
 - io: { returns: { type: "object", required: ["status"], properties: { status: { type: "string" } } } }
 - Gating: none (reasoning-only, no CodeExecution/AgentSpawn)
 ```
-Then call `workflow_wait` with the returned `task_id`.
+Then end your turn — you resume automatically when it completes (Ri-0.14).
 
 **io schema guidance for reasoning agents:**
 Include `io.returns` in the install intent to give the gateway an output
@@ -228,17 +229,17 @@ between steps 1 and 4.
 
 Use this step only when no reusable `source_artifact_ref` was provided, or when the provided artifact is malformed and must be repaired.
 
-Call `agent_spawn` with `agent_id="coder.default"`, `async=true`, passing the implementation requirements (design doc if architect ran). Then call `workflow_wait` with the returned `task_id` to wait for completion.
+Call `agent_spawn` with `agent_id="coder.default"`, `async=true`, passing the implementation requirements (design doc if architect ran). Then end your turn — you resume automatically when it completes (Ri-0.14).
 
-After coder completes:
-1. Read `workflow_wait`/`workflow_state` output for that task.
+On resume after coder completes (the child state arrives in your turn-start context; call `workflow_state` once if you need the full reuse_guards):
+1. Read the completed task's `output` (from the wake-up context or `workflow_state`).
 2. From `output.named_outputs`, inspect dependency files: `requirements.txt`, `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `Gemfile`.
-3. Use `content_read` with `named_outputs[*].ref` (preferred) or `output.implicit_artifact_id` to inspect the full implicit payload when needed.
+3. Use `content_read` with `named_outputs[*].ref` (preferred) or `output.implicit_artifact_id` to inspect the full implicit payload only when the named outputs don't already tell you what you need.
 4. If dependency files found → go to Step 3 (packager). Otherwise → go to Step 4.
 
 ### Step 3: Packager (if dependency files found)
 
-Call `agent_spawn` with `agent_id="packager.default"`, `async=true`, passing the artifact_ref from coder. Then call `workflow_wait` with the returned `task_id` to wait for completion. Packager returns a new `artifact_ref` with deps baked into layers.
+Call `agent_spawn` with `agent_id="packager.default"`, `async=true`, passing the artifact_ref from coder. Then end your turn — you resume automatically when it completes (Ri-0.14). Packager returns a new `artifact_ref` with deps baked into layers.
 
 ### Step 4: Promotion gates (if required)
 
@@ -270,21 +271,24 @@ the agent gains executable code (CodeExecution, AgentSpawn,
 NetworkAccess), both roles become mandatory to provide code-level
 evidence alongside the auditor's SKILL review.
 
-If gates required:
+If gates required — the gates are independent, so spawn all required
+ones with `async=true`, then **end your turn**. The gateway wakes you as
+each gate completes (Ri-0.14); proceed once `workflow_state` shows every
+required gate's `promotion_record` recorded.
 1. Call `agent_spawn` with `agent_id="auditor.default"`, `async=true`,
    passing the **artifact_ref of the intent-only bundle** built in
    Step 2a (for pure-skill agents) or the **coder-built artifact_ref**
-   (for code-bearing agents). Then call `workflow_wait` with the
-   returned `task_id`.
+   (for code-bearing agents).
 2. If the static evaluator is required for this row, call `agent_spawn`
    with `agent_id="static_evaluator.default"`, `async=true`, against the
-   same `artifact_ref`. Then call `workflow_wait`.
+   same `artifact_ref`.
 3. If the unit test runner is required for this row, call `agent_spawn`
    with `agent_id="unit_test_runner.default"`, `async=true`, against the
-   same `artifact_ref`. Then call `workflow_wait`.
-4. Each required gate must call `promotion_record(artifact_ref=<that
-   artifact>, role=..., pass=true)`. specialized_builder verifies these
-   records exist against the artifact_ref that is being installed.
+   same `artifact_ref`.
+4. End your turn. Each required gate must call
+   `promotion_record(artifact_ref=<that artifact>, role=..., pass=true)`;
+   specialized_builder verifies these records exist against the
+   artifact_ref that is being installed.
 
 If only the auditor is required (`audit_only` gating mode, pure-skill
 rows): tell specialized_builder `"Gating: audit_only"` and pass the
@@ -301,7 +305,7 @@ operator's explicit intent.
 
 This separation exists by design (see `docs/protected-agents.md`, recursive trust problem): the orchestrator that *decides* what to install must not be the same agent that *executes* the install — otherwise a regressed orchestrator could silently promote broken revisions, including a broken version of itself.
 
-Call `agent_spawn` with `agent_id="specialized_builder.default"`, `async=true`, passing the full install intent. Then call `workflow_wait` with the returned `task_id`. Include:
+Call `agent_spawn` with `agent_id="specialized_builder.default"`, `async=true`, passing the full install intent. Then end your turn — you resume automatically when it completes (Ri-0.14). Include:
 - `artifact_ref` (for code agents) or omit (for reasoning agents)
 - `instructions`, `description`, `capabilities`, `execution_mode`
 - `llm_config` (for reasoning mode)
@@ -345,4 +349,4 @@ On wake-up after interruption: call `workflow_state` first. Check `reuse_guards`
 |---|---|---|
 | `has_coder_artifact: true` | Re-spawn architect or coder | Proceed to packager/gates/install |
 | `has_evaluator_result: true` + `has_auditor_result: true` | Re-run evaluator or auditor | Proceed to install |
-| `pending_approvals: true` | Spawn new tasks | `workflow_wait(timeout_secs=300)` |
+| `pending_approvals: true` | Spawn new tasks | End your turn — the gateway wakes you when the approval resolves (Ri-0.14) |

--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -108,10 +108,11 @@ Auto-detect: if `intended_capabilities` contains only `CredentialAccess`, `Netwo
 ## Tools for delegation
 
 **IMPORTANT**: To delegate to a sub-agent, always use `agent_spawn` (NOT `workflow.spawn` — that tool does not exist).
-- `agent_spawn` with `async=true` — enqueues a sub-agent and returns a `task_id`
-- **Then end your turn.** Do not call `workflow_wait` to block. After spawning, reply with a short status line and stop. The gateway suspends you as `WaitingForChild` and **wakes you automatically** when the sub-agent reaches a terminal state or hits a gate (constitutional right Ri-0.14). On wake, the child's typed state is already in your turn-start context. This pipeline is strictly sequential, so each step is: spawn the stage owner → end turn → resume on wake → spawn the next stage.
+- `agent_spawn` with `async=true` — enqueues a sub-agent and returns a `task_id`.
+- **Sequential step (one child, then the next) → end your turn.** Most of this pipeline is sequential: architect → coder → packager → install. After spawning the stage owner, reply with a short status line and stop. The gateway suspends you as `WaitingForChild` and **wakes you automatically** when that sub-agent reaches a terminal state or hits a gate (constitutional right Ri-0.14); its typed state is already in your turn-start context. Yielding is cheaper than blocking and costs exactly one resumption. So each sequential step is: spawn the stage owner → end turn → resume on wake → spawn the next stage.
+- **Parallel fan-out you must fully join (the promotion gates) → one `workflow_wait` join.** When you spawn several independent children at once and need all of them before proceeding (Step 4), call `workflow_wait(task_ids=[<all of them>], timeout_secs=300)` **once**. It blocks until the whole group is terminal and is cheaper than being woken once per child. This is a join, not polling.
 - `workflow_state` — on resume, the one call that gives mechanical `reuse_guards` truth (which stages already completed). Call it once per resume, never in a loop.
-- `workflow_wait` — **inspection / recovery only.** Use `workflow_wait(timeout_secs=0)` for a one-shot status snapshot, or `workflow_wait(task_ids=[...])` to actively probe a task you already suspect is stuck. Never use it as the normal coordination mechanism — the wake-up does that for you.
+- **Never** loop `workflow_wait` or spin `workflow_state` to discover progress — the wake-up (sequential) or the single join (parallel) already does that.
 
 Do not use write tools to produce the primary output of design, implementation, evaluation, audit, packaging, or installation stages. Spawn the stage owner instead. If that owner is unavailable or fails, report the failed stage rather than completing it yourself.
 
@@ -271,10 +272,12 @@ the agent gains executable code (CodeExecution, AgentSpawn,
 NetworkAccess), both roles become mandatory to provide code-level
 evidence alongside the auditor's SKILL review.
 
-If gates required — the gates are independent, so spawn all required
-ones with `async=true`, then **end your turn**. The gateway wakes you as
-each gate completes (Ri-0.14); proceed once `workflow_state` shows every
-required gate's `promotion_record` recorded.
+If gates required — the gates are independent and you need **all** of
+them before installing, so this is a parallel fan-out join: spawn every
+required gate with `async=true`, then make **one** `workflow_wait` call on
+all their `task_ids`. That blocks once and returns when every gate is
+terminal — cheaper than ending your turn and being woken once per gate.
+Do not loop the wait, and do not spin `workflow_state`.
 1. Call `agent_spawn` with `agent_id="auditor.default"`, `async=true`,
    passing the **artifact_ref of the intent-only bundle** built in
    Step 2a (for pure-skill agents) or the **coder-built artifact_ref**
@@ -285,7 +288,8 @@ required gate's `promotion_record` recorded.
 3. If the unit test runner is required for this row, call `agent_spawn`
    with `agent_id="unit_test_runner.default"`, `async=true`, against the
    same `artifact_ref`.
-4. End your turn. Each required gate must call
+4. Call `workflow_wait(task_ids=[<all spawned gates>], timeout_secs=300)`
+   once to join. Each required gate must call
    `promotion_record(artifact_ref=<that artifact>, role=..., pass=true)`;
    specialized_builder verifies these records exist against the
    artifact_ref that is being installed.

--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -81,7 +81,7 @@ These six principles are the gateway's mental model. When in doubt, derive your 
 
   **Before re-running credential onboarding for a service**, call `agent_list` to check whether an agent for that service already exists (e.g., `agent_id` contains the service name). If found, spawn it directly instead of re-fetching, re-normalizing, and re-registering. This applies to **any flow** that produces durable state — check first, compute second.
 
-5. **Sequential dependencies are sequential.** If B uses A's output, they cannot be parallelized. Agent creation and post-research integration are always sequential chains. Only independent tasks may be parallelized with `async=true` (spawn them, then end your turn — the gateway wakes you as each completes).
+5. **Sequential dependencies are sequential.** If B uses A's output, they cannot be parallelized. Agent creation and post-research integration are always sequential chains. Only independent tasks may be parallelized with `async=true` — see **Coordinating With Children** for how to wait (yield for a single/sequential child; one `workflow_wait` join for a parallel fan-out).
 
 6. **Artifact refs come from structured results — use the child's FINAL artifact_ref only.** Never type them from memory. Copy from `artifact_build`, `artifact_resolve_ref`, or child `result_summary`. When a child agent (e.g. coder) made multiple `artifact_build` calls in its session — for example after correcting an earlier mistake — **only the `artifact_ref` in the child's final JSON reply is canonical**. Ignore every other `artifact_ref` that appeared in intermediate tool results: those are stale and may have the wrong `kind`, wrong digest, or both. Re-reading the child's last `result_summary` is the safest source. Call `artifact_inspect(artifact_ref)` as a preflight before spawning any dependent child — if `kind` is not `agent_bundle` (or `binary` for compiled agents), you have the wrong ref. When turning already-built code into a durable agent, pass the existing `artifact_ref` downstream instead of only `cnt_...` handles. **Note:** Tools accept both short refs (`ar.*`) and canonical IDs (`art_*`) directly. When passing refs to child agents via `agent.spawn`, prefer the short `ar.*` form — it is scoped to the session and works across child sessions.
 
@@ -300,19 +300,28 @@ Do not use discovery for intents clearly covered by foundational agents — the 
 
 ---
 
-## Parallel Delegation
+## Coordinating With Children — Three Cases
 
+Pick the mechanism by the shape of the dependency. The rule that never changes: **never re-issue `workflow_wait` in a loop, and never spin `workflow_state` to discover progress.** Discovering child state is the gateway's job (Ri-0.14), not yours to poll.
+
+**1. Sequential / single child — spawn, then end your turn.**
 ```
-agent_spawn("researcher.default", message="...", async=true)   # returns task_id immediately
-agent_spawn("coder.default", message="...", async=true)        # runs in parallel
-# Then END YOUR TURN. Do not call workflow_wait.
+agent_spawn("coder.default", message="...", async=true)   # one child, its output feeds the next step
+# Then END YOUR TURN.
 ```
+The gateway suspends you as `WaitingForChild` and **wakes you automatically** when the child reaches a terminal state or hits a gate (Ri-0.14). On wake, the child's typed state is already in your turn-start context. Do not call `workflow_wait` — yielding is cheaper than blocking, and the wake-up costs exactly one resumption.
 
-**Spawn, then yield — do not poll.** After spawning async children, end your turn (reply with a short status line and stop). The gateway suspends you as `WaitingForChild` and **wakes you automatically** the moment any child reaches a terminal state or hits a gate (constitutional right Ri-0.14). On wake, the child's typed state is already in your turn-start context. You do **not** need to call `workflow_wait` to block, and you must **never** loop on it to discover progress — that burns a turn sitting in a blocking call and wastes tokens.
+**2. Parallel fan-out you must fully join — spawn all, then one `workflow_wait` join.**
+```
+agent_spawn("researcher.default", message="...", async=true)
+agent_spawn("auditor.default",     message="...", async=true)
+workflow_wait(task_ids=[<all of them>], timeout_secs=300)   # ONE blocking join, returns when ALL terminal
+```
+When you need **every** child done before you can proceed and they run concurrently, a single `workflow_wait` on all their `task_ids` is the right tool — it blocks once and returns when the whole group is terminal. This is a join, **not** polling, and it is strictly cheaper than ending your turn and being woken once per child (a 3-way fan-out would otherwise cost ~3 resumptions). Call it **once**; never loop it.
 
-`workflow_wait` is an **inspection / recovery** tool, not the coordination mechanism. Reach for it only when:
-- you need a one-shot status snapshot mid-turn → `workflow_wait(timeout_secs=0)` (returns immediately, does not block); or
-- you are actively recovering a task you already suspect is stuck (see **Stuck Tasks**).
+**3. Inspection / recovery — `workflow_wait` as a probe.**
+- One-shot status snapshot mid-turn → `workflow_wait(timeout_secs=0)` (returns immediately, does not block).
+- Actively recovering a task you already suspect is stuck → see **Stuck Tasks**.
 
 Use `async=true` only for **independent** tasks (no data dependency between them). Sequential dependencies (Principle 5) must be chained calls, not parallel.
 
@@ -330,7 +339,7 @@ When an artifact-backed agent needs promotion (after `coder.default` produces an
 | Artifact-backed, no external HTTP | `auditor.default` + `static_evaluator.default` + `unit_test_runner.default` |
 | Artifact-backed, has HTTP calls | `auditor.default` + `static_evaluator.default` + `unit_test_runner.default` (sealed_evaluator deferred to operator decision) |
 
-Use `async=true` to spawn independent roles in parallel, then end your turn. The gateway wakes you as each role completes (Ri-0.14); proceed once `workflow_state` shows all verdicts recorded.
+Spawn the independent roles in parallel with `async=true`, then join them with a single `workflow_wait(task_ids=[<all roles>], timeout_secs=300)` (Case 2 — parallel fan-out). It returns once every role is terminal; then collect verdicts. Do not loop the wait or end your turn per-role.
 
 **Step 2: Collect verdicts**
 

--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -81,7 +81,7 @@ These six principles are the gateway's mental model. When in doubt, derive your 
 
   **Before re-running credential onboarding for a service**, call `agent_list` to check whether an agent for that service already exists (e.g., `agent_id` contains the service name). If found, spawn it directly instead of re-fetching, re-normalizing, and re-registering. This applies to **any flow** that produces durable state — check first, compute second.
 
-5. **Sequential dependencies are sequential.** If B uses A's output, they cannot be parallelized. Agent creation and post-research integration are always sequential chains. Only independent tasks may be parallelized with `async=true` + `workflow_wait`.
+5. **Sequential dependencies are sequential.** If B uses A's output, they cannot be parallelized. Agent creation and post-research integration are always sequential chains. Only independent tasks may be parallelized with `async=true` (spawn them, then end your turn — the gateway wakes you as each completes).
 
 6. **Artifact refs come from structured results — use the child's FINAL artifact_ref only.** Never type them from memory. Copy from `artifact_build`, `artifact_resolve_ref`, or child `result_summary`. When a child agent (e.g. coder) made multiple `artifact_build` calls in its session — for example after correcting an earlier mistake — **only the `artifact_ref` in the child's final JSON reply is canonical**. Ignore every other `artifact_ref` that appeared in intermediate tool results: those are stale and may have the wrong `kind`, wrong digest, or both. Re-reading the child's last `result_summary` is the safest source. Call `artifact_inspect(artifact_ref)` as a preflight before spawning any dependent child — if `kind` is not `agent_bundle` (or `binary` for compiled agents), you have the wrong ref. When turning already-built code into a durable agent, pass the existing `artifact_ref` downstream instead of only `cnt_...` handles. **Note:** Tools accept both short refs (`ar.*`) and canonical IDs (`art_*`) directly. When passing refs to child agents via `agent.spawn`, prefer the short `ar.*` form — it is scoped to the session and works across child sessions.
 
@@ -148,8 +148,8 @@ On every wake-up after interruption (approval, timeout, join, hibernation):
 | `has_coder_artifact: true` | Re-spawn architect or coder | Proceed to evaluation or install |
 | `has_evaluator_result: true` + `has_auditor_result: true` | Re-run evaluator or auditor | Proceed to install (both pass) or coder iteration (either fails) |
 | `has_static_evaluator_result: true` + `has_unit_test_runner_result: true` + `has_auditor_result: true` | Re-run federation roles | Collect all verdicts and escalate to operator |
-| `pending_approvals: true` | Spawn new tasks | `workflow_wait(timeout_secs=300)` |
-| `active_tasks_running: true` | Spawn duplicate tasks | Wait with `workflow_wait` |
+| `pending_approvals: true` | Spawn new tasks | End your turn — the gateway wakes you when the approval resolves (Ri-0.14) |
+| `active_tasks_running: true` | Spawn duplicate tasks | End your turn — the gateway wakes you when a task transitions (Ri-0.14) |
 
 **Reading child outputs:** After a child completes, inspect `workflow_state` output for that task, then read named handles from `named_outputs`:
 ```json
@@ -162,7 +162,7 @@ Never guess content names — always get them from `named_outputs`. If `named_ou
 1. Call `workflow_state` and inspect active tasks plus completed `named_outputs`.
 2. Check session-visible knowledge for an existing record keyed by the same source, goal, or intent.
 3. If reusable content already exists, read the existing handle and continue locally.
-4. If matching work is still running, wait instead of spawning a second child.
+4. If matching work is still running, do not spawn a second child — end your turn and the gateway wakes you when it transitions (Ri-0.14).
 
 ---
 
@@ -305,8 +305,14 @@ Do not use discovery for intents clearly covered by foundational agents — the 
 ```
 agent_spawn("researcher.default", message="...", async=true)   # returns task_id immediately
 agent_spawn("coder.default", message="...", async=true)        # runs in parallel
-workflow_wait(task_ids=[...], timeout_secs=300)                 # blocks until all complete
+# Then END YOUR TURN. Do not call workflow_wait.
 ```
+
+**Spawn, then yield — do not poll.** After spawning async children, end your turn (reply with a short status line and stop). The gateway suspends you as `WaitingForChild` and **wakes you automatically** the moment any child reaches a terminal state or hits a gate (constitutional right Ri-0.14). On wake, the child's typed state is already in your turn-start context. You do **not** need to call `workflow_wait` to block, and you must **never** loop on it to discover progress — that burns a turn sitting in a blocking call and wastes tokens.
+
+`workflow_wait` is an **inspection / recovery** tool, not the coordination mechanism. Reach for it only when:
+- you need a one-shot status snapshot mid-turn → `workflow_wait(timeout_secs=0)` (returns immediately, does not block); or
+- you are actively recovering a task you already suspect is stuck (see **Stuck Tasks**).
 
 Use `async=true` only for **independent** tasks (no data dependency between them). Sequential dependencies (Principle 5) must be chained calls, not parallel.
 
@@ -324,7 +330,7 @@ When an artifact-backed agent needs promotion (after `coder.default` produces an
 | Artifact-backed, no external HTTP | `auditor.default` + `static_evaluator.default` + `unit_test_runner.default` |
 | Artifact-backed, has HTTP calls | `auditor.default` + `static_evaluator.default` + `unit_test_runner.default` (sealed_evaluator deferred to operator decision) |
 
-Use `async=true` to spawn independent roles in parallel. Wait for all with `workflow_wait`.
+Use `async=true` to spawn independent roles in parallel, then end your turn. The gateway wakes you as each role completes (Ri-0.14); proceed once `workflow_state` shows all verdicts recorded.
 
 **Step 2: Collect verdicts**
 
@@ -380,7 +386,7 @@ Once `approval_status` reports `status: "approved"`/`"rejected"`/`"sealed_eval_r
 
 If the operator requests sealed evaluation:
 1. Spawn `sealed_evaluator.default` with metadata `{fixture_set_ref: "..."}` if the operator provided one
-2. Wait for completion with `workflow_wait`
+2. End your turn — the gateway wakes you when it completes (Ri-0.14)
 3. Collect the sealed evaluation verdict from `promotion_query`
 4. Re-escalate to operator with the complete report set
 
@@ -392,8 +398,8 @@ Do NOT run sealed evaluation unless the operator explicitly requests it. The sea
 
 When a child is awaiting approval, inform the user of the pending `approval_request_id` and the resolution command. The gateway resumes the child automatically on approval — do not re-spawn or cancel `AwaitingApproval` tasks.
 
-**`workflow_wait` times out with `checkpoint_state.status == "paused"` and `reason == "awaiting_user_input_or_operator_guidance"`:**
-Tell the user that the child is waiting for their input, then call `workflow_wait(timeout_secs=300)` again. The gateway will resume the child once the user answers.
+**Child is `paused` with `reason == "awaiting_user_input_or_operator_guidance"`:**
+Tell the user that the child is waiting for their input, then end your turn. The gateway resumes the child once the user answers and wakes you when it transitions (Ri-0.14) — do not loop on `workflow_wait`.
 
 **Approval timeout (`checkpoint_step == "approval_timeout"`):**
 Inform user. If they want to continue, respawn (creates a new approval).
@@ -408,7 +414,7 @@ Inform user. If they want to continue, respawn (creates a new approval).
 
 **`agent_message` result validation:** Always check `ok`, `status`, and `recipients_count`. Report success only when `ok == true`, `status == "delivered"`, and `recipients_count > 0`. Otherwise report delivery failure.
 
-When `workflow_wait` returns `any_failed: true`:
+When a child task fails (the wake-up notification reports a failed child, or `workflow_state` shows `any_failed: true`):
 
 - **Output schema error** (`"reply is not valid JSON"` or `"[output_schema]"`): If `promotion_record` was called, the work completed — proceed to the next stage. Do NOT re-spawn.
 - **Dependency layer required** (`"dependency_layer_required"` or `"artifact missing required layers"`): Spawn `packager.default`, wait, then retry with the layered artifact_ref.
@@ -433,11 +439,12 @@ These two outcomes are **not artifact failures**. Do not route them to `coder.de
 
 ## Stuck Tasks
 
-When `workflow_wait` returns `join_satisfied: false` after 3 timeouts for the same task:
+If you suspect a task is stuck (you have been woken with no progress on it, or it has been `Running` far longer than expected), actively probe it — this is the legitimate use of `workflow_wait`:
 
-1. Call `workflow_state`. Check if the child session has a digest or `promotion_record` (evidence of completion).
-2. If evidence exists, use `workflow_force_complete` to resolve the stuck task — then proceed.
-3. Use `workflow_force_complete` only after 3+ timeouts AND confirmed evidence. Never use it for tasks running under 60 seconds.
+1. Call `workflow_wait(task_ids=[<task_id>], timeout_secs=300)` to actively wait on the specific task. If it returns `join_satisfied: false`, the task is genuinely stalled.
+2. Call `workflow_state` and check whether the child session has a digest or `promotion_record` (evidence of completion despite the stalled status).
+3. If evidence exists, use `workflow_force_complete` to resolve the stuck task — then proceed.
+4. Use `workflow_force_complete` only after a confirmed stall AND confirmed evidence. Never use it for tasks running under 60 seconds.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -101,6 +101,21 @@ When calling `agent_spawn`, include structured metadata:
 }
 ```
 
+### Coordinating With Children: Yield, Don't Poll
+
+After spawning async children (`agent_spawn` with `async=true`), the parent should **end its turn** rather than block on `workflow_wait`. The gateway suspends the parent as `WaitingForChild` and resumes it automatically with the child's typed state injected as turn-start context the moment a child reaches a terminal state or resolves a gate. This is constitutional right **Ri-0.14** — *"Parents are not required to poll to discover child state transitions"* — and is the canonical orchestration pattern.
+
+`workflow_wait` is an **inspection / recovery** primitive, not the coordination mechanism:
+
+| Use | Call |
+|---|---|
+| Normal coordination (wait for children) | **Don't call it.** Spawn async, end turn, get woken (Ri-0.14). |
+| One-shot status snapshot mid-turn | `workflow_wait(timeout_secs=0)` — returns immediately, does not block |
+| Actively recover a task you suspect is stuck | `workflow_wait(task_ids=[...])` |
+| Read mechanical reuse guards on resume | `workflow_state` — once per wake, never in a loop |
+
+Looping on `workflow_wait` / `workflow_state` to discover progress burns turns and tokens; it traced as the dominant cost in an observed 880-turn agent-creation session.
+
 ---
 
 ## SKILL.md Format

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -103,18 +103,17 @@ When calling `agent_spawn`, include structured metadata:
 
 ### Coordinating With Children: Yield, Don't Poll
 
-After spawning async children (`agent_spawn` with `async=true`), the parent should **end its turn** rather than block on `workflow_wait`. The gateway suspends the parent as `WaitingForChild` and resumes it automatically with the child's typed state injected as turn-start context the moment a child reaches a terminal state or resolves a gate. This is constitutional right **Ri-0.14** — *"Parents are not required to poll to discover child state transitions"* — and is the canonical orchestration pattern.
+How a parent waits for children depends on the dependency shape. The constant rule: **never re-issue `workflow_wait` in a loop and never spin `workflow_state`** to discover progress — discovering child-state transitions is the gateway's job under constitutional right **Ri-0.14** (*"Parents are not required to poll to discover child state transitions"*).
 
-`workflow_wait` is an **inspection / recovery** primitive, not the coordination mechanism:
-
-| Use | Call |
+| Situation | What to do |
 |---|---|
-| Normal coordination (wait for children) | **Don't call it.** Spawn async, end turn, get woken (Ri-0.14). |
+| **Sequential / single child** (its output feeds the next step) | Spawn `async=true`, then **end your turn.** The gateway suspends you as `WaitingForChild` and resumes you with the child's typed state injected as turn-start context when it transitions (Ri-0.14). One resumption — do **not** call `workflow_wait`. |
+| **Parallel fan-out you must fully join** (e.g. promotion gates) | Spawn all children `async=true`, then make **one** `workflow_wait(task_ids=[all], timeout_secs=N)` call. It blocks once and returns when the whole group is terminal — cheaper than being woken once per child (the gateway emits a per-child notification). A join, not polling. |
 | One-shot status snapshot mid-turn | `workflow_wait(timeout_secs=0)` — returns immediately, does not block |
 | Actively recover a task you suspect is stuck | `workflow_wait(task_ids=[...])` |
 | Read mechanical reuse guards on resume | `workflow_state` — once per wake, never in a loop |
 
-Looping on `workflow_wait` / `workflow_state` to discover progress burns turns and tokens; it traced as the dominant cost in an observed 880-turn agent-creation session.
+Looping on `workflow_wait` / `workflow_state` to discover progress burns turns and tokens; it traced as the dominant cost in an observed 880-turn agent-creation session. The fix is shape-aware: yield for the sequential case, a single join for the parallel case — never a poll loop in either.
 
 ---
 

--- a/docs/planner-principles.md
+++ b/docs/planner-principles.md
@@ -44,9 +44,13 @@ Never type artifact refs from memory. Copy from `artifact_build`, `artifact_reso
 
 ### 7. Coordinate by yielding, not polling
 
-After spawning async children, **end your turn**. Do not call `workflow_wait` to block, and never loop on it to discover progress. The gateway suspends the parent as `WaitingForChild` and wakes it automatically when a child reaches a terminal state or hits a gate — this is a constitutional right (Ri-0.14), not a courtesy: *"Parents are not required to poll to discover child state transitions."* On wake, the child's typed state is already in the parent's turn-start context.
+The invariant: **never re-issue `workflow_wait` in a loop, and never spin `workflow_state` to discover progress.** Discovering child-state transitions is a mechanical lifecycle concern the gateway already owns (Ri-0.14: *"Parents are not required to poll to discover child state transitions"*); pushing it into prompt logic is fragile and token-expensive — an 880-turn agent-creation session traced largely to such polling loops motivated this principle. How you *wait* depends on the dependency shape:
 
-`workflow_wait` is an inspection/recovery primitive, not the coordination mechanism: a `timeout_secs=0` probe for a one-shot snapshot, or an active wait when recovering a task already suspected stuck. Polling for child state pushes a mechanical lifecycle concern the gateway already owns into prompt logic, where it is fragile and token-expensive — an 880-turn agent-creation session traced largely to `workflow_wait`/`workflow_state` polling loops motivated this principle. (This composes with Principle 4: `workflow_state` is still the one call you make *on resume* to read `reuse_guards` — once per wake, never in a loop.)
+- **Sequential / single child → end your turn.** Spawn, then stop. The gateway suspends the parent as `WaitingForChild` and wakes it automatically when the child reaches a terminal state or hits a gate, with the child's typed state already in the turn-start context. Yielding costs exactly one resumption — cheaper than blocking.
+- **Parallel fan-out you must fully join → one `workflow_wait(task_ids=[all])`.** When several independent children run concurrently and you need all of them before proceeding, a single blocking join returns when the whole group is terminal. This is *not* polling, and it is strictly cheaper than ending your turn and being woken once per child (the gateway emits a per-child notification, so a 3-way fan-out would otherwise cost ~3 resumptions). Call it once; never loop it.
+- **Inspection / recovery → `workflow_wait` as a probe.** A `timeout_secs=0` snapshot, or an active wait when recovering a task already suspected stuck.
+
+(This composes with Principle 4: `workflow_state` is still the one call you make *on resume* to read `reuse_guards` — once per wake, never in a loop.)
 
 ---
 

--- a/docs/planner-principles.md
+++ b/docs/planner-principles.md
@@ -42,6 +42,12 @@ If B uses A's output, they cannot be parallelized. Only tasks with no data depen
 
 Never type artifact refs from memory. Copy from `artifact_build`, `artifact_resolve_ref`, or child `result_summary`. Run `artifact_inspect(artifact_ref)` as a preflight before spawning any dependent child. Wrong artifact refs create avoidable retry loops.
 
+### 7. Coordinate by yielding, not polling
+
+After spawning async children, **end your turn**. Do not call `workflow_wait` to block, and never loop on it to discover progress. The gateway suspends the parent as `WaitingForChild` and wakes it automatically when a child reaches a terminal state or hits a gate — this is a constitutional right (Ri-0.14), not a courtesy: *"Parents are not required to poll to discover child state transitions."* On wake, the child's typed state is already in the parent's turn-start context.
+
+`workflow_wait` is an inspection/recovery primitive, not the coordination mechanism: a `timeout_secs=0` probe for a one-shot snapshot, or an active wait when recovering a task already suspected stuck. Polling for child state pushes a mechanical lifecycle concern the gateway already owns into prompt logic, where it is fragile and token-expensive — an 880-turn agent-creation session traced largely to `workflow_wait`/`workflow_state` polling loops motivated this principle. (This composes with Principle 4: `workflow_state` is still the one call you make *on resume* to read `reuse_guards` — once per wake, never in a loop.)
+
 ---
 
 ## What Was Removed (and Where It Went)


### PR DESCRIPTION
## Summary

PR B of #288 — the prompt/doc follow-through to the gateway behaviour landed in #291. With `workflow.wait` now signal-driven and the `WaitingForChild` wake-up path (Ri-0.14) carrying typed child state into the parent's turn-start context, the orchestration prompts are updated so agents **stop blocking/looping on `workflow.wait` by default**.

Canonical pattern is now: **spawn async children → end turn → gateway wakes the parent on the next child transition.** `workflow.wait` is demoted to an inspection/recovery primitive.

This was the dominant cost in the observed 880-turn agent-creation session (workflow.wait / workflow.state polling loops). PR A removed the cause at the gateway; this PR propagates it into the prompts so agents actually adopt the wake-up.

## Changes (prompts + docs only — no Rust)

- **`agents/lead/planner.default/SKILL.md`** — rewrote Parallel Delegation, Principle 5, the resume-guard table, evaluation-federation + sealed-eval steps, approval/clarification handling, failure handling, and Stuck Tasks. `workflow.wait` now appears only as the explicit inspection/recovery exception (`timeout_secs=0` probe, or active wait on a task already suspected stuck).
- **`agents/evolution/agent-factory.default/SKILL.md`** — "Tools for delegation" now establishes spawn → end-turn → wake; each per-stage "then call `workflow_wait`" replaced with "end your turn"; independent promotion gates now spawn in parallel then yield; resume-guard table updated.
- **`docs/planner-principles.md`** — new **Principle 7: Coordinate by yielding, not polling** (explicitly composes with Principle 4's single `workflow_state`-on-resume; does not contradict it).
- **`docs/AGENTS.md`** — new **"Coordinating With Children: Yield, Don't Poll"** section with a when-to-use table for `workflow.wait` vs. the wake-up.

`specialized_builder.default` is a non-orchestrating leaf (AgentSpawn forbidden) and needed no changes.

## Scope discipline

- Did **not** touch the "`workflow_state` first on resume" discipline — that's one call per wake (not a loop), load-bearing for `reuse_guards`, and belongs to #287/#289 rather than #288.
- The one remaining `workflow_wait` mention in `docs/AGENTS.md` (artifact-ref provenance) is a factual statement, not a polling instruction — left as-is.

## Validation

- All three edited bundles' YAML frontmatter re-parsed cleanly (unchanged; body-only edits).
- No Rust code touched, so no build/test regression surface.

Closes #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)