### PR TITLE
Output minimization: artifact_build emits content_read_ref, not full sha256 handle (#312 PR 3b)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -344,10 +344,13 @@ impl NativeTool for ArtifactBuildTool {
             "artifact_manifest_digest": bundle.artifact_manifest_digest,
             "kind": serde_json::to_value(&bundle.kind)
                 .unwrap_or(serde_json::Value::String("binary".to_string())),
+            // Emit the agent-usable read handle, not the full sha256 `handle`
+            // (matches artifact_inspect; avoids models mistaking the digest for
+            // a path). #312 output minimization.
             "files": bundle.files.iter().map(|f| serde_json::json!({
                 "name": f.name,
-                "handle": f.handle,
                 "alias": f.alias,
+                "content_read_ref": artifact_ref.as_ref().map(|r| format!("{}:{}", r, f.name)),
             })).collect::<Vec<_>>(),
             "entrypoints": bundle.entrypoints,
             "created_at": bundle.created_at,

--- a/docs/content-store.md
+++ b/docs/content-store.md
@@ -175,8 +175,8 @@ Homogeneity rule:
   "artifact_canonical_digest": "sha256:...",
   "artifact_manifest_digest": "sha256:...",
   "files": [
-    {"name": "src/main.py", "handle": "sha256:...", "alias": "a1b2c3d4"},
-    {"name": "src/utils.py", "handle": "sha256:...", "alias": "u5e6f7g8"}
+    {"name": "src/main.py", "alias": "a1b2c3d4", "content_read_ref": "ar.a1b2c3d4ab12:src/main.py"},
+    {"name": "src/utils.py", "alias": "u5e6f7g8", "content_read_ref": "ar.a1b2c3d4ab12:src/utils.py"}
   ],
   "entrypoints": ["src/main.py"],
   "created_at": "2026-03-19T..."


### PR DESCRIPTION
Output-side complement to #319. Repo-wide scan found most output-minimization is already done (content tools gate the canonical digest behind opt-in `include_canonical_digest`, default off). The only remaining default full-handle leak was `artifact_build`'s per-file `"handle"` (full sha256), inconsistent with `artifact_inspect`.

- `artifact_build` file output: drop `handle`, emit `content_read_ref` (`ar.<ref>:<name>`), keep name/alias — now matches `artifact_inspect`.
- docs/content-store.md build-response example updated.

Artifact-level canonical/manifest digests stay (identity anchors; content-level digests already opt-in). Build + artifact_build_ref_integration + artifact unit suites pass; no test asserted the removed field.

Advances #312 (output side). Independent of #319. Next: #320 (fold content_read into resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)