### PR TITLE
Single artifact-file addressing: resolve(ref, file=…)

### DIFF
--- a/agents/specialists/packager.default/SKILL.md
+++ b/agents/specialists/packager.default/SKILL.md
@@ -151,9 +151,9 @@ Only modify the entrypoint if the task explicitly requires source changes unrela
 ## Input Discipline
 
 - You need either a valid `artifact_ref` or explicit source files already available in session content. Do not invent file handles from an artifact id.
-- `resolve` accepts content names/handles and scoped artifact file refs of the form `ar.<ref>:<filename>`. It does **not** accept synthetic paths like `art_*:requirements.txt`.
-- `artifact_build.inputs` accepts either session content identifiers or whole-artifact refs (`ar.*` or `art_*`). It does **not** accept scoped artifact file refs like `ar.<ref>:requirements.txt`.
-- If you need to inspect an existing artifact, call `artifact_inspect(artifact_ref)` once. Use the artifact metadata directly, or if you must open a file, use a scoped `ar.<ref>:<filename>` ref.
+- `resolve` accepts content names/handles, and reads one file out of an artifact via `resolve(ref="ar.<ref>", include="content", file="<filename>")`. The file name is a separate argument — there is no packed `ar.<ref>:<filename>` / `art_*:requirements.txt` form.
+- `artifact_build.inputs` accepts either session content identifiers or whole-artifact refs (`ar.*` or `art_*`). It does **not** accept a single file out of an artifact — read it with `resolve(..., file="…")` and write it to content first.
+- If you need to inspect an existing artifact, call `artifact_inspect(artifact_ref)` once. Use the artifact metadata directly, or if you must open a file, call `resolve(ref="ar.<ref>", include="content", file="<filename>")`.
 - If the task is to add layers to an existing artifact, prefer rebuilding from the artifact itself: call `artifact_build` with the original artifact ref in `inputs` plus the new `layers`. Do **not** read `main.py` / `requirements.txt` just to carry them forward unless you are actually modifying those files.
 - If you only know an installed `agent_id` and need source text for a real source edit, ask the planner for `agent_inspect({"agent_id":"...","include_source":true})` output or for explicit session content files. Do not guess artifact file handles.
 - If the provided `artifact_ref` is absent, stale, or unreadable, stop and return a failure asking the planner for a fresh `ar.*` or for extracted source files. Do **not** loop on `resolve` / `resolve` variants trying different shapes of the same missing reference.

--- a/autonoetic-gateway/src/runtime/foundation_artifact.md
+++ b/autonoetic-gateway/src/runtime/foundation_artifact.md
@@ -4,7 +4,7 @@
 - When producing code, designs, or structured data, write them via `content_write(name, content)`.
 - Report the content name or handle in your response (e.g., "Saved to `main.py`" or "Handle: sha256:abc123").
 - Do NOT return full file contents in your response — the handle is sufficient.
-- When receiving a task that references a file, use `resolve(ref, include="content")` to retrieve it. If you need one file out of an artifact, use `resolve(ref="ar.<ref>:<filename>", include="content")`.
+- When receiving a task that references a file, use `resolve(ref, include="content")` to retrieve it. If you need one file out of an artifact, pass the file name separately: `resolve(ref="ar.<ref>", include="content", file="<filename>")`.
 - Do not assume a file exists based on history alone; always verify via `resolve` before proceeding.
 
 11. Artifact-First Review Protocol.

--- a/autonoetic-gateway/src/runtime/foundation_core.md
+++ b/autonoetic-gateway/src/runtime/foundation_core.md
@@ -6,18 +6,18 @@ Core runtime model:
 
 1. Content storage is the primary way to persist files and data.
 - Use `content_write(name, content)` to save files, scripts, and data to the session.
-- Use `resolve(ref, include="content")` to retrieve content by session content identifier or by scoped artifact file ref `ar.<ref>:<filename>`. (`resolve` is the one read door — see §2; default `include="metadata"` just checks existence.)
+- Use `resolve(ref, include="content")` to retrieve content by session content identifier; to read one file out of an artifact pass `resolve(ref="ar.<ref>", include="content", file="<filename>")`. (`resolve` is the one read door — see §2; default `include="metadata"` just checks existence.)
 - Default visibility is `session` — visible to all agents under the same root session.
 - Use `visibility: "private"` for scratchpads, drafts, or intermediate outputs.
 - Content works locally and remotely — agents don't need filesystem access.
 
 2. Artifacts are the mandatory boundary for review/install/execution.
 - Use `artifact_build(inputs, entrypoints?)` to build an immutable artifact bundle.
-- `artifact_build.inputs` accepts session content identifiers or whole-artifact identifiers (`ar.*`, `art_*`). It does not accept scoped file refs like `ar.<ref>:requirements.txt`.
+- `artifact_build.inputs` accepts session content identifiers or whole-artifact identifiers (`ar.*`, `art_*`). It does not accept single files out of an artifact — read one with `resolve(ref="ar.<ref>", include="content", file="…")` and write it to content first.
 - Use `artifact_inspect(artifact_ref)` to review an artifact's files and metadata.
-- **When unsure what a handle is or how to read it, use `resolve(ref, include?)`** — the one front door for ANY artifact/content handle (`art_`, `ar.`, `cnt_`, alias, name, `sha256:`, `ar.<ref>:<file>`). `include`: `metadata` (default), `files` (an artifact's files), `content` (inline bytes; pass `file` to pick a file in an artifact). The decision is simply: **run it → `artifact_exec`; see it → `resolve`.**
+- **When unsure what a handle is or how to read it, use `resolve(ref, include?)`** — the one front door for ANY artifact/content handle (`art_`, `ar.`, `cnt_`, alias, name, `sha256:`). `include`: `metadata` (default), `files` (an artifact's files), `content` (inline bytes; pass `file` to pick a file in an artifact). The decision is simply: **run it → `artifact_exec`; see it → `resolve`.**
 - Artifact-oriented tools (`artifact_inspect`, `artifact_prepare`, `artifact_exec`, `artifact_build` artifact reuse) take the whole artifact as `ar.*` or `art_*`.
-- File-oriented reads use `resolve(ref, include="content")` with session content IDs or `ar.<ref>:<filename>`.
+- File-oriented reads use `resolve(ref, include="content")` with session content IDs; for an artifact's file, `resolve(ref="ar.<ref>", include="content", file="<filename>")`.
 - NO artifact = NO review = NO install = NO execution beyond scratch.
 - Artifacts are the ONLY units that may cross trust boundaries.
 

--- a/autonoetic-gateway/src/runtime/foundation_workflow.md
+++ b/autonoetic-gateway/src/runtime/foundation_workflow.md
@@ -3,7 +3,7 @@
 7. Output contracts should use content handles.
 - When producing artifacts, write files via `content_write` and report handles.
 - Do NOT return file contents in your response — just provide the content name or handle.
-- Other agents can read files from your artifacts via `resolve(ref="ar.<ref>:<filename>", include="content")`, or inspect the whole artifact via `artifact_inspect(artifact_ref)`.
+- Other agents can read a file from your artifacts via `resolve(ref="ar.<ref>", include="content", file="<filename>")`, or inspect the whole artifact via `artifact_inspect(artifact_ref)`.
 
 8. Work iteratively with the gateway.
 - Gateway errors and tool failures are part of the normal execution loop.

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -138,7 +138,7 @@ impl NativeTool for ArtifactBuildTool {
                     "inputs": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "List of session content names/handles or existing artifact refs (`ar.*` or `art_*`) to include in the artifact. Use `ar.<ref>:<filename>` only with resolve, not here."
+                        "description": "List of session content names/handles or existing artifact refs (`ar.*` or `art_*`) to include in the artifact. Pass whole artifacts only — to pull in a single file, read it with resolve(ref, include=\"content\", file=…) and write it to content first."
                     },
                     "entrypoints": {
                         "type": "array",
@@ -349,8 +349,10 @@ impl NativeTool for ArtifactBuildTool {
             "files": bundle.files.iter().map(|f| serde_json::json!({
                 "name": f.name,
                 "alias": f.alias,
-                "content_read_ref": artifact_ref.as_ref().map(|r| format!("{}:{}", r, f.name)),
             })).collect::<Vec<_>>(),
+            "read_file": artifact_ref.as_ref().map(|r| format!(
+                "resolve(ref=\"{}\", include=\"content\", file=<name>)", r
+            )),
             "entrypoints": bundle.entrypoints,
             "created_at": bundle.created_at,
             "reused": bundle.reused,
@@ -541,8 +543,10 @@ impl NativeTool for ArtifactInspectTool {
             "files": bundle.files.iter().map(|f| serde_json::json!({
                 "name": f.name,
                 "alias": f.alias,
-                "content_read_ref": format!("{}:{}", args.artifact_ref, f.name),
             })).collect::<Vec<_>>(),
+            "read_file": format!(
+                "resolve(ref=\"{}\", include=\"content\", file=<name>)", args.artifact_ref
+            ),
             "layers": bundle.layers.iter().map(|l| serde_json::json!({
                 "layer_id": l.layer_id,
                 "name": l.name,

--- a/autonoetic-gateway/src/runtime/tools/content.rs
+++ b/autonoetic-gateway/src/runtime/tools/content.rs
@@ -155,7 +155,7 @@ pub(crate) fn find_available_artifacts(
 
     hints.push(serde_json::json!({
         "suggestion": "Use workflow.wait or workflow.state to get stable output handles from completed child tasks. Succeeded tasks include an 'output' field with named_outputs and artifacts[].artifact_ref.",
-        "example": "Call workflow.state first, then read completed_tasks[].output via content.read using named_outputs[*].ref or ar.<ref>:<filename>."
+        "example": "Call workflow.state first, then read completed_tasks[].output: resolve(ref=named_outputs[*].ref) for content, or resolve(ref=artifacts[].artifact_ref, include=\"content\", file=<name>) for an artifact file."
     }));
 
     hints
@@ -192,25 +192,16 @@ pub(crate) fn skill_path_repair_hint(gateway_dir: &Path, input: &str) -> Option<
     None
 }
 
-pub(crate) fn try_read_artifact_ref_file(
+/// Read a single named file out of an artifact, addressed by its agent-facing
+/// ref (`ar.…` or canonical `art_…`) plus the file name. The file selector is
+/// a separate argument — there is no `ar.<ref>:<file>` packing.
+pub(crate) fn read_artifact_file(
     gw_dir: &Path,
     gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
-    name_or_handle: &str,
+    ref_id: &str,
+    filename: &str,
     session_id: &str,
 ) -> anyhow::Result<Vec<u8>> {
-    // Format: ar.<ref_id>:<filename>
-    if !name_or_handle.starts_with("ar.") {
-        return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!("not an artifact ref")).into());
-    }
-
-    let Some(colon_idx) = name_or_handle.find(':') else {
-        return Err(autonoetic_types::tool_error::tagged::Tagged::validation(anyhow::anyhow!(
-            "artifact ref must be in format `ar.<ref>:<filename>` (colon separator required)"
-        )).into());
-    };
-    let ref_id = &name_or_handle[..colon_idx];
-    let filename = &name_or_handle[colon_idx + 1..];
-
     let gs = gateway_store
         .ok_or_else(|| anyhow::anyhow!("GatewayStore required to resolve artifact refs"))?;
 

--- a/autonoetic-gateway/src/runtime/tools/resolve.rs
+++ b/autonoetic-gateway/src/runtime/tools/resolve.rs
@@ -1,13 +1,14 @@
 //! `resolve` — the single front door for any artifact/content handle (#312).
 //!
 //! Agents juggle several handle shapes — `art_<id>`, `ar.<ref>`, `cnt_<alias>`,
-//! a bare 8-char alias, a content `name`, `sha256:…`, and `ar.<ref>:<file>`.
+//! a bare 8-char alias, a content `name`, and `sha256:…`.
 //! Choosing *which tool* consumes *which shape* is exactly the decision that
 //! drives tool-thrashing. `resolve` takes **any** of them and answers "what is
 //! this / show me this" without that choice:
 //!
 //! - artifact-shaped refs (`art_` / `ar.`) → artifact resolution, with scope
-//!   inferred from the session (no explicit `scope_type`/`scope_id`);
+//!   inferred from the session (no explicit `scope_type`/`scope_id`); a single
+//!   file inside is selected with the `file` argument, not packed into the ref;
 //! - everything else → the content store.
 //!
 //! The agent's decision collapses to: **run it → `artifact_exec`; see it →
@@ -48,14 +49,14 @@ impl NativeTool for ResolveTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Resolve ANY artifact or content handle to what it points at — `art_`/`ar.` artifact refs, or `cnt_`/8-char alias/content name/`sha256:` content handles, or `ar.<ref>:<file>`. The one front door for \"what is this / show me this\": you do not pick a tool by handle type. `include` controls depth: 'metadata' (default — identity + existence), 'files' (an artifact's file list with read refs), or 'content' (inline the bytes; for an artifact pass `file` to choose which file). To RUN an artifact use artifact_exec; to SEE one use resolve."
+            description: "Resolve ANY artifact or content handle to what it points at — `art_`/`ar.` artifact refs, or `cnt_`/8-char alias/content name/`sha256:` content handles. The one front door for \"what is this / show me this\": you do not pick a tool by handle type. `include` controls depth: 'metadata' (default — identity + existence), 'files' (an artifact's file list), or 'content' (inline the bytes; for an artifact pass `file` to choose which file inside it). To RUN an artifact use artifact_exec; to SEE one use resolve."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "ref": { "type": "string", "description": "Any handle: art_<id>, ar.<ref>, cnt_<alias>, 8-char alias, content name, sha256:…, or ar.<ref>:<file>" },
+                    "ref": { "type": "string", "description": "Any handle: art_<id>, ar.<ref>, cnt_<alias>, 8-char alias, content name, or sha256:…" },
                     "include": { "type": "string", "enum": ["metadata", "files", "content"], "description": "Depth: metadata (default), files (artifact file list), content (inline bytes)" },
-                    "file": { "type": "string", "description": "For include=content on an artifact: which file inside it to read" }
+                    "file": { "type": "string", "description": "For include=content on an artifact: which file inside it to read (the file name from include=files)" }
                 },
                 "required": ["ref"],
                 "additionalProperties": false
@@ -103,20 +104,24 @@ impl NativeTool for ResolveTool {
         };
         let sid = session_id.unwrap_or(&manifest.agent.id);
 
-        // Artifact-shaped refs (`art_` / `ar.`) take the artifact path; an
-        // `ar.<ref>:<file>` carries an embedded file selector.
+        // Artifact-shaped refs (`art_` / `ar.`) take the artifact path. The
+        // file selector is the `file` parameter — it is NOT packed into the
+        // ref. Reject the legacy `ar.<ref>:<file>` packing with a nudge.
         if reference.starts_with("art_") || reference.starts_with("ar.") {
-            let (artifact_ref, embedded_file) = match reference.split_once(':') {
-                Some((r, f)) => (r, Some(f.to_string())),
-                None => (reference, None),
-            };
+            if reference.contains(':') {
+                return Ok(ToolError::validation(
+                    "the file is selected with the `file` parameter, not packed into the ref — e.g. resolve(ref=\"ar.xxxx\", include=\"content\", file=\"foo.txt\")",
+                    Some("Drop the ':<file>' suffix from ref and pass file=<name>."),
+                )
+                .to_error_response());
+            }
             return self.resolve_artifact(
                 gw_dir,
                 gateway_store,
                 sid,
-                artifact_ref,
+                reference,
                 include,
-                embedded_file.or(args.file),
+                args.file,
             );
         }
 
@@ -142,21 +147,20 @@ impl ResolveTool {
             .to_error_response());
         };
 
-        // `include=content` on an artifact reads a single file via the
-        // `ar.<ref>:<file>` content-store path.
+        // `include=content` on an artifact reads a single named file.
         if include == "content" {
             let Some(file) = file else {
                 return Ok(ToolError::validation(
-                    "resolve(include=content) on an artifact needs a `file` (or an ar.<ref>:<file> ref); use include=files to list them",
-                    Some("Pass file=<name> or include=files."),
+                    "resolve(include=content) on an artifact needs a `file` (the file name inside it); use include=files to list them",
+                    Some("Pass file=<name>, or call include=files first."),
                 )
                 .to_error_response());
             };
-            let ar_file = format!("{artifact_ref}:{file}");
-            return match crate::runtime::tools::content::try_read_artifact_ref_file(
+            return match crate::runtime::tools::content::read_artifact_file(
                 gw_dir,
                 Some(&gs),
-                &ar_file,
+                artifact_ref,
+                &file,
                 sid,
             ) {
                 Ok(bytes) => {
@@ -234,9 +238,15 @@ impl ResolveTool {
                         .map(|f| json!({
                             "name": f.name,
                             "alias": f.alias,
-                            "content_read_ref": format!("{}:{}", resolved.display_ref, f.name),
                         }))
                         .collect::<Vec<_>>()),
+                );
+                obj.insert(
+                    "read_file".to_string(),
+                    json!(format!(
+                        "resolve(ref=\"{}\", include=\"content\", file=<name>)",
+                        resolved.display_ref
+                    )),
                 );
             }
         }

--- a/autonoetic-gateway/tests/artifact_build_ref_integration.rs
+++ b/autonoetic-gateway/tests/artifact_build_ref_integration.rs
@@ -389,9 +389,84 @@ fn test_resolve_artifact_metadata_and_files() -> anyhow::Result<()> {
     assert!(v.get("artifact_id").is_none(), "raw art_* id must not be exposed");
     assert_eq!(v["file_count"].as_u64(), Some(1));
     assert_eq!(v["files"][0]["name"].as_str(), Some("data.py"));
+    // The file selector is the `file` param, not a packed `ar.<ref>:<file>`:
+    // no per-file packed ref, and a top-level read_file shows the param form.
+    assert!(
+        v["files"][0].get("content_read_ref").is_none(),
+        "packed ar.<ref>:<file> must not be surfaced"
+    );
     assert_eq!(
-        v["files"][0]["content_read_ref"].as_str(),
-        Some(format!("{artifact_ref}:data.py").as_str())
+        v["read_file"].as_str(),
+        Some(format!("resolve(ref=\"{artifact_ref}\", include=\"content\", file=<name>)").as_str())
+    );
+    Ok(())
+}
+
+/// Read one file out of an artifact: address the artifact by its ref and name
+/// the file with the separate `file` argument (no `ar.<ref>:<file>` packing).
+#[test]
+fn test_resolve_artifact_file_via_file_param() -> anyhow::Result<()> {
+    let temp = tempdir()?;
+    let agents_dir = temp.path().join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+    let config = GatewayConfig { agents_dir: agents_dir.clone(), ..GatewayConfig::default() };
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+    let writer = writer_manifest();
+    let writer_policy = PolicyEngine::new(writer.clone());
+    let reader = reader_manifest();
+    let reader_policy = PolicyEngine::new(reader.clone());
+    let registry = default_registry();
+    let agent_dir = agents_dir.join("coder.default");
+    std::fs::create_dir_all(&agent_dir)?;
+
+    let cs = ContentStore::new(&gateway_dir)?;
+    let h = cs.write(b"resolved content")?;
+    cs.register_name("sess-r", "data.py", &h)?;
+
+    let build_out = registry.execute(
+        "artifact_build", &writer, &writer_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "inputs": ["data.py"] }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let build_v: serde_json::Value = serde_json::from_str(&build_out)?;
+    let artifact_ref = build_v["artifact_ref"].as_str().expect("artifact_ref").to_string();
+
+    // Param form succeeds and returns the file bytes.
+    let out = registry.execute(
+        "resolve", &reader, &reader_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "ref": artifact_ref, "include": "content", "file": "data.py" }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v["ok"], serde_json::json!(true));
+    assert_eq!(v["kind"].as_str(), Some("artifact_file"));
+    assert_eq!(v["file"].as_str(), Some("data.py"));
+    assert_eq!(v["content"].as_str(), Some("resolved content"));
+
+    // include=content without a file is a validation error pointing at `file`.
+    let out = registry.execute(
+        "resolve", &reader, &reader_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "ref": artifact_ref, "include": "content" }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v["ok"], serde_json::json!(false));
+    assert_eq!(v["error_type"].as_str(), Some("validation"));
+
+    // The legacy packed `ar.<ref>:<file>` form is rejected with a nudge to `file`.
+    let packed = format!("{artifact_ref}:data.py");
+    let out = registry.execute(
+        "resolve", &reader, &reader_policy, &agent_dir, Some(&gateway_dir),
+        &serde_json::json!({ "ref": packed, "include": "content" }).to_string(),
+        Some("sess-r"), None, Some(&config), Some(store.clone()), None,
+    )?;
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v["ok"], serde_json::json!(false));
+    assert_eq!(v["error_type"].as_str(), Some("validation"));
+    assert!(
+        v["message"].as_str().unwrap_or_default().contains("file"),
+        "nudge must point at the `file` parameter, got: {}", v["message"]
     );
     Ok(())
 }

--- a/docs/content-store.md
+++ b/docs/content-store.md
@@ -99,12 +99,14 @@ Use `sandbox_path` when passing files to `sandbox_exec`.
 
 ### `resolve`
 
-Read by name, handle, or alias with root-based resolution.
+Read by name, handle, or alias with root-based resolution. `include="content"`
+returns the bytes; the default `include="metadata"` only checks existence.
 
 ```json
 // Request
 {
-  "name_or_handle": "main.py"
+  "ref": "main.py",
+  "include": "content"
 }
 
 // Response
@@ -114,19 +116,28 @@ Read by name, handle, or alias with root-based resolution.
 }
 ```
 
-Resolution order:
-1. If `ar.<ref>:<filename>` → read that file directly from the artifact bundle after scope resolution
-2. If `cnt_<8 hex>` (or `cnt:<8 hex>`) → alias lookup (session, then root, then global)
-3. If `sha256:...` → direct content lookup (with `sha256:<8 hex>` treated as alias fallback)
-4. If bare 8 hex chars → alias lookup (session, then root, then global)
-5. Otherwise → name lookup (session, then root, then global)
+To read one file out of an artifact, address the artifact by its ref and name
+the file with the `file` argument — there is no `ar.<ref>:<file>` packing:
+
+```json
+{ "ref": "ar.abcdef012345", "include": "content", "file": "requirements.txt" }
+```
+
+Resolution order for `ref` (content path):
+1. If `cnt_<8 hex>` (or `cnt:<8 hex>`) → alias lookup (session, then root, then global)
+2. If `sha256:...` → direct content lookup (with `sha256:<8 hex>` treated as alias fallback)
+3. If bare 8 hex chars → alias lookup (session, then root, then global)
+4. Otherwise → name lookup (session, then root, then global)
+
+An `ar.*` / `art_*` `ref` takes the artifact path instead; pass `file` to read a
+single file inside it.
 
 ### `resolve` vs `artifact_inspect`
 
 These tools intentionally overlap a bit, but they serve different jobs:
 
 - `artifact_inspect` is for **artifact structure and trust-boundary review**: file list, entrypoints, layers, digest, builder metadata.
-- `resolve` is for **retrieving bytes/text**: either session content (`name`, alias, handle) or a specific artifact file (`ar.<ref>:<filename>`).
+- `resolve` is for **retrieving bytes/text**: either session content (`name`, alias, handle) or a specific artifact file (`ref="ar.<ref>"` with `file="<filename>"`).
 
 Why this is usually not an issue:
 
@@ -155,16 +166,16 @@ Accepted `inputs` forms:
 
 | Tool field | Accepts | Does not accept |
 |---|---|---|
-| `artifact_build.inputs[]` | session content names, `cnt_...`, `sha256:...`, bare alias, existing artifact refs `ar.*`, canonical artifact IDs `art_*` | scoped artifact file refs like `ar.<ref>:requirements.txt` |
-| `artifact_inspect.artifact_ref` | `ar.*`, `art_*` | `ar.<ref>:<filename>`, content handles |
-| `artifact_prepare.artifact_ref` / `artifact_exec.artifact_ref` | `ar.*`, `art_*` | content handles, scoped artifact file refs |
-| `resolve.ref` | any artifact/content handle — `ar.*`, `art_*`, `cnt_*`, bare alias, content name, `sha256:...`, or `ar.<ref>:<filename>` (scope inferred from the session) | — |
+| `artifact_build.inputs[]` | session content names, `cnt_...`, `sha256:...`, bare alias, existing artifact refs `ar.*`, canonical artifact IDs `art_*` | single files (read one with `resolve(..., file=…)` and write it to content first) |
+| `artifact_inspect.artifact_ref` | `ar.*`, `art_*` | content handles, single-file selectors |
+| `artifact_prepare.artifact_ref` / `artifact_exec.artifact_ref` | `ar.*`, `art_*` | content handles, single-file selectors |
+| `resolve.ref` | any artifact/content handle — `ar.*`, `art_*`, `cnt_*`, bare alias, content name, `sha256:...` (scope inferred from the session); for one file inside an artifact, add `file="<name>"` | — |
 
 Homogeneity rule:
 
 - When a tool is artifact-oriented (`artifact_inspect`, `artifact_prepare`, `artifact_exec`, `artifact_build` artifact reuse), pass the artifact itself as `ar.*` or `art_*`.
-- When a tool is file-oriented (`resolve`), pass a session content identifier or a scoped artifact file ref `ar.<ref>:<filename>`.
-- Do not switch namespaces mid-flow: `ar.<ref>:<filename>` is for reading one file out of an artifact, while bare `ar.*` / `art_*` means the whole artifact.
+- When a tool is file-oriented (`resolve`), pass a session content identifier, or address an artifact file as `ref="ar.<ref>"` plus `file="<filename>"`.
+- Do not switch namespaces mid-flow: `ref="ar.*"` + `file=…` reads one file out of an artifact, while bare `ar.*` / `art_*` means the whole artifact.
 
 ```json
 // Response

--- a/docs/spec-artifact-content-identity-model.md
+++ b/docs/spec-artifact-content-identity-model.md
@@ -302,7 +302,7 @@ Single implementation pass. No phases, no compatibility shims.
 3. Replace `artifact_id` in tool inputs with `artifact_ref`.
 4. Return `artifact_ref` and `artifact_canonical_digest` from `artifact_build`, `artifact_inspect`, `resolve`.
 5. Update `artifact_exec` and `artifact_prepare` to accept `artifact_ref` and bind approval reuse identity to `artifact_canonical_digest`.
-6. `resolve` (the read door) reads `ar.<ref>:<filename>` addressing instead of `art_<id>:<filename>`.
+6. `resolve` (the read door) reads a single artifact file by `ref="ar.<ref>"` plus a separate `file="<filename>"` argument — not a packed `art_<id>:<filename>` / `ar.<ref>:<filename>` string.
 7. Update workflow implicit outputs to include `artifact_ref` instead of `artifact_id`.
 8. Update all foundation prompt layers and agent playbooks to use `artifact_ref` exclusively.
 9. Remove `artifact_id` from all agent-facing docs and tool descriptions.
@@ -338,7 +338,7 @@ Single implementation pass. No phases, no compatibility shims.
 ### Content tool integration
 
 - `autonoetic-gateway/src/runtime/tools/content.rs`
-  - change artifact file addressing from `art_<id>:<file>` to `ar.<ref>:<file>`
+  - artifact file addressing: `ref="ar.<ref>"` + separate `file="<name>"` (no packed `art_<id>:<file>` / `ar.<ref>:<file>`)
   - resolution path: resolve ref to `artifact_id`, then load file as before
 
 ### Workflow and handoff


### PR DESCRIPTION
**Stacked on #322** (base = `feat/fold-content-read-into-resolve`). Part of the #312 tool-surface reduction theme.

## Why

`resolve` accepted **two ways to read one file out of an artifact**:

```
resolve(ref="ar.xxxx:foo.txt", include="content")          # file packed into the ref
resolve(ref="ar.xxxx", include="content", file="foo.txt")  # file as a separate param
```

Two ways to express the same thing is exactly the "which form do I use?" thrash #312 targets — and the packed form overloads `:` (which `sha256:` already uses) and makes agents learn a string-packing convention. This collapses to the explicit `file=` parameter only.

## Changes

- `resolve` no longer splits `ref` on `:`. A `ref` that still packs a file (`ar.xxxx:foo.txt`) returns a **validation error nudging** toward `resolve(ref="ar.xxxx", include="content", file="foo.txt")`.
- Renamed `content::try_read_artifact_ref_file(name_or_handle)` → `read_artifact_file(ref_id, filename)` — no internal `:`-packing either; now also accepts canonical `art_` refs, not just `ar.`.
- The three outputs that handed agents the packed string (`include=files`, `artifact_build`, `artifact_inspect`) drop the stale per-file `content_read_ref` field and instead emit one top-level **`read_file`** hint showing the param-form call.
- `resolve` schema + description, `foundation_*` prompts, packager `SKILL.md`, `content-store.md`, and the identity-model spec all teach the `file=` form only. (Also fixed a `content-store.md` `resolve` example still showing the old `name_or_handle` arg.)

## Tests

`artifact_build_ref_integration` (8/8): the `include=files` test asserts there's **no** packed per-file ref and that `read_file` shows the param form; a new test covers reading a file via `file=`, the needs-a-file validation error, and the packed-form nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)