### PR TITLE
runtime: session-scoped read cache for pure read tools (#289)

### DIFF
--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -53,6 +53,7 @@ pub mod session_resume;
 pub mod session_context;
 pub mod session_outcome_writer;
 pub mod session_overview;
+pub mod session_read_cache;
 pub mod session_report;
 pub mod session_tracer;
 pub mod state_attestation;

--- a/autonoetic-gateway/src/runtime/session_read_cache.rs
+++ b/autonoetic-gateway/src/runtime/session_read_cache.rs
@@ -1,0 +1,422 @@
+//! Session-scoped result cache for pure read tools (issue #289).
+//!
+//! Three read tools re-execute on every call even though their result is
+//! stable within a session:
+//!
+//! - `content_read` — content-addressed (`sha256:` handle → identical
+//!   bytes), so the result never changes for a given handle.
+//! - `agent_exists` — gateway-global existence/status fact; changes only
+//!   via explicit agent-mutating tools.
+//! - `artifact_inspect` — artifact metadata; changes only via
+//!   `artifact_build`.
+//!
+//! In long orchestration sessions the same handles get read dozens of
+//! times, re-injecting identical content into the LLM transcript each
+//! turn. This module memoizes the raw tool result keyed by
+//! `(tool_name, sha256(normalized_args))`, scoped to one session.
+//!
+//! Constitutional grounding: same family as R-2.6 / R-2.7 (deterministic
+//! operations skip re-execution), extended to pure reads where the safety
+//! argument is stronger — there is no side effect to skip.
+//!
+//! ## Safety choices
+//!
+//! - **Keyed by exact `session_id`, not root.** `content_read` honours
+//!   per-session visibility; caching a result under the exact session
+//!   that produced it means a sibling session can never be served another
+//!   session's private content from the cache.
+//! - **Only the raw `registry.execute` output is cached.** Disclosure
+//!   registration and secret-store redaction still run on every hit in
+//!   the caller, so caching is transparent to those invariants.
+//! - **Invalidation is coarse but obviously correct.** Agent-mutating and
+//!   artifact-building tools clear the corresponding tag class across all
+//!   session caches. `content_read` entries are never invalidated.
+//! - **Bounded + size-guarded.** Per-session LRU of `max_entries`
+//!   (default 128); results larger than `max_value_bytes` (default 1 MiB)
+//!   are not stored, so the cache can't balloon memory.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use sha2::{Digest, Sha256};
+
+/// Default per-session entry cap.
+pub const DEFAULT_MAX_ENTRIES: usize = 128;
+/// Default max cached value size in bytes (1 MiB).
+pub const DEFAULT_MAX_VALUE_BYTES: usize = 1024 * 1024;
+
+/// Invalidation tag classes. A cacheable read belongs to at most one tag;
+/// a mutating tool clears one tag across every session cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CacheTag {
+    /// `agent_exists` results — cleared by agent install / revision
+    /// create / promote / rollback.
+    AgentExistence,
+    /// `artifact_inspect` results — cleared by `artifact_build`.
+    ArtifactMetadata,
+}
+
+/// Cacheability decision for a read tool: cacheable under a tag (or no
+/// tag, meaning never invalidated), or not cacheable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadCachePolicy {
+    /// Cache forever within the session (content-addressed; e.g. `content_read`).
+    CacheStable,
+    /// Cache, but invalidate when the given tag is cleared.
+    CacheUnderTag(CacheTag),
+}
+
+/// Returns the caching policy for a read tool, or `None` if the tool is
+/// not a cacheable pure read.
+pub fn read_cache_policy(tool_name: &str) -> Option<ReadCachePolicy> {
+    match tool_name {
+        "content_read" => Some(ReadCachePolicy::CacheStable),
+        "agent_exists" => Some(ReadCachePolicy::CacheUnderTag(CacheTag::AgentExistence)),
+        "artifact_inspect" => Some(ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata)),
+        _ => None,
+    }
+}
+
+/// Returns the tag a mutating tool invalidates, or `None` if the tool does
+/// not affect any cached read class.
+pub fn invalidation_tag_for(tool_name: &str) -> Option<CacheTag> {
+    match tool_name {
+        "agent_install"
+        | "agent_revision_create_from_intent"
+        | "agent_revision_promote"
+        | "agent_revision_rollback" => Some(CacheTag::AgentExistence),
+        "artifact_build" => Some(CacheTag::ArtifactMetadata),
+        _ => None,
+    }
+}
+
+/// Normalize tool arguments before hashing into the cache key. Strips
+/// volatile fields that do not affect a read's result (currently the
+/// echoed `intent` string that models attach), mirroring the loop-guard
+/// fingerprint normalization so semantically-identical calls share a key.
+fn normalize_args(arguments_json: &str) -> String {
+    let Ok(mut v) = serde_json::from_str::<serde_json::Value>(arguments_json) else {
+        return arguments_json.to_string();
+    };
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("intent");
+    }
+    serde_json::to_string(&v).unwrap_or_else(|_| arguments_json.to_string())
+}
+
+fn cache_key(tool_name: &str, arguments_json: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(tool_name.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(normalize_args(arguments_json).as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+struct Entry {
+    value: String,
+    tag: Option<CacheTag>,
+}
+
+/// A single session's bounded LRU result cache.
+struct SessionReadCache {
+    entries: HashMap<String, Entry>,
+    /// Access order, least-recently-used at the front.
+    order: Vec<String>,
+    max_entries: usize,
+    max_value_bytes: usize,
+}
+
+impl SessionReadCache {
+    fn new(max_entries: usize, max_value_bytes: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: Vec::new(),
+            max_entries: max_entries.max(1),
+            max_value_bytes,
+        }
+    }
+
+    fn touch(&mut self, key: &str) {
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
+            let k = self.order.remove(pos);
+            self.order.push(k);
+        }
+    }
+
+    fn get(&mut self, key: &str) -> Option<String> {
+        if self.entries.contains_key(key) {
+            self.touch(key);
+            return self.entries.get(key).map(|e| e.value.clone());
+        }
+        None
+    }
+
+    fn put(&mut self, key: String, value: String, tag: Option<CacheTag>) {
+        if value.len() > self.max_value_bytes {
+            return; // size guard: do not poison the cache with large payloads
+        }
+        if !self.entries.contains_key(&key) {
+            while self.order.len() >= self.max_entries {
+                let evicted = self.order.remove(0);
+                self.entries.remove(&evicted);
+            }
+            self.order.push(key.clone());
+        } else {
+            self.touch(&key);
+        }
+        self.entries.insert(key, Entry { value, tag });
+    }
+
+    fn invalidate_tag(&mut self, tag: CacheTag) {
+        let to_remove: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|(_, e)| e.tag == Some(tag))
+            .map(|(k, _)| k.clone())
+            .collect();
+        for k in to_remove {
+            self.entries.remove(&k);
+            if let Some(pos) = self.order.iter().position(|o| o == &k) {
+                self.order.remove(pos);
+            }
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Registry of per-session read caches, shared on `GatewayStore`.
+///
+/// Cloning returns another handle to the same underlying map. Caches are
+/// created lazily on first store. Entries are not currently GC'd on
+/// session end (a session that never reads has no cache); periodic
+/// compaction is a possible follow-up — see issue #289.
+#[derive(Clone)]
+pub struct SessionReadCacheRegistry {
+    inner: Arc<Mutex<HashMap<String, SessionReadCache>>>,
+    max_entries: usize,
+    max_value_bytes: usize,
+}
+
+impl Default for SessionReadCacheRegistry {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_ENTRIES, DEFAULT_MAX_VALUE_BYTES)
+    }
+}
+
+impl SessionReadCacheRegistry {
+    pub fn new(max_entries: usize, max_value_bytes: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            max_entries,
+            max_value_bytes,
+        }
+    }
+
+    /// Look up a cached result for `(session_id, tool_name, arguments)`.
+    /// Returns `None` on miss or if the tool is not cacheable.
+    pub fn get(&self, session_id: &str, tool_name: &str, arguments_json: &str) -> Option<String> {
+        read_cache_policy(tool_name)?;
+        let key = cache_key(tool_name, arguments_json);
+        let mut guard = self.inner.lock().ok()?;
+        guard.get_mut(session_id)?.get(&key)
+    }
+
+    /// Store a result if the tool is cacheable and the value fits the size
+    /// guard. No-op otherwise.
+    pub fn put(&self, session_id: &str, tool_name: &str, arguments_json: &str, value: &str) {
+        let Some(policy) = read_cache_policy(tool_name) else {
+            return;
+        };
+        let tag = match policy {
+            ReadCachePolicy::CacheStable => None,
+            ReadCachePolicy::CacheUnderTag(t) => Some(t),
+        };
+        let key = cache_key(tool_name, arguments_json);
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        let cache = guard
+            .entry(session_id.to_string())
+            .or_insert_with(|| SessionReadCache::new(self.max_entries, self.max_value_bytes));
+        cache.put(key, value.to_string(), tag);
+    }
+
+    /// Invalidate every entry of `tag`'s class across **all** session
+    /// caches. Called when a mutating tool runs. Coarse by design — these
+    /// mutations are infrequent and the cleared reads are cheap to
+    /// recompute.
+    pub fn invalidate_tag_all_sessions(&self, tag: CacheTag) {
+        if let Ok(mut guard) = self.inner.lock() {
+            for cache in guard.values_mut() {
+                cache.invalidate_tag(tag);
+            }
+        }
+    }
+
+    /// Test/diagnostic: number of cached entries for a session.
+    pub fn entry_count(&self, session_id: &str) -> usize {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|g| g.get(session_id).map(|c| c.len()))
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const S: &str = "sess-1";
+
+    #[test]
+    fn policy_table_matches_issue_289() {
+        assert_eq!(
+            read_cache_policy("content_read"),
+            Some(ReadCachePolicy::CacheStable)
+        );
+        assert_eq!(
+            read_cache_policy("agent_exists"),
+            Some(ReadCachePolicy::CacheUnderTag(CacheTag::AgentExistence))
+        );
+        assert_eq!(
+            read_cache_policy("artifact_inspect"),
+            Some(ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata))
+        );
+        assert_eq!(read_cache_policy("sandbox_exec"), None);
+        assert_eq!(read_cache_policy("agent_spawn"), None);
+    }
+
+    #[test]
+    fn invalidation_tag_table() {
+        for t in [
+            "agent_install",
+            "agent_revision_create_from_intent",
+            "agent_revision_promote",
+            "agent_revision_rollback",
+        ] {
+            assert_eq!(invalidation_tag_for(t), Some(CacheTag::AgentExistence), "{t}");
+        }
+        assert_eq!(
+            invalidation_tag_for("artifact_build"),
+            Some(CacheTag::ArtifactMetadata)
+        );
+        assert_eq!(invalidation_tag_for("content_read"), None);
+    }
+
+    #[test]
+    fn hit_returns_cached_value() {
+        let reg = SessionReadCacheRegistry::default();
+        assert!(reg.get(S, "content_read", r#"{"name":"f"}"#).is_none());
+        reg.put(S, "content_read", r#"{"name":"f"}"#, "BYTES");
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"f"}"#).as_deref(), Some("BYTES"));
+    }
+
+    #[test]
+    fn intent_field_is_ignored_in_key() {
+        let reg = SessionReadCacheRegistry::default();
+        reg.put(S, "content_read", r#"{"name":"f","intent":"first"}"#, "BYTES");
+        // Different intent, same logical args → hit.
+        assert_eq!(
+            reg.get(S, "content_read", r#"{"name":"f","intent":"second"}"#).as_deref(),
+            Some("BYTES")
+        );
+    }
+
+    #[test]
+    fn distinct_args_do_not_collide() {
+        let reg = SessionReadCacheRegistry::default();
+        reg.put(S, "content_read", r#"{"name":"a"}"#, "AAA");
+        reg.put(S, "content_read", r#"{"name":"b"}"#, "BBB");
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"a"}"#).as_deref(), Some("AAA"));
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"b"}"#).as_deref(), Some("BBB"));
+    }
+
+    #[test]
+    fn sessions_are_isolated() {
+        let reg = SessionReadCacheRegistry::default();
+        reg.put("sess-A", "content_read", r#"{"name":"f"}"#, "A_PRIVATE");
+        // A sibling session must NOT be served A's cached content.
+        assert!(reg.get("sess-B", "content_read", r#"{"name":"f"}"#).is_none());
+    }
+
+    #[test]
+    fn non_cacheable_tool_is_never_stored() {
+        let reg = SessionReadCacheRegistry::default();
+        reg.put(S, "sandbox_exec", r#"{"command":"ls"}"#, "out");
+        assert!(reg.get(S, "sandbox_exec", r#"{"command":"ls"}"#).is_none());
+        assert_eq!(reg.entry_count(S), 0);
+    }
+
+    #[test]
+    fn agent_existence_invalidation_clears_only_that_tag() {
+        let reg = SessionReadCacheRegistry::default();
+        reg.put(S, "content_read", r#"{"name":"f"}"#, "BYTES");
+        reg.put(S, "agent_exists", r#"{"agent_id":"x"}"#, r#"{"exists":false}"#);
+        reg.put(S, "artifact_inspect", r#"{"artifact_ref":"a"}"#, r#"{"files":[]}"#);
+
+        reg.invalidate_tag_all_sessions(CacheTag::AgentExistence);
+
+        // agent_exists cleared; content_read + artifact_inspect untouched.
+        assert!(reg.get(S, "agent_exists", r#"{"agent_id":"x"}"#).is_none());
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"f"}"#).as_deref(), Some("BYTES"));
+        assert!(reg.get(S, "artifact_inspect", r#"{"artifact_ref":"a"}"#).is_some());
+    }
+
+    #[test]
+    fn invalidation_spans_all_sessions() {
+        let reg = SessionReadCacheRegistry::default();
+        reg.put("sess-A", "agent_exists", r#"{"agent_id":"x"}"#, "false");
+        reg.put("sess-B", "agent_exists", r#"{"agent_id":"x"}"#, "false");
+        // A mutation in any session invalidates the existence class everywhere.
+        reg.invalidate_tag_all_sessions(CacheTag::AgentExistence);
+        assert!(reg.get("sess-A", "agent_exists", r#"{"agent_id":"x"}"#).is_none());
+        assert!(reg.get("sess-B", "agent_exists", r#"{"agent_id":"x"}"#).is_none());
+    }
+
+    #[test]
+    fn lru_eviction_bounds_entries() {
+        let reg = SessionReadCacheRegistry::new(128, DEFAULT_MAX_VALUE_BYTES);
+        for i in 0..200 {
+            reg.put(S, "content_read", &format!(r#"{{"name":"f{i}"}}"#), &format!("v{i}"));
+        }
+        assert_eq!(reg.entry_count(S), 128, "cache must be bounded to max_entries");
+        // The oldest (f0..f71) evicted; the newest 128 (f72..f199) retained.
+        assert!(reg.get(S, "content_read", r#"{"name":"f0"}"#).is_none());
+        assert_eq!(
+            reg.get(S, "content_read", r#"{"name":"f199"}"#).as_deref(),
+            Some("v199")
+        );
+    }
+
+    #[test]
+    fn lru_access_protects_recently_used() {
+        let reg = SessionReadCacheRegistry::new(3, DEFAULT_MAX_VALUE_BYTES);
+        reg.put(S, "content_read", r#"{"name":"a"}"#, "A");
+        reg.put(S, "content_read", r#"{"name":"b"}"#, "B");
+        reg.put(S, "content_read", r#"{"name":"c"}"#, "C");
+        // Touch "a" so it is most-recently-used.
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"a"}"#).as_deref(), Some("A"));
+        // Insert "d" → should evict "b" (the LRU), not "a".
+        reg.put(S, "content_read", r#"{"name":"d"}"#, "D");
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"a"}"#).as_deref(), Some("A"));
+        assert!(reg.get(S, "content_read", r#"{"name":"b"}"#).is_none());
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"d"}"#).as_deref(), Some("D"));
+    }
+
+    #[test]
+    fn size_guard_skips_large_values() {
+        let reg = SessionReadCacheRegistry::new(128, 1024);
+        let big = "x".repeat(2048);
+        reg.put(S, "content_read", r#"{"name":"big"}"#, &big);
+        assert!(reg.get(S, "content_read", r#"{"name":"big"}"#).is_none());
+        assert_eq!(reg.entry_count(S), 0, "large value must not be stored");
+        // A small value alongside still caches fine.
+        reg.put(S, "content_read", r#"{"name":"small"}"#, "ok");
+        assert_eq!(reg.get(S, "content_read", r#"{"name":"small"}"#).as_deref(), Some("ok"));
+    }
+}

--- a/autonoetic-gateway/src/runtime/session_read_cache.rs
+++ b/autonoetic-gateway/src/runtime/session_read_cache.rs
@@ -81,7 +81,14 @@ pub fn read_cache_policy(tool_name: &str) -> Option<ReadCachePolicy> {
 /// not affect any cached read class.
 pub fn invalidation_tag_for(tool_name: &str) -> Option<CacheTag> {
     match tool_name {
-        "agent_install"
+        // Tools that change what `agent_exists` would return. `agent_exists`
+        // reports `unpromoted` as soon as a revision exists (see
+        // `AgentExistsTool::execute`), so revision *creation* — not just
+        // promotion — must invalidate. `skill_install` installs a SKILL.md
+        // as a brand-new agent. (There is no `agent_install` tool; that
+        // string is only an approval-action kind.)
+        "skill_install"
+        | "agent_revision_create"
         | "agent_revision_create_from_intent"
         | "agent_revision_promote"
         | "agent_revision_rollback" => Some(CacheTag::AgentExistence),
@@ -294,7 +301,8 @@ mod tests {
     #[test]
     fn invalidation_tag_table() {
         for t in [
-            "agent_install",
+            "skill_install",
+            "agent_revision_create",
             "agent_revision_create_from_intent",
             "agent_revision_promote",
             "agent_revision_rollback",
@@ -306,6 +314,11 @@ mod tests {
             Some(CacheTag::ArtifactMetadata)
         );
         assert_eq!(invalidation_tag_for("content_read"), None);
+        // `agent_install` is NOT a real tool (only an approval-action kind),
+        // so it must not be in the invalidation set.
+        assert_eq!(invalidation_tag_for("agent_install"), None);
+        // Read-only revision tools must not invalidate.
+        assert_eq!(invalidation_tag_for("agent_revision_list"), None);
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tool_call_processor.rs
+++ b/autonoetic-gateway/src/runtime/tool_call_processor.rs
@@ -336,19 +336,57 @@ impl<'a> ToolCallProcessor<'a> {
                 .call_tool(tool_name, &sanitized_args)
                 .await?
         } else if self.registry.has_tool(tool_name) {
-            self.registry.execute(
-                tool_name,
-                self.manifest,
-                &policy,
-                agent_dir,
-                gateway_dir,
-                &sanitized_args,
-                self.session_id.as_deref(),
-                self.turn_id.as_deref(),
-                self.config,
-                self.gateway_store.clone(),
-                self.run_context.as_ref(),
-            )?
+            // #289 session-scoped read cache: for pure read tools, return a
+            // memoized result instead of re-executing (and re-injecting the
+            // same content into the transcript). Caching wraps only the raw
+            // `registry.execute` output; disclosure + secret redaction below
+            // still run on every hit, so this is transparent to those
+            // invariants. The cache is consulted only when we have both a
+            // session id and a gateway store to hold the per-session cache.
+            let cache_ctx = match (self.session_id.as_deref(), self.gateway_store.as_ref()) {
+                (Some(sid), Some(store)) => Some((sid.to_string(), store.clone())),
+                _ => None,
+            };
+
+            if let Some((sid, store)) = cache_ctx.as_ref() {
+                if let Some(hit) = store
+                    .session_read_cache
+                    .get(sid, tool_name, &sanitized_args)
+                {
+                    self.emit_cache_hit_event(store, tool_name);
+                    hit
+                } else {
+                    let r = self.registry.execute(
+                        tool_name,
+                        self.manifest,
+                        &policy,
+                        agent_dir,
+                        gateway_dir,
+                        &sanitized_args,
+                        self.session_id.as_deref(),
+                        self.turn_id.as_deref(),
+                        self.config,
+                        self.gateway_store.clone(),
+                        self.run_context.as_ref(),
+                    )?;
+                    self.maybe_cache_or_invalidate(store, sid, tool_name, &sanitized_args, &r);
+                    r
+                }
+            } else {
+                self.registry.execute(
+                    tool_name,
+                    self.manifest,
+                    &policy,
+                    agent_dir,
+                    gateway_dir,
+                    &sanitized_args,
+                    self.session_id.as_deref(),
+                    self.turn_id.as_deref(),
+                    self.config,
+                    self.gateway_store.clone(),
+                    self.run_context.as_ref(),
+                )?
+            }
         } else {
             let agent_like_hint = if tc.name.contains('.') {
                 " This looks like an agent ID, not a tool name. Use agent_spawn with {\"agent_id\": \"...\", \"message\": \"...\"}."
@@ -378,6 +416,71 @@ impl<'a> ToolCallProcessor<'a> {
         }
 
         Ok(result)
+    }
+
+    /// After a successful `registry.execute` for a tool with cache
+    /// relevance: store cacheable read results, and invalidate the
+    /// affected cache-tag class when the tool was a mutator (#289).
+    fn maybe_cache_or_invalidate(
+        &self,
+        store: &std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>,
+        session_id: &str,
+        tool_name: &str,
+        arguments_json: &str,
+        result: &str,
+    ) {
+        use crate::runtime::session_read_cache::{invalidation_tag_for, read_cache_policy};
+
+        // Only memoize / invalidate on a successful result — a failed read
+        // must not be cached, and a failed mutation must not invalidate.
+        if !crate::runtime::tool_dispatch::tool_result_counts_as_progress(result) {
+            return;
+        }
+
+        if read_cache_policy(tool_name).is_some() {
+            store
+                .session_read_cache
+                .put(session_id, tool_name, arguments_json, result);
+        }
+
+        if let Some(tag) = invalidation_tag_for(tool_name) {
+            store.session_read_cache.invalidate_tag_all_sessions(tag);
+        }
+    }
+
+    /// Emit a `tool_call.cache_hit` causal event so the audit chain still
+    /// records the logical tool call when it was served from the #289
+    /// read cache. Best-effort: a failed write is logged, not fatal.
+    fn emit_cache_hit_event(
+        &self,
+        store: &std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>,
+        tool_name: &str,
+    ) {
+        let event = autonoetic_types::causal_chain::CausalEventRecord {
+            event_id: format!("cachehit-{}", uuid::Uuid::new_v4()),
+            agent_id: self.manifest.agent.id.clone(),
+            session_id: self.session_id.clone().unwrap_or_default(),
+            turn_id: self.turn_id.clone(),
+            event_seq: 0,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            category: "tool_call".to_string(),
+            action: "cache_hit".to_string(),
+            status: "SUCCESS".to_string(),
+            enforced_rules: autonoetic_types::causal_chain::default_enforced_rules(),
+            target: Some(tool_name.to_string()),
+            payload: None,
+            payload_ref: None,
+            evidence_ref: None,
+            reason: None,
+        };
+        if let Err(e) = store.create_causal_event(&event) {
+            tracing::warn!(
+                target: "session_read_cache",
+                error = %e,
+                tool = %tool_name,
+                "failed to emit tool_call.cache_hit causal event"
+            );
+        }
     }
 
     fn log_tool_failure(
@@ -1346,6 +1449,257 @@ mod tests {
         assert!(!proc.is_degraded_blocked_tool("content_write"));
         assert!(!proc.is_degraded_blocked_tool("knowledge_store"));
         assert!(!proc.is_degraded_blocked_tool("artifact_build"));
+    }
+
+    // ── #289 session read-cache wiring ──────────────────────────────────
+
+    /// A fake `content_read` that returns `{"ok":true,...}` and counts
+    /// real executions, so a cache hit is observable as "counter did not
+    /// increment".
+    struct FakeContentRead {
+        calls: Arc<AtomicUsize>,
+    }
+    impl NativeTool for FakeContentRead {
+        fn name(&self) -> &'static str {
+            "content_read"
+        }
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: self.name().to_string(),
+                description: "fake".to_string(),
+                input_schema: serde_json::json!({"type":"object"}),
+            }
+        }
+        fn is_available(&self, _m: &AgentManifest) -> bool {
+            true
+        }
+        fn execute(
+            &self,
+            _m: &AgentManifest,
+            _p: &PolicyEngine,
+            _ad: &Path,
+            _gd: Option<&Path>,
+            _args: &str,
+            _sid: Option<&str>,
+            _tid: Option<&str>,
+            _cfg: Option<&autonoetic_types::config::GatewayConfig>,
+            _gs: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+            _rc: Option<&crate::runtime::active_execution_registry::NativeToolRunContext>,
+        ) -> anyhow::Result<String> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(serde_json::json!({ "ok": true, "content": format!("bytes-{n}") }).to_string())
+        }
+    }
+
+    /// A fake `agent_exists` whose result counts executions.
+    struct FakeAgentExists {
+        calls: Arc<AtomicUsize>,
+    }
+    impl NativeTool for FakeAgentExists {
+        fn name(&self) -> &'static str {
+            "agent_exists"
+        }
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: self.name().to_string(),
+                description: "fake".to_string(),
+                input_schema: serde_json::json!({"type":"object"}),
+            }
+        }
+        fn is_available(&self, _m: &AgentManifest) -> bool {
+            true
+        }
+        fn execute(
+            &self,
+            _m: &AgentManifest,
+            _p: &PolicyEngine,
+            _ad: &Path,
+            _gd: Option<&Path>,
+            _args: &str,
+            _sid: Option<&str>,
+            _tid: Option<&str>,
+            _cfg: Option<&autonoetic_types::config::GatewayConfig>,
+            _gs: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+            _rc: Option<&crate::runtime::active_execution_registry::NativeToolRunContext>,
+        ) -> anyhow::Result<String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(serde_json::json!({ "ok": true, "exists": false }).to_string())
+        }
+    }
+
+    /// A fake `agent_revision_promote` mutator (returns ok; the processor
+    /// invalidates the AgentExistence cache class on success).
+    struct FakePromote;
+    impl NativeTool for FakePromote {
+        fn name(&self) -> &'static str {
+            "agent_revision_promote"
+        }
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: self.name().to_string(),
+                description: "fake".to_string(),
+                input_schema: serde_json::json!({"type":"object"}),
+            }
+        }
+        fn is_available(&self, _m: &AgentManifest) -> bool {
+            true
+        }
+        fn execute(
+            &self,
+            _m: &AgentManifest,
+            _p: &PolicyEngine,
+            _ad: &Path,
+            _gd: Option<&Path>,
+            _args: &str,
+            _sid: Option<&str>,
+            _tid: Option<&str>,
+            _cfg: Option<&autonoetic_types::config::GatewayConfig>,
+            _gs: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+            _rc: Option<&crate::runtime::active_execution_registry::NativeToolRunContext>,
+        ) -> anyhow::Result<String> {
+            Ok(serde_json::json!({ "ok": true }).to_string())
+        }
+    }
+
+    fn call(id: &str, name: &str, args: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: args.to_string(),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_cache_serves_repeat_content_read_without_re_executing() {
+        let temp = tempdir().unwrap();
+        let gw_dir = temp.path().join("gateway");
+        std::fs::create_dir_all(&gw_dir).unwrap();
+        let store = Arc::new(
+            crate::scheduler::gateway_store::GatewayStore::open(&gw_dir).unwrap(),
+        );
+
+        let manifest = test_manifest();
+        let mut mcp_runtime = crate::runtime::mcp::McpToolRuntime::empty();
+        let mut registry = NativeToolRegistry::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        registry.register(Box::new(FakeContentRead {
+            calls: Arc::clone(&calls),
+        }));
+        let mut disclosure_state = DisclosureState::default();
+
+        let mut processor = ToolCallProcessor::new(
+            &mut mcp_runtime,
+            &registry,
+            &manifest,
+            &mut disclosure_state,
+            None,
+            None,
+            Some(store.clone()),
+            None,
+        )
+        .with_session_context(Some("cache-sess".to_string()), Some("t1".to_string()));
+
+        let args = r#"{"name":"f"}"#;
+        // First call executes for real.
+        let (_ok1, r1) = processor
+            .process_tool_calls(&[call("tc1", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer())
+            .await
+            .unwrap();
+        // Second identical call must be served from cache (no re-exec).
+        let (_ok2, r2) = processor
+            .process_tool_calls(&[call("tc2", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer())
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "second read must hit cache, not re-execute");
+        assert_eq!(r1[0].2, r2[0].2, "cached result must be byte-identical");
+
+        // Audit: a tool_call.cache_hit causal event was recorded.
+        let events = store.search_causal_events(Some("cache-sess"), None, 50).unwrap();
+        assert!(
+            events.iter().any(|e| e.category == "tool_call" && e.action == "cache_hit"),
+            "expected a tool_call.cache_hit causal event; got {:?}",
+            events.iter().map(|e| format!("{}.{}", e.category, e.action)).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mutator_invalidates_agent_exists_cache() {
+        let temp = tempdir().unwrap();
+        let gw_dir = temp.path().join("gateway");
+        std::fs::create_dir_all(&gw_dir).unwrap();
+        let store = Arc::new(
+            crate::scheduler::gateway_store::GatewayStore::open(&gw_dir).unwrap(),
+        );
+
+        let manifest = test_manifest();
+        let mut mcp_runtime = crate::runtime::mcp::McpToolRuntime::empty();
+        let mut registry = NativeToolRegistry::new();
+        let exists_calls = Arc::new(AtomicUsize::new(0));
+        registry.register(Box::new(FakeAgentExists {
+            calls: Arc::clone(&exists_calls),
+        }));
+        registry.register(Box::new(FakePromote));
+        let mut disclosure_state = DisclosureState::default();
+
+        let mut processor = ToolCallProcessor::new(
+            &mut mcp_runtime,
+            &registry,
+            &manifest,
+            &mut disclosure_state,
+            None,
+            None,
+            Some(store.clone()),
+            None,
+        )
+        .with_session_context(Some("inv-sess".to_string()), Some("t1".to_string()));
+
+        let ea = r#"{"agent_id":"x"}"#;
+        // exists #1 (real), exists #2 (cache hit) → 1 execution.
+        processor.process_tool_calls(&[call("a1", "agent_exists", ea)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        processor.process_tool_calls(&[call("a2", "agent_exists", ea)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        assert_eq!(exists_calls.load(Ordering::SeqCst), 1, "second exists should be cached");
+
+        // A promote invalidates the AgentExistence class. `agent_revision_*`
+        // is intent-gated, so a real intent must be supplied for the tool to
+        // actually execute (and thus invalidate) — a missing intent would be
+        // rejected pre-execution and must NOT invalidate.
+        processor.process_tool_calls(&[call("p1", "agent_revision_promote", r#"{"intent":"promote x for invalidation test"}"#)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+
+        // exists #3 must re-execute (cache invalidated) → 2 executions.
+        processor.process_tool_calls(&[call("a3", "agent_exists", ea)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        assert_eq!(exists_calls.load(Ordering::SeqCst), 2, "exists after promote must re-execute");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_cache_noop_without_gateway_store() {
+        // No gateway store → no cache; the tool executes every time.
+        let temp = tempdir().unwrap();
+        let manifest = test_manifest();
+        let mut mcp_runtime = crate::runtime::mcp::McpToolRuntime::empty();
+        let mut registry = NativeToolRegistry::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        registry.register(Box::new(FakeContentRead {
+            calls: Arc::clone(&calls),
+        }));
+        let mut disclosure_state = DisclosureState::default();
+
+        let mut processor = ToolCallProcessor::new(
+            &mut mcp_runtime,
+            &registry,
+            &manifest,
+            &mut disclosure_state,
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_session_context(Some("no-store".to_string()), Some("t1".to_string()));
+
+        let args = r#"{"name":"f"}"#;
+        processor.process_tool_calls(&[call("c1", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        processor.process_tool_calls(&[call("c2", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "no cache without a gateway store");
     }
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -113,6 +113,8 @@ pub struct GatewayStore {
     /// hold an `Arc<GatewayStore>` for other hooks.
     policy_hook_executor: Mutex<Option<Weak<crate::scheduler::hooks::HookExecutor>>>,
     pub task_notify: crate::scheduler::task_notify::TaskNotifyRegistry,
+    /// Session-scoped result cache for pure read tools (issue #289).
+    pub session_read_cache: crate::runtime::session_read_cache::SessionReadCacheRegistry,
 }
 
 impl GatewayStore {
@@ -137,6 +139,8 @@ impl GatewayStore {
             escalation_flood_cap: std::sync::atomic::AtomicUsize::new(0),
             policy_hook_executor: Mutex::new(None),
             task_notify: crate::scheduler::task_notify::TaskNotifyRegistry::new(),
+            session_read_cache:
+                crate::runtime::session_read_cache::SessionReadCacheRegistry::default(),
         };
         {
             let mut conn = store.conn.lock().unwrap();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -841,6 +841,28 @@ Agent: {agent_id} | Started: {timestamp}
 
 ---
 
+## Session Read Cache
+
+A per-session, in-memory result cache for **pure read tools** memoizes deterministic reads so an agent that re-reads the same handle across turns does not re-execute the tool or re-inject identical content into the transcript. It lives on `GatewayStore` (`session_read_cache`) keyed by exact `session_id`, and is consulted in `ToolCallProcessor::execute_tool_call` *before* dispatch.
+
+| Tool | Policy | Invalidated by |
+|---|---|---|
+| `content_read` | Cache forever in-session (content-addressed) | never |
+| `agent_exists` | Cache | `agent_install`, `agent_revision_create_from_intent`, `agent_revision_promote`, `agent_revision_rollback` |
+| `artifact_inspect` | Cache | `artifact_build` |
+
+Properties:
+
+- **Keyed by exact session id**, not root — a cached `content_read` result is never served to a sibling session, preserving per-session content visibility.
+- **Wraps only the raw `registry.execute` output**; disclosure registration and secret redaction still run on every hit, so caching is transparent to those invariants.
+- **Bounded + size-guarded**: per-session LRU of 128 entries; results over 1 MiB are never stored.
+- **Invalidation is coarse but correct**: a mutating tool clears the affected tag class (`AgentExistence` / `ArtifactMetadata`) across *all* session caches, so a child session's promote invalidates the parent's `agent_exists` cache. `content_read` is never invalidated.
+- **Audited**: a cache hit emits a `tool_call.cache_hit` causal event (and the normal execution trace still records), so the causal chain shows every logical tool call.
+
+Grounding: extends the determinism-skip principle of R-2.6 / R-2.7 (approved-execution caching) to pure reads, where the safety argument is stronger — there is no side effect to skip.
+
+---
+
 ## Observability Surface
 
 The observability surface lets agents discover and inspect session reports across sessions. It is built on top of the causal chain (the authoritative spine) and is complementary to `execution_search` (which searches raw tool traces within a session).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -848,7 +848,7 @@ A per-session, in-memory result cache for **pure read tools** memoizes determini
 | Tool | Policy | Invalidated by |
 |---|---|---|
 | `content_read` | Cache forever in-session (content-addressed) | never |
-| `agent_exists` | Cache | `agent_install`, `agent_revision_create_from_intent`, `agent_revision_promote`, `agent_revision_rollback` |
+| `agent_exists` | Cache | `skill_install`, `agent_revision_create`, `agent_revision_create_from_intent`, `agent_revision_promote`, `agent_revision_rollback` |
 | `artifact_inspect` | Cache | `artifact_build` |
 
 Properties:


### PR DESCRIPTION
## Summary

Closes #289 — the third and final economy lever from the 880-turn diagnostic. Memoizes deterministic read-tool results within a session so an agent that re-reads the same handle across turns doesn't re-execute the tool or re-inject identical content into the transcript (the bulk of the per-turn token cost in that trace).

## Design

New `runtime/session_read_cache.rs` — a `SessionReadCacheRegistry` on `GatewayStore` (mirrors the merged `task_notify` registry from #291), keyed by **exact `session_id`**.

| Tool | Policy | Invalidated by |
|---|---|---|
| `content_read` | cache forever in-session (content-addressed) | never |
| `agent_exists` | cache | `agent_install`, `agent_revision_create_from_intent`, `agent_revision_promote`, `agent_revision_rollback` |
| `artifact_inspect` | cache | `artifact_build` |

Key safety choices:
- **Exact-session keying** — a cached `content_read` result is never served to a sibling session, preserving per-session content visibility.
- **Wraps only the raw `registry.execute` output** — disclosure registration + secret redaction still run on every hit, so caching is transparent to those invariants.
- **Bounded + size-guarded** — per-session LRU of 128 entries; results > 1 MiB are never stored.
- **Coarse-but-correct invalidation** — a mutating tool clears the affected tag class (`AgentExistence` / `ArtifactMetadata`) across *all* session caches, so a child session's `agent_revision_promote` invalidates the parent's `agent_exists` cache. `content_read` is never invalidated.
- **Audited** — a cache hit emits a `tool_call.cache_hit` causal event (and the normal execution trace still records), so the causal chain shows every logical tool call.
- **Only `ok:true` results** are cached / trigger invalidation — a failed read isn't cached; an intent-gated `agent_revision_*` rejected for a missing intent doesn't invalidate.

## Wiring

`ToolCallProcessor::execute_tool_call` consults the cache before dispatch; on hit returns the memoized result + emits the event; on a successful miss stores cacheable reads / invalidates on mutators. No-op when there's no gateway store or session id.

## Constitutional grounding

Extends the determinism-skip principle of **R-2.6 / R-2.7** (approved-execution caching) to pure reads, where the safety argument is stronger — there is no side effect to skip.

## Test plan

- [x] `cargo test -p autonoetic-gateway --lib runtime::session_read_cache::tests` — 12/12 (policy table, hit, intent-insensitive key, session isolation, tag-scoped + cross-session invalidation, LRU eviction + access ordering, size guard)
- [x] 3 processor integration tests: repeat `content_read` served without re-exec + `tool_call.cache_hit` audited; mutator invalidates `agent_exists`; no-op without a store — all pass
- [x] `cargo build --workspace --tests` clean
- [x] Pre-existing flaky `test_in_session_repair_loop_recovery_from_structured_error` (multi_thread, `default_registry`) fails identically with these changes stashed — unrelated to this PR

## Notes

- Caps (128 entries / 1 MiB) are compile-time defaults; a config knob is a possible follow-up (kept out here for smallest blast radius, per the issue's own guidance).
- Per-session caches are not GC'd on session end (same deferred-compaction note as the `task_notify` registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)