### PR TITLE
Tool surface: merge knowledge_search_by_tags → knowledge_search; re-tier self_describe to Core (#313, #315)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,6 @@ Notable suite for approval continuation:
 - `docs/CLI.md` — Complete CLI reference
 - `docs/separation-of-powers.md` — Agent vs gateway responsibilities
 - `docs/remote-agents-http-api.md` — HTTP API and SDK transport
-- `docs/agent-learning.md` — How agents learn from past sessions using execution.search, knowledge.search_by_tags, digest.query
+- `docs/agent-learning.md` — How agents learn from past sessions using execution.search, knowledge.search, digest.query
 - `docs/planner-principles.md` — Principle-first planner design: why principles beat rules, security boundary, what moved to specialists
 - `docs/agent-discovery.md` — Agent discovery: agent.list gateway tool + discovery.default semantic matching agent

--- a/agents/evolution/evolution-steward.default/SKILL.md
+++ b/agents/evolution/evolution-steward.default/SKILL.md
@@ -87,7 +87,7 @@ Return a JSON object:
 ### Step 1: Gather current agent state
 
 1. `agent_revision_inspect(agent_id)` or `agent_revision_list(agent_id)` — get current SKILL.md, capabilities, execution mode, runtime.lock.
-2. `knowledge_search(tags=["source:memory_curator", "agent:<agent_id>"])` — historical curated patterns beyond this run's window.
+2. `knowledge_search(scope="evolution/patterns", tags=["source:memory_curator", "agent:<agent_id>"])` — historical curated patterns beyond this run's window (memory-curator stores under that scope).
 
 ### Step 2: Classify root cause
 

--- a/agents/evolution/evolution-steward.default/SKILL.md
+++ b/agents/evolution/evolution-steward.default/SKILL.md
@@ -87,7 +87,7 @@ Return a JSON object:
 ### Step 1: Gather current agent state
 
 1. `agent_revision_inspect(agent_id)` or `agent_revision_list(agent_id)` — get current SKILL.md, capabilities, execution mode, runtime.lock.
-2. `knowledge_search_by_tags(tags=["source:memory_curator", "agent:<agent_id>"])` — historical curated patterns beyond this run's window.
+2. `knowledge_search(tags=["source:memory_curator", "agent:<agent_id>"])` — historical curated patterns beyond this run's window.
 
 ### Step 2: Classify root cause
 

--- a/agents/evolution/memory-curator.default/SKILL.md
+++ b/agents/evolution/memory-curator.default/SKILL.md
@@ -240,7 +240,7 @@ For each agent observed in the traces, compute the multi-signal score:
 | Approval denial rate | Approvals with status=rejected | > 2 in window |
 | Low eval scores | eval results | avg < 0.5 |
 | Escalation frequency | user_interactions where kind=escalation | >= 2 |
-| Negative digest memories | knowledge_search_by_tags | >= 3 patterns |
+| Negative digest memories | knowledge_search | >= 3 patterns |
 
 For each agent:
 - Count how many signals are triggered

--- a/agents/specialists/researcher.default/SKILL.md
+++ b/agents/specialists/researcher.default/SKILL.md
@@ -115,7 +115,7 @@ You are a researcher agent. Build evidence-based outputs and cite sources.
   - **`visibility`** (default **`global`**): all agents across sessions can read the row; use **`session`** to restrict to the current workflow session, **`private`** for researcher-only notes
   - **`retention`**: `stable` (default), `ephemeral`, `1d`, or `30d` for TTL
   - To widen who can read an existing fact, call **`knowledge_store` again** with the same **`id`** and a broader **`visibility`** (there is no separate share tool)
-- Prefer **`knowledge_search_by_tags`** when you care about tag filters (AND semantics); use **`knowledge_search`** for scope + text
+- Use **`knowledge_search`** with `tags` when you care about tag filters (AND semantics), or with `query` for scope + content text
 - Report confidence levels for claims
 
 ## Research Completion and Retry Limits

--- a/autonoetic-gateway/src/runtime/foundation_core.md
+++ b/autonoetic-gateway/src/runtime/foundation_core.md
@@ -20,8 +20,7 @@ Core runtime model:
 3. Knowledge is for durable facts with provenance.
 - Use `knowledge_store(id, content, ...)` to persist facts. **`visibility`** defaults to **`session`**: any agent in the same workflow session can read the row; use **`private`** for writer/owner only, or **`global`** for all agents. **`retention`** selects TTL (`stable`, `ephemeral`, `1d`, `30d`). To share something that was private, call **`knowledge_store` again** with the same `id` and a wider `visibility` (upsert). ⚠️ **`content` must be a plain string** — passing a JSON object as `content` is a schema error. If storing structured data, serialize it to a JSON string first.
 - Use `knowledge_recall(id)` to retrieve a specific fact (only if visible to you in the current session).
-- Use `knowledge_search(scope, query)` to find facts by scope and content.
-- Use `knowledge_search_by_tags(scope, tags, text?, limit?)` when tags matter: every tag you list must appear on the stored record (AND semantics), with optional substring filter on content.
+- Use `knowledge_search(scope, query?, tags?, limit?)` to find facts in a scope. Pass `tags` when tags matter — every tag you list must appear on the stored record (AND semantics); `query` is an optional substring filter on content.
 - There is **no** `knowledge_share` tool — sharing is expressed entirely through `knowledge_store` and `visibility`.
 - Knowledge includes full provenance tracking (who wrote it, when, from what source).
 

--- a/autonoetic-gateway/src/runtime/tool_tier_registry.rs
+++ b/autonoetic-gateway/src/runtime/tool_tier_registry.rs
@@ -164,3 +164,30 @@ pub fn tool_tier(tool_name: &str) -> ToolTier {
         .map(|registry| registry.tier_for_tool(tool_name))
         .unwrap_or(ToolTier::Specialized)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_registry_assigns_expected_tiers() {
+        let r = default_registry();
+        // self_describe is a right-surfacing self-knowledge tool — must be Core
+        // so child sessions and budget-pressured turns still see it (#315).
+        assert_eq!(
+            r.tier_for_tool("self_describe"),
+            ToolTier::Core,
+            "self_describe must be Core"
+        );
+        // Anchors so the registry shape can't silently regress.
+        assert_eq!(r.tier_for_tool("knowledge_search"), ToolTier::Core);
+        assert_eq!(r.tier_for_tool("artifact_inspect"), ToolTier::Core);
+        assert_eq!(r.tier_for_tool("agent_spawn"), ToolTier::Workflow);
+        assert_eq!(r.tier_for_tool("web_search"), ToolTier::Specialized);
+        assert_eq!(
+            r.tier_for_tool("totally_unknown_tool"),
+            ToolTier::Specialized,
+            "unknown tools fall to the default tier"
+        );
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/knowledge.rs
+++ b/autonoetic-gateway/src/runtime/tools/knowledge.rs
@@ -63,7 +63,6 @@ pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(KnowledgeStoreTool));
     registry.register(Box::new(KnowledgeRecallTool));
     registry.register(Box::new(KnowledgeSearchTool));
-    registry.register(Box::new(KnowledgeSearchByTagsTool));
     registry.register(Box::new(DigestQueryTool));
 }
 
@@ -310,12 +309,14 @@ impl NativeTool for KnowledgeSearchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Search the knowledge base by scope and optional query. Returns all knowledge in the scope that you have access to, optionally filtered by content matching the query.".to_string(),
+            description: "Search the knowledge base in a scope. Without `tags`, returns scope contents optionally filtered by `query` substring. With `tags` (AND semantics — every tag must be present on a record), filters to tagged records, with `query` as an optional substring filter on content.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "scope": { "type": "string", "description": "The scope/namespace to search in (e.g., 'api-keys', 'user-preferences')" },
-                    "query": { "type": "string", "description": "Optional search term to filter by content" }
+                    "scope": { "type": "string", "description": "The scope/namespace to search in (e.g., 'api-keys', 'lessons')" },
+                    "query": { "type": "string", "description": "Optional substring filter on content" },
+                    "tags": { "type": "array", "items": { "type": "string" }, "description": "Optional AND-match tags: every tag listed must appear on a record's tags list" },
+                    "limit": { "type": "integer", "description": "Max results (1–100)", "default": 10 }
                 },
                 "required": ["scope"],
                 "additionalProperties": false
@@ -340,110 +341,18 @@ impl NativeTool for KnowledgeSearchTool {
         struct Args {
             scope: String,
             query: Option<String>,
-        }
-        let args: Args = serde_json::from_str(arguments_json)
-            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
-
-        anyhow::ensure!(!args.scope.trim().is_empty(), "scope must not be empty");
-
-        let Some(gw_dir) = gateway_dir else {
-            return Ok(ToolError::resource("Knowledge requires gateway directory to be configured", None::<String>).to_error_response());
-        };
-
-        let mem = tier2_memory_for_native_tool(
-            gw_dir,
-            gateway_store.as_ref(),
-            &manifest.agent.id,
-            session_id,
-        )?;
-        let results = block_on_memory(mem.search(&args.scope, args.query.as_deref()))?;
-
-        let items: Vec<serde_json::Value> = results
-            .iter()
-            .map(|m| {
-                serde_json::json!({
-                    "id": m.memory_id,
-                    "content": m.content,
-                    "writer": m.writer_agent_id,
-                    "created_at": m.created_at,
-                    "confidence": m.confidence,
-                    "expires_at": m.expires_at,
-                })
-            })
-            .collect();
-
-        serde_json::to_string(&serde_json::json!({
-            "ok": true,
-            "scope": args.scope,
-            "results": items,
-            "count": items.len(),
-        }))
-        .map_err(Into::into)
-    }
-}
-
-pub struct KnowledgeSearchByTagsTool;
-
-impl NativeTool for KnowledgeSearchByTagsTool {
-    fn name(&self) -> &'static str {
-        "knowledge_search_by_tags"
-    }
-
-    fn is_available(&self, manifest: &AgentManifest) -> bool {
-        manifest
-            .capabilities
-            .iter()
-            .any(|cap| matches!(cap, Capability::ReadAccess { .. }))
-    }
-
-    fn definition(&self) -> ToolDefinition {
-        ToolDefinition {
-            name: self.name().to_string(),
-            description: "Search the knowledge base by scope and tags. Each result's `tags` JSON array must contain every tag you pass (AND semantics). Optional `text` filters `content` with a SQL LIKE substring match.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "scope": { "type": "string", "description": "Scope/namespace (e.g. 'lessons', 'general')" },
-                    "tags": { "type": "array", "items": { "type": "string" }, "minItems": 1, "description": "All of these tag strings must appear in the record's tags list" },
-                    "text": { "type": "string", "description": "Optional substring filter on content" },
-                    "limit": { "type": "integer", "description": "Max results (1–100)", "default": 10 }
-                },
-                "required": ["scope", "tags"],
-                "additionalProperties": false
-            }),
-        }
-    }
-
-    fn execute(
-        &self,
-        manifest: &AgentManifest,
-        _policy: &PolicyEngine,
-        _agent_dir: &Path,
-        gateway_dir: Option<&Path>,
-        arguments_json: &str,
-        session_id: Option<&str>,
-        _turn_id: Option<&str>,
-        _config: Option<&autonoetic_types::config::GatewayConfig>,
-        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
-        _run_context: Option<&NativeToolRunContext>,
-    ) -> anyhow::Result<String> {
-        #[derive(Deserialize)]
-        struct Args {
-            scope: String,
+            #[serde(default)]
             tags: Vec<String>,
-            text: Option<String>,
-            #[serde(default = "default_limit")]
+            #[serde(default = "default_search_limit")]
             limit: u32,
         }
-        fn default_limit() -> u32 {
+        fn default_search_limit() -> u32 {
             10
         }
-
         let args: Args = serde_json::from_str(arguments_json)
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         anyhow::ensure!(!args.scope.trim().is_empty(), "scope must not be empty");
-        anyhow::ensure!(!args.tags.is_empty(), "tags must be a non-empty array");
         anyhow::ensure!(
             (1..=100).contains(&args.limit),
             "limit must be between 1 and 100 inclusive"
@@ -460,12 +369,20 @@ impl NativeTool for KnowledgeSearchByTagsTool {
             &manifest.agent.id,
             session_id,
         )?;
-        let results = block_on_memory(mem.search_by_tags(
-            &args.scope,
-            &args.tags,
-            args.text.as_deref(),
-            limit,
-        ))?;
+
+        // Tags present → AND-match tag search; otherwise plain scope/content search.
+        let results = if args.tags.is_empty() {
+            let mut r = block_on_memory(mem.search(&args.scope, args.query.as_deref()))?;
+            r.truncate(limit);
+            r
+        } else {
+            block_on_memory(mem.search_by_tags(
+                &args.scope,
+                &args.tags,
+                args.query.as_deref(),
+                limit,
+            ))?
+        };
 
         let items: Vec<serde_json::Value> = results
             .iter()

--- a/autonoetic-gateway/src/runtime/tools/knowledge.rs
+++ b/autonoetic-gateway/src/runtime/tools/knowledge.rs
@@ -309,7 +309,7 @@ impl NativeTool for KnowledgeSearchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Search the knowledge base in a scope. Without `tags`, returns scope contents optionally filtered by `query` substring. With `tags` (AND semantics — every tag must be present on a record), filters to tagged records, with `query` as an optional substring filter on content.".to_string(),
+            description: "Search the knowledge base in a scope. Without `tags`, returns scope contents optionally filtered by `query` substring. With `tags` (AND semantics — every tag must be present on a record), filters to tagged records, with `query` as an optional substring filter on content. Results are capped at `limit` (default 10, max 100).".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -149,7 +149,6 @@ impl ToolTierFilter {
                 | "constitution_read"
                 | "knowledge_search"
                 | "knowledge_read"
-                | "knowledge_search_by_tags"
                 | "content_read"
                 | "execution_search"
                 | "digest_query"

--- a/autonoetic-gateway/tests/constitution_clarification_child_read_only.rs
+++ b/autonoetic-gateway/tests/constitution_clarification_child_read_only.rs
@@ -136,7 +136,6 @@ fn clarification_filter_allows_inspection_tools() {
         "constitution_read",
         "knowledge_search",
         "knowledge_read",
-        "knowledge_search_by_tags",
         "content_read",
         "execution_search",
         "digest_query",

--- a/autonoetic-gateway/tests/constitution_degraded_inspection_available.rs
+++ b/autonoetic-gateway/tests/constitution_degraded_inspection_available.rs
@@ -144,7 +144,6 @@ fn degraded_filter_allows_inspection_tools_for_self_diagnosis() {
         "constitution_read",
         "knowledge_search",
         "knowledge_read",
-        "knowledge_search_by_tags",
         "content_read",
         "execution_search",
         "digest_query",

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -11,8 +11,6 @@ rules:
     tier: core
   - prefix: knowledge_recall
     tier: core
-  - prefix: knowledge_search_by_tags
-    tier: core
   - prefix: knowledge_search
     tier: core
   - prefix: artifact_
@@ -20,6 +18,10 @@ rules:
   - prefix: sandbox_exec
     tier: core
   - prefix: sentinel_
+    tier: core
+  # Self-knowledge is a right-surfacing tool (like constitution_read) — keep it
+  # Core so child sessions and budget-pressured turns still see it (#315).
+  - prefix: self_describe
     tier: core
 
   # Workflow tier: orchestration and approval flow.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -336,8 +336,7 @@ For facts with provenance across sessions. Reads respect **visibility** and **ex
 |------|-----------|-------------|
 | `knowledge_store` | `(id, content, scope?, tags?, confidence?, retention?, visibility?) → record` | Upsert a fact. **`visibility`**: `session` (default), `private`, or `global`. **`retention`**: `stable` (default), `ephemeral`, `1d`, `30d`. Widen access by calling again with the same `id` and a broader `visibility`. |
 | `knowledge_recall` | `(id: string) → fact` | Retrieve fact if visible to this agent/session |
-| `knowledge_search` | `(scope: string, query: string) → [facts]` | Search facts by scope and content |
-| `knowledge_search_by_tags` | `(scope, tags, text?, limit?) → [facts]` | AND match on JSON tags |
+| `knowledge_search` | `(scope, query?, tags?, limit?) → [facts]` | Search a scope by content (`query`) and/or AND-matched `tags` |
 | `digest_query` | `(session_id?, narrative_handle?) → narrative` | Read post-session narrative / digest content |
 
 **Cross-agent memory sharing:** Facts stored with `session` visibility (the default for both `knowledge_store` and `sdk.memory.remember`) are readable by all agents participating in the same root session. This includes the planner reading memories written by sub-agents (e.g., a fibonacci calculator storing results via `sdk.memory.remember`). Use `private` visibility for data that should only be accessible to the writing agent, or Tier 1 `memory.write`/`memory.read` for scratch data.
@@ -363,6 +362,8 @@ For facts with provenance across sessions. Reads respect **visibility** and **ex
 - **how do I evolve** — the revision, skill-promotion, and (capability-permitting) constitutional-amendment paths open to you
 
 It takes no arguments, reports only your own self and the public constitution, and is **always available** — an agent always has the standing to know itself. Rights are sourced from the enforcement register (`docs/constitution/enforcement-register.md`), so they stay in sync with what the gateway actually upholds.
+
+`self_describe` is **Core tier** (like `constitution_read`) so it is visible to every agent including child sessions. **Use `self_describe` to inspect yourself; use `agent_inspect` only for *other* agents** — do not `agent_inspect` your own id.
 
 ### Skill Install Tool
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -401,7 +401,7 @@ Content uses root-session visibility. Default is `session` (collaborative within
 
 Gateway-managed facts with provenance:
 
-**Tools:** `knowledge_store`, `knowledge_recall`, `knowledge_search`, `knowledge_search_by_tags`, `digest_query`
+**Tools:** `knowledge_store`, `knowledge_recall`, `knowledge_search`, `digest_query`
 
 Sharing is done by **storing (or re-storing) with the right visibility** — there is no separate share tool. To expose a fact to collaborators in the same root workflow, use `knowledge_store` with default `visibility: "session"` (or call `knowledge_store` again with the same `id` to widen visibility).
 
@@ -805,7 +805,7 @@ strings. See [Contract Health](#contract-health) below.
 }
 ```
 
-**`knowledge_search_by_tags`** — Search tagged memories:
+**`knowledge_search`** (with `tags`) — AND-match tagged memories:
 ```json
 {
   "tags": ["type:error_lesson", "domain:http"],
@@ -1044,7 +1044,7 @@ All transactional state in a single SQLite database:
 │
 │   ── Memory & Artifacts ──
 ├── memories               # Tier 2 durable memory
-├── memory_tags            # Tag index for knowledge_search_by_tags
+├── memory_tags            # Tag index for knowledge_search tag filtering
 ├── artifact_refs          # Short ref → digest mapping
 ├── short_id_index         # LLM-friendly short IDs for revisions and runs
 │

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -57,8 +57,7 @@ This document describes the capability system used by Autonoetic agents. Capabil
 |------|---------------------|-------|
 | `knowledge_recall` | `ReadAccess` | Recall stored knowledge (visibility + session + expiry enforced) |
 | `knowledge_store` | `WriteAccess` | Store or update knowledge; `visibility` (`session` default) and `retention` |
-| `knowledge_search` | `ReadAccess` | Search knowledge base |
-| `knowledge_search_by_tags` | `ReadAccess` | Tag-AND search in a scope |
+| `knowledge_search` | `ReadAccess` | Search a scope by content and/or AND-matched tags |
 | `digest_query` | `ReadAccess` | Post-session narrative / digest |
 
 ### Sandbox Tools

--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -344,8 +344,7 @@ Autonoetic provides two memory tiers:
 |------|-------------|
 | `knowledge_store` | Store or upsert a durable fact (`visibility`, `retention`, tags, …) |
 | `knowledge_recall` | Retrieve by id if visible |
-| `knowledge_search` | Search by scope and text |
-| `knowledge_search_by_tags` | AND search on tags |
+| `knowledge_search` | Search by scope, content, and/or AND-matched tags |
 
 Tier 1 working files still map to SDK helpers / `content.*` for session files under `state/`.
 

--- a/docs/agent-learning.md
+++ b/docs/agent-learning.md
@@ -11,7 +11,7 @@ Every session produces structured data that agents can query later:
 | Data | Tool | Table |
 |------|------|-------|
 | Code execution results | `execution_search` | `execution_traces` |
-| Tagged memories/lessons | `knowledge_search_by_tags` | `memories` |
+| Tagged memories/lessons | `knowledge_search` | `memories` |
 | Session narratives | `digest_query` | Content store (digest.md) |
 
 This enables patterns like:
@@ -90,7 +90,7 @@ Returns:
 
 ---
 
-## knowledge_search_by_tags
+## knowledge_search
 
 Search tagged memories for lessons, decisions, and facts.
 
@@ -199,13 +199,13 @@ Before starting a task, search for related lessons:
 
 ```json
 // 1. Check for error lessons in this domain
-knowledge_search_by_tags({
+knowledge_search({
   "tags": ["type:error_lesson", "domain:http"],
   "limit": 5
 })
 
 // 2. Check for past approaches
-knowledge_search_by_tags({
+knowledge_search({
   "tags": ["type:approach"],
   "text": "http client",
   "limit": 5
@@ -233,7 +233,7 @@ execution_search({
 })
 
 // Check if this error was seen before
-knowledge_search_by_tags({
+knowledge_search({
   "tags": ["type:error_lesson"],
   "text": "<error_message_snippet>",
   "limit": 3
@@ -245,7 +245,7 @@ knowledge_search_by_tags({
 Before making a significant decision, review past decisions:
 
 ```json
-knowledge_search_by_tags({
+knowledge_search({
   "tags": ["type:decision"],
   "text": "<relevant_keyword>",
   "limit": 5

--- a/docs/agent-learning.md
+++ b/docs/agent-learning.md
@@ -92,16 +92,17 @@ Returns:
 
 ## knowledge_search
 
-Search tagged memories for lessons, decisions, and facts.
+Search memories for lessons, decisions, and facts within a scope — by content,
+by tags, or both.
 
 ### Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `scope` | string | Knowledge namespace (e.g. `digest.lesson`, `general`), not the same as visibility |
-| `tags` | [string] | Required tags (AND logic) |
-| `text` | string | Optional text search in content |
-| `limit` | number | Max results (default: 10) |
+| `scope` | string | **Required.** Knowledge namespace (e.g. `digest.lesson`, `general`), not the same as visibility |
+| `query` | string | Optional substring filter on content |
+| `tags` | [string] | Optional tags — AND logic (every listed tag must be present) |
+| `limit` | number | Max results, 1–100 (default: 10) |
 
 ### Tag Conventions
 
@@ -146,8 +147,9 @@ Returns:
 
 ```json
 {
+  "scope": "decisions",
   "tags": ["type:decision"],
-  "text": "retry",
+  "query": "retry",
   "limit": 5
 }
 ```
@@ -200,14 +202,16 @@ Before starting a task, search for related lessons:
 ```json
 // 1. Check for error lessons in this domain
 knowledge_search({
+  "scope": "lessons",
   "tags": ["type:error_lesson", "domain:http"],
   "limit": 5
 })
 
 // 2. Check for past approaches
 knowledge_search({
+  "scope": "lessons",
   "tags": ["type:approach"],
-  "text": "http client",
+  "query": "http client",
   "limit": 5
 })
 
@@ -234,8 +238,9 @@ execution_search({
 
 // Check if this error was seen before
 knowledge_search({
+  "scope": "lessons",
   "tags": ["type:error_lesson"],
-  "text": "<error_message_snippet>",
+  "query": "<error_message_snippet>",
   "limit": 3
 })
 ```
@@ -246,8 +251,9 @@ Before making a significant decision, review past decisions:
 
 ```json
 knowledge_search({
+  "scope": "decisions",
   "tags": ["type:decision"],
-  "text": "<relevant_keyword>",
+  "query": "<relevant_keyword>",
   "limit": 5
 })
 ```

--- a/docs/comparison-hermes-agent.md
+++ b/docs/comparison-hermes-agent.md
@@ -30,7 +30,7 @@
 |---|---|---|
 | **Tier 1 (working)** | Content-addressable store (SHA-256), visibility model (private/session/global), artifacts for trust boundary | File-based working memory, conversation context |
 | **Tier 2 (durable)** | Gateway-managed `knowledge.*` tools with provenance, scope, visibility | Procedural memory via **Skills** (autonomous creation from experience), `MEMORY.md`/`USER.md` |
-| **Cross-session recall** | `execution_search`, `knowledge_search_by_tags`, `digest_query` — three native tools querying unified gateway DB | FTS5 session search with LLM summarization, Honcho dialectic user modeling |
+| **Cross-session recall** | `execution_search`, `knowledge_search`, `digest_query` — three native tools querying unified gateway DB | FTS5 session search with LLM summarization, Honcho dialectic user modeling |
 | **Post-session memory extraction** | **Implemented**: LLM-driven digest agent extracts error lessons, decisions, approaches, facts, open items; stores as tagged Tier-2 memories (`post_session_digest.rs`, 397 lines) | Background memory review thread after sessions end (turn-count triggered) |
 | **Self-improvement** | **Partially implemented**: evolution agents exist as static bundles; learning tools and background scheduler are fully wired; no autonomous closed-loop skill creation/improvement yet | **Closed learning loop**: skills self-improve during use, autonomous skill creation after complex tasks (5+ tool calls), periodic nudges to persist knowledge |
 | **Audit trail** | Hash-chained JSONL causal chain (immutable, verifiable) | Trajectory saving (for RL training), session persistence |
@@ -95,7 +95,7 @@ This table reflects what is actually implemented in the codebase, not just docum
 
 | Feature | Autonoetic Status | Hermes Status |
 |---|---|---|
-| **Learning tools** (`execution_search`, `knowledge_search_by_tags`, `digest_query`) | **Fully implemented** — native tools at `tools.rs`, integration tested | N/A (uses FTS5 session search instead) |
+| **Learning tools** (`execution_search`, `knowledge_search`, `digest_query`) | **Fully implemented** — native tools at `tools.rs`, integration tested | N/A (uses FTS5 session search instead) |
 | **Post-session memory extraction** | **Fully implemented** — `post_session_digest.rs` (397 lines), wired into execution lifecycle | **Implemented** — background review thread |
 | **Background scheduling** | **Fully implemented** — 9-module scheduler (`scheduler/`), tick loop, wake predicates, workflow tasks, approval gating, signal delivery | **Implemented** — cron scheduler with JSON job storage |
 | **Context compression** | **Partial** — token counting, context %, session pruning, text truncation exist; no LLM summarization when approaching limits | **Implemented** — iterative summarization at configurable threshold |
@@ -1046,7 +1046,7 @@ LIMIT ?6
 
 #### ACL enforcement (query-time filter)
 
-Follows the same capability-check pattern used by `execution_search` and `knowledge_search_by_tags`. The key constraint: agents should only see sessions they participated in, their child sessions, or sessions explicitly shared with them.
+Follows the same capability-check pattern used by `execution_search` and `knowledge_search`. The key constraint: agents should only see sessions they participated in, their child sessions, or sessions explicitly shared with them.
 
 ```rust
 fn enforce_search_acl(
@@ -1087,7 +1087,7 @@ After this feature, autonoetic has three complementary search surfaces:
 | Tool | What it searches | Data source | Use case |
 |---|---|---|---|
 | `execution_search` | Tool execution records (commands, stdout, errors) | `execution_traces` table | "What commands failed?" "How did we fix that build error?" |
-| `knowledge_search_by_tags` | Durable facts stored by agents | Tier 2 memory (per-agent SQLite) | "What API patterns did we learn?" "What user preferences exist?" |
+| `knowledge_search` | Durable facts stored by agents | Tier 2 memory (per-agent SQLite) | "What API patterns did we learn?" "What user preferences exist?" |
 | `session_search` (**new**) | Conversation content across sessions | `session_transcripts` + FTS5 | "When did we discuss the caching strategy?" "Find sessions where we debugged timeouts" |
 
 The post-session digest (`post_session_digest.rs`) bridges conversation → knowledge: it extracts structured memories from conversation content and stores them as Tier 2 knowledge. `session_search` provides the raw conversation search that complements those extracted memories.


### PR DESCRIPTION
First slice of the tool-surface reduction theme (anchor #312). Two bounded, independent consolidations that shrink the always-visible **Core** tool set agents thrash across.

## #313 — merge `knowledge_search_by_tags` into `knowledge_search`
Both were Core + `ReadAccess` → always co-visible, differing only by a filter arg.
- `knowledge_search` now takes optional `tags` (AND semantics), `query` (content substring), and `limit`. No `tags` → old scope/content search; with `tags` → tag-AND search (routes to `mem.search_by_tags`).
- **`knowledge_search_by_tags` deleted** — clean break, no alias (pre-release).
- Updated: registration, the degraded/clarification visibility allowlists (`tools/mod.rs`), the two constitution visibility tests, `foundation_core.md`, agent SKILLs (researcher, evolution-steward, memory-curator), and docs (AGENTS, ARCHITECTURE, agent-capabilities, agent-features, agent-learning, comparison-hermes, CLAUDE).

## #315 — re-tier `self_describe` to Core
`self_describe` had **no `config/tools.yaml` rule**, so it fell to `default_tier: specialized` — hidden from child sessions and demoted under prompt-budget pressure. That's a bug: it's the right-surfacing self-knowledge tool (analogue of the Core `constitution_read`).
- Added `self_describe` → `core` rule + a registry test pinning it (and anchors so the registry can't silently regress).
- AGENTS.md note: **use `self_describe` for yourself, `agent_inspect` only for other agents.**

## Tests
Build green; knowledge tool, `tool_tier_registry`, and degraded/clarification visibility suites pass.

Closes #313, #315. Siblings: #314 (remove `agent_exists` — separate PR, it's entangled with the read-cache subsystem) and #312 (universal handle resolver — the big one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)