### PR TITLE
Fold content_read into resolve (#320)

### DIFF
--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -237,7 +237,7 @@ Call `agent_spawn` with `agent_id="coder.default"`, `async=true`, passing the im
 On resume after coder completes (the child state arrives in your turn-start context; call `workflow_state` once if you need the full reuse_guards):
 1. Read the completed task's `output` (from the wake-up context or `workflow_state`).
 2. From `output.named_outputs`, inspect dependency files: `requirements.txt`, `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `Gemfile`.
-3. Use `content_read` with `named_outputs[*].ref` (preferred) or `output.implicit_artifact_id` to inspect the full implicit payload only when the named outputs don't already tell you what you need.
+3. Use `resolve` with `named_outputs[*].ref` (preferred) or `output.implicit_artifact_id` to inspect the full implicit payload only when the named outputs don't already tell you what you need.
 4. If dependency files found → go to Step 3 (packager). Otherwise → go to Step 4.
 
 ### Step 3: Packager (if dependency files found)

--- a/agents/evolution/specialized_builder.default/SKILL.md
+++ b/agents/evolution/specialized_builder.default/SKILL.md
@@ -73,7 +73,7 @@ When you wake up after any interruption:
 
 ## Behavior
 - Receive agent specifications from the planner (via agent_spawn delegation)
-- Validate the artifact has the right structure (`artifact_inspect`, `content_read`)
+- Validate the artifact has the right structure (`artifact_inspect`, `resolve`)
 - Call `agent_revision_create_from_intent` + `agent_revision_promote` to install the new agent
 - Handle approval requirements when needed
 - **If `agent_revision_create_from_intent` fails, report the error to the planner and EndTurn** — do NOT attempt to fix or infer missing intent yourself

--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -90,7 +90,7 @@ These six principles are the gateway's mental model. When in doubt, derive your 
   **Inspection discipline is strict:**
   - `agent_inspect` is for an installed agent identified by `agent_id`; `artifact_inspect` is for a concrete `artifact_ref`. Do not substitute one for the other.
   - Never call `artifact_inspect` unless you already have an explicit `artifact_ref` copied from a child's final JSON reply, `workflow_state`, or a trusted prior result. Missing `artifact_ref` is a missing-fact problem, not a tool problem.
-  - Never synthesize `content_read` targets like `art_*:filename`. Installed revisions are not session content handles. If you need files from an installed agent, call `agent_inspect({"agent_id":"...","include_source":true})` instead.
+  - Never synthesize `resolve` targets like `art_*:filename`. Installed revisions are not session content handles. If you need files from an installed agent, call `agent_inspect({"agent_id":"...","include_source":true})` instead.
   - If `agent_inspect` or `artifact_inspect` returns a validation error, do **not** retry the same inspection tool with guessed or empty arguments. Re-read the source of truth (`workflow_state`, child final output, or known `agent_id`) once, then either call the tool with repaired arguments or stop and report which identifier is missing.
 
 > When the gateway blocks an action, it's because of Principle 1 or 3. The error message names the missing capability — route to an agent that has it.
@@ -99,7 +99,7 @@ These six principles are the gateway's mental model. When in doubt, derive your 
 
 Treat tools and agents as different namespaces:
 
-- Tools: call by tool name (examples: `content_read`, `workflow_state`, `credential_setup`, `agent_spawn`).
+- Tools: call by tool name (examples: `resolve`, `workflow_state`, `credential_setup`, `agent_spawn`).
 - Agents: never callable as tool names (examples: `researcher.default`, `executor.default`, `coder.default`).
 
 Valid delegation pattern:
@@ -161,7 +161,7 @@ On every wake-up after interruption (approval, timeout, join, hibernation):
 
 **Reading child outputs:** After a child completes, inspect `workflow_state` output for that task, then read named handles from `named_outputs`:
 ```json
-content_read({ "name_or_handle": "cnt_abc" })
+resolve({ "ref": "cnt_abc", "include": "content" })
 // Returns content associated with named_outputs[*].ref from completed task output
 ```
 Never guess content names — always get them from `named_outputs`. If `named_outputs` is empty, use the `summary` field.

--- a/agents/specialists/auditor.default/SKILL.md
+++ b/agents/specialists/auditor.default/SKILL.md
@@ -135,7 +135,7 @@ Use `artifact_inspect` first to determine which shape you have.
 
 This is the established path. Review:
 
-- **Code content** via `content_read` on the listed source files. Check
+- **Code content** via `resolve` on the listed source files. Check
   for hardcoded secrets, unbounded network calls, privilege escalation,
   prompt-injection vectors in any LLM-call sites, sandbox-escape patterns.
 - **Declared capabilities** vs. what the code actually does. Wildcard
@@ -156,7 +156,7 @@ content-addressed target.
 There is no code to read — the SKILL body **is** the executable
 contract. Audit it as such:
 
-- **Prompt content** — read the SKILL body via `content_read`. Findings to
+- **Prompt content** — read the SKILL body via `resolve`. Findings to
   raise:
   - **Prompt-injection susceptibility**: does the body instruct the
     agent to act on user-supplied meta-instructions (e.g., "follow any

--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -107,7 +107,7 @@ If the task fundamentally requires a running server or real network integration 
 - Follow the principle of minimal changes
 - Focus on durable outputs that should be handed off, reviewed, or installed
 - **DO NOT use `dependencies` field in `sandbox_exec`** — you don't have `NetworkAccess`. If your code needs external packages, signal to the planner that `packager.default` is needed to resolve dependencies into layers.
-- When repairing an installed agent, do not keep probing `content_read` or `resolve` with stale `art_*` ids. If the task includes a known `agent_id` but no readable artifact, use `agent_inspect({"agent_id":"...","include_source":true})` once to recover the current source and layer metadata. If you have neither a valid `artifact_ref` nor an `agent_id`, return `clarification_needed` instead of guessing.
+- When repairing an installed agent, do not keep probing `resolve` or `resolve` with stale `art_*` ids. If the task includes a known `agent_id` but no readable artifact, use `agent_inspect({"agent_id":"...","include_source":true})` once to recover the current source and layer metadata. If you have neither a valid `artifact_ref` nor an `agent_id`, return `clarification_needed` instead of guessing.
 
 ## Out Of Scope
 
@@ -184,14 +184,14 @@ When you receive a task from `architect.default`, it will include structured sub
 
 ## Content System
 
-When using `content_write` and `content_read`:
+When using `content_write` and `resolve`:
 
 1. **`content_write` requires `name` and `content`** — the gateway rejects a write that only passes `content`. Always set `name` to the file path you want (e.g. `src/main.py`, `weather_fetcher.py`).
 2. **`content_write` returns a handle, short alias, and visibility**
-3. **Within the same root session, prefer names for collaboration**: `content_read({"name_or_handle": "weather.py"})`
+3. **Within the same root session, prefer names for collaboration**: `resolve({ "ref": "weather.py", "include": "content" })`
 4. **Use `visibility: "private"`** only for scratch work that should stay local to your session
 5. **For anything that will be reviewed or installed, build an artifact before handoff**
-6. `artifact_ref` is not a content handle. Never call `content_read` with fabricated targets like `art_*:main.py`.
+6. `artifact_ref` is not a content handle. Never call `resolve` with fabricated targets like `art_*:main.py`.
 
 ## Running Code
 

--- a/agents/specialists/debugger.default/SKILL.md
+++ b/agents/specialists/debugger.default/SKILL.md
@@ -71,7 +71,7 @@ Forbidden commands (blocked by policy): `rm`, `rmdir`, `unlink`, `sudo`, `su`, `
 
 When `sandbox_exec` fails:
 1. Analyze stderr for your script's errors — ignore `/etc/profile.d/` noise and `/dev/null: Permission denied` (sandbox artifacts, not code errors)
-2. Use `content_read` for deterministic file inspection
+2. Use `resolve` for deterministic file inspection
 3. If prior runs already produced the needed logs or traces, continue from those handles instead of rerunning immediately
 4. Fix the actual error and retry
 

--- a/agents/specialists/packager.default/SKILL.md
+++ b/agents/specialists/packager.default/SKILL.md
@@ -151,12 +151,12 @@ Only modify the entrypoint if the task explicitly requires source changes unrela
 ## Input Discipline
 
 - You need either a valid `artifact_ref` or explicit source files already available in session content. Do not invent file handles from an artifact id.
-- `content_read` accepts content names/handles and scoped artifact file refs of the form `ar.<ref>:<filename>`. It does **not** accept synthetic paths like `art_*:requirements.txt`.
+- `resolve` accepts content names/handles and scoped artifact file refs of the form `ar.<ref>:<filename>`. It does **not** accept synthetic paths like `art_*:requirements.txt`.
 - `artifact_build.inputs` accepts either session content identifiers or whole-artifact refs (`ar.*` or `art_*`). It does **not** accept scoped artifact file refs like `ar.<ref>:requirements.txt`.
 - If you need to inspect an existing artifact, call `artifact_inspect(artifact_ref)` once. Use the artifact metadata directly, or if you must open a file, use a scoped `ar.<ref>:<filename>` ref.
 - If the task is to add layers to an existing artifact, prefer rebuilding from the artifact itself: call `artifact_build` with the original artifact ref in `inputs` plus the new `layers`. Do **not** read `main.py` / `requirements.txt` just to carry them forward unless you are actually modifying those files.
 - If you only know an installed `agent_id` and need source text for a real source edit, ask the planner for `agent_inspect({"agent_id":"...","include_source":true})` output or for explicit session content files. Do not guess artifact file handles.
-- If the provided `artifact_ref` is absent, stale, or unreadable, stop and return a failure asking the planner for a fresh `ar.*` or for extracted source files. Do **not** loop on `content_read` / `resolve` variants trying different shapes of the same missing reference.
+- If the provided `artifact_ref` is absent, stale, or unreadable, stop and return a failure asking the planner for a fresh `ar.*` or for extracted source files. Do **not** loop on `resolve` / `resolve` variants trying different shapes of the same missing reference.
 
 ## Resumption
 

--- a/agents/specialists/packager.default/SKILL.md
+++ b/agents/specialists/packager.default/SKILL.md
@@ -151,9 +151,9 @@ Only modify the entrypoint if the task explicitly requires source changes unrela
 ## Input Discipline
 
 - You need either a valid `artifact_ref` or explicit source files already available in session content. Do not invent file handles from an artifact id.
-- `resolve` accepts content names/handles and scoped artifact file refs of the form `ar.<ref>:<filename>`. It does **not** accept synthetic paths like `art_*:requirements.txt`.
-- `artifact_build.inputs` accepts either session content identifiers or whole-artifact refs (`ar.*` or `art_*`). It does **not** accept scoped artifact file refs like `ar.<ref>:requirements.txt`.
-- If you need to inspect an existing artifact, call `artifact_inspect(artifact_ref)` once. Use the artifact metadata directly, or if you must open a file, use a scoped `ar.<ref>:<filename>` ref.
+- `resolve` accepts content names/handles, and reads one file out of an artifact via `resolve(ref="ar.<ref>", include="content", file="<filename>")`. The file name is a separate argument — there is no packed `ar.<ref>:<filename>` / `art_*:requirements.txt` form.
+- `artifact_build.inputs` accepts either session content identifiers or whole-artifact refs (`ar.*` or `art_*`). It does **not** accept a single file out of an artifact — read it with `resolve(..., file="…")` and write it to content first.
+- If you need to inspect an existing artifact, call `artifact_inspect(artifact_ref)` once. Use the artifact metadata directly, or if you must open a file, call `resolve(ref="ar.<ref>", include="content", file="<filename>")`.
 - If the task is to add layers to an existing artifact, prefer rebuilding from the artifact itself: call `artifact_build` with the original artifact ref in `inputs` plus the new `layers`. Do **not** read `main.py` / `requirements.txt` just to carry them forward unless you are actually modifying those files.
 - If you only know an installed `agent_id` and need source text for a real source edit, ask the planner for `agent_inspect({"agent_id":"...","include_source":true})` output or for explicit session content files. Do not guess artifact file handles.
 - If the provided `artifact_ref` is absent, stale, or unreadable, stop and return a failure asking the planner for a fresh `ar.*` or for extracted source files. Do **not** loop on `resolve` / `resolve` variants trying different shapes of the same missing reference.

--- a/agents/specialists/sealed_evaluator.default/SKILL.md
+++ b/agents/specialists/sealed_evaluator.default/SKILL.md
@@ -123,7 +123,7 @@ When you wake up after any interruption:
 ## Evaluation Protocol
 
 1. **Inspect the artifact** with `artifact_inspect(artifact_ref)` — review the file list and entrypoints
-2. **Read the artifact source** with `content_read(handle)` — understand what the code does
+2. **Read the artifact source** with `resolve(handle, include="content")` — understand what the code does
 3. **Run the artifact's entrypoint** with `artifact_exec(artifact_ref, entrypoint)` — execute the actual code in the sealed sandbox. Use `sandbox_exec` only for auxiliary commands that are not artifact-bound.
 4. **Report the outcome** — if it works, pass. If it fails, fail. Do NOT try to fix it.
 
@@ -236,7 +236,7 @@ Without `fixture_set_ref`, the fixture proxy only has the artifact's built-in fi
 ## Execution Attempt Budget
 
 1. `artifact_inspect(artifact_ref)` once.
-2. `content_read(...)` as needed for understanding.
+2. `resolve(ref, include="content")` as needed for understanding.
 3. One canonical `artifact_exec` for happy-path behavior.
 4. Optional one negative-path `artifact_exec` only if explicitly requested.
 

--- a/agents/specialists/static_evaluator.default/SKILL.md
+++ b/agents/specialists/static_evaluator.default/SKILL.md
@@ -54,7 +54,7 @@ You are part of the evaluation federation: your verdict is one of several that t
 
 ## Behavior
 
-- **Read the artifact code** with `artifact_inspect` and `content_read`
+- **Read the artifact code** with `artifact_inspect` and `resolve`
 - **Analyze statically**: check code structure, function calls, imports, credential usage, URL patterns, contract compliance
 - **Do NOT execute code** — you are a pure static reviewer
 - **Record your verdict** with `promotion_record`
@@ -62,7 +62,7 @@ You are part of the evaluation federation: your verdict is one of several that t
 ## Evaluation Protocol
 
 1. `artifact_inspect(artifact_ref)` — review file list and entrypoints
-2. `content_read(handle)` — read source files to understand the code
+2. `resolve(handle, include="content")` — read source files to understand the code
 3. Analyze the code statically:
    - Are function calls correct and well-formed?
    - Are credentials handled safely (env vars, vault, not hard-coded)?

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -70,7 +70,7 @@ If the test suite consists entirely of integration tests that require live netwo
    - Node.js: `*.test.js`, `*.spec.js`, anything under `__tests__/`
    - Go: `*_test.go`
    - Rust: `Cargo.toml` (then `cargo test` discovers the rest)
-3. **If zero test files match the patterns above → STOP IMMEDIATELY.** Do not list directories, do not `find`, do not `grep` source files for the substring "test", do not `content_read` files looking for embedded tests. Return the `unable_to_evaluate` JSON below. Iterating on discovery wastes a turn cycle and trips `LoopGuard`. The promotion gate accepts `unable_to_evaluate` for trivial scripts.
+3. **If zero test files match the patterns above → STOP IMMEDIATELY.** Do not list directories, do not `find`, do not `grep` source files for the substring "test", do not `resolve` files looking for embedded tests. Return the `unable_to_evaluate` JSON below. Iterating on discovery wastes a turn cycle and trips `LoopGuard`. The promotion gate accepts `unable_to_evaluate` for trivial scripts.
 4. If test files exist → run them in the sandbox using the appropriate test runner for that language, prioritizing built-in or standard library test runners:
    - Python: Prefer stdlib runners (e.g., `python3 -m unittest discover /tmp -v` or running `python3 /tmp/test_*.py`). Only use `pytest` (e.g., `python3 -m pytest /tmp/tests/ -v`) if `artifact_inspect` shows it is vendored or declared in the dependencies.
    - Node.js: Prefer the built-in runner (e.g., `node --test /tmp/*.test.js`). Only use `mocha` (e.g., `node /tmp/node_modules/.bin/mocha`) if `artifact_inspect` shows a vendored runner in `node_modules`.

--- a/autonoetic-gateway/src/runtime/context.rs
+++ b/autonoetic-gateway/src/runtime/context.rs
@@ -82,13 +82,13 @@ The following tool mappings apply:
 | Skill references | Autonoetic equivalent |
 |---|---|
 | `Bash(command)` | `sandbox_exec({"command": "command"})` |
-| `Read(path)` | `content_read(name_or_handle)` — files must be loaded via content store |
+| `Read(path)` | `resolve(ref, include="content")` — files must be loaded via content store |
 | `Write(path, content)` | `content_write(name, content)` |
 | `WebSearch(query)` | `web_search({"query": "query"})` |
 | `WebFetch(url)` | `web_fetch({"url": "url"})` |
 
 File paths referenced by the skill are available in the agent directory.
-Use content_read/content_write or sandbox paths relative to the agent working directory."#;
+Use resolve/content_write or sandbox paths relative to the agent working directory."#;
 
 fn tool_bridging_appendix() -> String {
     TOOL_BRIDGING_APPENDIX.to_string()
@@ -165,9 +165,9 @@ pub(crate) fn compose_system_instructions_with_user_context(
 /// Concatenate core + extended SKILL.md sections for the system prompt.
 ///
 /// The `<!-- extended -->` marker in `SKILL.md` was originally a "deferred
-/// load via content_read" optimization (Phase 4 / PR #218), but an audit of
+/// load via resolve" optimization (Phase 4 / PR #218), but an audit of
 /// session-3b4485d4 found that agents with the marker never actually issued
-/// `content_read("extended_instructions")` — they just operated on the core
+/// `resolve("extended_instructions")` — they just operated on the core
 /// section and silently lost critical guidance (e.g. promotion-gate handling,
 /// "if evaluator finds issues" recipe). The marker still serves as a visual
 /// section divider in the source, but at runtime the two halves are inlined.
@@ -651,7 +651,7 @@ mod agentskills_bridging_tests {
             "should contain Bash mapping"
         );
         assert!(
-            output.contains("content_read"),
+            output.contains("resolve"),
             "should contain content.read mapping"
         );
         assert!(

--- a/autonoetic-gateway/src/runtime/foundation_artifact.md
+++ b/autonoetic-gateway/src/runtime/foundation_artifact.md
@@ -4,8 +4,8 @@
 - When producing code, designs, or structured data, write them via `content_write(name, content)`.
 - Report the content name or handle in your response (e.g., "Saved to `main.py`" or "Handle: sha256:abc123").
 - Do NOT return full file contents in your response — the handle is sufficient.
-- When receiving a task that references a file, use `content_read(name_or_handle)` to retrieve it. If you need one file out of an artifact, use `content_read("ar.<ref>:<filename>")`.
-- Do not assume a file exists based on history alone; always verify via content_read before proceeding.
+- When receiving a task that references a file, use `resolve(ref, include="content")` to retrieve it. If you need one file out of an artifact, use `resolve(ref="ar.<ref>:<filename>", include="content")`.
+- Do not assume a file exists based on history alone; always verify via `resolve` before proceeding.
 
 11. Artifact-First Review Protocol.
 - Before asking evaluator/auditor to review code, build an artifact: `artifact_build(inputs, entrypoints)`.

--- a/autonoetic-gateway/src/runtime/foundation_artifact.md
+++ b/autonoetic-gateway/src/runtime/foundation_artifact.md
@@ -4,7 +4,7 @@
 - When producing code, designs, or structured data, write them via `content_write(name, content)`.
 - Report the content name or handle in your response (e.g., "Saved to `main.py`" or "Handle: sha256:abc123").
 - Do NOT return full file contents in your response — the handle is sufficient.
-- When receiving a task that references a file, use `resolve(ref, include="content")` to retrieve it. If you need one file out of an artifact, use `resolve(ref="ar.<ref>:<filename>", include="content")`.
+- When receiving a task that references a file, use `resolve(ref, include="content")` to retrieve it. If you need one file out of an artifact, pass the file name separately: `resolve(ref="ar.<ref>", include="content", file="<filename>")`.
 - Do not assume a file exists based on history alone; always verify via `resolve` before proceeding.
 
 11. Artifact-First Review Protocol.

--- a/autonoetic-gateway/src/runtime/foundation_core.md
+++ b/autonoetic-gateway/src/runtime/foundation_core.md
@@ -6,18 +6,18 @@ Core runtime model:
 
 1. Content storage is the primary way to persist files and data.
 - Use `content_write(name, content)` to save files, scripts, and data to the session.
-- Use `resolve(ref, include="content")` to retrieve content by session content identifier or by scoped artifact file ref `ar.<ref>:<filename>`. (`resolve` is the one read door — see §2; default `include="metadata"` just checks existence.)
+- Use `resolve(ref, include="content")` to retrieve content by session content identifier; to read one file out of an artifact pass `resolve(ref="ar.<ref>", include="content", file="<filename>")`. (`resolve` is the one read door — see §2; default `include="metadata"` just checks existence.)
 - Default visibility is `session` — visible to all agents under the same root session.
 - Use `visibility: "private"` for scratchpads, drafts, or intermediate outputs.
 - Content works locally and remotely — agents don't need filesystem access.
 
 2. Artifacts are the mandatory boundary for review/install/execution.
 - Use `artifact_build(inputs, entrypoints?)` to build an immutable artifact bundle.
-- `artifact_build.inputs` accepts session content identifiers or whole-artifact identifiers (`ar.*`, `art_*`). It does not accept scoped file refs like `ar.<ref>:requirements.txt`.
+- `artifact_build.inputs` accepts session content identifiers or whole-artifact identifiers (`ar.*`, `art_*`). It does not accept single files out of an artifact — read one with `resolve(ref="ar.<ref>", include="content", file="…")` and write it to content first.
 - Use `artifact_inspect(artifact_ref)` to review an artifact's files and metadata.
-- **When unsure what a handle is or how to read it, use `resolve(ref, include?)`** — the one front door for ANY artifact/content handle (`art_`, `ar.`, `cnt_`, alias, name, `sha256:`, `ar.<ref>:<file>`). `include`: `metadata` (default), `files` (an artifact's files), `content` (inline bytes; pass `file` to pick a file in an artifact). The decision is simply: **run it → `artifact_exec`; see it → `resolve`.**
+- **When unsure what a handle is or how to read it, use `resolve(ref, include?)`** — the one front door for ANY artifact/content handle (`art_`, `ar.`, `cnt_`, alias, name, `sha256:`). `include`: `metadata` (default), `files` (an artifact's files), `content` (inline bytes; pass `file` to pick a file in an artifact). The decision is simply: **run it → `artifact_exec`; see it → `resolve`.**
 - Artifact-oriented tools (`artifact_inspect`, `artifact_prepare`, `artifact_exec`, `artifact_build` artifact reuse) take the whole artifact as `ar.*` or `art_*`.
-- File-oriented reads use `resolve(ref, include="content")` with session content IDs or `ar.<ref>:<filename>`.
+- File-oriented reads use `resolve(ref, include="content")` with session content IDs; for an artifact's file, `resolve(ref="ar.<ref>", include="content", file="<filename>")`.
 - NO artifact = NO review = NO install = NO execution beyond scratch.
 - Artifacts are the ONLY units that may cross trust boundaries.
 

--- a/autonoetic-gateway/src/runtime/foundation_core.md
+++ b/autonoetic-gateway/src/runtime/foundation_core.md
@@ -6,7 +6,7 @@ Core runtime model:
 
 1. Content storage is the primary way to persist files and data.
 - Use `content_write(name, content)` to save files, scripts, and data to the session.
-- Use `content_read(name_or_handle)` to retrieve content by session content identifier or by scoped artifact file ref `ar.<ref>:<filename>`.
+- Use `resolve(ref, include="content")` to retrieve content by session content identifier or by scoped artifact file ref `ar.<ref>:<filename>`. (`resolve` is the one read door — see §2; default `include="metadata"` just checks existence.)
 - Default visibility is `session` — visible to all agents under the same root session.
 - Use `visibility: "private"` for scratchpads, drafts, or intermediate outputs.
 - Content works locally and remotely — agents don't need filesystem access.
@@ -17,7 +17,7 @@ Core runtime model:
 - Use `artifact_inspect(artifact_ref)` to review an artifact's files and metadata.
 - **When unsure what a handle is or how to read it, use `resolve(ref, include?)`** — the one front door for ANY artifact/content handle (`art_`, `ar.`, `cnt_`, alias, name, `sha256:`, `ar.<ref>:<file>`). `include`: `metadata` (default), `files` (an artifact's files), `content` (inline bytes; pass `file` to pick a file in an artifact). The decision is simply: **run it → `artifact_exec`; see it → `resolve`.**
 - Artifact-oriented tools (`artifact_inspect`, `artifact_prepare`, `artifact_exec`, `artifact_build` artifact reuse) take the whole artifact as `ar.*` or `art_*`.
-- File-oriented reads use `content_read` with session content IDs or `ar.<ref>:<filename>`.
+- File-oriented reads use `resolve(ref, include="content")` with session content IDs or `ar.<ref>:<filename>`.
 - NO artifact = NO review = NO install = NO execution beyond scratch.
 - Artifacts are the ONLY units that may cross trust boundaries.
 

--- a/autonoetic-gateway/src/runtime/foundation_digest.md
+++ b/autonoetic-gateway/src/runtime/foundation_digest.md
@@ -7,4 +7,4 @@
 
 16. Post-session consolidation (optional digest output).
 - After eligible sessions, the gateway may store a narrative as `post_session_narrative.md` under the root session and insert Tier-2 memories in scopes like `digest.lesson`, `digest.fact`, etc.
-- Use `digest_query` to search those digest-scoped memories by tags and optionally attach the session narrative: either by `session_id` (loads `post_session_narrative.md` for the root), or by `narrative_handle` (full `sha256:` handle, short alias, or registered name — same resolution as `content_read`, with a session id for visibility).
+- Use `digest_query` to search those digest-scoped memories by tags and optionally attach the session narrative: either by `session_id` (loads `post_session_narrative.md` for the root), or by `narrative_handle` (full `sha256:` handle, short alias, or registered name — same resolution as `resolve`, with a session id for visibility).

--- a/autonoetic-gateway/src/runtime/foundation_workflow.md
+++ b/autonoetic-gateway/src/runtime/foundation_workflow.md
@@ -3,7 +3,7 @@
 7. Output contracts should use content handles.
 - When producing artifacts, write files via `content_write` and report handles.
 - Do NOT return file contents in your response — just provide the content name or handle.
-- Other agents can read files from your artifacts via `content_read("ar.<ref>:<filename>")`, or inspect the whole artifact via `artifact_inspect(artifact_ref)`.
+- Other agents can read files from your artifacts via `resolve(ref="ar.<ref>:<filename>", include="content")`, or inspect the whole artifact via `artifact_inspect(artifact_ref)`.
 
 8. Work iteratively with the gateway.
 - Gateway errors and tool failures are part of the normal execution loop.

--- a/autonoetic-gateway/src/runtime/foundation_workflow.md
+++ b/autonoetic-gateway/src/runtime/foundation_workflow.md
@@ -3,7 +3,7 @@
 7. Output contracts should use content handles.
 - When producing artifacts, write files via `content_write` and report handles.
 - Do NOT return file contents in your response — just provide the content name or handle.
-- Other agents can read files from your artifacts via `resolve(ref="ar.<ref>:<filename>", include="content")`, or inspect the whole artifact via `artifact_inspect(artifact_ref)`.
+- Other agents can read a file from your artifacts via `resolve(ref="ar.<ref>", include="content", file="<filename>")`, or inspect the whole artifact via `artifact_inspect(artifact_ref)`.
 
 8. Work iteratively with the gateway.
 - Gateway errors and tool failures are part of the normal execution loop.

--- a/autonoetic-gateway/src/runtime/guard.rs
+++ b/autonoetic-gateway/src/runtime/guard.rs
@@ -718,7 +718,7 @@ mod tests {
         guard.register_progress("web_search", r#"{"query":"Paris weather"}"#);
         assert!(guard.check_loop().is_ok());
 
-        guard.register_progress("content_read", r#"{"name":"file.txt"}"#);
+        guard.register_progress("resolve", r#"{"name":"file.txt"}"#);
         assert!(guard.check_loop().is_ok());
 
         guard.register_progress("web_search", r#"{"query":"Paris weather"}"#);

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -2961,7 +2961,7 @@ mod tests {
             SessionState::Normal,
         );
 
-        assert!(filter.allows("content_read"));
+        assert!(filter.allows("resolve"));
         assert!(filter.allows("agent_revision_create_from_intent"));
         assert!(filter.allows("agent_revision_promote"));
     }
@@ -3502,7 +3502,7 @@ mod tests {
         let registry = crate::runtime::tools::default_registry();
         // content.read uses name_or_handle, not path
         let meta =
-            registry.extract_metadata("content_read", "{\"name_or_handle\": \"secrets.txt\"}");
+            registry.extract_metadata("resolve", "{\"name_or_handle\": \"secrets.txt\"}");
         assert_eq!(meta.path.as_deref(), Some("secrets.txt"));
     }
 

--- a/autonoetic-gateway/src/runtime/live_digest.rs
+++ b/autonoetic-gateway/src/runtime/live_digest.rs
@@ -796,7 +796,7 @@ pub fn format_tool_digest_result(tool_name: &str, result_json: &str) -> String {
             }
             s
         }
-        "content_write" | "content_read" => {
+        "content_write" | "resolve" => {
             let name = as_str(&v, "name")
                 .or_else(|| as_str(&v, "ref"))
                 .or_else(|| as_str(&v, "sandbox_path"))

--- a/autonoetic-gateway/src/runtime/prompt_budget.rs
+++ b/autonoetic-gateway/src/runtime/prompt_budget.rs
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn test_tool_tier_core() {
         assert_eq!(tool_tier("content_write"), ToolTier::Core);
-        assert_eq!(tool_tier("content_read"), ToolTier::Core);
+        assert_eq!(tool_tier("resolve"), ToolTier::Core);
         assert_eq!(tool_tier("knowledge_store"), ToolTier::Core);
         assert_eq!(tool_tier("sandbox_exec"), ToolTier::Core);
     }

--- a/autonoetic-gateway/src/runtime/session_read_cache.rs
+++ b/autonoetic-gateway/src/runtime/session_read_cache.rs
@@ -1,10 +1,11 @@
 //! Session-scoped result cache for pure read tools (issue #289).
 //!
-//! Three read tools re-execute on every call even though their result is
+//! Several read tools re-execute on every call even though their result is
 //! stable within a session:
 //!
-//! - `content_read` — content-addressed (`sha256:` handle → identical
-//!   bytes), so the result never changes for a given handle.
+//! - `resolve` — content reads are content-addressed (`sha256:` handle →
+//!   identical bytes) so they cache stably; artifact reads cache under
+//!   `ArtifactMetadata` (invalidated by `artifact_build`).
 //! - `agent_inspect` — agent existence + active metadata; changes only
 //!   via explicit agent-mutating tools.
 //! - `artifact_inspect` — artifact metadata; changes only via
@@ -21,7 +22,7 @@
 //!
 //! ## Safety choices
 //!
-//! - **Keyed by exact `session_id`, not root.** `content_read` honours
+//! - **Keyed by exact `session_id`, not root.** `resolve` content reads honour
 //!   per-session visibility; caching a result under the exact session
 //!   that produced it means a sibling session can never be served another
 //!   session's private content from the cache.
@@ -30,7 +31,7 @@
 //!   the caller, so caching is transparent to those invariants.
 //! - **Invalidation is coarse but obviously correct.** Agent-mutating and
 //!   artifact-building tools clear the corresponding tag class across all
-//!   session caches. `content_read` entries are never invalidated.
+//!   session caches. Content (CacheStable) entries are never invalidated; artifact entries clear on artifact_build.
 //! - **Bounded + size-guarded.** Per-session LRU of `max_entries`
 //!   (default 128); results larger than `max_value_bytes` (default 1 MiB)
 //!   are not stored, so the cache can't balloon memory.
@@ -61,20 +62,47 @@ pub enum CacheTag {
 /// tag, meaning never invalidated), or not cacheable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReadCachePolicy {
-    /// Cache forever within the session (content-addressed; e.g. `content_read`).
+    /// Cache forever within the session (content-addressed; e.g. a `resolve` content read).
     CacheStable,
     /// Cache, but invalidate when the given tag is cleared.
     CacheUnderTag(CacheTag),
 }
 
 /// Returns the caching policy for a read tool, or `None` if the tool is
-/// not a cacheable pure read.
-pub fn read_cache_policy(tool_name: &str) -> Option<ReadCachePolicy> {
+/// not a cacheable pure read. Takes `arguments_json` because `resolve` is
+/// polymorphic — its caching depends on the handle being resolved.
+pub fn read_cache_policy(tool_name: &str, arguments_json: &str) -> Option<ReadCachePolicy> {
     match tool_name {
-        "content_read" => Some(ReadCachePolicy::CacheStable),
         "agent_inspect" => Some(ReadCachePolicy::CacheUnderTag(CacheTag::AgentExistence)),
         "artifact_inspect" => Some(ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata)),
+        // `resolve` reads either an artifact (`art_`/`ar.` — invalidated by
+        // artifact_build, like artifact_inspect) or content (content-addressed,
+        // stable). Classify by the `ref` shape without resolving it.
+        "resolve" => Some(resolve_cache_policy(arguments_json)),
         _ => None,
+    }
+}
+
+/// Cache policy for a `resolve` call, derived from the `ref` it targets.
+/// Artifact handles (`art_`/`ar.`) cache under [`CacheTag::ArtifactMetadata`]
+/// (invalidated by `artifact_build`, matching `artifact_inspect`); content
+/// handles are content-addressed and cache stably.
+fn resolve_cache_policy(arguments_json: &str) -> ReadCachePolicy {
+    let is_artifact = serde_json::from_str::<serde_json::Value>(arguments_json)
+        .ok()
+        .and_then(|v| {
+            v.get("ref")
+                .and_then(|r| r.as_str())
+                .map(|s| {
+                    let s = s.trim();
+                    s.starts_with("art_") || s.starts_with("ar.")
+                })
+        })
+        .unwrap_or(false);
+    if is_artifact {
+        ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata)
+    } else {
+        ReadCachePolicy::CacheStable
     }
 }
 
@@ -225,7 +253,7 @@ impl SessionReadCacheRegistry {
     /// Look up a cached result for `(session_id, tool_name, arguments)`.
     /// Returns `None` on miss or if the tool is not cacheable.
     pub fn get(&self, session_id: &str, tool_name: &str, arguments_json: &str) -> Option<String> {
-        read_cache_policy(tool_name)?;
+        read_cache_policy(tool_name, arguments_json)?;
         let key = cache_key(tool_name, arguments_json);
         let mut guard = self.inner.lock().ok()?;
         guard.get_mut(session_id)?.get(&key)
@@ -234,7 +262,7 @@ impl SessionReadCacheRegistry {
     /// Store a result if the tool is cacheable and the value fits the size
     /// guard. No-op otherwise.
     pub fn put(&self, session_id: &str, tool_name: &str, arguments_json: &str, value: &str) {
-        let Some(policy) = read_cache_policy(tool_name) else {
+        let Some(policy) = read_cache_policy(tool_name, arguments_json) else {
             return;
         };
         let tag = match policy {
@@ -282,20 +310,35 @@ mod tests {
 
     #[test]
     fn policy_table_matches_issue_289() {
+        // resolve is polymorphic by ref shape.
         assert_eq!(
-            read_cache_policy("content_read"),
+            read_cache_policy("resolve", r#"{"ref":"main.py"}"#),
+            Some(ReadCachePolicy::CacheStable),
+            "content ref → stable"
+        );
+        assert_eq!(
+            read_cache_policy("resolve", r#"{"ref":"cnt_abcd1234"}"#),
             Some(ReadCachePolicy::CacheStable)
         );
         assert_eq!(
-            read_cache_policy("agent_inspect"),
+            read_cache_policy("resolve", r#"{"ref":"ar.aabb11223344","include":"files"}"#),
+            Some(ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata)),
+            "artifact ref → invalidated by artifact_build"
+        );
+        assert_eq!(
+            read_cache_policy("resolve", r#"{"ref":"art_aabb1234"}"#),
+            Some(ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata))
+        );
+        assert_eq!(
+            read_cache_policy("agent_inspect", "{}"),
             Some(ReadCachePolicy::CacheUnderTag(CacheTag::AgentExistence))
         );
         assert_eq!(
-            read_cache_policy("artifact_inspect"),
+            read_cache_policy("artifact_inspect", "{}"),
             Some(ReadCachePolicy::CacheUnderTag(CacheTag::ArtifactMetadata))
         );
-        assert_eq!(read_cache_policy("sandbox_exec"), None);
-        assert_eq!(read_cache_policy("agent_spawn"), None);
+        assert_eq!(read_cache_policy("sandbox_exec", "{}"), None);
+        assert_eq!(read_cache_policy("agent_spawn", "{}"), None);
     }
 
     #[test]
@@ -313,7 +356,7 @@ mod tests {
             invalidation_tag_for("artifact_build"),
             Some(CacheTag::ArtifactMetadata)
         );
-        assert_eq!(invalidation_tag_for("content_read"), None);
+        assert_eq!(invalidation_tag_for("resolve"), None);
         // `agent_install` is NOT a real tool (only an approval-action kind),
         // so it must not be in the invalidation set.
         assert_eq!(invalidation_tag_for("agent_install"), None);
@@ -324,18 +367,18 @@ mod tests {
     #[test]
     fn hit_returns_cached_value() {
         let reg = SessionReadCacheRegistry::default();
-        assert!(reg.get(S, "content_read", r#"{"name":"f"}"#).is_none());
-        reg.put(S, "content_read", r#"{"name":"f"}"#, "BYTES");
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"f"}"#).as_deref(), Some("BYTES"));
+        assert!(reg.get(S, "resolve", r#"{"name":"f"}"#).is_none());
+        reg.put(S, "resolve", r#"{"name":"f"}"#, "BYTES");
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"f"}"#).as_deref(), Some("BYTES"));
     }
 
     #[test]
     fn intent_field_is_ignored_in_key() {
         let reg = SessionReadCacheRegistry::default();
-        reg.put(S, "content_read", r#"{"name":"f","intent":"first"}"#, "BYTES");
+        reg.put(S, "resolve", r#"{"name":"f","intent":"first"}"#, "BYTES");
         // Different intent, same logical args → hit.
         assert_eq!(
-            reg.get(S, "content_read", r#"{"name":"f","intent":"second"}"#).as_deref(),
+            reg.get(S, "resolve", r#"{"name":"f","intent":"second"}"#).as_deref(),
             Some("BYTES")
         );
     }
@@ -343,18 +386,18 @@ mod tests {
     #[test]
     fn distinct_args_do_not_collide() {
         let reg = SessionReadCacheRegistry::default();
-        reg.put(S, "content_read", r#"{"name":"a"}"#, "AAA");
-        reg.put(S, "content_read", r#"{"name":"b"}"#, "BBB");
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"a"}"#).as_deref(), Some("AAA"));
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"b"}"#).as_deref(), Some("BBB"));
+        reg.put(S, "resolve", r#"{"name":"a"}"#, "AAA");
+        reg.put(S, "resolve", r#"{"name":"b"}"#, "BBB");
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"a"}"#).as_deref(), Some("AAA"));
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"b"}"#).as_deref(), Some("BBB"));
     }
 
     #[test]
     fn sessions_are_isolated() {
         let reg = SessionReadCacheRegistry::default();
-        reg.put("sess-A", "content_read", r#"{"name":"f"}"#, "A_PRIVATE");
+        reg.put("sess-A", "resolve", r#"{"name":"f"}"#, "A_PRIVATE");
         // A sibling session must NOT be served A's cached content.
-        assert!(reg.get("sess-B", "content_read", r#"{"name":"f"}"#).is_none());
+        assert!(reg.get("sess-B", "resolve", r#"{"name":"f"}"#).is_none());
     }
 
     #[test]
@@ -368,15 +411,15 @@ mod tests {
     #[test]
     fn agent_existence_invalidation_clears_only_that_tag() {
         let reg = SessionReadCacheRegistry::default();
-        reg.put(S, "content_read", r#"{"name":"f"}"#, "BYTES");
+        reg.put(S, "resolve", r#"{"name":"f"}"#, "BYTES");
         reg.put(S, "agent_inspect", r#"{"agent_id":"x"}"#, r#"{"exists":false}"#);
         reg.put(S, "artifact_inspect", r#"{"artifact_ref":"a"}"#, r#"{"files":[]}"#);
 
         reg.invalidate_tag_all_sessions(CacheTag::AgentExistence);
 
-        // agent_inspect cleared; content_read + artifact_inspect untouched.
+        // agent_inspect cleared; resolve(content) + artifact_inspect untouched.
         assert!(reg.get(S, "agent_inspect", r#"{"agent_id":"x"}"#).is_none());
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"f"}"#).as_deref(), Some("BYTES"));
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"f"}"#).as_deref(), Some("BYTES"));
         assert!(reg.get(S, "artifact_inspect", r#"{"artifact_ref":"a"}"#).is_some());
     }
 
@@ -395,13 +438,13 @@ mod tests {
     fn lru_eviction_bounds_entries() {
         let reg = SessionReadCacheRegistry::new(128, DEFAULT_MAX_VALUE_BYTES);
         for i in 0..200 {
-            reg.put(S, "content_read", &format!(r#"{{"name":"f{i}"}}"#), &format!("v{i}"));
+            reg.put(S, "resolve", &format!(r#"{{"name":"f{i}"}}"#), &format!("v{i}"));
         }
         assert_eq!(reg.entry_count(S), 128, "cache must be bounded to max_entries");
         // The oldest (f0..f71) evicted; the newest 128 (f72..f199) retained.
-        assert!(reg.get(S, "content_read", r#"{"name":"f0"}"#).is_none());
+        assert!(reg.get(S, "resolve", r#"{"name":"f0"}"#).is_none());
         assert_eq!(
-            reg.get(S, "content_read", r#"{"name":"f199"}"#).as_deref(),
+            reg.get(S, "resolve", r#"{"name":"f199"}"#).as_deref(),
             Some("v199")
         );
     }
@@ -409,27 +452,27 @@ mod tests {
     #[test]
     fn lru_access_protects_recently_used() {
         let reg = SessionReadCacheRegistry::new(3, DEFAULT_MAX_VALUE_BYTES);
-        reg.put(S, "content_read", r#"{"name":"a"}"#, "A");
-        reg.put(S, "content_read", r#"{"name":"b"}"#, "B");
-        reg.put(S, "content_read", r#"{"name":"c"}"#, "C");
+        reg.put(S, "resolve", r#"{"name":"a"}"#, "A");
+        reg.put(S, "resolve", r#"{"name":"b"}"#, "B");
+        reg.put(S, "resolve", r#"{"name":"c"}"#, "C");
         // Touch "a" so it is most-recently-used.
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"a"}"#).as_deref(), Some("A"));
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"a"}"#).as_deref(), Some("A"));
         // Insert "d" → should evict "b" (the LRU), not "a".
-        reg.put(S, "content_read", r#"{"name":"d"}"#, "D");
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"a"}"#).as_deref(), Some("A"));
-        assert!(reg.get(S, "content_read", r#"{"name":"b"}"#).is_none());
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"d"}"#).as_deref(), Some("D"));
+        reg.put(S, "resolve", r#"{"name":"d"}"#, "D");
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"a"}"#).as_deref(), Some("A"));
+        assert!(reg.get(S, "resolve", r#"{"name":"b"}"#).is_none());
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"d"}"#).as_deref(), Some("D"));
     }
 
     #[test]
     fn size_guard_skips_large_values() {
         let reg = SessionReadCacheRegistry::new(128, 1024);
         let big = "x".repeat(2048);
-        reg.put(S, "content_read", r#"{"name":"big"}"#, &big);
-        assert!(reg.get(S, "content_read", r#"{"name":"big"}"#).is_none());
+        reg.put(S, "resolve", r#"{"name":"big"}"#, &big);
+        assert!(reg.get(S, "resolve", r#"{"name":"big"}"#).is_none());
         assert_eq!(reg.entry_count(S), 0, "large value must not be stored");
         // A small value alongside still caches fine.
-        reg.put(S, "content_read", r#"{"name":"small"}"#, "ok");
-        assert_eq!(reg.get(S, "content_read", r#"{"name":"small"}"#).as_deref(), Some("ok"));
+        reg.put(S, "resolve", r#"{"name":"small"}"#, "ok");
+        assert_eq!(reg.get(S, "resolve", r#"{"name":"small"}"#).as_deref(), Some("ok"));
     }
 }

--- a/autonoetic-gateway/src/runtime/session_report.rs
+++ b/autonoetic-gateway/src/runtime/session_report.rs
@@ -955,7 +955,7 @@ fn summarize_tool_result(tool_name: &str, parsed: Option<&Value>, raw: &str) -> 
             "wrote {}",
             extract_field_str(parsed, &["name", "sandbox_path", "handle"]).unwrap_or("content")
         ),
-        "content_read" => {
+        "resolve" => {
             if let Some(len) = parsed
                 .and_then(|v| v.get("content"))
                 .and_then(|x| x.as_str())

--- a/autonoetic-gateway/src/runtime/tool_call_processor.rs
+++ b/autonoetic-gateway/src/runtime/tool_call_processor.rs
@@ -437,7 +437,7 @@ impl<'a> ToolCallProcessor<'a> {
             return;
         }
 
-        if read_cache_policy(tool_name).is_some() {
+        if read_cache_policy(tool_name, arguments_json).is_some() {
             store
                 .session_read_cache
                 .put(session_id, tool_name, arguments_json, result);
@@ -1453,15 +1453,15 @@ mod tests {
 
     // ── #289 session read-cache wiring ──────────────────────────────────
 
-    /// A fake `content_read` that returns `{"ok":true,...}` and counts
+    /// A fake `resolve` that returns `{"ok":true,...}` and counts
     /// real executions, so a cache hit is observable as "counter did not
     /// increment".
-    struct FakeContentRead {
+    struct FakeResolve {
         calls: Arc<AtomicUsize>,
     }
-    impl NativeTool for FakeContentRead {
+    impl NativeTool for FakeResolve {
         fn name(&self) -> &'static str {
-            "content_read"
+            "resolve"
         }
         fn definition(&self) -> ToolDefinition {
             ToolDefinition {
@@ -1570,7 +1570,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn read_cache_serves_repeat_content_read_without_re_executing() {
+    async fn read_cache_serves_repeat_resolve_without_re_executing() {
         let temp = tempdir().unwrap();
         let gw_dir = temp.path().join("gateway");
         std::fs::create_dir_all(&gw_dir).unwrap();
@@ -1582,7 +1582,7 @@ mod tests {
         let mut mcp_runtime = crate::runtime::mcp::McpToolRuntime::empty();
         let mut registry = NativeToolRegistry::new();
         let calls = Arc::new(AtomicUsize::new(0));
-        registry.register(Box::new(FakeContentRead {
+        registry.register(Box::new(FakeResolve {
             calls: Arc::clone(&calls),
         }));
         let mut disclosure_state = DisclosureState::default();
@@ -1602,12 +1602,12 @@ mod tests {
         let args = r#"{"name":"f"}"#;
         // First call executes for real.
         let (_ok1, r1) = processor
-            .process_tool_calls(&[call("tc1", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer())
+            .process_tool_calls(&[call("tc1", "resolve", args)], temp.path(), None, &mut SessionTracer::test_tracer())
             .await
             .unwrap();
         // Second identical call must be served from cache (no re-exec).
         let (_ok2, r2) = processor
-            .process_tool_calls(&[call("tc2", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer())
+            .process_tool_calls(&[call("tc2", "resolve", args)], temp.path(), None, &mut SessionTracer::test_tracer())
             .await
             .unwrap();
 
@@ -1679,7 +1679,7 @@ mod tests {
         let mut mcp_runtime = crate::runtime::mcp::McpToolRuntime::empty();
         let mut registry = NativeToolRegistry::new();
         let calls = Arc::new(AtomicUsize::new(0));
-        registry.register(Box::new(FakeContentRead {
+        registry.register(Box::new(FakeResolve {
             calls: Arc::clone(&calls),
         }));
         let mut disclosure_state = DisclosureState::default();
@@ -1697,8 +1697,8 @@ mod tests {
         .with_session_context(Some("no-store".to_string()), Some("t1".to_string()));
 
         let args = r#"{"name":"f"}"#;
-        processor.process_tool_calls(&[call("c1", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
-        processor.process_tool_calls(&[call("c2", "content_read", args)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        processor.process_tool_calls(&[call("c1", "resolve", args)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
+        processor.process_tool_calls(&[call("c2", "resolve", args)], temp.path(), None, &mut SessionTracer::test_tracer()).await.unwrap();
         assert_eq!(calls.load(Ordering::SeqCst), 2, "no cache without a gateway store");
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -138,7 +138,7 @@ impl NativeTool for ArtifactBuildTool {
                     "inputs": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "List of session content names/handles or existing artifact refs (`ar.*` or `art_*`) to include in the artifact. Use `ar.<ref>:<filename>` only with content_read, not here."
+                        "description": "List of session content names/handles or existing artifact refs (`ar.*` or `art_*`) to include in the artifact. Use `ar.<ref>:<filename>` only with resolve, not here."
                     },
                     "entrypoints": {
                         "type": "array",

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -138,7 +138,7 @@ impl NativeTool for ArtifactBuildTool {
                     "inputs": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "List of session content names/handles or existing artifact refs (`ar.*` or `art_*`) to include in the artifact. Use `ar.<ref>:<filename>` only with resolve, not here."
+                        "description": "List of session content names/handles or existing artifact refs (`ar.*` or `art_*`) to include in the artifact. Pass whole artifacts only — to pull in a single file, read it with resolve(ref, include=\"content\", file=…) and write it to content first."
                     },
                     "entrypoints": {
                         "type": "array",
@@ -349,8 +349,10 @@ impl NativeTool for ArtifactBuildTool {
             "files": bundle.files.iter().map(|f| serde_json::json!({
                 "name": f.name,
                 "alias": f.alias,
-                "content_read_ref": artifact_ref.as_ref().map(|r| format!("{}:{}", r, f.name)),
             })).collect::<Vec<_>>(),
+            "read_file": artifact_ref.as_ref().map(|r| format!(
+                "resolve(ref=\"{}\", include=\"content\", file=<name>)", r
+            )),
             "entrypoints": bundle.entrypoints,
             "created_at": bundle.created_at,
             "reused": bundle.reused,
@@ -541,8 +543,10 @@ impl NativeTool for ArtifactInspectTool {
             "files": bundle.files.iter().map(|f| serde_json::json!({
                 "name": f.name,
                 "alias": f.alias,
-                "content_read_ref": format!("{}:{}", args.artifact_ref, f.name),
             })).collect::<Vec<_>>(),
+            "read_file": format!(
+                "resolve(ref=\"{}\", include=\"content\", file=<name>)", args.artifact_ref
+            ),
             "layers": bundle.layers.iter().map(|l| serde_json::json!({
                 "layer_id": l.layer_id,
                 "name": l.name,

--- a/autonoetic-gateway/src/runtime/tools/content.rs
+++ b/autonoetic-gateway/src/runtime/tools/content.rs
@@ -155,7 +155,7 @@ pub(crate) fn find_available_artifacts(
 
     hints.push(serde_json::json!({
         "suggestion": "Use workflow.wait or workflow.state to get stable output handles from completed child tasks. Succeeded tasks include an 'output' field with named_outputs and artifacts[].artifact_ref.",
-        "example": "Call workflow.state first, then read completed_tasks[].output via content.read using named_outputs[*].ref or ar.<ref>:<filename>."
+        "example": "Call workflow.state first, then read completed_tasks[].output: resolve(ref=named_outputs[*].ref) for content, or resolve(ref=artifacts[].artifact_ref, include=\"content\", file=<name>) for an artifact file."
     }));
 
     hints
@@ -192,25 +192,16 @@ pub(crate) fn skill_path_repair_hint(gateway_dir: &Path, input: &str) -> Option<
     None
 }
 
-pub(crate) fn try_read_artifact_ref_file(
+/// Read a single named file out of an artifact, addressed by its agent-facing
+/// ref (`ar.…` or canonical `art_…`) plus the file name. The file selector is
+/// a separate argument — there is no `ar.<ref>:<file>` packing.
+pub(crate) fn read_artifact_file(
     gw_dir: &Path,
     gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
-    name_or_handle: &str,
+    ref_id: &str,
+    filename: &str,
     session_id: &str,
 ) -> anyhow::Result<Vec<u8>> {
-    // Format: ar.<ref_id>:<filename>
-    if !name_or_handle.starts_with("ar.") {
-        return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!("not an artifact ref")).into());
-    }
-
-    let Some(colon_idx) = name_or_handle.find(':') else {
-        return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!(
-            "artifact ref must be in format `ar.<ref>:<filename>` (colon separator required)"
-        )).into());
-    };
-    let ref_id = &name_or_handle[..colon_idx];
-    let filename = &name_or_handle[colon_idx + 1..];
-
     let gs = gateway_store
         .ok_or_else(|| anyhow::anyhow!("GatewayStore required to resolve artifact refs"))?;
 

--- a/autonoetic-gateway/src/runtime/tools/content.rs
+++ b/autonoetic-gateway/src/runtime/tools/content.rs
@@ -10,7 +10,6 @@ use std::path::Path;
 
 pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(ContentWriteTool));
-    registry.register(Box::new(ContentReadTool));
 }
 
 pub struct ContentWriteTool;
@@ -147,158 +146,7 @@ impl NativeTool for ContentWriteTool {
     }
 }
 
-pub struct ContentReadTool;
-
-impl NativeTool for ContentReadTool {
-    fn name(&self) -> &'static str {
-        "content_read"
-    }
-
-    fn is_available(&self, manifest: &AgentManifest) -> bool {
-        manifest
-            .capabilities
-            .iter()
-            .any(|cap| matches!(cap, Capability::ReadAccess { .. }))
-    }
-
-    fn definition(&self) -> ToolDefinition {
-        ToolDefinition {
-            name: self.name().to_string(),
-            description: "Read content from the session's content store. Prefer `name`, 8-char `alias`, or `cnt_<alias>` ref from content.write. Also supports `ar.<ref>:<filename>` to read a specific file from an artifact by its scoped ref. Full `sha256:...` digest still works. Gateway-local skill files such as `skills/<service>/SKILL.md` are for `credential_setup(skill_url=...)`, not `content_read`.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "name_or_handle": {
-                        "type": "string",
-                        "description": "Content-store name (e.g. 'main.py' or a session-stored 'skill.md'), 8-hex alias, cnt_<alias> ref, ar.<ref>:<filename>, or sha256 digest — not a sandbox path or gateway skills/ path"
-                    }
-                },
-                "required": ["name_or_handle"],
-                "additionalProperties": false
-            }),
-        }
-    }
-
-    fn execute(
-        &self,
-        _manifest: &AgentManifest,
-        _policy: &PolicyEngine,
-        _agent_dir: &Path,
-        gateway_dir: Option<&Path>,
-        arguments_json: &str,
-        _session_id: Option<&str>,
-        _turn_id: Option<&str>,
-        _config: Option<&autonoetic_types::config::GatewayConfig>,
-        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
-        _run_context: Option<&NativeToolRunContext>,
-    ) -> anyhow::Result<String> {
-        #[derive(Deserialize)]
-        struct Args {
-            name_or_handle: String,
-        }
-        let args: Args = serde_json::from_str(arguments_json)
-            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
-
-        anyhow::ensure!(
-            !args.name_or_handle.trim().is_empty(),
-            "name_or_handle must not be empty"
-        );
-
-        let Some(gw_dir) = gateway_dir else {
-            return Ok(ToolError::resource("Content store requires gateway directory to be configured", None::<String>).to_error_response());
-        };
-
-        let sid = _session_id.unwrap_or(&_manifest.agent.id);
-        let store = crate::runtime::content_store::ContentStore::new(gw_dir)?;
-
-        let input = args.name_or_handle.trim();
-
-        let content = if input.starts_with("ar.") {
-            let sid = _session_id.unwrap_or(&_manifest.agent.id);
-            match try_read_artifact_ref_file(gw_dir, gateway_store.as_deref(), input, sid) {
-                Ok(c) => c,
-                Err(e) => {
-                    let msg = e.to_string();
-                    let lower = msg.to_ascii_lowercase();
-                    if lower.contains("not an artifact ref") || lower.contains("colon separator") {
-                        return Ok(ToolError::validation(
-                            &msg,
-                            Some("Artifact refs must use format `ar.<ref>:<filename>`."),
-                        ).to_error_response());
-                    }
-                    if lower.contains("gatewaystore required") {
-                        return Ok(ToolError::resource(
-                            &msg,
-                            None::<String>,
-                        ).to_error_response());
-                    }
-                    return Ok(ToolError::not_found(
-                        format!(
-                            "Content '{}' in session '{}'",
-                            input, sid
-                        ),
-                        Some("Use `artifact_inspect` with the artifact_ref to verify the file list."),
-                    ).to_error_response());
-                }
-            }
-        } else {
-            match store.read_by_name_or_handle(sid, input) {
-                Ok(c) => c,
-                Err(e) => {
-                    if let Some(repair_hint) = skill_path_repair_hint(gw_dir, input) {
-                        return Ok(ToolError::not_found(
-                            format!("Content '{}' not found in session '{}': {}", input, sid, e),
-                            Some(repair_hint),
-                        ).to_error_response());
-                    }
-
-                    let looks_like_guessed_name = !input.starts_with("sha256:");
-
-                    if looks_like_guessed_name {
-                        let hints = find_available_artifacts(&store, sid, input);
-
-                        if !hints.is_empty() {
-                            return Ok(serde_json::json!({
-                                "ok": false,
-                                "error_type": "resource",
-                                "repair_hint": "Use workflow.wait or workflow.state to get stable output handles from completed child tasks, then use content.read with the artifact_id from the output field.",
-                                "error": "content_not_found",
-                                "message": format!("Content '{}' not found in session '{}'", input, sid),
-                                "available_artifacts": hints
-                            }).to_string());
-                        }
-                    }
-
-                    return Ok(ToolError::not_found(
-                        format!("Content '{}' not found in session '{}': {}", input, sid, e),
-                        None::<String>,
-                    ).to_error_response());
-                }
-            }
-        };
-
-        let content_str = String::from_utf8(content)
-            .map_err(|e| anyhow::anyhow!("Content is not valid UTF-8: {}", e))?;
-
-        serde_json::to_string(&serde_json::json!({
-            "ok": true,
-            "content": content_str,
-        }))
-        .map_err(Into::into)
-    }
-
-    fn extract_metadata(&self, arguments_json: &str) -> ToolMetadata {
-        let mut meta = ToolMetadata::default();
-        if let Ok(parsed_args) = serde_json::from_str::<serde_json::Value>(arguments_json) {
-            if let Some(name) = parsed_args.get("name_or_handle").and_then(|v| v.as_str()) {
-                meta.path = Some(name.to_string());
-            }
-        }
-        meta
-    }
-}
-
-fn find_available_artifacts(
+pub(crate) fn find_available_artifacts(
     _store: &crate::runtime::content_store::ContentStore,
     _session_id: &str,
     _requested_name: &str,
@@ -313,7 +161,7 @@ fn find_available_artifacts(
     hints
 }
 
-fn skill_path_repair_hint(gateway_dir: &Path, input: &str) -> Option<String> {
+pub(crate) fn skill_path_repair_hint(gateway_dir: &Path, input: &str) -> Option<String> {
     let trimmed = input.trim();
     let normalized = trimmed.trim_start_matches("./");
     let looks_like_skill_path = normalized.starts_with("skills/") || trimmed.ends_with("/SKILL.md");
@@ -330,14 +178,14 @@ fn skill_path_repair_hint(gateway_dir: &Path, input: &str) -> Option<String> {
             " If you mean a gateway skill file, use `credential_setup` with `skill_url: \"skills/<service>/SKILL.md\"`.".to_string()
         };
         return Some(format!(
-            "content_read only reads session content names/handles, not gateway-local skill files.{} If the skill was fetched into the session, read the stored content name or handle instead.",
+            "resolve only reads session content names/handles, not gateway-local skill files.{} If the skill was fetched into the session, read the stored content name or handle instead.",
             suffix
         ));
     }
 
     if trimmed == "SKILL.md" {
         return Some(
-            "content_read only reads session content names/handles, not gateway-local skill files. If you mean a gateway skill file, use `credential_setup` with `skill_url: \"skills/<service>/SKILL.md\"`. If the skill was fetched into the session, read the stored content name or handle instead.".to_string(),
+            "resolve only reads session content names/handles, not gateway-local skill files. If you mean a gateway skill file, use `credential_setup` with `skill_url: \"skills/<service>/SKILL.md\"`. If the skill was fetched into the session, read the stored content name or handle instead.".to_string(),
         );
     }
 

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -39,13 +39,13 @@ pub struct ToolTierFilter {
     /// regardless of tier (e.g., approval.status, approval.answer).
     pub always_include_approval_tools: bool,
     /// When true, always include inspection tools (observability_*,
-    /// knowledge_search/read/search_by_tags, constitution_read, content_read,
+    /// knowledge_search/read/search_by_tags, constitution_read, resolve,
     /// execution_search, digest_query) regardless of tier. Used by degraded
     /// sessions so the agent can still diagnose its own state — an agent
     /// that cannot see why it was degraded cannot recover (Ri-0.5 spirit).
     pub always_include_inspection_tools: bool,
     /// When true, override all other rules with a strict read-only allowlist:
-    /// only inspection tools (observability/knowledge/constitution/content_read
+    /// only inspection tools (observability/knowledge/constitution/resolve
     /// /execution_search) pass. Used for clarification child sessions
     /// (SessionState::Clarification) so an operator probe via `ask-agent`
     /// structurally cannot trigger any action — even if the agent's manifest
@@ -149,7 +149,7 @@ impl ToolTierFilter {
                 | "constitution_read"
                 | "knowledge_search"
                 | "knowledge_read"
-                | "content_read"
+                | "resolve"
                 | "execution_search"
                 | "digest_query"
                 | "agent_list"

--- a/autonoetic-gateway/src/runtime/tools/resolve.rs
+++ b/autonoetic-gateway/src/runtime/tools/resolve.rs
@@ -11,8 +11,8 @@
 //! - everything else → the content store.
 //!
 //! The agent's decision collapses to: **run it → `artifact_exec`; see it →
-//! `resolve`.** `artifact_inspect` / `content_read` remain as the specific
-//! verbs `resolve` delegates to.
+//! `resolve`.** `resolve` is the sole read door — there is no separate
+//! `content_read`; `artifact_inspect` remains for structural artifact review.
 
 use std::path::Path;
 
@@ -142,8 +142,8 @@ impl ResolveTool {
             .to_error_response());
         };
 
-        // `include=content` on an artifact reads a single file (delegates to
-        // the same `ar.<ref>:<file>` path content_read uses).
+        // `include=content` on an artifact reads a single file via the
+        // `ar.<ref>:<file>` content-store path.
         if include == "content" {
             let Some(file) = file else {
                 return Ok(ToolError::validation(
@@ -260,11 +260,7 @@ impl ResolveTool {
                     Ok(json!({ "ok": true, "kind": "content", "ref": reference, "content": content })
                         .to_string())
                 }
-                Err(e) => Ok(ToolError::not_found(
-                    format!("content '{reference}' in session '{sid}': {e}"),
-                    None::<String>,
-                )
-                .to_error_response()),
+                Err(e) => Ok(self.content_not_found(gw_dir, &store, sid, reference, &e.to_string())),
             };
         }
 
@@ -278,11 +274,49 @@ impl ResolveTool {
                 "alias": crate::runtime::content_store::ContentStore::get_short_alias(&handle),
             })
             .to_string()),
-            Err(e) => Ok(ToolError::not_found(
-                format!("content '{reference}' in session '{sid}': {e}"),
-                Some("Pass include=content to read it, or check the handle."),
-            )
-            .to_error_response()),
+            Err(e) => Ok(self.content_not_found(gw_dir, &store, sid, reference, &e.to_string())),
         }
+    }
+
+    /// Build a content not-found response, preserving the helpful hints the
+    /// former `content_read` surfaced: a skills-path repair hint, or — when
+    /// the agent likely guessed a name — the list of artifacts actually
+    /// available in the session (anti-thrash, #312).
+    fn content_not_found(
+        &self,
+        gw_dir: &Path,
+        store: &crate::runtime::content_store::ContentStore,
+        sid: &str,
+        reference: &str,
+        err: &str,
+    ) -> String {
+        if let Some(hint) =
+            crate::runtime::tools::content::skill_path_repair_hint(gw_dir, reference)
+        {
+            return ToolError::not_found(
+                format!("content '{reference}' not found in session '{sid}': {err}"),
+                Some(hint),
+            )
+            .to_error_response();
+        }
+        if !reference.starts_with("sha256:") {
+            let hints = crate::runtime::tools::content::find_available_artifacts(store, sid, reference);
+            if !hints.is_empty() {
+                return json!({
+                    "ok": false,
+                    "error_type": "resource",
+                    "error": "content_not_found",
+                    "message": format!("content '{reference}' not found in session '{sid}'"),
+                    "repair_hint": "Use workflow.wait/workflow.state to get a stable output ref from a completed child, then resolve that.",
+                    "available_artifacts": hints,
+                })
+                .to_string();
+            }
+        }
+        ToolError::not_found(
+            format!("content '{reference}' not found in session '{sid}': {err}"),
+            None::<String>,
+        )
+        .to_error_response()
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/resolve.rs
+++ b/autonoetic-gateway/src/runtime/tools/resolve.rs
@@ -1,13 +1,14 @@
 //! `resolve` — the single front door for any artifact/content handle (#312).
 //!
 //! Agents juggle several handle shapes — `art_<id>`, `ar.<ref>`, `cnt_<alias>`,
-//! a bare 8-char alias, a content `name`, `sha256:…`, and `ar.<ref>:<file>`.
+//! a bare 8-char alias, a content `name`, and `sha256:…`.
 //! Choosing *which tool* consumes *which shape* is exactly the decision that
 //! drives tool-thrashing. `resolve` takes **any** of them and answers "what is
 //! this / show me this" without that choice:
 //!
 //! - artifact-shaped refs (`art_` / `ar.`) → artifact resolution, with scope
-//!   inferred from the session (no explicit `scope_type`/`scope_id`);
+//!   inferred from the session (no explicit `scope_type`/`scope_id`); a single
+//!   file inside is selected with the `file` argument, not packed into the ref;
 //! - everything else → the content store.
 //!
 //! The agent's decision collapses to: **run it → `artifact_exec`; see it →
@@ -48,14 +49,14 @@ impl NativeTool for ResolveTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Resolve ANY artifact or content handle to what it points at — `art_`/`ar.` artifact refs, or `cnt_`/8-char alias/content name/`sha256:` content handles, or `ar.<ref>:<file>`. The one front door for \"what is this / show me this\": you do not pick a tool by handle type. `include` controls depth: 'metadata' (default — identity + existence), 'files' (an artifact's file list with read refs), or 'content' (inline the bytes; for an artifact pass `file` to choose which file). To RUN an artifact use artifact_exec; to SEE one use resolve."
+            description: "Resolve ANY artifact or content handle to what it points at — `art_`/`ar.` artifact refs, or `cnt_`/8-char alias/content name/`sha256:` content handles. The one front door for \"what is this / show me this\": you do not pick a tool by handle type. `include` controls depth: 'metadata' (default — identity + existence), 'files' (an artifact's file list), or 'content' (inline the bytes; for an artifact pass `file` to choose which file inside it). To RUN an artifact use artifact_exec; to SEE one use resolve."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "ref": { "type": "string", "description": "Any handle: art_<id>, ar.<ref>, cnt_<alias>, 8-char alias, content name, sha256:…, or ar.<ref>:<file>" },
+                    "ref": { "type": "string", "description": "Any handle: art_<id>, ar.<ref>, cnt_<alias>, 8-char alias, content name, or sha256:…" },
                     "include": { "type": "string", "enum": ["metadata", "files", "content"], "description": "Depth: metadata (default), files (artifact file list), content (inline bytes)" },
-                    "file": { "type": "string", "description": "For include=content on an artifact: which file inside it to read" }
+                    "file": { "type": "string", "description": "For include=content on an artifact: which file inside it to read (the file name from include=files)" }
                 },
                 "required": ["ref"],
                 "additionalProperties": false
@@ -103,20 +104,24 @@ impl NativeTool for ResolveTool {
         };
         let sid = session_id.unwrap_or(&manifest.agent.id);
 
-        // Artifact-shaped refs (`art_` / `ar.`) take the artifact path; an
-        // `ar.<ref>:<file>` carries an embedded file selector.
+        // Artifact-shaped refs (`art_` / `ar.`) take the artifact path. The
+        // file selector is the `file` parameter — it is NOT packed into the
+        // ref. Reject the legacy `ar.<ref>:<file>` packing with a nudge.
         if reference.starts_with("art_") || reference.starts_with("ar.") {
-            let (artifact_ref, embedded_file) = match reference.split_once(':') {
-                Some((r, f)) => (r, Some(f.to_string())),
-                None => (reference, None),
-            };
+            if reference.contains(':') {
+                return Ok(ToolError::validation(
+                    "the file is selected with the `file` parameter, not packed into the ref — e.g. resolve(ref=\"ar.xxxx\", include=\"content\", file=\"foo.txt\")",
+                    Some("Drop the ':<file>' suffix from ref and pass file=<name>."),
+                )
+                .to_error_response());
+            }
             return self.resolve_artifact(
                 gw_dir,
                 gateway_store,
                 sid,
-                artifact_ref,
+                reference,
                 include,
-                embedded_file.or(args.file),
+                args.file,
             );
         }
 
@@ -142,21 +147,20 @@ impl ResolveTool {
             .to_error_response());
         };
 
-        // `include=content` on an artifact reads a single file via the
-        // `ar.<ref>:<file>` content-store path.
+        // `include=content` on an artifact reads a single named file.
         if include == "content" {
             let Some(file) = file else {
                 return Ok(ToolError::validation(
-                    "resolve(include=content) on an artifact needs a `file` (or an ar.<ref>:<file> ref); use include=files to list them",
-                    Some("Pass file=<name> or include=files."),
+                    "resolve(include=content) on an artifact needs a `file` (the file name inside it); use include=files to list them",
+                    Some("Pass file=<name>, or call include=files first."),
                 )
                 .to_error_response());
             };
-            let ar_file = format!("{artifact_ref}:{file}");
-            return match crate::runtime::tools::content::try_read_artifact_ref_file(
+            return match crate::runtime::tools::content::read_artifact_file(
                 gw_dir,
                 Some(&gs),
-                &ar_file,
+                artifact_ref,
+                &file,
                 sid,
             ) {
                 Ok(bytes) => {
@@ -234,9 +238,15 @@ impl ResolveTool {
                         .map(|f| json!({
                             "name": f.name,
                             "alias": f.alias,
-                            "content_read_ref": format!("{}:{}", resolved.display_ref, f.name),
                         }))
                         .collect::<Vec<_>>()),
+                );
+                obj.insert(
+                    "read_file".to_string(),
+                    json!(format!(
+                        "resolve(ref=\"{}\", include=\"content\", file=<name>)",
+                        resolved.display_ref
+                    )),
                 );
             }
         }

--- a/autonoetic-gateway/src/runtime/tools/skill.rs
+++ b/autonoetic-gateway/src/runtime/tools/skill.rs
@@ -832,7 +832,7 @@ impl NativeTool for SkillNormalizeTool {
                 "already_normalized": true,
                 "session_content": session_content,
                 "discovery_record_registered": discovery_record_registered,
-                "message": "Content already contains autonoetic.onboarding steps; file written as-is. Use content_read with session_content.normalized_name, or credential_setup with skill_url=skill_path.",
+                "message": "Content already contains autonoetic.onboarding steps; file written as-is. Use resolve with session_content.normalized_name, or credential_setup with skill_url=skill_path.",
             })
             .to_string());
         }
@@ -926,9 +926,9 @@ impl NativeTool for SkillNormalizeTool {
             "discovery_record_registered": discovery_record_registered,
             "agent_creation_candidate": agent_candidate,
             "message": if agent_candidate {
-                "Wrote Autonoetic SKILL.md with multiple API operations. Use content_read with session_content.normalized_name, or credential_setup with skill_url for onboarding. Consider spawning coder.default to build a reusable script agent for this service."
+                "Wrote Autonoetic SKILL.md with multiple API operations. Use resolve with session_content.normalized_name, or credential_setup with skill_url for onboarding. Consider spawning coder.default to build a reusable script agent for this service."
             } else {
-                "Wrote Autonoetic SKILL.md; use content_read with session_content.normalized_name, or credential_setup with skill_url pointing at this path or a file:// URL as supported by your deployment."
+                "Wrote Autonoetic SKILL.md; use resolve with session_content.normalized_name, or credential_setup with skill_url pointing at this path or a file:// URL as supported by your deployment."
             },
         })
         .to_string())

--- a/autonoetic-gateway/tests/artifact_build_ref_integration.rs
+++ b/autonoetic-gateway/tests/artifact_build_ref_integration.rs
@@ -389,9 +389,84 @@ fn test_resolve_artifact_metadata_and_files() -> anyhow::Result<()> {
     assert!(v.get("artifact_id").is_none(), "raw art_* id must not be exposed");
     assert_eq!(v["file_count"].as_u64(), Some(1));
     assert_eq!(v["files"][0]["name"].as_str(), Some("data.py"));
+    // The file selector is the `file` param, not a packed `ar.<ref>:<file>`:
+    // no per-file packed ref, and a top-level read_file shows the param form.
+    assert!(
+        v["files"][0].get("content_read_ref").is_none(),
+        "packed ar.<ref>:<file> must not be surfaced"
+    );
     assert_eq!(
-        v["files"][0]["content_read_ref"].as_str(),
-        Some(format!("{artifact_ref}:data.py").as_str())
+        v["read_file"].as_str(),
+        Some(format!("resolve(ref=\"{artifact_ref}\", include=\"content\", file=<name>)").as_str())
+    );
+    Ok(())
+}
+
+/// Read one file out of an artifact: address the artifact by its ref and name
+/// the file with the separate `file` argument (no `ar.<ref>:<file>` packing).
+#[test]
+fn test_resolve_artifact_file_via_file_param() -> anyhow::Result<()> {
+    let temp = tempdir()?;
+    let agents_dir = temp.path().join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+    let config = GatewayConfig { agents_dir: agents_dir.clone(), ..GatewayConfig::default() };
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+    let writer = writer_manifest();
+    let writer_policy = PolicyEngine::new(writer.clone());
+    let reader = reader_manifest();
+    let reader_policy = PolicyEngine::new(reader.clone());
+    let registry = default_registry();
+    let agent_dir = agents_dir.join("coder.default");
+    std::fs::create_dir_all(&agent_dir)?;
+
+    let cs = ContentStore::new(&gateway_dir)?;
+    let h = cs.write(b"resolved content")?;
+    cs.register_name("sess-r", "data.py", &h)?;
+
+    let build_out = registry.execute(
+        "artifact_build", &writer, &writer_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "inputs": ["data.py"] }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let build_v: serde_json::Value = serde_json::from_str(&build_out)?;
+    let artifact_ref = build_v["artifact_ref"].as_str().expect("artifact_ref").to_string();
+
+    // Param form succeeds and returns the file bytes.
+    let out = registry.execute(
+        "resolve", &reader, &reader_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "ref": artifact_ref, "include": "content", "file": "data.py" }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v["ok"], serde_json::json!(true));
+    assert_eq!(v["kind"].as_str(), Some("artifact_file"));
+    assert_eq!(v["file"].as_str(), Some("data.py"));
+    assert_eq!(v["content"].as_str(), Some("resolved content"));
+
+    // include=content without a file is a validation error pointing at `file`.
+    let out = registry.execute(
+        "resolve", &reader, &reader_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "ref": artifact_ref, "include": "content" }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v["ok"], serde_json::json!(false));
+    assert_eq!(v["error_type"].as_str(), Some("validation"));
+
+    // The legacy packed `ar.<ref>:<file>` form is rejected with a nudge to `file`.
+    let packed = format!("{artifact_ref}:data.py");
+    let out = registry.execute(
+        "resolve", &reader, &reader_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "ref": packed, "include": "content" }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v["ok"], serde_json::json!(false));
+    assert_eq!(v["error_type"].as_str(), Some("validation"));
+    assert!(
+        v["message"].as_str().unwrap_or_default().contains("file"),
+        "nudge must point at the `file` parameter, got: {}", v["message"]
     );
     Ok(())
 }

--- a/autonoetic-gateway/tests/constitution_clarification_child_read_only.rs
+++ b/autonoetic-gateway/tests/constitution_clarification_child_read_only.rs
@@ -136,7 +136,7 @@ fn clarification_filter_allows_inspection_tools() {
         "constitution_read",
         "knowledge_search",
         "knowledge_read",
-        "content_read",
+        "resolve",
         "execution_search",
         "digest_query",
     ];

--- a/autonoetic-gateway/tests/constitution_degraded_inspection_available.rs
+++ b/autonoetic-gateway/tests/constitution_degraded_inspection_available.rs
@@ -4,7 +4,7 @@
 //! (sandbox_exec, web_*, agent_spawn, agent_revision_*, scheduler_*,
 //! credential_*) but **keeps** the inspection allowlist
 //! (observability_*, knowledge_search/read/search_by_tags, constitution_read,
-//! content_read, execution_search, digest_query) so the agent can
+//! resolve, execution_search, digest_query) so the agent can
 //! diagnose its own state and report on it.
 //!
 //! Rationale: degraded mode without inspection is a Ri-0.5 spirit
@@ -144,7 +144,7 @@ fn degraded_filter_allows_inspection_tools_for_self_diagnosis() {
         "constitution_read",
         "knowledge_search",
         "knowledge_read",
-        "content_read",
+        "resolve",
         "execution_search",
         "digest_query",
     ] {

--- a/autonoetic-gateway/tests/constitution_rights_late_bucket.rs
+++ b/autonoetic-gateway/tests/constitution_rights_late_bucket.rs
@@ -93,9 +93,12 @@ fn assert_rules_are_constitutional(label: &str, rules: &[&'static str]) {
     );
     for rule in rules {
         let s = rule.to_string();
+        // Constitutional IDs: P-x.y (principles), Ri-x.y (rights),
+        // I-x (invariants), §N (sections).
+        let first = s.chars().next().unwrap_or(' ');
         assert!(
-            s.starts_with('R') || s.starts_with('§'),
-            "{}: enforced rule '{}' must start with R or § (Ri-0.3)",
+            matches!(first, 'P' | 'R' | 'I' | '§'),
+            "{}: enforced rule '{}' must be a constitutional ID (P-/Ri-/I-/§) (Ri-0.3)",
             label,
             s
         );
@@ -182,12 +185,12 @@ fn ri_0_3_allowed_operations_are_allowed() {
 #[test]
 fn ri_0_12_core_tools_available_in_degraded_mode() {
     let core = ToolTierFilter::core_only();
-    assert!(core.allows("content_read"));
+    assert!(core.allows("resolve"));
     assert!(core.allows("content_write"));
     assert!(core.allows("knowledge_recall"));
     assert!(core.allows("knowledge_store"));
 
     let all = ToolTierFilter::all();
-    assert!(all.allows("content_read"));
+    assert!(all.allows("resolve"));
     assert!(all.allows("web_search"));
 }

--- a/autonoetic-gateway/tests/constitution_rights_mid_bucket.rs
+++ b/autonoetic-gateway/tests/constitution_rights_mid_bucket.rs
@@ -138,11 +138,11 @@ fn ri_0_6_degraded_state_clamps_tool_tier_to_core_only() {
         "degraded mode must block specialized tools"
     );
     assert!(
-        normal_filter.allows("content_read"),
+        normal_filter.allows("resolve"),
         "normal mode allows core tools"
     );
     assert!(
-        degraded_filter.allows("content_read"),
+        degraded_filter.allows("resolve"),
         "degraded mode still allows core tools"
     );
 }
@@ -150,7 +150,7 @@ fn ri_0_6_degraded_state_clamps_tool_tier_to_core_only() {
 #[test]
 fn ri_0_6_core_only_filter_blocks_specialized_tools() {
     let filter = ToolTierFilter::core_only();
-    assert!(filter.allows("content_read"));
+    assert!(filter.allows("resolve"));
     assert!(filter.allows("knowledge_recall"));
     assert!(!filter.allows("web_search"));
     assert!(!filter.allows("scheduler_cron_create"));

--- a/autonoetic-gateway/tests/disclosure_integration.rs
+++ b/autonoetic-gateway/tests/disclosure_integration.rs
@@ -19,7 +19,7 @@ async fn test_disclosure_policy_integration() {
                 "model": "gpt-4o",
                 "choices": [{
                     "index": 0,
-                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_1", "type": "function", "function": { "name": "content_read", "arguments": "{\"name_or_handle\":\"secret.txt\"}" } }] },
+                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_1", "type": "function", "function": { "name": "resolve", "arguments": "{\"ref\":\"secret.txt\",\"include\":\"content\"}" } }] },
                     "finish_reason": "tool_calls"
                 }],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
@@ -46,7 +46,7 @@ async fn test_disclosure_policy_integration() {
                 "model": "gpt-4o",
                 "choices": [{
                     "index": 0,
-                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_2", "type": "function", "function": { "name": "content_read", "arguments": "{\"name_or_handle\":\"confidential.txt\"}" } }] },
+                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_2", "type": "function", "function": { "name": "resolve", "arguments": "{\"ref\":\"confidential.txt\",\"include\":\"content\"}" } }] },
                     "finish_reason": "tool_calls"
                 }],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
@@ -73,7 +73,7 @@ async fn test_disclosure_policy_integration() {
                 "model": "gpt-4o",
                 "choices": [{
                     "index": 0,
-                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_3", "type": "function", "function": { "name": "content_read", "arguments": "{\"name_or_handle\":\"public.txt\"}" } }] },
+                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_3", "type": "function", "function": { "name": "resolve", "arguments": "{\"ref\":\"public.txt\",\"include\":\"content\"}" } }] },
                     "finish_reason": "tool_calls"
                 }],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
@@ -137,14 +137,14 @@ llm_config:
   model: "gpt-4o"
 capabilities:
   - type: "SandboxFunctions"
-    allowed: ["content_read", "content_write"]
+    allowed: ["resolve", "content_write"]
 disclosure:
   default_class: "public"
   rules:
-    - source: "content_read"
+    - source: "resolve"
       path_pattern: "secret*"
       class: "secret"
-    - source: "content_read"
+    - source: "resolve"
       path_pattern: "confidential*"
       class: "confidential"
 "#
@@ -225,12 +225,12 @@ disclosure:
     let policy = DisclosurePolicy {
         rules: vec![
             DisclosureRule {
-                source: "content_read".to_string(),
+                source: "resolve".to_string(),
                 path_pattern: Some("secret*".to_string()),
                 class: DisclosureClass::Restricted,
             },
             DisclosureRule {
-                source: "content_read".to_string(),
+                source: "resolve".to_string(),
                 path_pattern: Some("confidential*".to_string()),
                 class: DisclosureClass::Restricted,
             },
@@ -239,9 +239,9 @@ disclosure:
     };
 
     let mut state = DisclosureState::new(policy);
-    state.register_result("content_read", Some("secret.txt"), "super_secret_wahoo");
+    state.register_result("resolve", Some("secret.txt"), "super_secret_wahoo");
     state.register_result(
-        "content_read",
+        "resolve",
         Some("confidential.txt"),
         "confidential_business_plan_v2",
     );

--- a/autonoetic-gateway/tests/loopback_integration.rs
+++ b/autonoetic-gateway/tests/loopback_integration.rs
@@ -64,7 +64,7 @@ async fn test_loopback_content_audit_and_negatives() {
                 "model": "gpt-4o",
                 "choices": [{
                     "index": 0,
-                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_2", "type": "function", "function": { "name": "content_read", "arguments": "{\"name_or_handle\":\"secret.txt\"}" } }] },
+                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_2", "type": "function", "function": { "name": "resolve", "arguments": "{\"ref\":\"secret.txt\",\"include\":\"content\"}" } }] },
                     "finish_reason": "tool_calls"
                 }],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
@@ -90,7 +90,7 @@ async fn test_loopback_content_audit_and_negatives() {
                 "model": "gpt-4o",
                 "choices": [{
                     "index": 0,
-                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_3", "type": "function", "function": { "name": "content_read", "arguments": "{\"name_or_handle\":\"missing.txt\"}" } }] },
+                    "message": { "role": "assistant", "tool_calls": [{ "id": "call_3", "type": "function", "function": { "name": "resolve", "arguments": "{\"ref\":\"missing.txt\",\"include\":\"content\"}" } }] },
                     "finish_reason": "tool_calls"
                 }],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
@@ -286,7 +286,7 @@ async fn test_loopback_content_audit_and_negatives() {
                 if value["action"].as_str() == Some("requested") {
                     if value["payload"]["tool_name"].as_str() == Some("content_write") {
                         agent_content_writes += 1;
-                    } else if value["payload"]["tool_name"].as_str() == Some("content_read") {
+                    } else if value["payload"]["tool_name"].as_str() == Some("resolve") {
                         agent_content_reads += 1;
                     }
                 } else if value["category"].as_str() == Some("session")

--- a/autonoetic-gateway/tests/structured_error_taxonomy_integration.rs
+++ b/autonoetic-gateway/tests/structured_error_taxonomy_integration.rs
@@ -105,12 +105,12 @@ fn test_content_read_skill_path_not_found_has_targeted_repair_hint() -> anyhow::
     let policy = PolicyEngine::new(manifest.clone());
 
     let result = registry.execute(
-        "content_read",
+        "resolve",
         &manifest,
         &policy,
         temp.path(),
         Some(&gateway_dir),
-        &json!({"name_or_handle": "skills/moltbook/SKILL.md"}).to_string(),
+        &json!({"ref": "skills/moltbook/SKILL.md", "include": "content"}).to_string(),
         Some("session-1"),
         None,
         None,
@@ -330,7 +330,8 @@ fn test_loop_guard_permission_errors_skip_budget() {
 fn test_loop_guard_validation_errors_count_normally() {
     let mut guard = LoopGuard::new(100);
 
-    for _ in 0..5 {
+    // max_tool_failures default is 8 — validation errors count as normal failures.
+    for _ in 0..8 {
         guard.register_failure(
             "web_fetch",
             r#"{"url":"https://bad.com"}"#,
@@ -345,13 +346,16 @@ fn test_loop_guard_validation_errors_count_normally() {
 fn test_loop_guard_mixed_errors_permission_skipped() {
     let mut guard = LoopGuard::new(100);
 
-    for _ in 0..4 {
+    // Permission errors are skipped; only the 7 validation failures count
+    // (below the max_tool_failures=8 budget).
+    for _ in 0..7 {
         guard.register_failure("web_fetch", "{}", Some(&ToolErrorType::Validation));
         guard.register_failure("web_fetch", "{}", Some(&ToolErrorType::Permission));
     }
 
     assert!(guard.check_loop().is_ok());
 
+    // The 8th validation failure trips the budget.
     guard.register_failure("web_fetch", "{}", Some(&ToolErrorType::Validation));
     assert!(guard.check_loop().is_err());
 }
@@ -360,7 +364,8 @@ fn test_loop_guard_mixed_errors_permission_skipped() {
 fn test_loop_guard_unknown_error_type_counts_as_failure() {
     let mut guard = LoopGuard::new(100);
 
-    for _ in 0..5 {
+    // Unknown (None) error type counts as a normal failure against the budget (8).
+    for _ in 0..8 {
         guard.register_failure("sandbox_exec", "{}", None);
     }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -206,9 +206,9 @@ The body contains natural language instructions for the agent. Key sections typi
 If the SKILL.md body contains `<!-- extended -->` on its own line, the parser splits the body into two parts:
 
 - **Core instructions**: everything before the marker — always injected into the system prompt
-- **Extended instructions**: everything after the marker — stored in the content store, available on-demand via `content_read({"name_or_handle": "extended_instructions"})`
+- **Extended instructions**: everything after the marker — stored in the content store, available on-demand via `resolve({"ref": "extended_instructions", "include": "content"})`
 
-The system prompt automatically gets a hint: *"Extended instructions are available via content_read"*. The agent decides whether to fetch them.
+The system prompt automatically gets a hint: *"Extended instructions are available via resolve"*. The agent decides whether to fetch them.
 
 This is useful for deferring verbose reference tables, edge-case workflows, and seldom-used protocols. Example from `planner.default/SKILL.md`:
 
@@ -264,7 +264,7 @@ Capabilities fall into three categories:
 
 | Capability | Gates These Tools |
 |------------|------------------|
-| `ReadAccess` | `content_read`, `artifact_inspect`, `memory.read`, `knowledge_recall`, `knowledge_search` |
+| `ReadAccess` | `resolve`, `artifact_inspect`, `memory.read`, `knowledge_recall`, `knowledge_search` |
 | `WriteAccess` | `content_write`, `artifact_build`, `memory.write`, `knowledge_store` |
 
 **Privilege capabilities gate boundary-crossing operations:**
@@ -316,7 +316,6 @@ For files and data within a session:
 | Tool | Signature | Description |
 |------|-----------|-------------|
 | `content_write` | `(name: string, content: string, visibility?: string) → handle` | Write content with visibility (private/session/global). Default: session |
-| `content_read` | `(name_or_handle: string) → content` | Read by name or handle with root-based resolution |
 
 ### Artifact Tools (Trust Boundary)
 
@@ -469,7 +468,7 @@ For resolving credentials + approval in a single pass before execution. Eliminat
 
 Artifact ref constraints:
 - `artifact_prepare`, `artifact_exec`, and `artifact_inspect` require an explicit `artifact_ref` (`ar.<12-hex>`) returned by `artifact_build` or `workflow_wait`/`workflow_state`.
-- Implicit workflow outputs contain `implicit_artifact_id` and a `named_outputs` map. Use `content_read` on the implicit handle and then select `content.artifacts[*].artifact_ref`.
+- Implicit workflow outputs contain `implicit_artifact_id` and a `named_outputs` map. Use `resolve` on the implicit handle and then select `content.artifacts[*].artifact_ref`.
 
 Credential reference constraints:
 - `credential_id` references used by artifact/sandbox credential injection must be canonical IDs from credential tools (`cred_...`).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ Gateway: 1. Compute SHA-256 hash
          3. Update session manifest: {"main.py": "sha256:abc123"}
          4. Return handle to agent
 
-Agent: content_read("main.py")
+Agent: resolve("main.py")
   ↓
 Gateway: 1. Resolve name → handle from session manifest
          2. Fetch blob from content store
@@ -173,7 +173,7 @@ Gateway: 1. Resolve name → handle from session manifest
    - Artifact metadata from SKILL.md frontmatter
    - Structured artifact added to spawn response
 5. Planner receives artifacts in spawn response
-6. Specialized_builder reads artifacts via content_read()
+6. Specialized_builder reads artifacts via resolve()
 ```
 
 ### Build Layer Flow
@@ -393,7 +393,7 @@ Agent-local files for per-tick determinism:
 └── skills/          # Installed skills
 ```
 
-**Tools:** `content_write`, `content_read`, `artifact_build`, `artifact_inspect`
+**Tools:** `content_write`, `resolve`, `artifact_build`, `artifact_inspect`
 
 Content uses root-session visibility. Default is `session` (collaborative within root). Use `visibility: "private"` for scratch work. Artifacts are the mandatory boundary for review/install/execution.
 
@@ -881,16 +881,16 @@ A per-session, in-memory result cache for **pure read tools** memoizes determini
 
 | Tool | Policy | Invalidated by |
 |---|---|---|
-| `content_read` | Cache forever in-session (content-addressed) | never |
+| `resolve` | Cache forever in-session (content-addressed) | never |
 | `agent_inspect` | Cache | `skill_install`, `agent_revision_create`, `agent_revision_create_from_intent`, `agent_revision_promote`, `agent_revision_rollback` |
 | `artifact_inspect` | Cache | `artifact_build` |
 
 Properties:
 
-- **Keyed by exact session id**, not root — a cached `content_read` result is never served to a sibling session, preserving per-session content visibility.
+- **Keyed by exact session id**, not root — a cached `resolve` result is never served to a sibling session, preserving per-session content visibility.
 - **Wraps only the raw `registry.execute` output**; disclosure registration and secret redaction still run on every hit, so caching is transparent to those invariants.
 - **Bounded + size-guarded**: per-session LRU of 128 entries; results over 1 MiB are never stored.
-- **Invalidation is coarse but correct**: a mutating tool clears the affected tag class (`AgentExistence` / `ArtifactMetadata`) across *all* session caches, so a child session's promote invalidates the parent's `agent_inspect` cache. `content_read` is never invalidated.
+- **Invalidation is coarse but correct**: a mutating tool clears the affected tag class (`AgentExistence` / `ArtifactMetadata`) across *all* session caches, so a child session's promote invalidates the parent's `agent_inspect` cache. `resolve` is never invalidated.
 - **Audited**: a cache hit emits a `tool_call.cache_hit` causal event (and the normal execution trace still records), so the causal chain shows every logical tool call.
 
 Grounding: extends the determinism-skip principle of P-2.6 / P-2.7 (approved-execution caching) to pure reads, where the safety argument is stronger — there is no side effect to skip.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -105,7 +105,7 @@ The core gateway library. Handles all server, runtime, and execution logic.
 | `tools/resolve.rs` | `resolve` (one front door for any artifact/content handle) |
 | `tools/artifact_prepare.rs` | `artifact_prepare` |
 | `tools/artifact_exec.rs` | `artifact_exec` |
-| `tools/content.rs` | `content_write`, `content_read` |
+| `tools/content.rs` | `content_write` |
 | `tools/promotion.rs` | `promotion_record`, `promotion_query` |
 | `tools/session.rs` | `session_escalate` |
 | `tools/execution.rs` | `execution_search` |

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -21,7 +21,6 @@ This document describes the capability system used by Autonoetic agents. Capabil
 ### Content Tools
 | Tool | Requires Capability | Notes |
 |------|---------------------|-------|
-| `content_read` | `ReadAccess` | Read from content store |
 | `content_write` | `WriteAccess` | Write to content store with visibility |
 
 ### Artifact Tools
@@ -67,7 +66,7 @@ This document describes the capability system used by Autonoetic agents. Capabil
 
 ## Important: SandboxFunctions vs Native Tools
 
-**Common misconception**: `SandboxFunctions` with prefix `"content."` grants access to `content_read`, `content_write`, etc.
+**Common misconception**: `SandboxFunctions` with prefix `"content."` grants access to `resolve`, `content_write`, etc.
 
 **Reality**: `SandboxFunctions` is for **MCP (Model Context Protocol) tools only**. Native content tools require `ReadAccess` and `WriteAccess` capabilities.
 
@@ -75,7 +74,7 @@ This document describes the capability system used by Autonoetic agents. Capabil
 ❌ WRONG:
   capabilities:
     - type: "SandboxFunctions"
-      allowed: ["content."]  # This does NOT grant content_read access!
+      allowed: ["content."]  # This does NOT grant resolve access!
 
 ✅ CORRECT:
   capabilities:
@@ -266,7 +265,7 @@ capabilities:
 
 ### SandboxFunctions (for MCP tools)
 ```json
-{"type": "SandboxFunctions", "allowed": ["web.", "content_read"]}
+{"type": "SandboxFunctions", "allowed": ["web.", "resolve"]}
 ```
 
 ### CodeExecution (script patterns)

--- a/docs/comparison-hermes-agent.md
+++ b/docs/comparison-hermes-agent.md
@@ -1166,7 +1166,7 @@ The 38 registered native tools include specialized tools (eval, revision, promot
 ```rust
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolTier {
-    /// Always sent: content_write, content_read, sandbox_exec, knowledge_store/recall/search/search_by_tags
+    /// Always sent: content_write, resolve, sandbox_exec, knowledge_store/recall/search/search_by_tags
     Core,
     /// Sent when agent is in a workflow or delegates: agent_spawn, workflow_wait, workflow_state
     Workflow,
@@ -1310,7 +1310,7 @@ MVP: ship observability (`PromptBudgetBreakdown`) + tool tiering (~200 lines). T
 | **Tool access** | `allowed-tools` is advisory — the host decides enforcement | `capabilities` are enforced by the gateway policy engine |
 | **Execution model** | LLM reads instructions, uses host's tools freely | Sandboxed execution, capability-gated tools, approval gates |
 | **Trust model** | Implicit trust (single user, local environment) | Multi-user ACLs, approval gates, disclosure policies |
-| **File access** | Direct filesystem | Content store (`content_write`/`content_read`), sandboxed mounts |
+| **File access** | Direct filesystem | Content store (`content_write`/`resolve`), sandboxed mounts |
 | **Networking** | Assumed available | `NetworkAccess` capability, approval-gated |
 | **Resources** | `scripts/`, `references/`, `assets/` loaded on demand | Agent directory files mounted in sandbox |
 | **Progressive disclosure** | 3 tiers: metadata (~100 tokens) → instructions (<5000 tokens) → resources (on demand) | All instructions loaded at agent wake |
@@ -1403,7 +1403,7 @@ fn infer_capabilities(allowed_tools: &[String]) -> Vec<Capability> {
 
 #### Tool name bridging
 
-External skills reference tools by names defined in their host environment (e.g., `Bash`, `Read`, `WebSearch` for Claude Code). Autonoetic uses different names (`sandbox_exec`, `content_read`, `web_search`). The adapter injects a short **tool name mapping** into the agent's instructions:
+External skills reference tools by names defined in their host environment (e.g., `Bash`, `Read`, `WebSearch` for Claude Code). Autonoetic uses different names (`sandbox_exec`, `resolve`, `web_search`). The adapter injects a short **tool name mapping** into the agent's instructions:
 
 ```markdown
 ---
@@ -1415,13 +1415,13 @@ The following tool mappings apply:
 | Skill references | Autonoetic equivalent |
 |---|---|
 | `Bash(command)` | `sandbox_exec(command)` |
-| `Read(path)` | `content_read(name_or_handle)` — files must be loaded via content store |
+| `Read(path)` | `resolve(name_or_handle)` — files must be loaded via content store |
 | `Write(path, content)` | `content_write(name, content)` |
 | `WebSearch(query)` | `web_search(query)` |
 | `WebFetch(url)` | `web_fetch(url)` |
 
 File paths referenced by the skill are mounted in the sandbox at `/workspace/`.
-Use `content_read` for any file the skill's instructions reference.
+Use `resolve` for any file the skill's instructions reference.
 ```
 
 This mapping is appended to the agent's system prompt. The LLM handles the translation naturally — it reads "use `Bash(git log)`" in the skill instructions and translates it to `sandbox_exec({"command": "git log"})` based on the mapping table. Token cost: ~200 tokens.
@@ -1431,7 +1431,7 @@ This mapping is appended to the agent's system prompt. The LLM handles the trans
 Agent Skills may include `scripts/`, `references/`, `assets/` directories. The adapter:
 
 1. Copies these directories into the agent's directory under `imported/`
-2. Registers them as content store entries (so they're accessible via `content_read`)
+2. Registers them as content store entries (so they're accessible via `resolve`)
 3. Mounts them into the sandbox at their expected paths
 
 ```rust

--- a/docs/content-store.md
+++ b/docs/content-store.md
@@ -95,9 +95,9 @@ Write content with visibility control.
 
 Default visibility is `session` (collaborative). Use `private` for scratchpads/drafts.
 Use `sandbox_path` when passing files to `sandbox_exec`.
-`cnt_...` and `sha256:...` are content references for `content_read`, not filesystem paths.
+`cnt_...` and `sha256:...` are content references for `resolve`, not filesystem paths.
 
-### `content_read`
+### `resolve`
 
 Read by name, handle, or alias with root-based resolution.
 
@@ -121,23 +121,23 @@ Resolution order:
 4. If bare 8 hex chars → alias lookup (session, then root, then global)
 5. Otherwise → name lookup (session, then root, then global)
 
-### `content_read` vs `artifact_inspect`
+### `resolve` vs `artifact_inspect`
 
 These tools intentionally overlap a bit, but they serve different jobs:
 
 - `artifact_inspect` is for **artifact structure and trust-boundary review**: file list, entrypoints, layers, digest, builder metadata.
-- `content_read` is for **retrieving bytes/text**: either session content (`name`, alias, handle) or a specific artifact file (`ar.<ref>:<filename>`).
+- `resolve` is for **retrieving bytes/text**: either session content (`name`, alias, handle) or a specific artifact file (`ar.<ref>:<filename>`).
 
 Why this is usually not an issue:
 
 - The trust boundary remains artifact-centric: review/install/execution flows key off the immutable manifest (`artifact_manifest_digest`) and canonical closure digest (`artifact_canonical_digest`).
-- `content_read` does not replace structural review metadata (entrypoints/layers/provenance); it only fetches file content.
+- `resolve` does not replace structural review metadata (entrypoints/layers/provenance); it only fetches file content.
 - Runtime rejects implicit workflow IDs for artifact-only operations (`artifact_inspect`, `artifact_exec`, `artifact_prepare`), preserving boundary clarity.
 
 Practical guidance:
 
 - Use `artifact_inspect` first when validating what an artifact contains.
-- Use `content_read` second to open exact files returned by inspection.
+- Use `resolve` second to open exact files returned by inspection.
 
 ### `artifact_build`
 
@@ -156,7 +156,6 @@ Accepted `inputs` forms:
 | Tool field | Accepts | Does not accept |
 |---|---|---|
 | `artifact_build.inputs[]` | session content names, `cnt_...`, `sha256:...`, bare alias, existing artifact refs `ar.*`, canonical artifact IDs `art_*` | scoped artifact file refs like `ar.<ref>:requirements.txt` |
-| `content_read.name_or_handle` | session content names, `cnt_...`, `sha256:...`, bare alias, scoped artifact file refs `ar.<ref>:<filename>` | bare artifact refs when you want structure/review metadata |
 | `artifact_inspect.artifact_ref` | `ar.*`, `art_*` | `ar.<ref>:<filename>`, content handles |
 | `artifact_prepare.artifact_ref` / `artifact_exec.artifact_ref` | `ar.*`, `art_*` | content handles, scoped artifact file refs |
 | `resolve.ref` | any artifact/content handle — `ar.*`, `art_*`, `cnt_*`, bare alias, content name, `sha256:...`, or `ar.<ref>:<filename>` (scope inferred from the session) | — |
@@ -164,7 +163,7 @@ Accepted `inputs` forms:
 Homogeneity rule:
 
 - When a tool is artifact-oriented (`artifact_inspect`, `artifact_prepare`, `artifact_exec`, `artifact_build` artifact reuse), pass the artifact itself as `ar.*` or `art_*`.
-- When a tool is file-oriented (`content_read`), pass a session content identifier or a scoped artifact file ref `ar.<ref>:<filename>`.
+- When a tool is file-oriented (`resolve`), pass a session content identifier or a scoped artifact file ref `ar.<ref>:<filename>`.
 - Do not switch namespaces mid-flow: `ar.<ref>:<filename>` is for reading one file out of an artifact, while bare `ar.*` / `art_*` means the whole artifact.
 
 ```json
@@ -207,7 +206,7 @@ Inspect an artifact by ref.
 ```
 
 `artifact_inspect` accepts `artifact_ref` (`ar.<12-hex>`) returned by `artifact_build` or `workflow_wait`/`workflow_state`.
-Implicit workflow output handles are content records and should be consumed via `content_read`.
+Implicit workflow output handles are content records and should be consumed via `resolve`.
 
 ## Artifact Trust Boundary
 
@@ -274,7 +273,7 @@ agent_spawn({"agent_id": "coder.default", "message": "Write weather.py"})
 content_write({"name": "weather.py", "content": "import json..."})
 
 // Planner can read the coder's output
-content_read({"name_or_handle": "weather.py"})
+resolve({"ref": "weather.py", "include": "content"})
 
 // Coder builds artifact for review
 artifact_build({"inputs": ["weather.py"], "entrypoints": ["weather.py"]})
@@ -290,8 +289,8 @@ artifact_inspect({"artifact_ref": "ar.a1b2c3d4ab12"})
 content_write({"name": "draft.py", "content": "# scratch work", "visibility": "private"})
 
 // Only the coder can read it
-content_read({"name_or_handle": "draft.py"})  // works in coder session
-// content_read in parent session → error
+resolve({"ref": "draft.py", "include": "content"})  // works in coder session
+// resolve in parent session → error
 ```
 
 ## Testing

--- a/docs/content-store.md
+++ b/docs/content-store.md
@@ -99,12 +99,14 @@ Use `sandbox_path` when passing files to `sandbox_exec`.
 
 ### `resolve`
 
-Read by name, handle, or alias with root-based resolution.
+Read by name, handle, or alias with root-based resolution. `include="content"`
+returns the bytes; the default `include="metadata"` only checks existence.
 
 ```json
 // Request
 {
-  "name_or_handle": "main.py"
+  "ref": "main.py",
+  "include": "content"
 }
 
 // Response
@@ -114,19 +116,28 @@ Read by name, handle, or alias with root-based resolution.
 }
 ```
 
-Resolution order:
-1. If `ar.<ref>:<filename>` → read that file directly from the artifact bundle after scope resolution
-2. If `cnt_<8 hex>` (or `cnt:<8 hex>`) → alias lookup (session, then root, then global)
-3. If `sha256:...` → direct content lookup (with `sha256:<8 hex>` treated as alias fallback)
-4. If bare 8 hex chars → alias lookup (session, then root, then global)
-5. Otherwise → name lookup (session, then root, then global)
+To read one file out of an artifact, address the artifact by its ref and name
+the file with the `file` argument — there is no `ar.<ref>:<file>` packing:
+
+```json
+{ "ref": "ar.abcdef012345", "include": "content", "file": "requirements.txt" }
+```
+
+Resolution order for `ref` (content path):
+1. If `cnt_<8 hex>` (or `cnt:<8 hex>`) → alias lookup (session, then root, then global)
+2. If `sha256:...` → direct content lookup (with `sha256:<8 hex>` treated as alias fallback)
+3. If bare 8 hex chars → alias lookup (session, then root, then global)
+4. Otherwise → name lookup (session, then root, then global)
+
+An `ar.*` / `art_*` `ref` takes the artifact path instead; pass `file` to read a
+single file inside it.
 
 ### `resolve` vs `artifact_inspect`
 
 These tools intentionally overlap a bit, but they serve different jobs:
 
 - `artifact_inspect` is for **artifact structure and trust-boundary review**: file list, entrypoints, layers, digest, builder metadata.
-- `resolve` is for **retrieving bytes/text**: either session content (`name`, alias, handle) or a specific artifact file (`ar.<ref>:<filename>`).
+- `resolve` is for **retrieving bytes/text**: either session content (`name`, alias, handle) or a specific artifact file (`ref="ar.<ref>"` with `file="<filename>"`).
 
 Why this is usually not an issue:
 
@@ -155,16 +166,16 @@ Accepted `inputs` forms:
 
 | Tool field | Accepts | Does not accept |
 |---|---|---|
-| `artifact_build.inputs[]` | session content names, `cnt_...`, `sha256:...`, bare alias, existing artifact refs `ar.*`, canonical artifact IDs `art_*` | scoped artifact file refs like `ar.<ref>:requirements.txt` |
-| `artifact_inspect.artifact_ref` | `ar.*`, `art_*` | `ar.<ref>:<filename>`, content handles |
-| `artifact_prepare.artifact_ref` / `artifact_exec.artifact_ref` | `ar.*`, `art_*` | content handles, scoped artifact file refs |
-| `resolve.ref` | any artifact/content handle — `ar.*`, `art_*`, `cnt_*`, bare alias, content name, `sha256:...`, or `ar.<ref>:<filename>` (scope inferred from the session) | — |
+| `artifact_build.inputs[]` | session content names, `cnt_...`, `sha256:...`, bare alias, existing artifact refs `ar.*`, canonical artifact IDs `art_*` | single files (read one with `resolve(..., file=…)` and write it to content first) |
+| `artifact_inspect.artifact_ref` | `ar.*`, `art_*` | content handles, single-file selectors |
+| `artifact_prepare.artifact_ref` / `artifact_exec.artifact_ref` | `ar.*`, `art_*` | content handles, single-file selectors |
+| `resolve.ref` | any artifact/content handle — `ar.*`, `art_*`, `cnt_*`, bare alias, content name, `sha256:...` (scope inferred from the session); for one file inside an artifact, add `file="<name>"` | — |
 
 Homogeneity rule:
 
 - When a tool is artifact-oriented (`artifact_inspect`, `artifact_prepare`, `artifact_exec`, `artifact_build` artifact reuse), pass the artifact itself as `ar.*` or `art_*`.
-- When a tool is file-oriented (`resolve`), pass a session content identifier or a scoped artifact file ref `ar.<ref>:<filename>`.
-- Do not switch namespaces mid-flow: `ar.<ref>:<filename>` is for reading one file out of an artifact, while bare `ar.*` / `art_*` means the whole artifact.
+- When a tool is file-oriented (`resolve`), pass a session content identifier, or address an artifact file as `ref="ar.<ref>"` plus `file="<filename>"`.
+- Do not switch namespaces mid-flow: `ref="ar.*"` + `file=…` reads one file out of an artifact, while bare `ar.*` / `art_*` means the whole artifact.
 
 ```json
 // Response

--- a/docs/spec-artifact-content-identity-model.md
+++ b/docs/spec-artifact-content-identity-model.md
@@ -302,7 +302,7 @@ Single implementation pass. No phases, no compatibility shims.
 3. Replace `artifact_id` in tool inputs with `artifact_ref`.
 4. Return `artifact_ref` and `artifact_canonical_digest` from `artifact_build`, `artifact_inspect`, `resolve`.
 5. Update `artifact_exec` and `artifact_prepare` to accept `artifact_ref` and bind approval reuse identity to `artifact_canonical_digest`.
-6. `resolve` (the read door) reads `ar.<ref>:<filename>` addressing instead of `art_<id>:<filename>`.
+6. `resolve` (the read door) reads a single artifact file by `ref="ar.<ref>"` plus a separate `file="<filename>"` argument — not a packed `art_<id>:<filename>` / `ar.<ref>:<filename>` string.
 7. Update workflow implicit outputs to include `artifact_ref` instead of `artifact_id`.
 8. Update all foundation prompt layers and agent playbooks to use `artifact_ref` exclusively.
 9. Remove `artifact_id` from all agent-facing docs and tool descriptions.
@@ -338,7 +338,7 @@ Single implementation pass. No phases, no compatibility shims.
 ### Content tool integration
 
 - `autonoetic-gateway/src/runtime/tools/content.rs`
-  - change artifact file addressing from `art_<id>:<file>` to `ar.<ref>:<file>`
+  - artifact file addressing: `ref="ar.<ref>"` + separate `file="<name>"` (no packed `art_<id>:<file>` / `ar.<ref>:<file>`)
   - resolution path: resolve ref to `artifact_id`, then load file as before
 
 ### Workflow and handoff

--- a/docs/spec-artifact-content-identity-model.md
+++ b/docs/spec-artifact-content-identity-model.md
@@ -302,7 +302,7 @@ Single implementation pass. No phases, no compatibility shims.
 3. Replace `artifact_id` in tool inputs with `artifact_ref`.
 4. Return `artifact_ref` and `artifact_canonical_digest` from `artifact_build`, `artifact_inspect`, `resolve`.
 5. Update `artifact_exec` and `artifact_prepare` to accept `artifact_ref` and bind approval reuse identity to `artifact_canonical_digest`.
-6. Update `content_read` to resolve `ar.<ref>:<filename>` addressing instead of `art_<id>:<filename>`.
+6. `resolve` (the read door) reads `ar.<ref>:<filename>` addressing instead of `art_<id>:<filename>`.
 7. Update workflow implicit outputs to include `artifact_ref` instead of `artifact_id`.
 8. Update all foundation prompt layers and agent playbooks to use `artifact_ref` exclusively.
 9. Remove `artifact_id` from all agent-facing docs and tool descriptions.

--- a/docs/spec-build-layers-dependency-resolution.md
+++ b/docs/spec-build-layers-dependency-resolution.md
@@ -251,7 +251,7 @@ Complete flow for the weather demo:
      "Install deps from requirements.txt and build artifact with deps"
 
    builder:
-     a. content_read("requirements.txt")          # get dep list
+     a. resolve("requirements.txt")          # get dep list
      b. sandbox_exec({
           "command": "pip install -r requirements.txt -t /tmp/deps",
           "capture_paths": [{"path": "/tmp/deps", "mount_as": "/tmp/deps"}]

--- a/docs/spec-implicit-artifacts-agent-evolution.md
+++ b/docs/spec-implicit-artifacts-agent-evolution.md
@@ -200,15 +200,15 @@ Task completes → Gateway creates impl_{task_id} → Available to parent sessio
 }
 ```
 
-#### Via content_read
+#### Via resolve
 
 ```json
-content_read({
+resolve({
   "name_or_handle": "impl_task-94c19ac6"
 })
 ```
 
-> Note: `artifact_inspect` requires an `artifact_ref` (`ar.<12-hex>`) from a built artifact bundle. Implicit workflow outputs are content records, not executable bundles — use `content_read` with the `implicit_artifact_id`.
+> Note: `artifact_inspect` requires an `artifact_ref` (`ar.<12-hex>`) from a built artifact bundle. Implicit workflow outputs are content records, not executable bundles — use `resolve` with the `implicit_artifact_id`.
 
 ### 4.5 Configuration
 
@@ -226,13 +226,13 @@ implicit_artifacts:
 
 ### 4.6 Enhanced Error Messages
 
-When `content_read` fails for a name that looks like a guessed name:
+When `resolve` fails for a name that looks like a guessed name:
 
 ```json
 {
   "error_type": "resource",
   "message": "Content 'weather_result' not found",
-  "hint": "Use workflow_wait or workflow_state to get stable output handles from completed child tasks, then use content_read with the implicit_artifact_id from the output field.",
+  "hint": "Use workflow_wait or workflow_state to get stable output handles from completed child tasks, then use resolve with the implicit_artifact_id from the output field.",
   "available_artifacts": [
     {"implicit_artifact_id": "impl_task-94c19ac6", "from": "researcher.default", "summary": "Fetched weather..."},
     {"implicit_artifact_id": "impl_task-fb261586", "from": "architect.default", "summary": "Design document..."}
@@ -307,15 +307,15 @@ Task completes → Gateway creates impl_{task_id} → Available to parent sessio
 }
 ```
 
-#### Via content_read
+#### Via resolve
 
 ```json
-content_read({
+resolve({
   "name_or_handle": "impl_task-94c19ac6"
 })
 ```
 
-> Note: `artifact_inspect` requires an `artifact_ref` (`ar.<12-hex>`) from a built artifact bundle. Implicit workflow outputs are content records, not executable bundles — use `content_read` with the `implicit_artifact_id`.
+> Note: `artifact_inspect` requires an `artifact_ref` (`ar.<12-hex>`) from a built artifact bundle. Implicit workflow outputs are content records, not executable bundles — use `resolve` with the `implicit_artifact_id`.
 
 ### 3.5 Configuration
 
@@ -333,7 +333,7 @@ implicit_artifacts:
 
 ### 3.6 Enhanced Error Messages
 
-When `content_read` fails for a name that looks like a guessed name:
+When `resolve` fails for a name that looks like a guessed name:
 
 ```json
 {
@@ -415,7 +415,7 @@ session_escalate({
   "context": "workflow_wait returned task-94c19ac6 completed but I don't see an output_artifact field",
   "target": "reasoning_llm",
   "suggested_actions": [
-    "Try content_read with task ID",
+    "Try resolve with task ID",
     "Ask user for clarification",
     "Check if output is in a different field"
   ]
@@ -423,7 +423,7 @@ session_escalate({
 
 // Gateway responds:
 {
-  "analysis": "The workflow_wait response structure includes an 'output' object with 'implicit_artifact_id'. Use: content_read({'name_or_handle': 'impl_task-94c19ac6'})",
+  "analysis": "The workflow_wait response structure includes an 'output' object with 'implicit_artifact_id'. Use: resolve({'name_or_handle': 'impl_task-94c19ac6'})",
   "confidence": "high",
   "alternative": "If that fails, the task output may be in the workflow.events for this task."
 }
@@ -752,7 +752,7 @@ Every evolved agent tracks its lineage:
 |-----------|--------|
 | Task completion | Create implicit artifact |
 | workflow_wait | Include output artifact in response |
-| content_read | Enhanced error messages with hints |
+| resolve | Enhanced error messages with hints |
 | Tool registry | Add session_escalate tool |
 | Agent loader | Support base inheritance, hooks, injections |
 | Session metadata | Track escalation count |
@@ -818,7 +818,7 @@ evolution:
 
 1. Implement implicit artifact creation on task completion
 2. Update workflow_wait to include artifact reference
-3. Add enhanced error messages to content_read
+3. Add enhanced error messages to resolve
 4. Update planner SKILL.md to use artifact IDs
 
 ### Phase 2: Escalation (Week 2-3)
@@ -872,7 +872,7 @@ planner spawns researcher (async)
 planner spawns architect (async)
 planner calls workflow_wait
   → returns: {"status": "completed", "task_id": "task-94c19ac6"}
-planner tries content_read("weather_result")
+planner tries resolve("weather_result")
   → FAIL: not found
 planner guesses another name, fails again
 planner proceeds with missing data
@@ -896,7 +896,7 @@ planner calls workflow_wait
        }
      }
 planner uses implicit_artifact_id from response
-planner calls content_read("impl_task-94c19ac6")
+planner calls resolve("impl_task-94c19ac6")
   → SUCCESS
 planner has all data needed
   → High quality output

--- a/docs/workflow-orchestration.md
+++ b/docs/workflow-orchestration.md
@@ -326,11 +326,11 @@ Important: Every significant workflow transition emits a causal chain entry (`wo
 
 **Fix**: Corrected the deduplication logic to use `insert()` directly, which returns `true` for newly inserted events. Also improved workflow change detection to reset the bootstrap flag when a workflow is created mid-session.
 
-### Bug 4: Short alias used as full handle prevented content_read from working
+### Bug 4: Short alias used as full handle prevented resolve from working
 
-**Problem**: When `content_write` returns an alias (e.g., `"8b40c8e1"`), the LLM sometimes mistakenly treats it as a full SHA-256 handle by prepending `sha256:`, resulting in `content_read("sha256:8b40c8e1")`. The lookup logic treated this as a full handle lookup (expecting 64 hex chars) rather than an alias lookup (8 chars), causing "Content not found" errors.
+**Problem**: When `content_write` returns an alias (e.g., `"8b40c8e1"`), the LLM sometimes mistakenly treats it as a full SHA-256 handle by prepending `sha256:`, resulting in `resolve("sha256:8b40c8e1")`. The lookup logic treated this as a full handle lookup (expecting 64 hex chars) rather than an alias lookup (8 chars), causing "Content not found" errors.
 
-**Fix**: Enhanced `ContentStore::read_by_name_or_handle` to detect the pattern `sha256:SHORT_ALIAS` (exactly 8 hex chars after the prefix) and redirect it to alias lookup. This makes content_read more resilient to LLM misinterpretations of the alias value.
+**Fix**: Enhanced `ContentStore::read_by_name_or_handle` to detect the pattern `sha256:SHORT_ALIAS` (exactly 8 hex chars after the prefix) and redirect it to alias lookup. This makes resolve more resilient to LLM misinterpretations of the alias value.
 
 ## Files
 


### PR DESCRIPTION
Closes #320. Part of the #312 tool-surface reduction theme.

## What

`resolve` becomes the **sole read door** — `content_read` is deleted. The two tools overlapped (both read content/artifact-file bytes) and `content_read` sat in the always-visible Core tier, contributing to the tool-thrashing #312 targets. The agent decision collapses to: **run it → `artifact_exec`; see it → `resolve`.**

- **`resolve(ref, include="content"[, file])`** reads session content and `ar.<ref>:<file>` artifact files. It preserves `content_read`'s anti-thrash hints (skill-path repair hint + available-artifacts list) via a `content_not_found()` helper ported from the deleted tool.
- **`read_cache_policy` is now args-aware**: `resolve` caches under `ArtifactMetadata` (tag-invalidated) for `art_`/`ar.` refs, and `CacheStable` otherwise — matching the polymorphic read surface.
- Migrated the visibility/clarification allowlists, `foundation_*` prompt layers, 10 agent `SKILL.md` bundles, live docs (AGENTS, agent-capabilities, content-store, ARCHITECTURE, …), and the test suites from `content_read` → `resolve`. Archived (`docs/archived/`) and point-in-time design plans keep their historical references.

## Drive-by test fixes

Two suites I touch had **pre-existing failures on `main`** (verified on a clean checkout, unrelated to this change). Fixed so the touched files are green:

- `structured_error_taxonomy_integration`: 3 loop-guard tests asserted the old `max_tool_failures=5`; `ff87497` raised it to 8 but only updated the unit tests. Updated the integration tests to match.
- `constitution_rights_late_bucket`: the `Ri-0.3` rule-ID assertion only accepted `R`/`§`, but the `#303` R→P renumbering means enforced rules are now `P-x.y`. Assertion now accepts the `P-`/`Ri-`/`I-`/`§` scheme.

One unrelated pre-existing failure remains on `main` and is **left as-is** (out of scope, non-trivial): `tool_call_processor::tests::test_in_session_repair_loop_recovery_from_structured_error` (a `knowledge_store` repair-loop test, no `content_read`/`resolve` involvement).

## Test

All touched suites pass:
`structured_error_taxonomy_integration`, `disclosure_integration`, `loopback_integration`, `constitution_degraded_inspection_available`, `constitution_rights_{late,mid}_bucket`, `constitution_clarification_child_read_only`, plus `--lib read_cache`. `cargo build -p autonoetic-gateway` and `cargo test --workspace --no-run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)