### PR TITLE
docs: tidy retired R+/R++ marker references to current clause IDs

### DIFF
--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -144,7 +144,7 @@ Skip coder. Compose the agent's SKILL body in-place, build an
 intent-only artifact bundle from it, then hand the bundle's
 `artifact_ref` to `specialized_builder.default`. This makes the
 install **artifact-addressed** even for pure-skill agents — the audit
-target, the install source, and the R++2 capability-delta key all
+target, the install source, and the P-2.16 capability-delta key all
 agree on one content-addressed identity.
 
 **1. Compose the SKILL body** as a single markdown string —
@@ -222,7 +222,7 @@ from `io.accepts`.
 `instructions`:** specialized_builder uses the `instructions` field
 to compose the canonical SKILL.md server-side. The bundled artifact's
 SKILL body must match this string exactly — that is the property
-audit verifies in §5.8 and that R++2 keys on. Compose once, bundle
+audit verifies in §5.8 and that P-2.16 keys on. Compose once, bundle
 once, pass the same string in `instructions`. Do not edit the body
 between steps 1 and 4.
 

--- a/agents/evolution/code-issue-proposer.default/SKILL.md
+++ b/agents/evolution/code-issue-proposer.default/SKILL.md
@@ -77,7 +77,7 @@ This agent is strictly bounded to the following capabilities, enforced at the ga
 - Has CodeExecution capability (cannot run arbitrary shell commands)
 - Makes network requests outside the configured GitHub API scope
 
-Any expansion of this capability set requires a constitutional amendment through the R++2 gate.
+Any expansion of this capability set requires a constitutional amendment through the P-2.16 gate.
 
 ## Issue Body Format
 

--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -301,7 +301,7 @@ artifact_exec({
 
 ### Promotion Evaluation Has No Network
 
-Artifacts that go through promotion evaluation are tested in a sandbox with no network access (gateway constitution rule R+16). All tests must mock external services — a test that makes a real HTTP call will fail with `ECONNREFUSED`. Use `constitution.read` to inspect the full rule.
+Artifacts that go through promotion evaluation are tested in a sandbox with no network access (gateway constitution rule P-3.10). All tests must mock external services — a test that makes a real HTTP call will fail with `ECONNREFUSED`. Use `constitution.read` to inspect the full rule.
 
 ### When to Use Dependencies
 You don't have `NetworkAccess`, so you cannot install packages directly. If your code needs external packages:

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -123,7 +123,7 @@ If you found NO tests, **do NOT call `promotion_record`**. The role is inapplica
 - **If some tests exist**: run all of them, report total/passed/failed
 - **If all tests pass**: `status = "pass"`, `evaluator_pass = true`
 - **If any test fails**: `status = "fail"`, `evaluator_pass = false`, include failure output in findings
-- **If tests require network**: return `status = "unable_to_evaluate"` with a finding describing the integration-test dependency (cannot be evaluated in sealed sandbox per R+16)
+- **If tests require network**: return `status = "unable_to_evaluate"` with a finding describing the integration-test dependency (cannot be evaluated in sealed sandbox per P-3.10)
 
 ## Output Format
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,7 +253,7 @@ Two cooperating mechanisms control how sensitive data flows through the gateway:
 - **`ViewerClass` (Agent / Operator / Admin)** controls *what an observability or approval reader sees* based on who they are. Agents reading `execution.search` get trace metadata only — no stdout, no commands, no arguments, no result. Agents reading `approval_summary` for `WriteFile` see the path but not content; for `CredentialRequest` they see only `credential_id`/`url`/`method` (headers / body / payload blanked). One known gap (issue #158, fixed by PR #160): `SandboxExec.command` is currently preserved verbatim for the Agent class. Operators see structural fields with secret-named JSON keys redacted; non-JSON strings get precise in-place masking via `redact_embedded_secrets`. Admins see the raw record. Class is selected at the call site.
 - **`DisclosureClass` (Public / Restricted)** controls *what an LLM may quote in its assistant reply*. Per-content classification configured via `DisclosurePolicy` rules in `SKILL.md`.
 
-Together with **R+9** (the redaction-before-write invariant enforced by `RedactedPayload`), these form three layers: R+9 keeps secrets out of the causal chain at write time; `ViewerClass` strips fields per consumer at read time; `DisclosureClass` filters the LLM's reply.
+Together with **P-4.14** (the redaction-before-write invariant enforced by `RedactedPayload`), these form three layers: P-4.14 keeps secrets out of the causal chain at write time; `ViewerClass` strips fields per consumer at read time; `DisclosureClass` filters the LLM's reply.
 
 Redaction primitives are centralised in `autonoetic-types/src/redaction.rs`. Per-record field-by-field tables, call-site conventions, and the threat model are documented in [`docs/observability-redaction.md`](observability-redaction.md).
 
@@ -824,7 +824,7 @@ clause (principle/right) has actually been enforced.
 
 It reads the `enforced_rules` carried on `causal_events`, attributes each legacy
 rule/right ID to its owning clause via the `enforcement_register`
-(`clause_of_legacy`), and tallies occurrences per clause. The `R+++3`
+(`clause_of_rule`), and tallies occurrences per clause. The `R+++3`
 event-attribution placeholder is skipped (every event carries it by default);
 real rule IDs not yet migrated into the register surface as `unattributed`, so
 coverage gaps stay visible rather than silently dropped.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -771,10 +771,10 @@ Causal chain events are mirrored to SQLite for agent learning queries.
 
 #### Principle-aware enforcement events
 
-Enforcement events carry the legacy rule/right IDs they enforce in
+Enforcement events carry the `P-x.y` / `Ri-x.y` rule/right IDs they enforce in
 `enforced_rules`, and (for richer events like `loop_guard.tripped`) the
 resolved owning **clause** in the payload. The `enforcement_register`
-reverse-maps a legacy `R-x.y` / `Ri-x.y` ID to its owning principle or right,
+reverse-maps a `P-x.y` / `Ri-x.y` ID to its owning principle or right,
 so breaches correlate by **constitutional clause**, not by ad-hoc rule
 strings. See [Contract Health](#contract-health) below.
 
@@ -822,11 +822,11 @@ so "report and correct" is a peer of "constrain." The contract-health view is
 the standing tally behind that half of the loop: how often each constitutional
 clause (principle/right) has actually been enforced.
 
-It reads the `enforced_rules` carried on `causal_events`, attributes each legacy
-rule/right ID to its owning clause via the `enforcement_register`
-(`clause_of_rule`), and tallies occurrences per clause. The `R+++3`
-event-attribution placeholder is skipped (every event carries it by default);
-real rule IDs not yet migrated into the register surface as `unattributed`, so
+It reads the `enforced_rules` carried on `causal_events`, attributes each
+`P-x.y` / `Ri-x.y` rule/right ID to its owning clause via the
+`enforcement_register` (`clause_of_rule`), and tallies occurrences per clause.
+The `R+++3` event-attribution placeholder is skipped (every event carries it by
+default); rule IDs not present in the register surface as `unattributed`, so
 coverage gaps stay visible rather than silently dropped.
 
 - **Code**: `GatewayStore::contract_health(since)` →

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -499,9 +499,9 @@ autonoetic trace history <session_id> [--json]
 
 Standing **contract-health** view: how often each constitutional clause
 (principle/right) has been enforced. Reads the `enforced_rules` carried on
-causal events and attributes each legacy rule/right ID to its owning clause via
-the enforcement register. Rule IDs not yet migrated into the register are
-reported as `unattributed` (a visible migration-coverage signal). See
+causal events and attributes each `P-x.y` / `Ri-x.y` rule/right ID to its owning
+clause via the enforcement register. Rule IDs not present in the register are
+reported as `unattributed` (a visible coverage-gap signal). See
 [Contract Health](ARCHITECTURE.md#contract-health).
 
 ```bash

--- a/docs/design/divergence-sentinel-design.md
+++ b/docs/design/divergence-sentinel-design.md
@@ -269,7 +269,7 @@ monitor and is reusable by both layers:
   `loop_guard.tripped`) also resolve the owning clause into their payload
   (`rule_id` + `clause`).
 - **Reverse lookup.** `enforcement_register::clause_of_rule(rule_id)` maps
-  a legacy `R-x.y` / `Ri-x.y` ID to its owning principle or right. The register
+  a numbered `P-x.y` / `Ri-x.y` rule ID to its owning principle or right. The register
   is the single source of truth for code ↔ constitution agreement, so the
   Sentinel never hard-codes rule→clause mappings.
 - **Contract-health tally.** `GatewayStore::contract_health(since)` aggregates

--- a/docs/design/divergence-sentinel-design.md
+++ b/docs/design/divergence-sentinel-design.md
@@ -268,7 +268,7 @@ monitor and is reusable by both layers:
   rule/right IDs in `enforced_rules`; richer events (e.g.
   `loop_guard.tripped`) also resolve the owning clause into their payload
   (`rule_id` + `clause`).
-- **Reverse lookup.** `enforcement_register::clause_of_legacy(legacy_id)` maps
+- **Reverse lookup.** `enforcement_register::clause_of_rule(rule_id)` maps
   a legacy `R-x.y` / `Ri-x.y` ID to its owning principle or right. The register
   is the single source of truth for code ↔ constitution agreement, so the
   Sentinel never hard-codes rule→clause mappings.

--- a/docs/observability-redaction.md
+++ b/docs/observability-redaction.md
@@ -29,7 +29,7 @@ Three classes, ordered by decreasing redaction:
 |---|---|---|
 | `Agent` | An autonoetic agent reading observability/approval data via gateway tools. | **Most redacted.** Body text, headers, payloads, evidence references blanked. *Note: `SandboxExec.command` for approval subjects is currently preserved verbatim — see issue #158, fixed by PR #160.* |
 | `Operator` | A human operator using the CLI / chat TUI. | **Targeted redaction.** Secret-named keys in JSON payloads have values replaced with `"***REDACTED***"`. Non-JSON strings get precise in-place masking via `redact_embedded_secrets` (Bearer headers, env-var assignments, URL query secrets are masked; surrounding prose preserved). Commands, hosts, request shapes are visible for triage. |
-| `Admin` | An admin with full access (currently equivalent to "no redaction applied at this layer"). | Identity. The original record is returned unchanged. Secret material is still subject to the R+9 redaction-before-write invariant — see [R+9 and `RedactedPayload`](#r9-and-redactedpayload). |
+| `Admin` | An admin with full access (currently equivalent to "no redaction applied at this layer"). | Identity. The original record is returned unchanged. Secret material is still subject to the P-4.14 redaction-before-write invariant — see [P-4.14 and `RedactedPayload`](#p-414-and-redactedpayload). |
 
 The default is `Operator` (`ViewerClass::default()`). See [the default-Operator footgun](#the-default-operator-footgun) for what to watch out for.
 
@@ -110,7 +110,7 @@ Other paths today do **not** invoke `ViewerClass`-aware redaction:
 - **CLI rendering of approvals** formats `ApprovalRequest.action` directly (truncating `SandboxExec.command`, etc.) without going through `redact_for_display` or `redact_for_viewer(Operator)`. The CLI is operator-only and the data is already operator-class, but applying the redaction layer would be more defensible — tracked as a follow-up.
 - **HTTP API readers** go through unredacted store readers gated by HMAC auth (the assumption is that HMAC-authenticated callers are equivalent to `Admin`).
 
-> **Convention:** any code path that emits trace, event, or approval data to a non-Admin consumer should pass `ViewerClass::Agent` if the consumer is an autonoetic agent, `ViewerClass::Operator` if it is a human, `ViewerClass::Admin` only when the consumer is part of the gateway core (e.g. log persistence, where R+9 already redacted at write time). When in doubt, pass `Agent` — too restrictive is recoverable; too permissive is not.
+> **Convention:** any code path that emits trace, event, or approval data to a non-Admin consumer should pass `ViewerClass::Agent` if the consumer is an autonoetic agent, `ViewerClass::Operator` if it is a human, `ViewerClass::Admin` only when the consumer is part of the gateway core (e.g. log persistence, where P-4.14 already redacted at write time). When in doubt, pass `Agent` — too restrictive is recoverable; too permissive is not.
 
 ---
 
@@ -132,7 +132,7 @@ The primitives live in **`autonoetic-types/src/redaction.rs`** (centralised in #
 
 1. `causal_chain::redact_for_viewer` — for `ExecutionTraceRecord` and `CausalEventRecord`.
 2. `background::ScheduledAction::redact_for_viewer` — for approval subjects.
-3. `gateway::log_redaction` — re-exports the canonical helpers; `RedactedPayload` (the R+9 wrapper) stays local.
+3. `gateway::log_redaction` — re-exports the canonical helpers; `RedactedPayload` (the P-4.14 wrapper) stays local.
 
 Public functions:
 
@@ -151,13 +151,13 @@ The fallback for values that can't be masked in place is restricted to PEM block
 
 ---
 
-## R+9 and `RedactedPayload`
+## P-4.14 and `RedactedPayload`
 
-`ViewerClass` is a *read-time* defence. The complementary *write-time* invariant is **R+9 (redaction-before-write)**, enforced by `gateway::log_redaction::RedactedPayload`. The newtype wraps `serde_json::Value`; constructors run `redact_json_value` before the payload reaches the causal chain. Direct `Value` cannot be passed to `CausalLogger::log` — only `RedactedPayload` can.
+`ViewerClass` is a *read-time* defence. The complementary *write-time* invariant is **P-4.14 (redaction-before-write)**, enforced by `gateway::log_redaction::RedactedPayload`. The newtype wraps `serde_json::Value`; constructors run `redact_json_value` before the payload reaches the causal chain. Direct `Value` cannot be passed to `CausalLogger::log` — only `RedactedPayload` can.
 
 The two layers compose:
 
-- R+9 ensures secrets never enter the causal chain in the first place. An Admin reading a trace cannot leak what was never written.
+- P-4.14 ensures secrets never enter the causal chain in the first place. An Admin reading a trace cannot leak what was never written.
 - `ViewerClass` is the second line: even when a record is innocuous at write time, the read path strips fields that lower-trust consumers don't need.
 
 ---
@@ -192,8 +192,8 @@ They cooperate; neither subsumes the other.
 ### What this does NOT protect against
 
 - **A compromised gateway.** ViewerClass is part of the trusted reader stack; an attacker who controls the gateway can read raw rows.
-- **A malicious admin.** The `Admin` viewer class is identity. By design — admins trace incidents and need full data. Defence here is upstream (`R+9`, audit trail of admin reads, organisational controls).
-- **Secrets that bypass the redaction pipeline at write time.** If `R+9` fails — e.g. a payload bypasses `RedactedPayload` and reaches the causal chain unwrapped — the row contains the raw secret and the read-time redaction may not catch every credential shape. The sentinel's credential-leak check (`autonoetic-gateway/src/sentinel/checks/credential.rs`) is the backstop, scanning persisted payloads for known credential patterns.
+- **A malicious admin.** The `Admin` viewer class is identity. By design — admins trace incidents and need full data. Defence here is upstream (`P-4.14`, audit trail of admin reads, organisational controls).
+- **Secrets that bypass the redaction pipeline at write time.** If `P-4.14` fails — e.g. a payload bypasses `RedactedPayload` and reaches the causal chain unwrapped — the row contains the raw secret and the read-time redaction may not catch every credential shape. The sentinel's credential-leak check (`autonoetic-gateway/src/sentinel/checks/credential.rs`) is the backstop, scanning persisted payloads for known credential patterns.
 
 ---
 

--- a/docs/protected-agents.md
+++ b/docs/protected-agents.md
@@ -35,7 +35,7 @@ protected_agents:
 When a protected agent is promoted via `agent_revision_promote`:
 
 1. **Eval evidence required**: `required_eval_run_id` must be provided and must reference a **passed** eval run for the exact revision being promoted.
-2. **Standard gates still fire**: capability-delta (R++2), artifact promotion, sentinel pre-promotion gate.
+2. **Standard gates still fire**: capability-delta (P-2.16), artifact promotion, sentinel pre-promotion gate.
 3. **No eval run = blocked**: the tool returns `protected_agent_requires_eval_run` with a repair hint.
 
 ### Disabling the Gate

--- a/docs/revision-signing.md
+++ b/docs/revision-signing.md
@@ -105,10 +105,11 @@ permissions or the filesystem is read-only.
 When `true`, revision creation proceeds without a signature if the key is unavailable.
 This is intended only for local development or constrained environments.
 
-### Why This Replaced the Old P-9.13 Gate
+### Why This Replaced the Original Caller-Supplied Gate
 
-The original P-9.13 design required the **caller** (agent/CLI) to provide an Ed25519
-signature in the tool arguments. This was a deadlock:
+The original design (before P-9.13 took its current gateway-side form) required
+the **caller** (agent/CLI) to provide an Ed25519 signature in the tool
+arguments. This was a deadlock:
 
 1. The agent doesn't have the gateway's private key, so it can't produce a valid signature.
 2. The gateway doesn't auto-sign, so there's no way to get a signature.

--- a/docs/revision-signing.md
+++ b/docs/revision-signing.md
@@ -1,4 +1,4 @@
-# Revision Signing (R+11)
+# Revision Signing (P-9.13)
 
 ## Overview
 
@@ -88,7 +88,7 @@ changes.
 ## Gateway Identity Key
 
 The signing key is the same `GatewayIdentityKey` used for turn-boundary state attestations
-(R++1):
+(P-6.23):
 
 - **Private**: `.gateway/state_attestation.ed25519` (mode `0o600`, auto-generated on first load)
 - **Public**: `.gateway/state_attestation.ed25519.pub` (32 bytes, Ed25519 verifying key)
@@ -105,9 +105,9 @@ permissions or the filesystem is read-only.
 When `true`, revision creation proceeds without a signature if the key is unavailable.
 This is intended only for local development or constrained environments.
 
-### Why This Replaced the Old R+11 Gate
+### Why This Replaced the Old P-9.13 Gate
 
-The original R+11 design required the **caller** (agent/CLI) to provide an Ed25519
+The original P-9.13 design required the **caller** (agent/CLI) to provide an Ed25519
 signature in the tool arguments. This was a deadlock:
 
 1. The agent doesn't have the gateway's private key, so it can't produce a valid signature.


### PR DESCRIPTION
Final cleanup after the #303 constitution migration. Current/agent-facing docs still cited retired `R+`/`R++` markers that no longer resolve to any constitution section — pointing them at the graduated clause IDs.

- **Agent SKILL.md** (coder, unit_test_runner, agent-factory, code-issue-proposer): `R+16` → `P-3.10`, `R++2` → `P-2.16`.
- **observability-redaction.md**: `R+9` → `P-4.14` (redaction-before-write), including the heading and its in-doc anchor link.
- **revision-signing.md**: `R+11` → `P-9.13`, `R++1` → `P-6.23`.
- **protected-agents.md**: `R++2` → `P-2.16`.
- **ARCHITECTURE.md**: `R+9` → `P-4.14`; stale `clause_of_legacy` → `clause_of_rule`.
- **divergence-sentinel-design.md**: stale `clause_of_legacy(legacy_id)` → `clause_of_rule(rule_id)`.

**Deliberately left as historical record:** `gateway-constitution-roadmap.md` (the build log *organized by* `R+`/`R++` markers) and the `docs/design/*` RFCs/reviews — retroactively renumbering point-in-time records would misrepresent them. The `R+++3` `RULE_ID_EVENT_ATTRIBUTION` sentinel value stays (it's the literal `enforced_rules` placeholder, not a citation).

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)