### PR TITLE
Contract-health live view: store query + CLI (#302)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Reference bundles are under `agents/`:
 - **Causal Chain**: Every session produces a hash-chained audit trail of turns and events
 - **Checkpoint**: Universal session snapshots at every yield point (hibernation, approval, budget exhaustion, emergency stop). Enables crash recovery and session forking.
 - **Queryable Event Store**: Causal events mirrored to SQLite (`causal_events` table) for agent learning queries
+- **Contract Health**: Standing view of how often each constitutional clause (principle/right) has been enforced. Enforcement events carry their legacy rule ID (e.g. `loop_guard.tripped` → `R-7.19`); the `enforcement_register` reverse-maps these to their owning clause, and `GatewayStore::contract_health` tallies occurrences by clause (unrecognised IDs surfaced as `unattributed`). Surfaced via `autonoetic trace contract-health`.
 - **Execution Traces**: Full code execution results (stdout, stderr, exit_code) in `execution_traces` table — not truncated
 - **Live Digest**: Real-time session narrative in `digest.md`, replacing flat timeline
 - **Artifact Store**: Content-addressed (SHA-256) storage; agents pass handles, not inline blobs

--- a/autonoetic-gateway/src/enforcement_register.rs
+++ b/autonoetic-gateway/src/enforcement_register.rs
@@ -194,6 +194,14 @@ pub fn clause_exists(clause_id: &str) -> bool {
     principle(clause_id).is_some() || right(clause_id).is_some()
 }
 
+/// Human-readable title for a clause (principle *or* right). `None` if the
+/// clause is unknown.
+pub fn clause_title(clause_id: &str) -> Option<&'static str> {
+    principle(clause_id)
+        .map(|p| p.title)
+        .or_else(|| right(clause_id).map(|r| r.title))
+}
+
 /// Bind direction for a clause: principles bind the agent, rights bind the
 /// gateway. `None` if the clause is unknown.
 pub fn binds(clause_id: &str) -> Option<Binds> {

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -356,6 +356,52 @@ impl GatewayStore {
         Ok(results)
     }
 
+    /// Standing **contract-health** view (#302): tally how often each
+    /// constitutional clause (principle/right) has been enforced, by reading
+    /// the `enforced_rules` carried on causal events and attributing each
+    /// legacy rule/right ID to its owning clause via the enforcement register.
+    ///
+    /// The `R+++3` event-attribution placeholder (every event carries it by
+    /// default) is skipped — only events that named a concrete rule/right
+    /// contribute. Real rule IDs not yet in the register surface in
+    /// `ContractHealth::unattributed`, keeping migration gaps visible rather
+    /// than silently dropped.
+    ///
+    /// `since` is an optional RFC3339 lower bound on `timestamp`; `None` scans
+    /// all retained events.
+    pub fn contract_health(
+        &self,
+        since: Option<&str>,
+    ) -> Result<crate::enforcement_register::ContractHealth> {
+        let conn = self.conn.lock().unwrap();
+        let placeholder = autonoetic_types::causal_chain::RULE_ID_EVENT_ATTRIBUTION;
+
+        let (query, params): (&str, Vec<rusqlite::types::Value>) = match since {
+            Some(ts) => (
+                "SELECT enforced_rules FROM causal_events WHERE timestamp >= ?1",
+                vec![rusqlite::types::Value::Text(ts.to_string())],
+            ),
+            None => ("SELECT enforced_rules FROM causal_events", Vec::new()),
+        };
+
+        let mut stmt = conn.prepare(query)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+            row.get::<_, String>(0)
+        })?;
+
+        let mut legacy_ids: Vec<String> = Vec::new();
+        for raw in rows {
+            let raw = raw?;
+            // Each cell is a JSON array of rule/right IDs; tolerate malformed
+            // rows by skipping rather than failing the whole tally.
+            if let Ok(ids) = serde_json::from_str::<Vec<String>>(&raw) {
+                legacy_ids.extend(ids.into_iter().filter(|id| id != placeholder));
+            }
+        }
+
+        Ok(crate::enforcement_register::contract_health(legacy_ids))
+    }
+
     /// List curator decision events (`category = 'curator'`, `action = 'decision'`)
     /// for a specific target URI/id. Used by operator workflows asking
     /// "why was memory X dropped" (issue #30). The underlying `idx_causal_target`

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -368,30 +368,43 @@ impl GatewayStore {
     /// than silently dropped.
     ///
     /// `since` is an optional RFC3339 lower bound on `timestamp`; `None` scans
-    /// all retained events.
+    /// all retained events. The bound is parsed and compared by absolute
+    /// instant (not raw text), so offset forms like `Z` vs `+02:00` behave
+    /// correctly and malformed operator input fails clearly.
     pub fn contract_health(
         &self,
         since: Option<&str>,
     ) -> Result<crate::enforcement_register::ContractHealth> {
+        // Parse + validate the bound up front: raw SQLite text comparison on
+        // RFC3339 is wrong across offset forms, and an unparsed string would
+        // silently yield empty/partial results instead of a clear error.
+        let since_dt = match since {
+            Some(ts) => Some(chrono::DateTime::parse_from_rfc3339(ts).map_err(|e| {
+                anyhow::anyhow!("invalid `since` timestamp {ts:?}: {e} (expected RFC3339)")
+            })?),
+            None => None,
+        };
+
         let conn = self.conn.lock().unwrap();
         let placeholder = autonoetic_types::causal_chain::RULE_ID_EVENT_ATTRIBUTION;
 
-        let (query, params): (&str, Vec<rusqlite::types::Value>) = match since {
-            Some(ts) => (
-                "SELECT enforced_rules FROM causal_events WHERE timestamp >= ?1",
-                vec![rusqlite::types::Value::Text(ts.to_string())],
-            ),
-            None => ("SELECT enforced_rules FROM causal_events", Vec::new()),
-        };
-
-        let mut stmt = conn.prepare(query)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
-            row.get::<_, String>(0)
-        })?;
+        let mut stmt = conn.prepare("SELECT enforced_rules, timestamp FROM causal_events")?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
 
         let mut legacy_ids: Vec<String> = Vec::new();
-        for raw in rows {
-            let raw = raw?;
+        for r in rows {
+            let (raw, ts) = r?;
+            // Filter by absolute time when a bound is set. An event whose own
+            // timestamp won't parse is kept rather than dropped — we never
+            // hide enforcement activity over a formatting quirk.
+            if let Some(bound) = since_dt {
+                if let Ok(event_dt) = chrono::DateTime::parse_from_rfc3339(&ts) {
+                    if event_dt < bound {
+                        continue;
+                    }
+                }
+            }
             // Each cell is a JSON array of rule/right IDs; tolerate malformed
             // rows by skipping rather than failing the whole tally.
             if let Ok(ids) = serde_json::from_str::<Vec<String>>(&raw) {

--- a/autonoetic-gateway/tests/observability_integration.rs
+++ b/autonoetic-gateway/tests/observability_integration.rs
@@ -505,5 +505,19 @@ fn test_contract_health_tallies_by_clause() -> anyhow::Result<()> {
     assert_eq!(health_since.by_clause, vec![("Ri-0.14".to_string(), 1)]);
     assert_eq!(health_since.unattributed, 1);
 
+    // `since` is compared by absolute instant, not raw text: an offset form
+    // equal to 00:00:04Z must filter identically to the `Z` form above.
+    let health_offset = store.contract_health(Some("2026-05-29T02:00:04+02:00"))?;
+    assert_eq!(health_offset, health_since);
+
+    // Malformed `since` fails clearly rather than silently returning nothing.
+    let err = store
+        .contract_health(Some("not-a-timestamp"))
+        .expect_err("invalid since must error");
+    assert!(
+        err.to_string().contains("invalid `since` timestamp"),
+        "unexpected error: {err}"
+    );
+
     Ok(())
 }

--- a/autonoetic-gateway/tests/observability_integration.rs
+++ b/autonoetic-gateway/tests/observability_integration.rs
@@ -446,3 +446,64 @@ fn test_observability_search_after_publish() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Contract-health view (#302): the store tallies `enforced_rules` carried on
+/// causal events by their constitutional clause, attributing legacy rule/right
+/// IDs via the enforcement register and surfacing unrecognised IDs separately.
+#[test]
+fn test_contract_health_tallies_by_clause() -> anyhow::Result<()> {
+    use autonoetic_types::causal_chain::{CausalEventRecord, EntryStatus};
+
+    let temp = tempdir()?;
+    let gateway_dir = temp.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+    let store = GatewayStore::open(&gateway_dir)?;
+
+    // Helper to insert a causal event carrying a given set of enforced rules.
+    let mut seq = 0u64;
+    let mut emit = |rules: Vec<&str>| -> anyhow::Result<()> {
+        seq += 1;
+        store.create_causal_event(&CausalEventRecord {
+            event_id: format!("evt-{seq}"),
+            agent_id: "agent.x".to_string(),
+            session_id: "sess-1".to_string(),
+            turn_id: None,
+            event_seq: seq,
+            timestamp: format!("2026-05-29T00:00:{:02}Z", seq),
+            category: "loop_guard".to_string(),
+            action: "tripped".to_string(),
+            status: EntryStatus::Error.to_string(),
+            enforced_rules: rules.into_iter().map(|s| s.to_string()).collect(),
+            target: None,
+            payload: None,
+            payload_ref: None,
+            evidence_ref: None,
+            reason: None,
+        })
+    };
+
+    // R-7.19 + R-7.5 both belong to principle P-7; Ri-0.14 is its own clause.
+    // R-9.99 is not (yet) in the register → unattributed. The bare placeholder
+    // event contributes nothing.
+    emit(vec!["R-7.19"])?;
+    emit(vec!["R-7.19"])?;
+    emit(vec!["R-7.5"])?;
+    emit(vec!["Ri-0.14"])?;
+    emit(vec!["R-9.99"])?;
+    emit(vec!["R+++3"])?; // default placeholder — skipped entirely
+
+    let health = store.contract_health(None)?;
+    assert_eq!(
+        health.by_clause,
+        vec![("P-7".to_string(), 3), ("Ri-0.14".to_string(), 1)]
+    );
+    assert_eq!(health.unattributed, 1);
+
+    // `since` filter excludes the earliest events.
+    let health_since = store.contract_health(Some("2026-05-29T00:00:04Z"))?;
+    // Only Ri-0.14 (seq 4), R-9.99 (seq 5), placeholder (seq 6) remain.
+    assert_eq!(health_since.by_clause, vec![("Ri-0.14".to_string(), 1)]);
+    assert_eq!(health_since.unattributed, 1);
+
+    Ok(())
+}

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -1065,6 +1065,15 @@ pub enum TraceCommands {
         #[arg(long)]
         follow: bool,
     },
+    /// Contract-health view: how often each constitutional clause has been enforced (#302)
+    ContractHealth {
+        /// Only count enforcement events at or after this RFC3339 timestamp
+        #[arg(long)]
+        since: Option<String>,
+        /// Emit machine-readable JSON output
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/autonoetic/src/cli/trace.rs
+++ b/autonoetic/src/cli/trace.rs
@@ -484,6 +484,99 @@ pub fn handle_trace_digest(
     Ok(())
 }
 
+/// `autonoetic trace contract-health` — the standing contract-health view
+/// (#302). Tallies how often each constitutional clause (principle/right) has
+/// been enforced, sourced from the `enforced_rules` carried on causal events
+/// and attributed to clauses via the enforcement register.
+pub fn handle_trace_contract_health(
+    config_path: &Path,
+    since: Option<&str>,
+    json_output: bool,
+) -> anyhow::Result<()> {
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_dir = config.agents_dir.join(".gateway");
+    let store = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir)?;
+    let health = store.contract_health(since)?;
+
+    if json_output {
+        let body = serde_json::json!({
+            "since": since,
+            "by_clause": health.by_clause.iter().map(|(clause, count)| {
+                serde_json::json!({
+                    "clause": clause,
+                    "count": count,
+                    "title": autonoetic_gateway::enforcement_register::clause_title(clause),
+                    "binds": autonoetic_gateway::enforcement_register::binds(clause)
+                        .map(|b| b.label()),
+                })
+            }).collect::<Vec<_>>(),
+            "unattributed": health.unattributed,
+        });
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        return Ok(());
+    }
+
+    println!(
+        "{}Contract health{} {}",
+        color::BOLD,
+        color::RESET,
+        match since {
+            Some(ts) => color::dim(&format!("(since {ts})")),
+            None => color::dim("(all retained events)"),
+        }
+    );
+    println!();
+
+    if health.by_clause.is_empty() {
+        println!(
+            "{}No clause enforcements recorded.{}",
+            color::DIM,
+            color::RESET
+        );
+    } else {
+        println!(
+            "{}{}{:<10} {:<8} {:<8} {}{}",
+            color::DIM,
+            color::BOLD,
+            "CLAUSE",
+            "COUNT",
+            "BINDS",
+            "TITLE",
+            color::RESET
+        );
+        println!("{}", color::separator(72));
+        for (clause, count) in &health.by_clause {
+            let title = autonoetic_gateway::enforcement_register::clause_title(clause)
+                .unwrap_or("<unknown>");
+            let binds = autonoetic_gateway::enforcement_register::binds(clause)
+                .map(|b| b.label())
+                .unwrap_or("-");
+            println!(
+                "{}{:<10}{} {}{:<8}{} {:<8} {}",
+                color::BRIGHT_CYAN,
+                clause,
+                color::RESET,
+                color::BRIGHT_YELLOW,
+                count,
+                color::RESET,
+                binds,
+                title,
+            );
+        }
+    }
+
+    if health.unattributed > 0 {
+        println!();
+        println!(
+            "{}{} unattributed enforcement(s){} — legacy rule/right IDs not yet in the register (migration gap).",
+            color::YELLOW,
+            health.unattributed,
+            color::RESET
+        );
+    }
+    Ok(())
+}
+
 pub fn load_agent_traces(
     config_path: &Path,
     requested_agent: Option<&str>,

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -370,6 +370,13 @@ async fn main() -> anyhow::Result<()> {
                 cli::trace::handle_trace_graph(&config_path, session_or_workflow, *json, *follow)
                     .await?;
             }
+            cli::common::TraceCommands::ContractHealth { since, json } => {
+                cli::trace::handle_trace_contract_health(
+                    &config_path,
+                    since.as_deref(),
+                    *json,
+                )?;
+            }
         },
 
         Commands::Skill(args) => match &args.command {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,7 @@ Autonoetic is a Rust-first runtime for autonomous, self-evolving AI agents with 
 - [Causal Chain](#causal-chain)
 - [Session Checkpoints, Continuations, and Forks](#session-checkpoints-continuations-and-forks)
 - [Queryable Event Store](#queryable-event-store)
+- [Contract Health](#contract-health)
 - [Live Digest](#live-digest)
 - [Observability Surface](#observability-surface)
 - [Hook System](#hook-system)
@@ -763,9 +764,19 @@ Causal chain events are mirrored to SQLite for agent learning queries.
 | `category` | tool_invoke, llm, lifecycle, memory... |
 | `action` | requested, completed, failure... |
 | `status` | SUCCESS, ERROR, DENIED |
+| `enforced_rules` | JSON array of constitutional rule/right IDs this event enforced (default placeholder `R+++3` when none) |
 | `target` | Tool name, model name, etc. |
 | `payload` | Full JSON (not truncated) |
 | `timestamp` | RFC3339 |
+
+#### Principle-aware enforcement events
+
+Enforcement events carry the legacy rule/right IDs they enforce in
+`enforced_rules`, and (for richer events like `loop_guard.tripped`) the
+resolved owning **clause** in the payload. The `enforcement_register`
+reverse-maps a legacy `R-x.y` / `Ri-x.y` ID to its owning principle or right,
+so breaches correlate by **constitutional clause**, not by ad-hoc rule
+strings. See [Contract Health](#contract-health) below.
 
 **`execution_traces`** — Full code execution results:
 
@@ -801,6 +812,29 @@ Causal chain events are mirrored to SQLite for agent learning queries.
   "limit": 10
 }
 ```
+
+---
+
+## Contract Health
+
+Trust-through-predictability holds only if breaches are detected and corrected —
+so "report and correct" is a peer of "constrain." The contract-health view is
+the standing tally behind that half of the loop: how often each constitutional
+clause (principle/right) has actually been enforced.
+
+It reads the `enforced_rules` carried on `causal_events`, attributes each legacy
+rule/right ID to its owning clause via the `enforcement_register`
+(`clause_of_legacy`), and tallies occurrences per clause. The `R+++3`
+event-attribution placeholder is skipped (every event carries it by default);
+real rule IDs not yet migrated into the register surface as `unattributed`, so
+coverage gaps stay visible rather than silently dropped.
+
+- **Code**: `GatewayStore::contract_health(since)` →
+  `enforcement_register::ContractHealth { by_clause, unattributed }`
+- **CLI**: `autonoetic trace contract-health [--since <RFC3339>] [--json]`
+
+This is the foundation for principle-aware sentinel correlation; see
+`docs/design/divergence-sentinel-design.md`.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -495,6 +495,22 @@ View the conversation history of a session.
 autonoetic trace history <session_id> [--json]
 ```
 
+### `autonoetic trace contract-health`
+
+Standing **contract-health** view: how often each constitutional clause
+(principle/right) has been enforced. Reads the `enforced_rules` carried on
+causal events and attributes each legacy rule/right ID to its owning clause via
+the enforcement register. Rule IDs not yet migrated into the register are
+reported as `unattributed` (a visible migration-coverage signal). See
+[Contract Health](ARCHITECTURE.md#contract-health).
+
+```bash
+autonoetic trace contract-health [--since <RFC3339>] [--json]
+```
+
+- `--since` — only count enforcement events at or after this RFC3339 timestamp.
+- `--json` — machine-readable output (`by_clause` with clause/count/title/binds, plus `unattributed`).
+
 ---
 
 ## Capsule Commands

--- a/docs/design/divergence-sentinel-design.md
+++ b/docs/design/divergence-sentinel-design.md
@@ -258,6 +258,32 @@ modify session state. Pure observer.
 
 Each phase is independently shippable and provides value on its own.
 
+## 5b. Principle-Aware Correlation (Contract Health) — implemented foundation
+
+The Sentinel correlates breaches by **constitutional clause**, not by ad-hoc
+rule strings. This foundation is implemented (#302) ahead of the Layer-1
+monitor and is reusable by both layers:
+
+- **Events carry clause attribution.** Enforcement events keep their legacy
+  rule/right IDs in `enforced_rules`; richer events (e.g.
+  `loop_guard.tripped`) also resolve the owning clause into their payload
+  (`rule_id` + `clause`).
+- **Reverse lookup.** `enforcement_register::clause_of_legacy(legacy_id)` maps
+  a legacy `R-x.y` / `Ri-x.y` ID to its owning principle or right. The register
+  is the single source of truth for code ↔ constitution agreement, so the
+  Sentinel never hard-codes rule→clause mappings.
+- **Contract-health tally.** `GatewayStore::contract_health(since)` aggregates
+  occurrences per clause over `causal_events`, surfacing IDs not yet migrated
+  into the register as `unattributed` (a visible migration-coverage signal
+  rather than a silent drop). The `R+++3` event-attribution placeholder is
+  excluded.
+- **Operator surface.** `autonoetic trace contract-health [--since] [--json]`.
+
+This gives the "report" half of report-and-correct a standing, queryable view:
+which principles trip, how often, and whether enforcement is concentrating on
+particular clauses. Layer 1 consumes the same correlation when emitting
+`divergence.*` events; Layer 2 can cite per-clause history in its judgment.
+
 ## 6. Validating the "Digest-Reader Bias" Hypothesis
 
 Before building Layer 2, run a **falsifiable experiment** on archived


### PR DESCRIPTION
## What

The **live surface** for the detection-loop foundation (epic #297, design `docs/design/constitution-restructure.md`). Builds on PR #307 (which added the reverse-lookup + tally + enriched `loop_guard.tripped` event) to make contract health queryable by operators.

### Gateway
- `enforcement_register::clause_title(clause_id)` — human-readable title for a clause (principle *or* right).
- `GatewayStore::contract_health(since)` — aggregates the `enforced_rules` carried on `causal_events`, attributes each legacy rule/right ID to its owning clause via the register, and tallies per clause. Skips the `R+++3` event-attribution placeholder; surfaces unmigrated IDs as `unattributed` (visible migration-coverage signal). Optional RFC3339 `since` lower bound.

### CLI
- `autonoetic trace contract-health [--since <RFC3339>] [--json]` — prints a clause/count/binds/title table (or JSON), with an explicit unattributed footnote.

### Tests
- `observability_integration::test_contract_health_tallies_by_clause` — verifies tally-by-clause (R-7.19 + R-7.5 → P-7, Ri-0.14 standalone), placeholder skip, unattributed counting, and `since` filtering over a temp store.

### Docs (#302 calls these out explicitly)
- `docs/ARCHITECTURE.md` — new **Contract Health** section, `enforced_rules` column, principle-aware enforcement-events note, TOC entry.
- `docs/CLI.md` — new `trace contract-health` subcommand.
- `CLAUDE.md` — Contract Health key concept.
- `docs/design/divergence-sentinel-design.md` — §5b principle-aware correlation as the implemented foundation Layer 1/2 will consume.

## Scope

Aggregation + read surface only. **No `constitution.md` change → no re-sign required.** Gate-denial principle tagging and the live Layer-1 sentinel monitor remain follow-ups (gate-denial vocab intersects the signing-gated #301).

Advances #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)