### PR TITLE
self_describe: autonoetic self-awareness surface (#300 foundation)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -975,6 +975,7 @@ pub mod quality_trend;
 pub mod sandbox;
 pub mod scheduler;
 pub mod security_redteam;
+pub mod self_describe;
 pub mod sentinel;
 pub mod session;
 pub mod skill;
@@ -1028,6 +1029,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::skill::register_tools(&mut registry);
     crate::runtime::tools::admin_proposal::register_tools(&mut registry);
     crate::runtime::tools::capsule::register_tools(&mut registry);
+    crate::runtime::tools::self_describe::register_tools(&mut registry);
     crate::runtime::tools::constitution::register_tools(&mut registry);
     crate::runtime::tools::security_redteam::register_tools(&mut registry);
     crate::runtime::tools::sentinel::register_tools(&mut registry);

--- a/autonoetic-gateway/src/runtime/tools/self_describe.rs
+++ b/autonoetic-gateway/src/runtime/tools/self_describe.rs
@@ -1,0 +1,239 @@
+//! `self_describe` — the autonoetic self-awareness surface (#300, epic #297;
+//! design `docs/design/constitution-restructure.md`).
+//!
+//! Autonoetic consciousness is self-knowing across time. Today an agent
+//! must *assemble* self-knowledge from scattered tools (`agent_inspect`,
+//! `digest_query`, `constitution_read`, revision lookups). This tool makes
+//! autonoesis a single first-class capability, answering in one call:
+//!
+//! - **who am I** — identity + persona (from the manifest)
+//! - **what may I do** — declared capabilities + allowed tool tiers
+//! - **what am I guaranteed** — the Bill of Rights (from the enforcement
+//!   register's `rights()`), surfaced front-line
+//! - **what have I done** — a pointer to the agent's own history surfaces
+//! - **how do I evolve** — the amendment / promotion / revision paths open
+//!   to it
+//!
+//! It is **always available**: an agent always has the standing to know
+//! itself. It reports only the calling agent's *own* identity and the
+//! *public* constitution — no cross-agent data, no privileged lookups — so
+//! it needs no capability gate.
+//!
+//! This first slice composes the manifest + the register's rights with
+//! structured pointers for the history/evolution dimensions; richer inline
+//! history aggregation is a follow-up.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
+
+use crate::enforcement_register;
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::tools::{NativeTool, NativeToolRunContext};
+
+pub fn register_tools(registry: &mut crate::runtime::tools::NativeToolRegistry) {
+    registry.register(Box::new(SelfDescribeTool));
+}
+
+pub struct SelfDescribeTool;
+
+impl NativeTool for SelfDescribeTool {
+    fn name(&self) -> &'static str {
+        "self_describe"
+    }
+
+    /// Always available — an agent always has the standing to know itself.
+    fn is_available(&self, _manifest: &AgentManifest) -> bool {
+        true
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Describe yourself: who you are (identity, persona), what you may do \
+                          (capabilities, tool tiers), what you are guaranteed (your rights under \
+                          the constitution), what you have done (where your history lives), and \
+                          how you can evolve. Takes no arguments; reports only your own self."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        _arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&autonoetic_types::config::GatewayConfig>,
+        _gateway_store: Option<Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        let can_propose_amendments = manifest
+            .capabilities
+            .iter()
+            .any(|c| matches!(c, Capability::ConstitutionalProposal { .. }));
+
+        // what am I guaranteed — the Bill of Rights, surfaced front-line.
+        let rights: Vec<serde_json::Value> = enforcement_register::rights()
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "title": r.title,
+                    "guarantee": r.statement,
+                    "binds": "gateway",
+                })
+            })
+            .collect();
+
+        let out = serde_json::json!({
+            "ok": true,
+            // who am I
+            "identity": {
+                "agent_id": manifest.agent.id,
+                "name": manifest.agent.name,
+                "description": manifest.agent.description,
+            },
+            // what may I do
+            "may_do": {
+                "capabilities": manifest
+                    .capabilities
+                    .iter()
+                    .map(|c| serde_json::to_value(c).unwrap_or(serde_json::Value::Null))
+                    .collect::<Vec<_>>(),
+                "allowed_tool_tiers": manifest.allowed_tool_tiers,
+            },
+            // what am I guaranteed (rights front-line)
+            "guaranteed": {
+                "note": "Rights bind the gateway on your behalf — these are upheld for you, \
+                         not granted at discretion.",
+                "rights": rights,
+            },
+            // what have I done — pointer to the agent's own history surfaces
+            "history": {
+                "session_id": session_id,
+                "how_to_inspect": [
+                    "digest_query — your own session digests",
+                    "observability_search / observability_read — your published session reports",
+                ],
+            },
+            // how do I evolve
+            "evolution": {
+                "may_propose_amendments": can_propose_amendments,
+                "paths": [
+                    "agent revisions — immutable, content-addressed; promotion advances the alias",
+                    "skill promotion — crystallise successful tactics into reusable skills",
+                    if can_propose_amendments {
+                        "constitution_propose_amendment — you hold the ConstitutionalProposal capability (Ri-0.8)"
+                    } else {
+                        "constitutional amendment — requires the ConstitutionalProposal capability, which you do not currently hold"
+                    },
+                ],
+            },
+        });
+        Ok(out.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::agent::{AgentIdentity, RuntimeDeclaration};
+
+    fn manifest_with(caps: Vec<Capability>) -> AgentManifest {
+        AgentManifest {
+            version: "1.0".to_string(),
+            runtime: RuntimeDeclaration {
+                engine: "autonoetic".to_string(),
+                gateway_version: "0.1.0".to_string(),
+                sdk_version: "0.1.0".to_string(),
+                runtime_type: "stateful".to_string(),
+                sandbox: "bubblewrap".to_string(),
+                runtime_lock: "runtime.lock".to_string(),
+            },
+            agent: AgentIdentity {
+                id: "demo.agent".to_string(),
+                name: "Demo".to_string(),
+                description: "a demo".to_string(),
+            },
+            capabilities: caps,
+            llm_config: None,
+            limits: None,
+            background: None,
+            disclosure: None,
+            io: None,
+            middleware: None,
+            execution_mode: Default::default(),
+            script_entry: None,
+            script_input_mode: Default::default(),
+            gateway_url: None,
+            gateway_token: None,
+            allowed_tool_tiers: vec![],
+            agentskills_import: None,
+            compression: None,
+            sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+        }
+    }
+
+    fn run(manifest: &AgentManifest) -> serde_json::Value {
+        let tool = SelfDescribeTool;
+        let policy = PolicyEngine::new(manifest.clone());
+        let r = tool
+            .execute(
+                manifest,
+                &policy,
+                Path::new("/tmp"),
+                None,
+                "{}",
+                Some("sess-1"),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        serde_json::from_str(&r).unwrap()
+    }
+
+    #[test]
+    fn always_available() {
+        assert!(SelfDescribeTool.is_available(&manifest_with(vec![])));
+    }
+
+    #[test]
+    fn surfaces_identity_and_rights() {
+        let v = run(&manifest_with(vec![]));
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["identity"]["agent_id"], "demo.agent");
+        // Rights are surfaced front-line, sourced from the register.
+        let rights = v["guaranteed"]["rights"].as_array().unwrap();
+        assert_eq!(rights.len(), enforcement_register::rights().len());
+        assert!(rights.iter().all(|r| r["binds"] == "gateway"));
+        assert!(
+            rights.iter().any(|r| r["id"] == "Ri-0.14"),
+            "expected the wake-up right to be surfaced"
+        );
+    }
+
+    #[test]
+    fn evolution_reflects_amendment_capability() {
+        let without = run(&manifest_with(vec![]));
+        assert_eq!(without["evolution"]["may_propose_amendments"], false);
+
+        let with = run(&manifest_with(vec![Capability::ConstitutionalProposal {
+            patterns: vec!["*".to_string()],
+        }]));
+        assert_eq!(with["evolution"]["may_propose_amendments"], true);
+    }
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -349,6 +349,20 @@ For facts with provenance across sessions. Reads respect **visibility** and **ex
 | `agent_spawn` | `(agent_id: string, message: any, ...) → result` | Spawn child agent |
 | `agent_exists` | `(agent_id: string) → bool` | Check if agent exists |
 | `agent_discover` | `(intent: string, ...) → [candidates]` | Find reusable agents |
+| `agent_inspect` | `(agent_id: string, ...) → metadata` | Inspect *any* installed agent's metadata/capabilities/revision |
+| `self_describe` | `() → self` | Describe *yourself* — see below |
+
+### Self-Awareness (`self_describe`)
+
+*Autonoetic* consciousness is self-knowing across time. `self_describe` makes that a first-class, single-call capability for the **calling** agent, rather than something assembled from scattered tools. It answers:
+
+- **who am I** — identity + persona
+- **what may I do** — declared capabilities + allowed tool tiers
+- **what am I guaranteed** — your **rights** under the constitution (the Bill of Rights), surfaced front-line: these *bind the gateway* on your behalf, not granted at discretion
+- **what have I done** — where your history lives (`digest_query`, `observability_*`)
+- **how do I evolve** — the revision, skill-promotion, and (capability-permitting) constitutional-amendment paths open to you
+
+It takes no arguments, reports only your own self and the public constitution, and is **always available** — an agent always has the standing to know itself. Rights are sourced from the enforcement register (`docs/constitution/enforcement-register.md`), so they stay in sync with what the gateway actually upholds.
 
 ### Skill Install Tool
 


### PR DESCRIPTION
Next step down the restructure epic (#297). **Stacked on #305** (rights in the register) — retargets to `main` automatically once #305 merges. Design: `docs/design/constitution-restructure.md`.

Makes *autonoesis* a single first-class capability instead of an assembly job across `agent_inspect` / `digest_query` / `constitution_read` / revision lookups.

## New `self_describe` tool

Answers about the **calling** agent, in one call:
- **who am I** — identity + persona (from the manifest)
- **what may I do** — capabilities + allowed tool tiers
- **what am I guaranteed** — the **Bill of Rights**, surfaced front-line from `enforcement_register::rights()` (the payoff of #305). Each right is tagged `binds: gateway`, so it reads as a guarantee upheld *for* the agent, not a discretionary grant.
- **what have I done** — pointer to the agent's history surfaces (`digest_query`, `observability_*`)
- **how do I evolve** — revision / skill-promotion / constitutional-amendment paths, the last reflecting whether the agent holds `ConstitutionalProposal` (Ri-0.8)

**Always available** (no capability gate): an agent always has the standing to know itself; it reports only its own identity + the public constitution — no cross-agent or privileged data.

## Why rights come from the register

Sourcing rights from `enforcement_register::rights()` (not a hand-copied list) means the agent-facing Bill of Rights stays in sync with what the gateway actually upholds — exactly the rule-to-code-gap closure the restructure is about.

## Scope

Foundation slice: composes manifest + register rights + structured pointers for history/evolution. Richer inline history aggregation is a follow-up. **No `constitution.md` change → no re-sign.**

## Tests

3 unit tests (always-available; identity+rights surfaced; evolution reflects amendment capability). `docs/AGENTS.md` documents the surface + the autonoetic thesis.

Refs #300, #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)