### PR TITLE
Detection-loop foundation: principle-aware enforcement events (#302)

### DIFF
--- a/autonoetic-gateway/src/enforcement_register.rs
+++ b/autonoetic-gateway/src/enforcement_register.rs
@@ -241,18 +241,27 @@ pub struct ContractHealth {
 }
 
 /// Tally enforcement occurrences (each identified by its legacy rule/right
-/// ID) into a [`ContractHealth`], attributing each to its clause via
-/// [`clause_of_legacy`].
+/// ID) into a [`ContractHealth`], attributing each to its clause.
+///
+/// Builds the legacy-ID → clause map once up front (rather than rescanning
+/// the register per occurrence via [`clause_of_legacy`]), keeping the tally
+/// `O(register_entries + occurrences)` even as the register grows during
+/// migration (#303).
 pub fn contract_health<I, S>(legacy_ids: I) -> ContractHealth
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
     use std::collections::BTreeMap;
+    let legacy_to_clause: std::collections::HashMap<&'static str, &'static str> =
+        enforcement_register()
+            .iter()
+            .map(|e| (e.legacy_id, e.clause_id))
+            .collect();
     let mut counts: BTreeMap<&'static str, u64> = BTreeMap::new();
     let mut unattributed = 0u64;
     for id in legacy_ids {
-        match clause_of_legacy(id.as_ref()) {
+        match legacy_to_clause.get(id.as_ref()) {
             Some(clause) => *counts.entry(clause).or_insert(0) += 1,
             None => unattributed += 1,
         }

--- a/autonoetic-gateway/src/enforcement_register.rs
+++ b/autonoetic-gateway/src/enforcement_register.rs
@@ -213,6 +213,60 @@ pub fn entries_for(clause_id: &str) -> impl Iterator<Item = &'static Enforcement
         .filter(move |e| e.clause_id == clause_id)
 }
 
+/// Reverse-lookup: which clause does a legacy `R-x.y` / `Ri-x.y` ID belong
+/// to? Lets enforcement events that still carry legacy rule IDs (e.g.
+/// `loop_guard.tripped`'s `enforced_rules`) be attributed to their
+/// principle/right for detection-loop correlation (#302). `None` if the
+/// legacy ID is not (yet) in the register.
+pub fn clause_of_legacy(legacy_id: &str) -> Option<&'static str> {
+    enforcement_register()
+        .iter()
+        .find(|e| e.legacy_id == legacy_id)
+        .map(|e| e.clause_id)
+}
+
+/// A per-clause tally of enforcement occurrences — the raw signal behind a
+/// "contract health" view (#302): which principles/rights are tripping, and
+/// how often. Pure aggregation over occurrences the caller has already
+/// gathered (e.g. from `causal_events`), so it is trivially testable and
+/// carries no I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractHealth {
+    /// `(clause_id, count)` sorted by descending count, then clause_id.
+    pub by_clause: Vec<(String, u64)>,
+    /// Occurrences whose legacy ID did not resolve to any register clause
+    /// (e.g. a not-yet-migrated rule) — surfaced rather than dropped so
+    /// coverage gaps stay visible.
+    pub unattributed: u64,
+}
+
+/// Tally enforcement occurrences (each identified by its legacy rule/right
+/// ID) into a [`ContractHealth`], attributing each to its clause via
+/// [`clause_of_legacy`].
+pub fn contract_health<I, S>(legacy_ids: I) -> ContractHealth
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    use std::collections::BTreeMap;
+    let mut counts: BTreeMap<&'static str, u64> = BTreeMap::new();
+    let mut unattributed = 0u64;
+    for id in legacy_ids {
+        match clause_of_legacy(id.as_ref()) {
+            Some(clause) => *counts.entry(clause).or_insert(0) += 1,
+            None => unattributed += 1,
+        }
+    }
+    let mut by_clause: Vec<(String, u64)> =
+        counts.into_iter().map(|(c, n)| (c.to_string(), n)).collect();
+    // Descending count, then clause_id for stable ordering.
+    by_clause.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ContractHealth {
+        by_clause,
+        unattributed,
+    }
+}
+
 /// Render the register as a stable markdown document. This is the generated
 /// artifact committed at `docs/constitution/enforcement-register.md`; the
 /// [`tests::generated_register_matches_committed_doc`] test guards against
@@ -360,6 +414,35 @@ mod tests {
             assert_eq!(binds(r.id), Some(Binds::Gateway), "right {} must bind gateway", r.id);
         }
         assert_eq!(binds("nope"), None);
+    }
+
+    // ── Detection-loop foundation (#302) ────────────────────────────────
+
+    #[test]
+    fn clause_of_legacy_resolves_and_misses() {
+        assert_eq!(clause_of_legacy("R-7.19"), Some("P-7"));
+        assert_eq!(clause_of_legacy("R-7.5"), Some("P-7"));
+        assert_eq!(clause_of_legacy("Ri-0.14"), Some("Ri-0.14"));
+        assert_eq!(clause_of_legacy("R-9.99"), None);
+    }
+
+    #[test]
+    fn contract_health_tallies_by_clause_descending() {
+        let occurrences = ["R-7.19", "R-7.19", "R-7.5", "Ri-0.14", "R-9.99"];
+        let health = contract_health(occurrences);
+        // R-7.19 + R-7.5 both → P-7 (3), Ri-0.14 → Ri-0.14 (1); R-9.99 unattributed.
+        assert_eq!(health.by_clause, vec![
+            ("P-7".to_string(), 3),
+            ("Ri-0.14".to_string(), 1),
+        ]);
+        assert_eq!(health.unattributed, 1);
+    }
+
+    #[test]
+    fn contract_health_empty_is_empty() {
+        let health = contract_health(Vec::<String>::new());
+        assert!(health.by_clause.is_empty());
+        assert_eq!(health.unattributed, 0);
     }
 
     // ── Code ↔ register bridge (real, not aspirational) ─────────────────

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1201,9 +1201,15 @@ impl AgentExecutor {
                 if let (Some(reason), Some(store)) =
                     (self.guard.last_trip_reason(), self.gateway_store.as_ref())
                 {
+                    // Attribute the trip to its constitutional principle/right
+                    // (via the enforcement register) in addition to the legacy
+                    // rule ID, so the detection loop can correlate breaches by
+                    // principle, not just by rule string (#302).
                     let payload = serde_json::json!({
                         "reason": reason.code(),
                         "detail": format!("{:?}", reason),
+                        "rule_id": reason.rule_id(),
+                        "principle": crate::enforcement_register::clause_of_legacy(reason.rule_id()),
                     });
                     let session_id_for_event =
                         self.session_id.clone().unwrap_or_default();

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1201,15 +1201,16 @@ impl AgentExecutor {
                 if let (Some(reason), Some(store)) =
                     (self.guard.last_trip_reason(), self.gateway_store.as_ref())
                 {
-                    // Attribute the trip to its constitutional principle/right
-                    // (via the enforcement register) in addition to the legacy
-                    // rule ID, so the detection loop can correlate breaches by
-                    // principle, not just by rule string (#302).
+                    // Attribute the trip to its constitutional clause (a
+                    // principle *or* a right, via the enforcement register) in
+                    // addition to the legacy rule ID, so the detection loop can
+                    // correlate breaches by clause, not just by rule string
+                    // (#302).
                     let payload = serde_json::json!({
                         "reason": reason.code(),
                         "detail": format!("{:?}", reason),
                         "rule_id": reason.rule_id(),
-                        "principle": crate::enforcement_register::clause_of_legacy(reason.rule_id()),
+                        "clause": crate::enforcement_register::clause_of_legacy(reason.rule_id()),
                     });
                     let session_id_for_event =
                         self.session_id.clone().unwrap_or_default();


### PR DESCRIPTION
## What

The no-signing foundation for the constitution **detection loop** (epic #297, design `docs/design/constitution-restructure.md`). Lets enforcement events be correlated by **constitutional principle**, not just by legacy rule string.

### `enforcement_register.rs`
- **`clause_of_legacy(legacy_id) -> Option<&'static str>`** — reverse-lookup from a legacy `R-x.y` / `Ri-x.y` ID to its owning principle/right clause.
- **`contract_health(legacy_ids) -> ContractHealth`** — pure tally grouping enforcement occurrences by clause, sorted by descending count. Occurrences whose legacy ID does not (yet) resolve to a register clause are counted in `unattributed` and surfaced rather than dropped, so migration coverage gaps stay visible.

### `runtime/lifecycle.rs`
- Enrich the `loop_guard.tripped` causal event payload with `rule_id` and the resolved `principle` (via `clause_of_legacy(reason.rule_id())`), so the detection loop can aggregate breaches by principle.

## Why

The register already proves code ↔ constitution agreement (#305). This adds the reverse direction needed for a detection loop: when something trips, attribute it to the principle it serves so contract health can be tallied per-principle.

## Scope

Pure reverse-lookup + aggregation, fully unit-tested. **No `constitution.md` change → no re-sign required.** Live sentinel/CLI wiring is a noted follow-up.

Advances #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)