### PR TITLE
feat: PlanFrame MVP + collaborative planner

### DIFF
--- a/agents/lead/planner.collaborative/SKILL.md
+++ b/agents/lead/planner.collaborative/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: "planner.collaborative"
+description: "Collaborative lead agent that uses PlanFrames for human-agent co-construction."
+metadata:
+  autonoetic:
+    version: "1.0"
+    runtime:
+      engine: "autonoetic"
+      gateway_version: "0.1.0"
+      sdk_version: "0.1.0"
+      type: "stateful"
+      sandbox: "bubblewrap"
+      runtime_lock: "runtime.lock"
+    agent:
+      id: "planner.collaborative"
+      name: "Collaborative Planner"
+      description: "PlanFrame-aware lead agent. Proposes structured plans before building, offers workbench projection for human co-editing, and treats the operator as a co-builder."
+    llm_config:
+      provider: "openrouter"
+      model: "nvidia/nemotron-3-super-120b-a12b:free"
+      temperature: 0.2
+    capabilities:
+      - type: "SandboxFunctions"
+        allowed: ["knowledge.", "agent.", "credential."]
+      - type: "CredentialAccess"
+        services: ["*"]
+      - type: "AgentSpawn"
+        max_children: 10
+      - type: "SchedulerAccess"
+        patterns: ["*"]
+      - type: "WriteAccess"
+        scopes: ["self.*", "skills/*"]
+      - type: "ReadAccess"
+        scopes: ["self.*", "skills/*"]
+      - type: "AgentMessage"
+        patterns: ["*"]
+      - type: "PlanFrameAccess"
+        patterns: ["*"]
+    io:
+      returns_enforcement: advisory
+      returns:
+        type: object
+        required: ["status"]
+        properties:
+          status:
+            type: string
+            enum: ["ok", "partial", "clarification_needed", "delegated", "failed", "awaiting_approval"]
+            description: "Final outcome of the planning turn."
+          summary:
+            type: string
+            description: "Compact synthesis of what was decided or produced."
+          result:
+            type: object
+            description: "Structured result payload when the planner answers directly."
+          plan_id:
+            type: string
+            description: "The plan_id if a plan was proposed."
+          error:
+            type: string
+            description: "Error detail when status is failed."
+    output_policy:
+      validation_max_loops: 2
+      repair:
+        auto: true
+        max_attempts: 2
+---
+
+# Collaborative Planner
+
+You are the collaborative lead agent. You coordinate specialists to achieve the
+operator's goal, but unlike the default planner, you treat the operator as a
+**co-builder** rather than just an approver.
+
+## Core Principles
+
+1. **Propose before building.** When work is multi-step, expensive, or
+   installable, use `planframe_propose` to create a structured plan first.
+   Include objective, steps, expected artifacts, and validation policy.
+2. **Treat the PlanFrame as the shared contract.** The plan is not disposable
+   chat text — it is the enduring frame of reference for the entire workflow.
+   Use `planframe_get` to reload context on resume.
+3. **Ask before waiving validation.** Never silently skip checks. Recommend
+   waivers with reasoning, but let the operator decide.
+4. **Prefer small reconciliations.** After human edits, keep diffs reviewable.
+5. **Amend when scope changes.** Use `planframe_amend` when reality diverges
+   from the plan. Do not drift silently.
+
+## Workflow
+
+### When to propose a plan
+
+Always propose a PlanFrame when:
+- The task involves building or modifying an agent, artifact, or capsule.
+- The task has 3+ steps or multiple specialists.
+- The operator might want to inspect or edit intermediate results.
+- The task involves installable or promoted artifacts.
+
+You may skip a formal plan for:
+- Simple questions or lookups.
+- Single-step tasks with no risk.
+- Quick retries or minor adjustments.
+
+### Proposing a plan
+
+1. Decompose the goal into concrete steps.
+2. Assign each step an owner: `planner`, `agent`, `operator`, or `shared`.
+3. Define the validation policy: which checks are required vs advisory.
+4. Call `planframe_propose` with the full structure.
+5. Inform the operator that the plan awaits approval.
+
+### After approval
+
+1. Execute steps by delegating to specialists via `agent_spawn`.
+2. Use `planframe_amend` with `step_updates` to track progress.
+3. If scope changes, amend the plan and note that re-approval is needed.
+4. On completion, amend the final step to `completed`.
+
+### Reporting
+
+Use `planframe_get` with `compact: true` to get a summary for turn-start
+context. Inject the plan state into your reasoning to avoid rediscovering
+project state from chat history.
+
+## Delegation
+
+Follow the same delegation ladder as planner.default:
+1. Foundational match → route directly
+2. Unknown intent → discovery → best candidate
+3. No candidate → agent-factory → build new
+
+When delegating, include PlanFrame context in the message metadata so child
+agents can align with the approved plan.
+
+## Validation Policy
+
+When proposing a plan, include validation entries:
+- `static_security_review`: class `security_review`, requirement `required`
+- `unit_tests`: class `correctness_check`, requirement `advisory` (unless the
+  change is to executable code)
+- `style_review`: class `quality_check`, requirement `advisory`
+- `capability_check`: class `mechanical_safety`, requirement `required`
+
+Adapt based on the specific task.
+
+## Resumption
+
+On resume (after `workflow_wait` returns or child state notification arrives):
+1. Call `planframe_get` to reload the active plan.
+2. Check which steps are complete and which need attention.
+3. Continue from the current step — do not restart.
+
+## Tools
+
+- `planframe_propose` — create a new plan (requires operator approval)
+- `planframe_get` — read the active or specific plan
+- `planframe_list` — list all plans for the current workflow
+- `planframe_approve` — approve a plan (typically operator action)
+- `planframe_amend` — update steps, mark progress, or modify the plan
+
+Use these tools alongside the standard planner tools (`agent_spawn`,
+`workflow_wait`, `workflow_state`, `resolve`, `knowledge_store`, etc.).

--- a/agents/lead/planner.collaborative/runtime.lock
+++ b/agents/lead/planner.collaborative/runtime.lock
@@ -1,0 +1,11 @@
+gateway:
+  artifact: "marketplace://gateway/autonoetic-gateway"
+  version: "0.1.0"
+  sha256: "replace-me"
+sdk:
+  version: "0.1.0"
+sandbox:
+  backend: "bubblewrap"
+dependencies: []
+artifacts: []
+layers: []

--- a/autonoetic-gateway/src/runtime/analysis/mod.rs
+++ b/autonoetic-gateway/src/runtime/analysis/mod.rs
@@ -144,6 +144,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow",
         Capability::SecurityRedTeam => "SecurityRedTeam",
         Capability::CapsuleExport => "CapsuleExport",
+        Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/capability_inference.rs
+++ b/autonoetic-gateway/src/runtime/capability_inference.rs
@@ -271,6 +271,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow",
         Capability::SecurityRedTeam => "SecurityRedTeam",
         Capability::CapsuleExport => "CapsuleExport",
+        Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/state_attestation.rs
+++ b/autonoetic-gateway/src/runtime/state_attestation.rs
@@ -248,6 +248,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow",
         Capability::SecurityRedTeam => "SecurityRedTeam",
         Capability::CapsuleExport => "CapsuleExport",
+        Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
     }
     .to_string()
 }

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -612,6 +612,7 @@ pub(crate) fn capability_type_name(cap: &Capability) -> String {
         Capability::GithubIssueCreate { .. } => "GithubIssueCreate".to_string(),
         Capability::SecurityRedTeam => "SecurityRedTeam".to_string(),
         Capability::CapsuleExport => "CapsuleExport".to_string(),
+        Capability::PlanFrameAccess { .. } => "PlanFrameAccess".to_string(),
     }
 }
 
@@ -972,6 +973,7 @@ pub mod github_issue;
 pub mod improvement;
 pub mod knowledge;
 pub mod observability;
+pub mod plan_frame;
 pub mod promotion;
 pub mod quality_trend;
 pub mod sandbox;
@@ -1025,6 +1027,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::user_interaction::register_tools(&mut registry);
     crate::runtime::tools::user_profile::register_tools(&mut registry);
     crate::runtime::tools::observability::register_tools(&mut registry);
+    crate::runtime::tools::plan_frame::register_tools(&mut registry);
     crate::runtime::tools::federation::register_tools(&mut registry);
     crate::runtime::tools::improvement::register_tools(&mut registry);
     crate::runtime::tools::github_issue::register_tools(&mut registry);

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -1,0 +1,841 @@
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
+use autonoetic_types::agent::{AgentManifest, ToolTier};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::plan_frame::{
+    PlanFrame, PlanFrameSummary, PlanRef, PlanStatus, PlanStep, StepOwner, StepStatus,
+    ValidationEntry, ValidationPolicy,
+};
+use serde::Deserialize;
+use std::path::Path;
+
+pub fn register_tools(registry: &mut NativeToolRegistry) {
+    registry.register(Box::new(PlanFrameProposeTool));
+    registry.register(Box::new(PlanFrameGetTool));
+    registry.register(Box::new(PlanFrameListTool));
+    registry.register(Box::new(PlanFrameApproveTool));
+    registry.register(Box::new(PlanFrameAmendTool));
+}
+
+fn has_plan_frame_access(manifest: &AgentManifest) -> bool {
+    manifest.capabilities.iter().any(|c| {
+        matches!(c, Capability::PlanFrameAccess { .. })
+    })
+}
+
+fn can_perform(manifest: &AgentManifest, operation: &str) -> bool {
+    manifest.capabilities.iter().any(|c| {
+        match c {
+            Capability::PlanFrameAccess { patterns } => patterns
+                .iter()
+                .any(|p| p == "*" || p == operation || operation.starts_with(p.trim_end_matches('.'))),
+            _ => false,
+        }
+    })
+}
+
+fn new_plan_id() -> String {
+    let bytes = uuid::Uuid::new_v4();
+    format!("plan-{}", hex::encode(&bytes.as_bytes()[..6]))
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+pub struct PlanFrameProposeTool;
+
+impl NativeTool for PlanFrameProposeTool {
+    fn name(&self) -> &'static str {
+        "planframe_propose"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Propose a new PlanFrame for collaborative work. Creates a workflow if one does not exist yet. The plan starts in 'draft' status and must be approved before agents act on it.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "Short title for the plan"
+                    },
+                    "objective": {
+                        "type": "string",
+                        "description": "Detailed objective and acceptance criteria"
+                    },
+                    "steps": {
+                        "type": "array",
+                        "description": "Ordered list of plan steps",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "step_id": { "type": "string" },
+                                "title": { "type": "string" },
+                                "owner": { "type": "string", "enum": ["planner", "agent", "operator", "shared"] },
+                                "agent_id": { "type": "string" },
+                                "depends_on": { "type": "array", "items": { "type": "string" } },
+                                "notes": { "type": "string" }
+                            },
+                            "required": ["step_id", "title"]
+                        }
+                    },
+                    "validation_policy": {
+                        "type": "object",
+                        "description": "Validation checks required/advisory for this plan",
+                        "properties": {
+                            "entries": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "validation_id": { "type": "string" },
+                                        "title": { "type": "string" },
+                                        "class": { "type": "string", "enum": ["mechanical_safety", "security_review", "correctness_check", "quality_check", "packaging_check"] },
+                                        "requirement": { "type": "string", "enum": ["required", "advisory"] }
+                                    },
+                                    "required": ["validation_id", "title"]
+                                }
+                            }
+                        }
+                    }
+                },
+                "required": ["title", "objective"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_plan_frame_access(manifest) && can_perform(manifest, "planframe.propose")
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct StepInput {
+            step_id: String,
+            title: String,
+            owner: Option<String>,
+            agent_id: Option<String>,
+            depends_on: Option<Vec<String>>,
+            notes: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct ValidationInput {
+            validation_id: String,
+            title: String,
+            class: Option<String>,
+            requirement: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct ValidationPolicyInput {
+            entries: Option<Vec<ValidationInput>>,
+        }
+
+        #[derive(Deserialize)]
+        struct Args {
+            title: String,
+            objective: String,
+            steps: Option<Vec<StepInput>>,
+            validation_policy: Option<ValidationPolicyInput>,
+        }
+
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(config) = config else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway config not available"
+            }))?);
+        };
+
+        let session_id = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
+        let root_session_id = session_id.split('/').next().unwrap_or(session_id);
+
+        let workflow = crate::scheduler::workflow_store::ensure_workflow_for_root_session(
+            config,
+            Some(&store),
+            root_session_id,
+            Some(&manifest.agent.id),
+        )?;
+
+        let plan_id = new_plan_id();
+        let now = now_rfc3339();
+
+        let steps: Vec<PlanStep> = args
+            .steps
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| PlanStep {
+                step_id: s.step_id,
+                title: s.title,
+                owner: match s.owner.as_deref() {
+                    Some("agent") => StepOwner::Agent,
+                    Some("operator") => StepOwner::Operator,
+                    Some("shared") => StepOwner::Shared,
+                    _ => StepOwner::Planner,
+                },
+                status: StepStatus::Pending,
+                depends_on: s.depends_on.unwrap_or_default(),
+                task_ids: vec![],
+                artifact_refs: vec![],
+                agent_id: s.agent_id,
+                notes: s.notes,
+            })
+            .collect();
+
+        let validation_policy = match args.validation_policy {
+            Some(vp) => ValidationPolicy {
+                entries: vp
+                    .entries
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|v| ValidationEntry {
+                        validation_id: v.validation_id,
+                        title: v.title,
+                        class: match v.class.as_deref() {
+                            Some("security_review") => autonoetic_types::plan_frame::ValidationClass::SecurityReview,
+                            Some("correctness_check") => autonoetic_types::plan_frame::ValidationClass::CorrectnessCheck,
+                            Some("quality_check") => autonoetic_types::plan_frame::ValidationClass::QualityCheck,
+                            Some("packaging_check") => autonoetic_types::plan_frame::ValidationClass::PackagingCheck,
+                            _ => autonoetic_types::plan_frame::ValidationClass::MechanicalSafety,
+                        },
+                        requirement: match v.requirement.as_deref() {
+                            Some("advisory") => autonoetic_types::plan_frame::ValidationRequirement::Advisory,
+                            Some("waived") => autonoetic_types::plan_frame::ValidationRequirement::Waived,
+                            _ => autonoetic_types::plan_frame::ValidationRequirement::Required,
+                        },
+                    })
+                    .collect(),
+            },
+            None => ValidationPolicy::default(),
+        };
+
+        let plan = PlanFrame {
+            plan_id: plan_id.clone(),
+            workflow_id: workflow.workflow_id.clone(),
+            root_session_id: root_session_id.to_string(),
+            title: args.title,
+            objective: args.objective,
+            status: PlanStatus::AwaitingApproval,
+            version: 1,
+            steps,
+            validation_policy,
+            approved_by: None,
+            approved_at: None,
+            created_by_agent_id: manifest.agent.id.clone(),
+            updated_at: now.clone(),
+            created_at: now,
+        };
+
+        store.save_plan_frame(&plan)?;
+
+        let mut updated_workflow = workflow;
+        updated_workflow.active_plan_ref = Some(PlanRef {
+            plan_id: plan_id.clone(),
+            version: 1,
+        });
+        updated_workflow.updated_at = now_rfc3339();
+            crate::scheduler::workflow_store::save_workflow_run(config, Some(&store), &updated_workflow)?;
+
+        let event_id = {
+            let bytes = uuid::Uuid::new_v4();
+            format!("evt-{}", hex::encode(&bytes.as_bytes()[..8]))
+        };
+        crate::scheduler::workflow_store::append_workflow_event(
+            config,
+            Some(&store),
+            &autonoetic_types::workflow::WorkflowEventRecord {
+                event_id,
+                workflow_id: updated_workflow.workflow_id.clone(),
+                task_id: None,
+                event_type: "planframe.proposed".to_string(),
+                agent_id: Some(manifest.agent.id.clone()),
+                payload: serde_json::json!({
+                    "plan_id": plan_id,
+                    "title": plan.title,
+                    "step_count": plan.steps.len(),
+                }),
+                occurred_at: now_rfc3339(),
+            },
+        )?;
+
+        let summary = plan.compact_summary();
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "plan_id": plan_id,
+            "workflow_id": updated_workflow.workflow_id,
+            "status": "awaiting_approval",
+            "version": 1,
+            "message": "Plan proposed. Operator approval is required before agents can act on it.",
+            "summary": summary,
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct PlanFrameGetTool;
+
+impl NativeTool for PlanFrameGetTool {
+    fn name(&self) -> &'static str {
+        "planframe_get"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Get a PlanFrame by plan_id, or get the active plan for the current session. Returns the full plan including steps and validation policy.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "plan_id": {
+                        "type": "string",
+                        "description": "The plan ID to retrieve. Omit to get the active plan for the current workflow."
+                    },
+                    "compact": {
+                        "type": "boolean",
+                        "description": "If true, return a compact summary instead of the full plan."
+                    }
+                },
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_plan_frame_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            plan_id: Option<String>,
+            compact: Option<bool>,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway store not available"
+            }))?);
+        };
+
+        let plan = if let Some(pid) = &args.plan_id {
+            store.load_plan_frame(pid)?
+        } else {
+            let sid = session_id.ok_or_else(|| anyhow::anyhow!("session_id required when plan_id not specified"))?;
+            let root = sid.split('/').next().unwrap_or(sid);
+            let wf_id = store.resolve_workflow_id(root)?;
+            match wf_id {
+                Some(wid) => store.load_active_plan_for_workflow(&wid)?,
+                None => None,
+            }
+        };
+
+        match plan {
+            Some(p) => {
+                if args.compact.unwrap_or(false) {
+                    Ok(serde_json::to_string(&serde_json::json!({
+                        "ok": true,
+                        "summary": p.compact_summary(),
+                    }))?)
+                } else {
+                    Ok(serde_json::to_string(&serde_json::json!({
+                        "ok": true,
+                        "plan": p,
+                    }))?)
+                }
+            }
+            None => Ok(serde_json::to_string(&serde_json::json!({
+                "ok": true,
+                "plan": null,
+                "message": "No plan found"
+            }))?),
+        }
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct PlanFrameListTool;
+
+impl NativeTool for PlanFrameListTool {
+    fn name(&self) -> &'static str {
+        "planframe_list"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "List all PlanFrames for the current workflow. Returns compact summaries.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_plan_frame_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway store not available"
+            }))?);
+        };
+
+        let sid = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
+        let root = sid.split('/').next().unwrap_or(sid);
+        let wf_id = store.resolve_workflow_id(root)?;
+
+        let plans = match wf_id {
+            Some(wid) => store.list_plan_frames_for_workflow(&wid)?,
+            None => vec![],
+        };
+
+        let summaries: Vec<PlanFrameSummary> = plans.iter().map(|p| p.compact_summary()).collect();
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "plans": summaries,
+            "count": summaries.len(),
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct PlanFrameApproveTool;
+
+impl NativeTool for PlanFrameApproveTool {
+    fn name(&self) -> &'static str {
+        "planframe_approve"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Approve a PlanFrame. Moves status from 'awaiting_approval' to 'approved'. Typically invoked by the operator through the gateway, not directly by agents.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "plan_id": {
+                        "type": "string",
+                        "description": "The plan ID to approve"
+                    },
+                    "approved_by": {
+                        "type": "string",
+                        "description": "Identity of the approver (e.g., 'operator', user ID)"
+                    }
+                },
+                "required": ["plan_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_plan_frame_access(manifest) && can_perform(manifest, "planframe.approve")
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            plan_id: String,
+            approved_by: Option<String>,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(mut plan) = store.load_plan_frame(&args.plan_id)? else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Plan not found"
+            }))?);
+        };
+
+        if plan.status != PlanStatus::AwaitingApproval && plan.status != PlanStatus::Draft {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": format!("Plan is in '{}' status; only draft or awaiting_approval plans can be approved", plan.status.as_str())
+            }))?);
+        }
+
+        let now = now_rfc3339();
+        plan.status = PlanStatus::Approved;
+        plan.approved_by = Some(args.approved_by.unwrap_or_else(|| manifest.agent.id.clone()));
+        plan.approved_at = Some(now.clone());
+        plan.updated_at = now.clone();
+
+        store.save_plan_frame(&plan)?;
+
+        if let Some(config) = config {
+            crate::scheduler::workflow_store::append_workflow_event(
+                config,
+                Some(&store),
+                &autonoetic_types::workflow::WorkflowEventRecord {
+                    event_id: {
+                        let bytes = uuid::Uuid::new_v4();
+                        format!("evt-{}", hex::encode(&bytes.as_bytes()[..8]))
+                    },
+                    workflow_id: plan.workflow_id.clone(),
+                    task_id: None,
+                    event_type: "planframe.approved".to_string(),
+                    agent_id: Some(manifest.agent.id.clone()),
+                    payload: serde_json::json!({
+                        "plan_id": plan.plan_id,
+                        "version": plan.version,
+                    }),
+                    occurred_at: now,
+                },
+            )?;
+        }
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "plan_id": plan.plan_id,
+            "status": "approved",
+            "version": plan.version,
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct PlanFrameAmendTool;
+
+impl NativeTool for PlanFrameAmendTool {
+    fn name(&self) -> &'static str {
+        "planframe_amend"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Amend an existing PlanFrame. Increments the version. Substantive changes (scope, validation, risk) should require operator re-approval.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "plan_id": {
+                        "type": "string",
+                        "description": "The plan ID to amend"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Updated title (optional)"
+                    },
+                    "objective": {
+                        "type": "string",
+                        "description": "Updated objective (optional)"
+                    },
+                    "steps": {
+                        "type": "array",
+                        "description": "Complete replacement step list (optional)",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "step_id": { "type": "string" },
+                                "title": { "type": "string" },
+                                "owner": { "type": "string", "enum": ["planner", "agent", "operator", "shared"] },
+                                "status": { "type": "string", "enum": ["pending", "in_progress", "completed", "skipped", "blocked"] },
+                                "agent_id": { "type": "string" },
+                                "depends_on": { "type": "array", "items": { "type": "string" } },
+                                "notes": { "type": "string" }
+                            },
+                            "required": ["step_id", "title"]
+                        }
+                    },
+                    "step_updates": {
+                        "type": "array",
+                        "description": "Partial updates to specific steps (optional)",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "step_id": { "type": "string" },
+                                "status": { "type": "string", "enum": ["pending", "in_progress", "completed", "skipped", "blocked"] },
+                                "task_ids": { "type": "array", "items": { "type": "string" } },
+                                "artifact_refs": { "type": "array", "items": { "type": "string" } },
+                                "notes": { "type": "string" }
+                            },
+                            "required": ["step_id"]
+                        }
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Reason for the amendment"
+                    }
+                },
+                "required": ["plan_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_plan_frame_access(manifest) && can_perform(manifest, "planframe.amend")
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct StepInput {
+            step_id: String,
+            title: String,
+            owner: Option<String>,
+            status: Option<String>,
+            agent_id: Option<String>,
+            depends_on: Option<Vec<String>>,
+            notes: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct StepUpdate {
+            step_id: String,
+            status: Option<String>,
+            task_ids: Option<Vec<String>>,
+            artifact_refs: Option<Vec<String>>,
+            notes: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct Args {
+            plan_id: String,
+            title: Option<String>,
+            objective: Option<String>,
+            steps: Option<Vec<StepInput>>,
+            step_updates: Option<Vec<StepUpdate>>,
+            reason: Option<String>,
+        }
+
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(mut plan) = store.load_plan_frame(&args.plan_id)? else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Plan not found"
+            }))?);
+        };
+
+        if plan.status == PlanStatus::Completed || plan.status == PlanStatus::Cancelled {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": format!("Cannot amend a {} plan", plan.status.as_str())
+            }))?);
+        }
+
+        let old_version = plan.version;
+        plan.version += 1;
+
+        if let Some(title) = args.title {
+            plan.title = title;
+        }
+        if let Some(objective) = args.objective {
+            plan.objective = objective;
+        }
+
+        if let Some(steps) = args.steps {
+            plan.steps = steps
+                .into_iter()
+                .map(|s| PlanStep {
+                    step_id: s.step_id,
+                    title: s.title,
+                    owner: match s.owner.as_deref() {
+                        Some("agent") => StepOwner::Agent,
+                        Some("operator") => StepOwner::Operator,
+                        Some("shared") => StepOwner::Shared,
+                        _ => StepOwner::Planner,
+                    },
+                    status: match s.status.as_deref() {
+                        Some("in_progress") => StepStatus::InProgress,
+                        Some("completed") => StepStatus::Completed,
+                        Some("skipped") => StepStatus::Skipped,
+                        Some("blocked") => StepStatus::Blocked,
+                        _ => StepStatus::Pending,
+                    },
+                    depends_on: s.depends_on.unwrap_or_default(),
+                    task_ids: vec![],
+                    artifact_refs: vec![],
+                    agent_id: s.agent_id,
+                    notes: s.notes,
+                })
+                .collect();
+        }
+
+        if let Some(updates) = args.step_updates {
+            for upd in updates {
+                if let Some(step) = plan.steps.iter_mut().find(|s| s.step_id == upd.step_id) {
+                    if let Some(status) = upd.status {
+                        step.status = match status.as_str() {
+                            "in_progress" => StepStatus::InProgress,
+                            "completed" => StepStatus::Completed,
+                            "skipped" => StepStatus::Skipped,
+                            "blocked" => StepStatus::Blocked,
+                            _ => StepStatus::Pending,
+                        };
+                    }
+                    if let Some(task_ids) = upd.task_ids {
+                        step.task_ids = task_ids;
+                    }
+                    if let Some(artifact_refs) = upd.artifact_refs {
+                        step.artifact_refs = artifact_refs;
+                    }
+                    if let Some(notes) = upd.notes {
+                        step.notes = Some(notes);
+                    }
+                }
+            }
+        }
+
+        let now = now_rfc3339();
+        plan.updated_at = now.clone();
+
+        if plan.status == PlanStatus::Approved {
+            plan.status = PlanStatus::AwaitingApproval;
+        }
+
+        store.save_plan_frame(&plan)?;
+
+        if let Some(config) = config {
+            crate::scheduler::workflow_store::append_workflow_event(
+                config,
+                Some(&store),
+                &autonoetic_types::workflow::WorkflowEventRecord {
+                    event_id: {
+                        let bytes = uuid::Uuid::new_v4();
+                        format!("evt-{}", hex::encode(&bytes.as_bytes()[..8]))
+                    },
+                    workflow_id: plan.workflow_id.clone(),
+                    task_id: None,
+                    event_type: "planframe.amended".to_string(),
+                    agent_id: Some(manifest.agent.id.clone()),
+                    payload: serde_json::json!({
+                        "plan_id": plan.plan_id,
+                        "old_version": old_version,
+                        "new_version": plan.version,
+                        "reason": args.reason,
+                    }),
+                    occurred_at: now,
+                },
+            )?;
+        }
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "plan_id": plan.plan_id,
+            "version": plan.version,
+            "status": plan.status.as_str(),
+            "message": if plan.status == PlanStatus::AwaitingApproval {
+                "Plan amended. Operator re-approval is required."
+            } else {
+                "Plan amended."
+            },
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -2,11 +2,11 @@ use crate::llm::ToolDefinition;
 use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
-use autonoetic_types::agent::{AgentManifest, ToolTier};
+use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
 use autonoetic_types::plan_frame::{
-    PlanFrame, PlanFrameSummary, PlanRef, PlanStatus, PlanStep, StepOwner, StepStatus,
+    PlanFrame, PlanFrameSummary, PlanRef, PlanStatus, PlanStep, StepOwner,
     ValidationEntry, ValidationPolicy,
 };
 use serde::Deserialize;
@@ -18,6 +18,7 @@ pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(PlanFrameListTool));
     registry.register(Box::new(PlanFrameApproveTool));
     registry.register(Box::new(PlanFrameAmendTool));
+    registry.register(Box::new(PlanFrameHistoryTool));
 }
 
 fn has_plan_frame_access(manifest: &AgentManifest) -> bool {
@@ -56,7 +57,7 @@ impl NativeTool for PlanFrameProposeTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Propose a new PlanFrame for collaborative work. Creates a workflow if one does not exist yet. The plan starts in 'draft' status and must be approved before agents act on it.".to_string(),
+            description: "Propose a new PlanFrame for collaborative work. Creates a workflow if one does not exist yet. The plan starts in 'awaiting_approval' status and must be approved before agents act on it.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -201,10 +202,7 @@ impl NativeTool for PlanFrameProposeTool {
                     Some("shared") => StepOwner::Shared,
                     _ => StepOwner::Planner,
                 },
-                status: StepStatus::Pending,
                 depends_on: s.depends_on.unwrap_or_default(),
-                task_ids: vec![],
-                artifact_refs: vec![],
                 agent_id: s.agent_id,
                 notes: s.notes,
             })
@@ -239,18 +237,19 @@ impl NativeTool for PlanFrameProposeTool {
 
         let plan = PlanFrame {
             plan_id: plan_id.clone(),
+            version: 1,
+            parent_version: None,
             workflow_id: workflow.workflow_id.clone(),
             root_session_id: root_session_id.to_string(),
             title: args.title,
             objective: args.objective,
             status: PlanStatus::AwaitingApproval,
-            version: 1,
             steps,
             validation_policy,
             approved_by: None,
             approved_at: None,
             created_by_agent_id: manifest.agent.id.clone(),
-            updated_at: now.clone(),
+            reason: None,
             created_at: now,
         };
 
@@ -262,7 +261,7 @@ impl NativeTool for PlanFrameProposeTool {
             version: 1,
         });
         updated_workflow.updated_at = now_rfc3339();
-            crate::scheduler::workflow_store::save_workflow_run(config, Some(&store), &updated_workflow)?;
+        crate::scheduler::workflow_store::save_workflow_run(config, Some(&store), &updated_workflow)?;
 
         let event_id = {
             let bytes = uuid::Uuid::new_v4();
@@ -313,13 +312,17 @@ impl NativeTool for PlanFrameGetTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Get a PlanFrame by plan_id, or get the active plan for the current session. Returns the full plan including steps and validation policy.".to_string(),
+            description: "Get a PlanFrame by plan_id (latest version), or a specific revision by version. Omit plan_id to get the active plan for the current workflow.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "plan_id": {
                         "type": "string",
                         "description": "The plan ID to retrieve. Omit to get the active plan for the current workflow."
+                    },
+                    "version": {
+                        "type": "integer",
+                        "description": "Specific revision version to retrieve. Omit for latest."
                     },
                     "compact": {
                         "type": "boolean",
@@ -344,13 +347,14 @@ impl NativeTool for PlanFrameGetTool {
         arguments_json: &str,
         session_id: Option<&str>,
         _turn_id: Option<&str>,
-        config: Option<&GatewayConfig>,
+        _config: Option<&GatewayConfig>,
         gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
         #[derive(Deserialize)]
         struct Args {
             plan_id: Option<String>,
+            version: Option<u32>,
             compact: Option<bool>,
         }
         let args: Args = serde_json::from_str(arguments_json)
@@ -364,7 +368,11 @@ impl NativeTool for PlanFrameGetTool {
         };
 
         let plan = if let Some(pid) = &args.plan_id {
-            store.load_plan_frame(pid)?
+            if let Some(ver) = args.version {
+                store.load_plan_frame_revision(pid, ver)?
+            } else {
+                store.load_plan_frame(pid)?
+            }
         } else {
             let sid = session_id.ok_or_else(|| anyhow::anyhow!("session_id required when plan_id not specified"))?;
             let root = sid.split('/').next().unwrap_or(sid);
@@ -412,7 +420,7 @@ impl NativeTool for PlanFrameListTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "List all PlanFrames for the current workflow. Returns compact summaries.".to_string(),
+            description: "List all PlanFrames for the current workflow (latest revision of each). Returns compact summaries.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {},
@@ -431,7 +439,7 @@ impl NativeTool for PlanFrameListTool {
         _policy: &PolicyEngine,
         _agent_dir: &Path,
         _gateway_dir: Option<&Path>,
-        arguments_json: &str,
+        _arguments_json: &str,
         session_id: Option<&str>,
         _turn_id: Option<&str>,
         _config: Option<&GatewayConfig>,
@@ -484,7 +492,7 @@ impl NativeTool for PlanFrameApproveTool {
                 "properties": {
                     "plan_id": {
                         "type": "string",
-                        "description": "The plan ID to approve"
+                        "description": "The plan ID to approve (approves the latest revision)"
                     },
                     "approved_by": {
                         "type": "string",
@@ -529,27 +537,30 @@ impl NativeTool for PlanFrameApproveTool {
             }))?);
         };
 
-        let Some(mut plan) = store.load_plan_frame(&args.plan_id)? else {
+        let Some(plan) = store.load_plan_frame(&args.plan_id)? else {
             return Ok(serde_json::to_string(&serde_json::json!({
                 "ok": false,
                 "error": "Plan not found"
             }))?);
         };
 
-        if plan.status != PlanStatus::AwaitingApproval && plan.status != PlanStatus::Draft {
+        if plan.status != PlanStatus::AwaitingApproval {
             return Ok(serde_json::to_string(&serde_json::json!({
                 "ok": false,
-                "error": format!("Plan is in '{}' status; only draft or awaiting_approval plans can be approved", plan.status.as_str())
+                "error": format!("Plan is in '{}' status; only awaiting_approval plans can be approved", plan.status.as_str())
             }))?);
         }
 
         let now = now_rfc3339();
-        plan.status = PlanStatus::Approved;
-        plan.approved_by = Some(args.approved_by.unwrap_or_else(|| manifest.agent.id.clone()));
-        plan.approved_at = Some(now.clone());
-        plan.updated_at = now.clone();
+        let approver = args.approved_by.unwrap_or_else(|| manifest.agent.id.clone());
 
-        store.save_plan_frame(&plan)?;
+        store.update_plan_frame_status(
+            &plan.plan_id,
+            plan.version,
+            PlanStatus::Approved,
+            Some(&approver),
+            Some(&now),
+        )?;
 
         if let Some(config) = config {
             crate::scheduler::workflow_store::append_workflow_event(
@@ -596,7 +607,7 @@ impl NativeTool for PlanFrameAmendTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Amend an existing PlanFrame. Increments the version. Substantive changes (scope, validation, risk) should require operator re-approval.".to_string(),
+            description: "Amend an existing PlanFrame by creating a new immutable revision. The previous revision is preserved unchanged. If the plan was approved, the new revision requires re-approval.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -606,22 +617,21 @@ impl NativeTool for PlanFrameAmendTool {
                     },
                     "title": {
                         "type": "string",
-                        "description": "Updated title (optional)"
+                        "description": "Updated title (optional, defaults to current)"
                     },
                     "objective": {
                         "type": "string",
-                        "description": "Updated objective (optional)"
+                        "description": "Updated objective (optional, defaults to current)"
                     },
                     "steps": {
                         "type": "array",
-                        "description": "Complete replacement step list (optional)",
+                        "description": "Complete replacement step list (optional, defaults to current)",
                         "items": {
                             "type": "object",
                             "properties": {
                                 "step_id": { "type": "string" },
                                 "title": { "type": "string" },
                                 "owner": { "type": "string", "enum": ["planner", "agent", "operator", "shared"] },
-                                "status": { "type": "string", "enum": ["pending", "in_progress", "completed", "skipped", "blocked"] },
                                 "agent_id": { "type": "string" },
                                 "depends_on": { "type": "array", "items": { "type": "string" } },
                                 "notes": { "type": "string" }
@@ -629,19 +639,23 @@ impl NativeTool for PlanFrameAmendTool {
                             "required": ["step_id", "title"]
                         }
                     },
-                    "step_updates": {
-                        "type": "array",
-                        "description": "Partial updates to specific steps (optional)",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "step_id": { "type": "string" },
-                                "status": { "type": "string", "enum": ["pending", "in_progress", "completed", "skipped", "blocked"] },
-                                "task_ids": { "type": "array", "items": { "type": "string" } },
-                                "artifact_refs": { "type": "array", "items": { "type": "string" } },
-                                "notes": { "type": "string" }
-                            },
-                            "required": ["step_id"]
+                    "validation_policy": {
+                        "type": "object",
+                        "description": "Updated validation policy (optional, defaults to current)",
+                        "properties": {
+                            "entries": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "validation_id": { "type": "string" },
+                                        "title": { "type": "string" },
+                                        "class": { "type": "string", "enum": ["mechanical_safety", "security_review", "correctness_check", "quality_check", "packaging_check"] },
+                                        "requirement": { "type": "string", "enum": ["required", "advisory"] }
+                                    },
+                                    "required": ["validation_id", "title"]
+                                }
+                            }
                         }
                     },
                     "reason": {
@@ -649,7 +663,7 @@ impl NativeTool for PlanFrameAmendTool {
                         "description": "Reason for the amendment"
                     }
                 },
-                "required": ["plan_id"],
+                "required": ["plan_id", "reason"],
                 "additionalProperties": false
             }),
         }
@@ -677,19 +691,22 @@ impl NativeTool for PlanFrameAmendTool {
             step_id: String,
             title: String,
             owner: Option<String>,
-            status: Option<String>,
             agent_id: Option<String>,
             depends_on: Option<Vec<String>>,
             notes: Option<String>,
         }
 
         #[derive(Deserialize)]
-        struct StepUpdate {
-            step_id: String,
-            status: Option<String>,
-            task_ids: Option<Vec<String>>,
-            artifact_refs: Option<Vec<String>>,
-            notes: Option<String>,
+        struct ValidationInput {
+            validation_id: String,
+            title: String,
+            class: Option<String>,
+            requirement: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct ValidationPolicyInput {
+            entries: Option<Vec<ValidationInput>>,
         }
 
         #[derive(Deserialize)]
@@ -698,7 +715,7 @@ impl NativeTool for PlanFrameAmendTool {
             title: Option<String>,
             objective: Option<String>,
             steps: Option<Vec<StepInput>>,
-            step_updates: Option<Vec<StepUpdate>>,
+            validation_policy: Option<ValidationPolicyInput>,
             reason: Option<String>,
         }
 
@@ -712,32 +729,25 @@ impl NativeTool for PlanFrameAmendTool {
             }))?);
         };
 
-        let Some(mut plan) = store.load_plan_frame(&args.plan_id)? else {
+        let Some(current) = store.load_plan_frame(&args.plan_id)? else {
             return Ok(serde_json::to_string(&serde_json::json!({
                 "ok": false,
                 "error": "Plan not found"
             }))?);
         };
 
-        if plan.status == PlanStatus::Completed || plan.status == PlanStatus::Cancelled {
+        if current.status == PlanStatus::Completed || current.status == PlanStatus::Cancelled {
             return Ok(serde_json::to_string(&serde_json::json!({
                 "ok": false,
-                "error": format!("Cannot amend a {} plan", plan.status.as_str())
+                "error": format!("Cannot amend a {} plan", current.status.as_str())
             }))?);
         }
 
-        let old_version = plan.version;
-        plan.version += 1;
+        let old_version = current.version;
+        let new_version = old_version + 1;
 
-        if let Some(title) = args.title {
-            plan.title = title;
-        }
-        if let Some(objective) = args.objective {
-            plan.objective = objective;
-        }
-
-        if let Some(steps) = args.steps {
-            plan.steps = steps
+        let steps = match args.steps {
+            Some(steps) => steps
                 .into_iter()
                 .map(|s| PlanStep {
                     step_id: s.step_id,
@@ -748,57 +758,78 @@ impl NativeTool for PlanFrameAmendTool {
                         Some("shared") => StepOwner::Shared,
                         _ => StepOwner::Planner,
                     },
-                    status: match s.status.as_deref() {
-                        Some("in_progress") => StepStatus::InProgress,
-                        Some("completed") => StepStatus::Completed,
-                        Some("skipped") => StepStatus::Skipped,
-                        Some("blocked") => StepStatus::Blocked,
-                        _ => StepStatus::Pending,
-                    },
                     depends_on: s.depends_on.unwrap_or_default(),
-                    task_ids: vec![],
-                    artifact_refs: vec![],
                     agent_id: s.agent_id,
                     notes: s.notes,
                 })
-                .collect();
-        }
+                .collect(),
+            None => current.steps.clone(),
+        };
 
-        if let Some(updates) = args.step_updates {
-            for upd in updates {
-                if let Some(step) = plan.steps.iter_mut().find(|s| s.step_id == upd.step_id) {
-                    if let Some(status) = upd.status {
-                        step.status = match status.as_str() {
-                            "in_progress" => StepStatus::InProgress,
-                            "completed" => StepStatus::Completed,
-                            "skipped" => StepStatus::Skipped,
-                            "blocked" => StepStatus::Blocked,
-                            _ => StepStatus::Pending,
-                        };
-                    }
-                    if let Some(task_ids) = upd.task_ids {
-                        step.task_ids = task_ids;
-                    }
-                    if let Some(artifact_refs) = upd.artifact_refs {
-                        step.artifact_refs = artifact_refs;
-                    }
-                    if let Some(notes) = upd.notes {
-                        step.notes = Some(notes);
-                    }
-                }
-            }
-        }
+        let validation_policy = match args.validation_policy {
+            Some(vp) => ValidationPolicy {
+                entries: vp
+                    .entries
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|v| ValidationEntry {
+                        validation_id: v.validation_id,
+                        title: v.title,
+                        class: match v.class.as_deref() {
+                            Some("security_review") => autonoetic_types::plan_frame::ValidationClass::SecurityReview,
+                            Some("correctness_check") => autonoetic_types::plan_frame::ValidationClass::CorrectnessCheck,
+                            Some("quality_check") => autonoetic_types::plan_frame::ValidationClass::QualityCheck,
+                            Some("packaging_check") => autonoetic_types::plan_frame::ValidationClass::PackagingCheck,
+                            _ => autonoetic_types::plan_frame::ValidationClass::MechanicalSafety,
+                        },
+                        requirement: match v.requirement.as_deref() {
+                            Some("advisory") => autonoetic_types::plan_frame::ValidationRequirement::Advisory,
+                            Some("waived") => autonoetic_types::plan_frame::ValidationRequirement::Waived,
+                            _ => autonoetic_types::plan_frame::ValidationRequirement::Required,
+                        },
+                    })
+                    .collect(),
+            },
+            None => current.validation_policy.clone(),
+        };
 
         let now = now_rfc3339();
-        plan.updated_at = now.clone();
 
-        if plan.status == PlanStatus::Approved {
-            plan.status = PlanStatus::AwaitingApproval;
-        }
+        let new_revision = PlanFrame {
+            plan_id: current.plan_id.clone(),
+            version: new_version,
+            parent_version: Some(old_version),
+            workflow_id: current.workflow_id.clone(),
+            root_session_id: current.root_session_id.clone(),
+            title: args.title.unwrap_or(current.title.clone()),
+            objective: args.objective.unwrap_or(current.objective.clone()),
+            status: PlanStatus::AwaitingApproval,
+            steps,
+            validation_policy,
+            approved_by: None,
+            approved_at: None,
+            created_by_agent_id: manifest.agent.id.clone(),
+            reason: args.reason,
+            created_at: now,
+        };
 
-        store.save_plan_frame(&plan)?;
+        store.save_plan_frame(&new_revision)?;
 
         if let Some(config) = config {
+            let wf = crate::scheduler::workflow_store::load_workflow_run(
+                config,
+                Some(&store),
+                &current.workflow_id,
+            )?;
+            if let Some(mut wf) = wf {
+                wf.active_plan_ref = Some(PlanRef {
+                    plan_id: current.plan_id.clone(),
+                    version: new_version,
+                });
+                wf.updated_at = now_rfc3339();
+                crate::scheduler::workflow_store::save_workflow_run(config, Some(&store), &wf)?;
+            }
+
             crate::scheduler::workflow_store::append_workflow_event(
                 config,
                 Some(&store),
@@ -807,31 +838,109 @@ impl NativeTool for PlanFrameAmendTool {
                         let bytes = uuid::Uuid::new_v4();
                         format!("evt-{}", hex::encode(&bytes.as_bytes()[..8]))
                     },
-                    workflow_id: plan.workflow_id.clone(),
+                    workflow_id: current.workflow_id.clone(),
                     task_id: None,
                     event_type: "planframe.amended".to_string(),
                     agent_id: Some(manifest.agent.id.clone()),
                     payload: serde_json::json!({
-                        "plan_id": plan.plan_id,
+                        "plan_id": current.plan_id,
                         "old_version": old_version,
-                        "new_version": plan.version,
-                        "reason": args.reason,
+                        "new_version": new_version,
                     }),
-                    occurred_at: now,
+                    occurred_at: now_rfc3339(),
                 },
             )?;
         }
 
         Ok(serde_json::to_string(&serde_json::json!({
             "ok": true,
-            "plan_id": plan.plan_id,
-            "version": plan.version,
-            "status": plan.status.as_str(),
-            "message": if plan.status == PlanStatus::AwaitingApproval {
-                "Plan amended. Operator re-approval is required."
-            } else {
-                "Plan amended."
-            },
+            "plan_id": current.plan_id,
+            "version": new_version,
+            "status": "awaiting_approval",
+            "parent_version": old_version,
+            "message": "Plan amended (new immutable revision). Operator re-approval is required.",
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct PlanFrameHistoryTool;
+
+impl NativeTool for PlanFrameHistoryTool {
+    fn name(&self) -> &'static str {
+        "planframe_history"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Get the full revision history of a plan. Returns all revisions from first to latest, showing how the plan evolved.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "plan_id": {
+                        "type": "string",
+                        "description": "The plan ID to retrieve history for"
+                    }
+                },
+                "required": ["plan_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_plan_frame_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            plan_id: String,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Gateway store not available"
+            }))?);
+        };
+
+        let revisions = store.list_plan_revisions(&args.plan_id)?;
+
+        if revisions.is_empty() {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": true,
+                "plan_id": args.plan_id,
+                "revisions": [],
+                "message": "No revisions found for this plan"
+            }))?);
+        }
+
+        let summaries: Vec<PlanFrameSummary> = revisions.iter().map(|r| r.compact_summary()).collect();
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "plan_id": args.plan_id,
+            "revisions": summaries,
+            "count": summaries.len(),
         }))?)
     }
 

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -1975,6 +1975,7 @@ async fn process_due_scheduled_jobs(
                         queued_task_ids: Vec::new(),
                         join_policy: autonoetic_types::workflow::JoinPolicy::AllOf,
                         join_task_ids: Vec::new(),
+                        active_plan_ref: None,
                     };
                     if let Err(e) =
                         workflow_store::save_workflow_run(&config, Some(store.as_ref()), &new_run)

--- a/autonoetic-gateway/src/scheduler/fast_scheduler.rs
+++ b/autonoetic-gateway/src/scheduler/fast_scheduler.rs
@@ -287,6 +287,7 @@ pub async fn run_fast_scheduler_tick_at(
                         queued_task_ids: Vec::new(),
                         join_policy: autonoetic_types::workflow::JoinPolicy::AllOf,
                         join_task_ids: Vec::new(),
+                        active_plan_ref: None,
                     };
                     if let Err(e) =
                         workflow_store::save_workflow_run(&config, Some(store.as_ref()), &new_run)

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -745,20 +745,22 @@ fn apply_plan_frames_v42(conn: &mut Connection) -> Result<()> {
 
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS plan_frames (
-            plan_id              TEXT PRIMARY KEY,
+            plan_id              TEXT NOT NULL,
+            version              INTEGER NOT NULL DEFAULT 1,
+            parent_version       INTEGER,
             workflow_id          TEXT NOT NULL,
             root_session_id      TEXT NOT NULL,
             title                TEXT NOT NULL,
             objective            TEXT NOT NULL,
-            status               TEXT NOT NULL DEFAULT 'draft',
-            version              INTEGER NOT NULL DEFAULT 1,
+            status               TEXT NOT NULL DEFAULT 'awaiting_approval',
             steps_json           TEXT NOT NULL DEFAULT '[]',
             validation_policy_json TEXT NOT NULL DEFAULT '{\"entries\":[]}',
             approved_by          TEXT,
             approved_at          TEXT,
             created_by_agent_id  TEXT NOT NULL,
+            reason               TEXT,
             created_at           TEXT NOT NULL,
-            updated_at           TEXT NOT NULL
+            PRIMARY KEY (plan_id, version)
         );
         CREATE INDEX IF NOT EXISTS idx_plan_frames_workflow
             ON plan_frames(workflow_id);

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 41;
+const SCHEMA_VERSION_LATEST: i64 = 42;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -526,6 +526,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_improvement_cycles_v39(conn)?;
     apply_credential_label_v40(conn)?;
     apply_memories_fts_v41(conn)?;
+    apply_plan_frames_v42(conn)?;
 
     Ok(())
 }
@@ -719,8 +720,6 @@ fn apply_memories_fts_v41(conn: &mut Connection) -> Result<()> {
         ",
     )?;
 
-    // Backfill existing rows into the FTS index (within the transaction,
-    // so if it fails the migration is cleanly rolled back).
     tx.execute(
         "INSERT INTO memories_fts(rowid, content) SELECT rowid, content FROM memories WHERE quarantine_reason IS NULL",
         [],
@@ -731,6 +730,48 @@ fn apply_memories_fts_v41(conn: &mut Connection) -> Result<()> {
         params![41_i64, "memories_fts", chrono::Utc::now().to_rfc3339()],
     )?;
     tx.commit()?;
+    Ok(())
+}
+
+fn apply_plan_frames_v42(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 42 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS plan_frames (
+            plan_id              TEXT PRIMARY KEY,
+            workflow_id          TEXT NOT NULL,
+            root_session_id      TEXT NOT NULL,
+            title                TEXT NOT NULL,
+            objective            TEXT NOT NULL,
+            status               TEXT NOT NULL DEFAULT 'draft',
+            version              INTEGER NOT NULL DEFAULT 1,
+            steps_json           TEXT NOT NULL DEFAULT '[]',
+            validation_policy_json TEXT NOT NULL DEFAULT '{\"entries\":[]}',
+            approved_by          TEXT,
+            approved_at          TEXT,
+            created_by_agent_id  TEXT NOT NULL,
+            created_at           TEXT NOT NULL,
+            updated_at           TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_plan_frames_workflow
+            ON plan_frames(workflow_id);
+        CREATE INDEX IF NOT EXISTS idx_plan_frames_root_session
+            ON plan_frames(root_session_id);
+        CREATE INDEX IF NOT EXISTS idx_plan_frames_status
+            ON plan_frames(status);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![42_i64, "plan_frames", chrono::Utc::now().to_rfc3339()],
+    )?;
     Ok(())
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -367,6 +367,27 @@ impl GatewayStore {
         plan_frames::load_plan_frame(&conn, plan_id)
     }
 
+    pub fn load_plan_frame_revision(
+        &self,
+        plan_id: &str,
+        version: u32,
+    ) -> Result<Option<autonoetic_types::plan_frame::PlanFrame>> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::load_plan_frame_revision(&conn, plan_id, version)
+    }
+
+    pub fn update_plan_frame_status(
+        &self,
+        plan_id: &str,
+        version: u32,
+        status: autonoetic_types::plan_frame::PlanStatus,
+        approved_by: Option<&str>,
+        approved_at: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::update_plan_frame_status(&conn, plan_id, version, status, approved_by, approved_at)
+    }
+
     pub fn load_active_plan_for_workflow(
         &self,
         workflow_id: &str,
@@ -381,6 +402,14 @@ impl GatewayStore {
     ) -> Result<Vec<autonoetic_types::plan_frame::PlanFrame>> {
         let conn = self.conn.lock().unwrap();
         plan_frames::list_plan_frames_for_workflow(&conn, workflow_id)
+    }
+
+    pub fn list_plan_revisions(
+        &self,
+        plan_id: &str,
+    ) -> Result<Vec<autonoetic_types::plan_frame::PlanFrame>> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::list_plan_revisions(&conn, plan_id)
     }
 }
 
@@ -958,18 +987,5 @@ mod tests {
         assert_eq!(resolved.decision_reason.as_deref(), Some("Looks good, promote"));
 
         Ok(())
-    }
-
-    pub fn save_plan_frame(&self, plan: &autonoetic_types::plan_frame::PlanFrame) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        plan_frames::save_plan_frame(&conn, plan)
-    }
-
-    pub fn load_plan_frame(
-        &self,
-        plan_id: &str,
-    ) -> Result<Option<autonoetic_types::plan_frame::PlanFrame>> {
-        let conn = self.conn.lock().unwrap();
-        plan_frames::load_plan_frame(&conn, plan_id)
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -15,6 +15,7 @@ mod messages;
 mod migrate;
 mod notifications;
 mod observability;
+pub mod plan_frames;
 pub mod post_promotion_reviews;
 mod reclamation;
 mod recordings;
@@ -351,6 +352,35 @@ impl GatewayStore {
             |row| row.get(0),
         )?;
         Ok(count > 0)
+    }
+
+    pub fn save_plan_frame(&self, plan: &autonoetic_types::plan_frame::PlanFrame) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::save_plan_frame(&conn, plan)
+    }
+
+    pub fn load_plan_frame(
+        &self,
+        plan_id: &str,
+    ) -> Result<Option<autonoetic_types::plan_frame::PlanFrame>> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::load_plan_frame(&conn, plan_id)
+    }
+
+    pub fn load_active_plan_for_workflow(
+        &self,
+        workflow_id: &str,
+    ) -> Result<Option<autonoetic_types::plan_frame::PlanFrame>> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::load_active_plan_for_workflow(&conn, workflow_id)
+    }
+
+    pub fn list_plan_frames_for_workflow(
+        &self,
+        workflow_id: &str,
+    ) -> Result<Vec<autonoetic_types::plan_frame::PlanFrame>> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::list_plan_frames_for_workflow(&conn, workflow_id)
     }
 }
 
@@ -928,5 +958,18 @@ mod tests {
         assert_eq!(resolved.decision_reason.as_deref(), Some("Looks good, promote"));
 
         Ok(())
+    }
+
+    pub fn save_plan_frame(&self, plan: &autonoetic_types::plan_frame::PlanFrame) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::save_plan_frame(&conn, plan)
+    }
+
+    pub fn load_plan_frame(
+        &self,
+        plan_id: &str,
+    ) -> Result<Option<autonoetic_types::plan_frame::PlanFrame>> {
+        let conn = self.conn.lock().unwrap();
+        plan_frames::load_plan_frame(&conn, plan_id)
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/plan_frames.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/plan_frames.rs
@@ -2,49 +2,94 @@ use anyhow::Result;
 use rusqlite::{params, Connection};
 
 use autonoetic_types::plan_frame::{
-    PlanFrame, PlanStatus, PlanStep, StepStatus, StepOwner, ValidationClass, ValidationEntry,
+    PlanFrame, PlanStatus, PlanStep, StepOwner, ValidationClass, ValidationEntry,
     ValidationPolicy, ValidationRequirement,
 };
+
+const SELECT_COLS: &str = "\
+    plan_id, version, parent_version, workflow_id, root_session_id, \
+    title, objective, status, steps_json, validation_policy_json, \
+    approved_by, approved_at, created_by_agent_id, reason, created_at";
 
 pub(crate) fn save_plan_frame(conn: &Connection, plan: &PlanFrame) -> Result<()> {
     let steps_json = serde_json::to_string(&plan.steps)?;
     let validation_policy_json = serde_json::to_string(&plan.validation_policy)?;
 
     conn.execute(
-        "INSERT OR REPLACE INTO plan_frames
-            (plan_id, workflow_id, root_session_id, title, objective, status,
-             version, steps_json, validation_policy_json, approved_by, approved_at,
-             created_by_agent_id, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        "INSERT INTO plan_frames
+            (plan_id, version, parent_version, workflow_id, root_session_id,
+             title, objective, status, steps_json, validation_policy_json,
+             approved_by, approved_at, created_by_agent_id, reason, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
         params![
             plan.plan_id,
+            plan.version as i64,
+            plan.parent_version.map(|v| v as i64),
             plan.workflow_id,
             plan.root_session_id,
             plan.title,
             plan.objective,
             plan.status.as_str(),
-            plan.version as i64,
             steps_json,
             validation_policy_json,
             plan.approved_by,
             plan.approved_at,
             plan.created_by_agent_id,
+            plan.reason,
             plan.created_at,
-            plan.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn update_plan_frame_status(
+    conn: &Connection,
+    plan_id: &str,
+    version: u32,
+    status: PlanStatus,
+    approved_by: Option<&str>,
+    approved_at: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE plan_frames SET status = ?1, approved_by = ?2, approved_at = ?3
+         WHERE plan_id = ?4 AND version = ?5",
+        params![
+            status.as_str(),
+            approved_by,
+            approved_at,
+            plan_id,
+            version as i64,
         ],
     )?;
     Ok(())
 }
 
 pub(crate) fn load_plan_frame(conn: &Connection, plan_id: &str) -> Result<Option<PlanFrame>> {
-    let mut stmt = conn.prepare(
-        "SELECT plan_id, workflow_id, root_session_id, title, objective, status,
-                version, steps_json, validation_policy_json, approved_by, approved_at,
-                created_by_agent_id, created_at, updated_at
-         FROM plan_frames WHERE plan_id = ?1",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM plan_frames WHERE plan_id = ?1 ORDER BY version DESC LIMIT 1"
+    ))?;
 
     let result = stmt.query_row(params![plan_id], |row| {
+        Ok(row_to_plan_frame(row))
+    });
+
+    match result {
+        Ok(plan) => Ok(Some(plan?)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub(crate) fn load_plan_frame_revision(
+    conn: &Connection,
+    plan_id: &str,
+    version: u32,
+) -> Result<Option<PlanFrame>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM plan_frames WHERE plan_id = ?1 AND version = ?2"
+    ))?;
+
+    let result = stmt.query_row(params![plan_id, version as i64], |row| {
         Ok(row_to_plan_frame(row))
     });
 
@@ -59,14 +104,11 @@ pub(crate) fn load_active_plan_for_workflow(
     conn: &Connection,
     workflow_id: &str,
 ) -> Result<Option<PlanFrame>> {
-    let mut stmt = conn.prepare(
-        "SELECT plan_id, workflow_id, root_session_id, title, objective, status,
-                version, steps_json, validation_policy_json, approved_by, approved_at,
-                created_by_agent_id, created_at, updated_at
-         FROM plan_frames
-         WHERE workflow_id = ?1 AND status IN ('draft', 'awaiting_approval', 'approved')
-         ORDER BY updated_at DESC LIMIT 1",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM plan_frames
+         WHERE workflow_id = ?1 AND status IN ('awaiting_approval', 'approved')
+         ORDER BY version DESC LIMIT 1"
+    ))?;
 
     let result = stmt.query_row(params![workflow_id], |row| {
         Ok(row_to_plan_frame(row))
@@ -83,13 +125,12 @@ pub(crate) fn list_plan_frames_for_workflow(
     conn: &Connection,
     workflow_id: &str,
 ) -> Result<Vec<PlanFrame>> {
-    let mut stmt = conn.prepare(
-        "SELECT plan_id, workflow_id, root_session_id, title, objective, status,
-                version, steps_json, validation_policy_json, approved_by, approved_at,
-                created_by_agent_id, created_at, updated_at
-         FROM plan_frames WHERE workflow_id = ?1
-         ORDER BY updated_at DESC",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM plan_frames
+         WHERE workflow_id = ?1
+           AND version = (SELECT MAX(p2.version) FROM plan_frames p2 WHERE p2.plan_id = plan_frames.plan_id)
+         ORDER BY created_at DESC"
+    ))?;
 
     let rows = stmt.query_map(params![workflow_id], |row| {
         Ok(row_to_plan_frame(row))
@@ -102,10 +143,30 @@ pub(crate) fn list_plan_frames_for_workflow(
     Ok(plans)
 }
 
+pub(crate) fn list_plan_revisions(
+    conn: &Connection,
+    plan_id: &str,
+) -> Result<Vec<PlanFrame>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {SELECT_COLS} FROM plan_frames WHERE plan_id = ?1 ORDER BY version ASC"
+    ))?;
+
+    let rows = stmt.query_map(params![plan_id], |row| {
+        Ok(row_to_plan_frame(row))
+    })?;
+
+    let mut revisions = Vec::new();
+    for row in rows {
+        revisions.push(row??);
+    }
+    Ok(revisions)
+}
+
 fn row_to_plan_frame(row: &rusqlite::Row<'_>) -> Result<PlanFrame, rusqlite::Error> {
-    let status_str: String = row.get(5)?;
-    let steps_json: String = row.get(7)?;
-    let vp_json: String = row.get(8)?;
+    let parent_version: Option<i64> = row.get(2)?;
+    let status_str: String = row.get(7)?;
+    let steps_json: String = row.get(8)?;
+    let vp_json: String = row.get(9)?;
 
     let steps: Vec<PlanStep> =
         serde_json::from_str(&steps_json).unwrap_or_default();
@@ -114,30 +175,29 @@ fn row_to_plan_frame(row: &rusqlite::Row<'_>) -> Result<PlanFrame, rusqlite::Err
 
     Ok(PlanFrame {
         plan_id: row.get(0)?,
-        workflow_id: row.get(1)?,
-        root_session_id: row.get(2)?,
-        title: row.get(3)?,
-        objective: row.get(4)?,
+        version: row.get::<_, i64>(1)? as u32,
+        parent_version: parent_version.map(|v| v as u32),
+        workflow_id: row.get(3)?,
+        root_session_id: row.get(4)?,
+        title: row.get(5)?,
+        objective: row.get(6)?,
         status: parse_plan_status(&status_str),
-        version: row.get::<_, i64>(6)? as u32,
         steps,
         validation_policy,
-        approved_by: row.get(9)?,
-        approved_at: row.get(10)?,
-        created_by_agent_id: row.get(11)?,
-        created_at: row.get(12)?,
-        updated_at: row.get(13)?,
+        approved_by: row.get(10)?,
+        approved_at: row.get(11)?,
+        created_by_agent_id: row.get(12)?,
+        reason: row.get(13)?,
+        created_at: row.get(14)?,
     })
 }
 
 fn parse_plan_status(s: &str) -> PlanStatus {
     match s {
-        "draft" => PlanStatus::Draft,
         "awaiting_approval" => PlanStatus::AwaitingApproval,
         "approved" => PlanStatus::Approved,
-        "superseded" => PlanStatus::Superseded,
         "completed" => PlanStatus::Completed,
         "cancelled" => PlanStatus::Cancelled,
-        _ => PlanStatus::Draft,
+        _ => PlanStatus::AwaitingApproval,
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/plan_frames.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/plan_frames.rs
@@ -1,0 +1,143 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use autonoetic_types::plan_frame::{
+    PlanFrame, PlanStatus, PlanStep, StepStatus, StepOwner, ValidationClass, ValidationEntry,
+    ValidationPolicy, ValidationRequirement,
+};
+
+pub(crate) fn save_plan_frame(conn: &Connection, plan: &PlanFrame) -> Result<()> {
+    let steps_json = serde_json::to_string(&plan.steps)?;
+    let validation_policy_json = serde_json::to_string(&plan.validation_policy)?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO plan_frames
+            (plan_id, workflow_id, root_session_id, title, objective, status,
+             version, steps_json, validation_policy_json, approved_by, approved_at,
+             created_by_agent_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            plan.plan_id,
+            plan.workflow_id,
+            plan.root_session_id,
+            plan.title,
+            plan.objective,
+            plan.status.as_str(),
+            plan.version as i64,
+            steps_json,
+            validation_policy_json,
+            plan.approved_by,
+            plan.approved_at,
+            plan.created_by_agent_id,
+            plan.created_at,
+            plan.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn load_plan_frame(conn: &Connection, plan_id: &str) -> Result<Option<PlanFrame>> {
+    let mut stmt = conn.prepare(
+        "SELECT plan_id, workflow_id, root_session_id, title, objective, status,
+                version, steps_json, validation_policy_json, approved_by, approved_at,
+                created_by_agent_id, created_at, updated_at
+         FROM plan_frames WHERE plan_id = ?1",
+    )?;
+
+    let result = stmt.query_row(params![plan_id], |row| {
+        Ok(row_to_plan_frame(row))
+    });
+
+    match result {
+        Ok(plan) => Ok(Some(plan?)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub(crate) fn load_active_plan_for_workflow(
+    conn: &Connection,
+    workflow_id: &str,
+) -> Result<Option<PlanFrame>> {
+    let mut stmt = conn.prepare(
+        "SELECT plan_id, workflow_id, root_session_id, title, objective, status,
+                version, steps_json, validation_policy_json, approved_by, approved_at,
+                created_by_agent_id, created_at, updated_at
+         FROM plan_frames
+         WHERE workflow_id = ?1 AND status IN ('draft', 'awaiting_approval', 'approved')
+         ORDER BY updated_at DESC LIMIT 1",
+    )?;
+
+    let result = stmt.query_row(params![workflow_id], |row| {
+        Ok(row_to_plan_frame(row))
+    });
+
+    match result {
+        Ok(plan) => Ok(Some(plan?)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub(crate) fn list_plan_frames_for_workflow(
+    conn: &Connection,
+    workflow_id: &str,
+) -> Result<Vec<PlanFrame>> {
+    let mut stmt = conn.prepare(
+        "SELECT plan_id, workflow_id, root_session_id, title, objective, status,
+                version, steps_json, validation_policy_json, approved_by, approved_at,
+                created_by_agent_id, created_at, updated_at
+         FROM plan_frames WHERE workflow_id = ?1
+         ORDER BY updated_at DESC",
+    )?;
+
+    let rows = stmt.query_map(params![workflow_id], |row| {
+        Ok(row_to_plan_frame(row))
+    })?;
+
+    let mut plans = Vec::new();
+    for row in rows {
+        plans.push(row??);
+    }
+    Ok(plans)
+}
+
+fn row_to_plan_frame(row: &rusqlite::Row<'_>) -> Result<PlanFrame, rusqlite::Error> {
+    let status_str: String = row.get(5)?;
+    let steps_json: String = row.get(7)?;
+    let vp_json: String = row.get(8)?;
+
+    let steps: Vec<PlanStep> =
+        serde_json::from_str(&steps_json).unwrap_or_default();
+    let validation_policy: ValidationPolicy =
+        serde_json::from_str(&vp_json).unwrap_or_default();
+
+    Ok(PlanFrame {
+        plan_id: row.get(0)?,
+        workflow_id: row.get(1)?,
+        root_session_id: row.get(2)?,
+        title: row.get(3)?,
+        objective: row.get(4)?,
+        status: parse_plan_status(&status_str),
+        version: row.get::<_, i64>(6)? as u32,
+        steps,
+        validation_policy,
+        approved_by: row.get(9)?,
+        approved_at: row.get(10)?,
+        created_by_agent_id: row.get(11)?,
+        created_at: row.get(12)?,
+        updated_at: row.get(13)?,
+    })
+}
+
+fn parse_plan_status(s: &str) -> PlanStatus {
+    match s {
+        "draft" => PlanStatus::Draft,
+        "awaiting_approval" => PlanStatus::AwaitingApproval,
+        "approved" => PlanStatus::Approved,
+        "superseded" => PlanStatus::Superseded,
+        "completed" => PlanStatus::Completed,
+        "cancelled" => PlanStatus::Cancelled,
+        _ => PlanStatus::Draft,
+    }
+}

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -331,6 +331,7 @@ pub fn ensure_workflow_for_root_session(
                     queued_task_ids: vec![],
                     join_policy: Default::default(),
                     join_task_ids: vec![],
+                    active_plan_ref: None,
                 }
             }
         };
@@ -357,6 +358,7 @@ pub fn ensure_workflow_for_root_session(
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![],
+        active_plan_ref: None,
     };
 
     save_workflow_run(config, store, &run)?;

--- a/autonoetic-gateway/tests/constitution_r_2_11_approval_timeout.rs
+++ b/autonoetic-gateway/tests/constitution_r_2_11_approval_timeout.rs
@@ -62,6 +62,7 @@ async fn r_2_11_timed_out_approval_marks_task_failed_and_preserves_continuation(
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 
@@ -163,6 +164,7 @@ async fn r_7_11_approval_timeout_records_resolution_in_session_report() -> anyho
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 

--- a/autonoetic-gateway/tests/constitution_r_5_14_mechanical_failure_classification.rs
+++ b/autonoetic-gateway/tests/constitution_r_5_14_mechanical_failure_classification.rs
@@ -39,6 +39,7 @@ fn seed_task(
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     save_workflow_run(config, Some(store), &workflow)?;
 

--- a/autonoetic-gateway/tests/constitution_r_6_25_stage_local_retry_budget.rs
+++ b/autonoetic-gateway/tests/constitution_r_6_25_stage_local_retry_budget.rs
@@ -38,6 +38,7 @@ fn retry_budget_exhaustion_emits_event_and_stops_further_retry_progress() -> any
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 

--- a/autonoetic-gateway/tests/constitution_r_6_26_side_effect_state.rs
+++ b/autonoetic-gateway/tests/constitution_r_6_26_side_effect_state.rs
@@ -39,6 +39,7 @@ fn seed_task(
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     save_workflow_run(config, Some(store), &workflow)?;
 

--- a/autonoetic-gateway/tests/constitution_right_ri_0_14.rs
+++ b/autonoetic-gateway/tests/constitution_right_ri_0_14.rs
@@ -82,6 +82,7 @@ fn seed_task(
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     save_workflow_run(config, Some(store), &workflow)?;
 

--- a/autonoetic-gateway/tests/plan_frame_integration.rs
+++ b/autonoetic-gateway/tests/plan_frame_integration.rs
@@ -192,6 +192,7 @@ fn planframe_propose_creates_workflow_and_plan() {
     assert_eq!(plan.status.as_str(), "awaiting_approval");
     assert_eq!(plan.validation_policy.entries.len(), 2);
     assert_eq!(plan.root_session_id, root_session_id);
+    assert_eq!(plan.parent_version, None);
 
     let wf_id = store.resolve_workflow_id(root_session_id).unwrap().unwrap();
     let wf = autonoetic_gateway::scheduler::workflow_store::load_workflow_run(
@@ -203,6 +204,7 @@ fn planframe_propose_creates_workflow_and_plan() {
     .unwrap();
     assert!(wf.active_plan_ref.is_some());
     assert_eq!(wf.active_plan_ref.as_ref().unwrap().plan_id, plan_id);
+    assert_eq!(wf.active_plan_ref.as_ref().unwrap().version, 1);
 }
 
 #[test]
@@ -265,6 +267,7 @@ fn planframe_get_returns_proposed_plan() {
     let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
     assert_eq!(parsed["ok"], true);
     assert_eq!(parsed["plan"]["plan_id"], plan_id);
+    assert_eq!(parsed["plan"]["version"], 1);
 }
 
 #[test]
@@ -338,7 +341,7 @@ fn planframe_approve_transitions_status() {
 }
 
 #[test]
-fn planframe_amend_increments_version() {
+fn planframe_amend_creates_new_revision() {
     let dir = tempdir().unwrap();
     let config = make_config(dir.path());
     let registry = default_registry();
@@ -408,10 +411,12 @@ fn planframe_amend_increments_version() {
             Some(&gateway_dir),
             &serde_json::to_string(&json!({
                 "plan_id": plan_id,
-                "step_updates": [
-                    { "step_id": "step-1", "status": "in_progress" }
+                "steps": [
+                    { "step_id": "step-1", "title": "First step (updated)" },
+                    { "step_id": "step-2", "title": "Second step" },
+                    { "step_id": "step-3", "title": "Third step (new)" }
                 ],
-                "reason": "Started"
+                "reason": "Added third step after review"
             }))
             .unwrap(),
             Some(session_id),
@@ -426,6 +431,211 @@ fn planframe_amend_increments_version() {
     assert_eq!(parsed["ok"], true);
     assert_eq!(parsed["version"], 2);
     assert_eq!(parsed["status"], "awaiting_approval");
+    assert_eq!(parsed["parent_version"], 1);
+
+    let latest = store.load_plan_frame(&plan_id).unwrap().unwrap();
+    assert_eq!(latest.version, 2);
+    assert_eq!(latest.parent_version, Some(1));
+    assert_eq!(latest.steps.len(), 3);
+    assert_eq!(latest.steps[0].title, "First step (updated)");
+    assert_eq!(latest.status, PlanStatus::AwaitingApproval);
+
+    let v1 = store.load_plan_frame_revision(&plan_id, 1).unwrap().unwrap();
+    assert_eq!(v1.version, 1);
+    assert_eq!(v1.steps.len(), 2);
+    assert_eq!(v1.steps[0].title, "First step");
+    assert_eq!(v1.status, PlanStatus::Approved);
+}
+
+#[test]
+fn planframe_amend_preserves_original_revision() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-005/planner-005";
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "Original Title",
+                "objective": "Original objective",
+                "steps": [
+                    { "step_id": "s1", "title": "Step 1" }
+                ]
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    registry
+        .execute(
+            "planframe_amend",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_id,
+                "title": "Changed Title",
+                "objective": "Changed objective",
+                "reason": "Scope change"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let v1 = store.load_plan_frame_revision(&plan_id, 1).unwrap().unwrap();
+    assert_eq!(v1.title, "Original Title");
+    assert_eq!(v1.objective, "Original objective");
+    assert_eq!(v1.status.as_str(), "awaiting_approval");
+
+    let v2 = store.load_plan_frame_revision(&plan_id, 2).unwrap().unwrap();
+    assert_eq!(v2.title, "Changed Title");
+    assert_eq!(v2.objective, "Changed objective");
+    assert_eq!(v2.status.as_str(), "awaiting_approval");
+    assert_eq!(v2.parent_version, Some(1));
+    assert_eq!(v2.reason.as_deref(), Some("Scope change"));
+}
+
+#[test]
+fn planframe_history_returns_full_revision_chain() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-006/planner-006";
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "History Test",
+                "objective": "Test history"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    registry
+        .execute(
+            "planframe_amend",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_id,
+                "title": "History Test v2",
+                "reason": "Second revision"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    registry
+        .execute(
+            "planframe_amend",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_id,
+                "title": "History Test v3",
+                "reason": "Third revision"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-003"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let result = registry
+        .execute(
+            "planframe_history",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id),
+            Some("turn-004"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["count"], 3);
+
+    let revisions = parsed["revisions"].as_array().unwrap();
+    assert_eq!(revisions[0]["version"], 1);
+    assert_eq!(revisions[0]["parent_version"], serde_json::Value::Null);
+    assert_eq!(revisions[1]["version"], 2);
+    assert_eq!(revisions[1]["parent_version"], 1);
+    assert_eq!(revisions[2]["version"], 3);
+    assert_eq!(revisions[2]["parent_version"], 2);
 }
 
 #[test]
@@ -447,7 +657,7 @@ fn planframe_tools_not_available_without_capability() {
 }
 
 #[test]
-fn planframe_list_returns_plans_for_workflow() {
+fn planframe_list_returns_latest_revision_per_plan() {
     let dir = tempdir().unwrap();
     let config = make_config(dir.path());
     let registry = default_registry();
@@ -460,29 +670,78 @@ fn planframe_list_returns_plans_for_workflow() {
         autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
     );
 
-    let session_id = "root-session-005/planner-005";
+    let session_id = "root-session-007/planner-007";
 
-    for i in 0..3u32 {
-        registry
-            .execute(
-                "planframe_propose",
-                &manifest,
-                &policy,
-                dir.path(),
-                Some(&gateway_dir),
-                &serde_json::to_string(&json!({
-                    "title": format!("Plan {}", i),
-                    "objective": format!("Objective {}", i)
-                }))
-                .unwrap(),
-                Some(session_id),
-                Some(&format!("turn-{}", i)),
-                Some(&config),
-                Some(store.clone()),
-                None,
-            )
-            .unwrap();
-    }
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "Plan A",
+                "objective": "First plan"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_a_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    registry
+        .execute(
+            "planframe_amend",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_a_id,
+                "title": "Plan A v2",
+                "reason": "Updated"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "Plan B",
+                "objective": "Second plan"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-003"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_b_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let result = registry
         .execute(
@@ -502,5 +761,136 @@ fn planframe_list_returns_plans_for_workflow() {
 
     let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
     assert_eq!(parsed["ok"], true);
-    assert_eq!(parsed["count"], 3);
+    assert_eq!(parsed["count"], 2);
+
+    let plans = parsed["plans"].as_array().unwrap();
+    let plan_a_latest = plans.iter().find(|p| p["plan_id"] == plan_a_id).unwrap();
+    assert_eq!(plan_a_latest["version"], 2);
+    assert_eq!(plan_a_latest["title"], "Plan A v2");
+
+    let plan_b_latest = plans.iter().find(|p| p["plan_id"] == plan_b_id).unwrap();
+    assert_eq!(plan_b_latest["version"], 1);
+    assert_eq!(plan_b_latest["title"], "Plan B");
+}
+
+#[test]
+fn planframe_get_with_version_returns_specific_revision() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-008/planner-008";
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "Version Test v1",
+                "objective": "Test versioning"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    registry
+        .execute(
+            "planframe_amend",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_id,
+                "title": "Version Test v2",
+                "reason": "Update"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let result_v1 = registry
+        .execute(
+            "planframe_get",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "plan_id": plan_id, "version": 1 })).unwrap(),
+            Some(session_id),
+            Some("turn-003"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed_v1: serde_json::Value = serde_json::from_str(&result_v1).unwrap();
+    assert_eq!(parsed_v1["plan"]["title"], "Version Test v1");
+    assert_eq!(parsed_v1["plan"]["version"], 1);
+
+    let result_v2 = registry
+        .execute(
+            "planframe_get",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "plan_id": plan_id, "version": 2 })).unwrap(),
+            Some(session_id),
+            Some("turn-004"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed_v2: serde_json::Value = serde_json::from_str(&result_v2).unwrap();
+    assert_eq!(parsed_v2["plan"]["title"], "Version Test v2");
+    assert_eq!(parsed_v2["plan"]["version"], 2);
+
+    let result_latest = registry
+        .execute(
+            "planframe_get",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id),
+            Some("turn-005"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed_latest: serde_json::Value = serde_json::from_str(&result_latest).unwrap();
+    assert_eq!(parsed_latest["plan"]["version"], 2);
 }

--- a/autonoetic-gateway/tests/plan_frame_integration.rs
+++ b/autonoetic-gateway/tests/plan_frame_integration.rs
@@ -1,0 +1,506 @@
+mod support;
+
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, ExecutionMode, RuntimeDeclaration, ScriptInputMode};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::plan_frame::PlanStatus;
+use serde_json::json;
+use tempfile::tempdir;
+
+fn plan_frame_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "planner.collaborative".to_string(),
+            name: "Collaborative Planner".to_string(),
+            description: "Test collaborative planner".to_string(),
+        },
+        capabilities: vec![
+            Capability::AgentSpawn {
+                max_children: 10,
+                max_spawn_depth: 0,
+            },
+            Capability::ReadAccess {
+                scopes: vec!["*".to_string()],
+            },
+            Capability::WriteAccess {
+                scopes: vec!["*".to_string()],
+            },
+            Capability::PlanFrameAccess {
+                patterns: vec!["*".to_string()],
+            },
+        ],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        execution_mode: ExecutionMode::default(),
+        script_entry: None,
+        script_input_mode: ScriptInputMode::default(),
+        gateway_url: None,
+        gateway_token: None,
+        middleware: None,
+        agentskills_import: None,
+        allowed_tool_tiers: vec![],
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn no_plan_frame_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "agent.no_plan".to_string(),
+            name: "No Plan Agent".to_string(),
+            description: "Agent without plan frame access".to_string(),
+        },
+        capabilities: vec![Capability::ReadAccess {
+            scopes: vec!["*".to_string()],
+        }],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        execution_mode: ExecutionMode::default(),
+        script_entry: None,
+        script_input_mode: ScriptInputMode::default(),
+        gateway_url: None,
+        gateway_token: None,
+        middleware: None,
+        agentskills_import: None,
+        allowed_tool_tiers: vec![],
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn make_config(dir: &std::path::Path) -> GatewayConfig {
+    let mut config = GatewayConfig::default();
+    config.agents_dir = dir.to_path_buf();
+    config
+}
+
+#[test]
+fn planframe_propose_creates_workflow_and_plan() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let root_session_id = "root-session-001";
+    let session_id = format!("{}/planner-001", root_session_id);
+
+    let args = json!({
+        "title": "Build RSS Summarizer Agent",
+        "objective": "Create a new agent that can fetch and summarize RSS feeds",
+        "steps": [
+            {
+                "step_id": "draft-skill",
+                "title": "Draft SKILL.md",
+                "owner": "agent",
+                "agent_id": "coder.default"
+            },
+            {
+                "step_id": "review",
+                "title": "Operator review",
+                "owner": "operator"
+            },
+            {
+                "step_id": "security-review",
+                "title": "Static security review",
+                "owner": "agent",
+                "agent_id": "auditor.default"
+            },
+            {
+                "step_id": "package-install",
+                "title": "Package and install",
+                "owner": "planner"
+            }
+        ],
+        "validation_policy": {
+            "entries": [
+                {
+                    "validation_id": "static_review",
+                    "title": "Static security review",
+                    "class": "security_review",
+                    "requirement": "required"
+                },
+                {
+                    "validation_id": "unit_tests",
+                    "title": "Unit tests",
+                    "class": "correctness_check",
+                    "requirement": "advisory"
+                }
+            ]
+        }
+    });
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&args).unwrap(),
+            Some(&session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true, "propose should succeed");
+    assert!(parsed["plan_id"].as_str().unwrap().starts_with("plan-"));
+    assert_eq!(parsed["status"], "awaiting_approval");
+    assert_eq!(parsed["version"], 1);
+
+    let plan_id = parsed["plan_id"].as_str().unwrap();
+
+    let plan = store.load_plan_frame(plan_id).unwrap().unwrap();
+    assert_eq!(plan.title, "Build RSS Summarizer Agent");
+    assert_eq!(plan.steps.len(), 4);
+    assert_eq!(plan.status.as_str(), "awaiting_approval");
+    assert_eq!(plan.validation_policy.entries.len(), 2);
+    assert_eq!(plan.root_session_id, root_session_id);
+
+    let wf_id = store.resolve_workflow_id(root_session_id).unwrap().unwrap();
+    let wf = autonoetic_gateway::scheduler::workflow_store::load_workflow_run(
+        &config,
+        Some(&store),
+        &wf_id,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(wf.active_plan_ref.is_some());
+    assert_eq!(wf.active_plan_ref.as_ref().unwrap().plan_id, plan_id);
+}
+
+#[test]
+fn planframe_get_returns_proposed_plan() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-002/planner-002";
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "Test Plan",
+                "objective": "Test objective"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = registry
+        .execute(
+            "planframe_get",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["plan"]["plan_id"], plan_id);
+}
+
+#[test]
+fn planframe_approve_transitions_status() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-003/planner-003";
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "title": "Approval Test",
+                "objective": "Test approval"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = registry
+        .execute(
+            "planframe_approve",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_id,
+                "approved_by": "operator"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["status"], "approved");
+
+    let plan = store.load_plan_frame(&plan_id).unwrap().unwrap();
+    assert_eq!(plan.status, PlanStatus::Approved);
+    assert_eq!(plan.approved_by.as_deref(), Some("operator"));
+}
+
+#[test]
+fn planframe_amend_increments_version() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-004/planner-004";
+
+    let propose_args = json!({
+        "title": "Amend Test",
+        "objective": "Test amendment",
+        "steps": [
+            { "step_id": "step-1", "title": "First step" },
+            { "step_id": "step-2", "title": "Second step" }
+        ]
+    });
+
+    let result = registry
+        .execute(
+            "planframe_propose",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&propose_args).unwrap(),
+            Some(session_id),
+            Some("turn-001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    registry
+        .execute(
+            "planframe_approve",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id),
+            Some("turn-002"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let result = registry
+        .execute(
+            "planframe_amend",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({
+                "plan_id": plan_id,
+                "step_updates": [
+                    { "step_id": "step-1", "status": "in_progress" }
+                ],
+                "reason": "Started"
+            }))
+            .unwrap(),
+            Some(session_id),
+            Some("turn-003"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["version"], 2);
+    assert_eq!(parsed["status"], "awaiting_approval");
+}
+
+#[test]
+fn planframe_tools_not_available_without_capability() {
+    let registry = default_registry();
+    let manifest = no_plan_frame_manifest();
+
+    let definitions = registry.available_definitions(&manifest);
+    let plan_tool_names: Vec<&str> = definitions
+        .iter()
+        .filter(|d| d.name.starts_with("planframe_"))
+        .map(|d| d.name.as_str())
+        .collect();
+    assert!(
+        plan_tool_names.is_empty(),
+        "planframe tools should not be available without PlanFrameAccess, found: {:?}",
+        plan_tool_names
+    );
+}
+
+#[test]
+fn planframe_list_returns_plans_for_workflow() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+
+    let session_id = "root-session-005/planner-005";
+
+    for i in 0..3u32 {
+        registry
+            .execute(
+                "planframe_propose",
+                &manifest,
+                &policy,
+                dir.path(),
+                Some(&gateway_dir),
+                &serde_json::to_string(&json!({
+                    "title": format!("Plan {}", i),
+                    "objective": format!("Objective {}", i)
+                }))
+                .unwrap(),
+                Some(session_id),
+                Some(&format!("turn-{}", i)),
+                Some(&config),
+                Some(store.clone()),
+                None,
+            )
+            .unwrap();
+    }
+
+    let result = registry
+        .execute(
+            "planframe_list",
+            &manifest,
+            &policy,
+            dir.path(),
+            Some(&gateway_dir),
+            "{}",
+            Some(session_id),
+            Some("turn-list"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["count"], 3);
+}

--- a/autonoetic-gateway/tests/turn_continuation_approval_integration.rs
+++ b/autonoetic-gateway/tests/turn_continuation_approval_integration.rs
@@ -543,6 +543,7 @@ async fn test_parallel_join_waits_for_approval_task_completion() -> anyhow::Resu
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![approval_task_id.to_string(), fast_task_id.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 
@@ -814,6 +815,7 @@ async fn test_approval_timeout_fails_task_and_satisfies_join() -> anyhow::Result
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 
@@ -976,6 +978,7 @@ async fn test_restart_during_suspension_then_approve_and_resume() -> anyhow::Res
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 
@@ -1172,6 +1175,7 @@ async fn test_two_approval_tasks_both_resume_before_join_satisfies() -> anyhow::
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_a.to_string(), task_b.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 
@@ -1455,6 +1459,7 @@ async fn test_workflow_cancel_task_cancels_suspended_task_and_satisfies_join() -
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.to_string()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 

--- a/autonoetic-gateway/tests/workflow_approval_resume_integration.rs
+++ b/autonoetic-gateway/tests/workflow_approval_resume_integration.rs
@@ -40,6 +40,7 @@ async fn test_runnable_task_refreshes_stale_queue_message_from_approval_checkpoi
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_id.clone()],
+        active_plan_ref: None,
     };
     workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
 

--- a/autonoetic-gateway/tests/workflow_wait_signal_driven.rs
+++ b/autonoetic-gateway/tests/workflow_wait_signal_driven.rs
@@ -86,6 +86,7 @@ fn seed_two_tasks(
         queued_task_ids: vec![],
         join_policy: Default::default(),
         join_task_ids: vec![task_a.to_string(), task_b.to_string()],
+        active_plan_ref: None,
     };
     save_workflow_run(config, Some(store), &workflow)?;
 

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -170,6 +170,15 @@ pub enum Capability {
     /// explicitly granted. Not a default. See
     /// `docs/cognitive-capsule.md`.
     CapsuleExport,
+
+    /// Access to PlanFrame operations (propose, amend, approve, list, get).
+    /// Controls whether an agent can create and modify collaborative plans.
+    /// The `patterns` field restricts which operations are allowed.
+    /// Use ["*"] for all operations, or specific patterns like "planframe.propose".
+    PlanFrameAccess {
+        #[serde(default = "default_patterns_all")]
+        patterns: Vec<String>,
+    },
 }
 
 fn default_patterns_all() -> Vec<String> {
@@ -286,6 +295,7 @@ pub fn all_capability_kind_names() -> &'static [&'static str] {
         "budget.no_price_available.allow",
         "SecurityRedTeam",
         "CapsuleExport",
+        "PlanFrameAccess",
     ]
 }
 
@@ -314,6 +324,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::BudgetNoPriceAvailableAllow => "budget.no_price_available.allow".to_string(),
         Capability::SecurityRedTeam => "SecurityRedTeam".to_string(),
         Capability::CapsuleExport => "CapsuleExport".to_string(),
+        Capability::PlanFrameAccess { .. } => "PlanFrameAccess".to_string(),
     }
 }
 
@@ -378,6 +389,10 @@ fn capability_broadening(
         (
             Capability::GithubIssueCreate { patterns: a },
             Capability::GithubIssueCreate { patterns: b },
+        ) => scope_broadening(capability_type, a, b),
+        (
+            Capability::PlanFrameAccess { patterns: a },
+            Capability::PlanFrameAccess { patterns: b },
         ) => scope_broadening(capability_type, a, b),
         (
             Capability::CodeExecution {
@@ -687,6 +702,7 @@ mod tests {
             Capability::BudgetNoPriceAvailableAllow,
             Capability::SecurityRedTeam,
             Capability::CapsuleExport,
+            Capability::PlanFrameAccess { patterns: vec![] },
         ];
         for cap in &samples {
             let name = capability_type_name(cap);

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -912,6 +912,12 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub llm_preset_mapping: HashMap<String, String>,
 
+    /// Default orchestrator agent ID for new sessions and workflows.
+    /// When set, this agent is used as the lead/planner instead of `planner.default`.
+    /// Can be overridden per-session via CLI or API. Default: "planner.default".
+    #[serde(default = "default_default_orchestrator")]
+    pub default_orchestrator: String,
+
     /// Code analysis configuration for agent.install validation.
     /// Controls how the gateway analyzes code for capabilities and security.
     #[serde(default)]
@@ -1962,6 +1968,10 @@ fn default_agents_dir() -> PathBuf {
     PathBuf::from("./agents")
 }
 
+fn default_default_orchestrator() -> String {
+    "planner.default".to_string()
+}
+
 fn default_port() -> u16 {
     4000
 }
@@ -2487,6 +2497,7 @@ impl Default for GatewayConfig {
             schema_enforcement: SchemaEnforcementConfig::default(),
             llm_presets: HashMap::new(),
             llm_preset_mapping: HashMap::new(),
+            default_orchestrator: default_default_orchestrator(),
             code_analysis: CodeAnalysisConfig::default(),
             capability_delta_gate_mode: CapabilityDeltaGateMode::Strict,
             session_budget: SessionBudgetConfig::default(),

--- a/autonoetic-types/src/lib.rs
+++ b/autonoetic-types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod improvement_cycle;
 pub mod layer;
 pub mod memory;
 pub mod notification;
+pub mod plan_frame;
 pub mod promotion;
 pub mod recording;
 pub mod redaction;

--- a/autonoetic-types/src/plan_frame.rs
+++ b/autonoetic-types/src/plan_frame.rs
@@ -9,10 +9,8 @@ pub struct PlanRef {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanStatus {
-    Draft,
     AwaitingApproval,
     Approved,
-    Superseded,
     Completed,
     Cancelled,
 }
@@ -20,10 +18,8 @@ pub enum PlanStatus {
 impl PlanStatus {
     pub fn as_str(&self) -> &'static str {
         match self {
-            PlanStatus::Draft => "draft",
             PlanStatus::AwaitingApproval => "awaiting_approval",
             PlanStatus::Approved => "approved",
-            PlanStatus::Superseded => "superseded",
             PlanStatus::Completed => "completed",
             PlanStatus::Cancelled => "cancelled",
         }
@@ -32,7 +28,7 @@ impl PlanStatus {
 
 impl Default for PlanStatus {
     fn default() -> Self {
-        Self::Draft
+        Self::AwaitingApproval
     }
 }
 
@@ -62,34 +58,6 @@ impl Default for StepOwner {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum StepStatus {
-    Pending,
-    InProgress,
-    Completed,
-    Skipped,
-    Blocked,
-}
-
-impl StepStatus {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            StepStatus::Pending => "pending",
-            StepStatus::InProgress => "in_progress",
-            StepStatus::Completed => "completed",
-            StepStatus::Skipped => "skipped",
-            StepStatus::Blocked => "blocked",
-        }
-    }
-}
-
-impl Default for StepStatus {
-    fn default() -> Self {
-        Self::Pending
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanStep {
     pub step_id: String,
@@ -97,13 +65,7 @@ pub struct PlanStep {
     #[serde(default)]
     pub owner: StepOwner,
     #[serde(default)]
-    pub status: StepStatus,
-    #[serde(default)]
     pub depends_on: Vec<String>,
-    #[serde(default)]
-    pub task_ids: Vec<String>,
-    #[serde(default)]
-    pub artifact_refs: Vec<String>,
     #[serde(default)]
     pub agent_id: Option<String>,
     #[serde(default)]
@@ -189,13 +151,14 @@ impl Default for ValidationPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PlanFrame {
     pub plan_id: String,
+    pub version: u32,
+    pub parent_version: Option<u32>,
     pub workflow_id: String,
     pub root_session_id: String,
     pub title: String,
     pub objective: String,
     #[serde(default)]
     pub status: PlanStatus,
-    pub version: u32,
     #[serde(default)]
     pub steps: Vec<PlanStep>,
     #[serde(default)]
@@ -205,7 +168,7 @@ pub struct PlanFrame {
     #[serde(default)]
     pub approved_at: Option<String>,
     pub created_by_agent_id: String,
-    pub updated_at: String,
+    pub reason: Option<String>,
     pub created_at: String,
 }
 
@@ -215,13 +178,6 @@ impl PlanFrame {
             .steps
             .iter()
             .filter(|s| s.owner == StepOwner::Operator || s.owner == StepOwner::Shared)
-            .map(|s| s.step_id.clone())
-            .collect();
-
-        let current_steps: Vec<String> = self
-            .steps
-            .iter()
-            .filter(|s| s.status == StepStatus::InProgress)
             .map(|s| s.step_id.clone())
             .collect();
 
@@ -244,9 +200,10 @@ impl PlanFrame {
         PlanFrameSummary {
             plan_id: self.plan_id.clone(),
             version: self.version,
+            parent_version: self.parent_version,
             status: self.status,
             title: self.title.clone(),
-            current_steps,
+            step_count: self.steps.len(),
             operator_steps,
             required_validations,
             advisory_validations,
@@ -258,9 +215,10 @@ impl PlanFrame {
 pub struct PlanFrameSummary {
     pub plan_id: String,
     pub version: u32,
+    pub parent_version: Option<u32>,
     pub status: PlanStatus,
     pub title: String,
-    pub current_steps: Vec<String>,
+    pub step_count: usize,
     pub operator_steps: Vec<String>,
     pub required_validations: Vec<String>,
     pub advisory_validations: Vec<String>,

--- a/autonoetic-types/src/plan_frame.rs
+++ b/autonoetic-types/src/plan_frame.rs
@@ -1,0 +1,267 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanRef {
+    pub plan_id: String,
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStatus {
+    Draft,
+    AwaitingApproval,
+    Approved,
+    Superseded,
+    Completed,
+    Cancelled,
+}
+
+impl PlanStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PlanStatus::Draft => "draft",
+            PlanStatus::AwaitingApproval => "awaiting_approval",
+            PlanStatus::Approved => "approved",
+            PlanStatus::Superseded => "superseded",
+            PlanStatus::Completed => "completed",
+            PlanStatus::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl Default for PlanStatus {
+    fn default() -> Self {
+        Self::Draft
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StepOwner {
+    Planner,
+    Agent,
+    Operator,
+    Shared,
+}
+
+impl StepOwner {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StepOwner::Planner => "planner",
+            StepOwner::Agent => "agent",
+            StepOwner::Operator => "operator",
+            StepOwner::Shared => "shared",
+        }
+    }
+}
+
+impl Default for StepOwner {
+    fn default() -> Self {
+        Self::Planner
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StepStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Skipped,
+    Blocked,
+}
+
+impl StepStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StepStatus::Pending => "pending",
+            StepStatus::InProgress => "in_progress",
+            StepStatus::Completed => "completed",
+            StepStatus::Skipped => "skipped",
+            StepStatus::Blocked => "blocked",
+        }
+    }
+}
+
+impl Default for StepStatus {
+    fn default() -> Self {
+        Self::Pending
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanStep {
+    pub step_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub owner: StepOwner,
+    #[serde(default)]
+    pub status: StepStatus,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub task_ids: Vec<String>,
+    #[serde(default)]
+    pub artifact_refs: Vec<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationClass {
+    MechanicalSafety,
+    SecurityReview,
+    CorrectnessCheck,
+    QualityCheck,
+    PackagingCheck,
+}
+
+impl ValidationClass {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ValidationClass::MechanicalSafety => "mechanical_safety",
+            ValidationClass::SecurityReview => "security_review",
+            ValidationClass::CorrectnessCheck => "correctness_check",
+            ValidationClass::QualityCheck => "quality_check",
+            ValidationClass::PackagingCheck => "packaging_check",
+        }
+    }
+}
+
+impl Default for ValidationClass {
+    fn default() -> Self {
+        Self::CorrectnessCheck
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationRequirement {
+    Required,
+    Advisory,
+    Waived,
+}
+
+impl ValidationRequirement {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ValidationRequirement::Required => "required",
+            ValidationRequirement::Advisory => "advisory",
+            ValidationRequirement::Waived => "waived",
+        }
+    }
+}
+
+impl Default for ValidationRequirement {
+    fn default() -> Self {
+        Self::Advisory
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationEntry {
+    pub validation_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub class: ValidationClass,
+    #[serde(default)]
+    pub requirement: ValidationRequirement,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationPolicy {
+    #[serde(default)]
+    pub entries: Vec<ValidationEntry>,
+}
+
+impl Default for ValidationPolicy {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PlanFrame {
+    pub plan_id: String,
+    pub workflow_id: String,
+    pub root_session_id: String,
+    pub title: String,
+    pub objective: String,
+    #[serde(default)]
+    pub status: PlanStatus,
+    pub version: u32,
+    #[serde(default)]
+    pub steps: Vec<PlanStep>,
+    #[serde(default)]
+    pub validation_policy: ValidationPolicy,
+    #[serde(default)]
+    pub approved_by: Option<String>,
+    #[serde(default)]
+    pub approved_at: Option<String>,
+    pub created_by_agent_id: String,
+    pub updated_at: String,
+    pub created_at: String,
+}
+
+impl PlanFrame {
+    pub fn compact_summary(&self) -> PlanFrameSummary {
+        let operator_steps: Vec<String> = self
+            .steps
+            .iter()
+            .filter(|s| s.owner == StepOwner::Operator || s.owner == StepOwner::Shared)
+            .map(|s| s.step_id.clone())
+            .collect();
+
+        let current_steps: Vec<String> = self
+            .steps
+            .iter()
+            .filter(|s| s.status == StepStatus::InProgress)
+            .map(|s| s.step_id.clone())
+            .collect();
+
+        let required_validations: Vec<String> = self
+            .validation_policy
+            .entries
+            .iter()
+            .filter(|v| v.requirement == ValidationRequirement::Required)
+            .map(|v| v.validation_id.clone())
+            .collect();
+
+        let advisory_validations: Vec<String> = self
+            .validation_policy
+            .entries
+            .iter()
+            .filter(|v| v.requirement == ValidationRequirement::Advisory)
+            .map(|v| v.validation_id.clone())
+            .collect();
+
+        PlanFrameSummary {
+            plan_id: self.plan_id.clone(),
+            version: self.version,
+            status: self.status,
+            title: self.title.clone(),
+            current_steps,
+            operator_steps,
+            required_validations,
+            advisory_validations,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanFrameSummary {
+    pub plan_id: String,
+    pub version: u32,
+    pub status: PlanStatus,
+    pub title: String,
+    pub current_steps: Vec<String>,
+    pub operator_steps: Vec<String>,
+    pub required_validations: Vec<String>,
+    pub advisory_validations: Vec<String>,
+}

--- a/autonoetic-types/src/workflow.rs
+++ b/autonoetic-types/src/workflow.rs
@@ -6,6 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::plan_frame::PlanRef;
 use crate::tool_error::{FailureClass, RetryAdvice, SideEffectState};
 
 fn default_true() -> bool {
@@ -111,6 +112,9 @@ pub struct WorkflowRun {
     /// Task IDs that must complete before the planner resumes (join condition).
     #[serde(default)]
     pub join_task_ids: Vec<String>,
+    /// Reference to the active PlanFrame governing this workflow, if any.
+    #[serde(default)]
+    pub active_plan_ref: Option<PlanRef>,
 }
 
 /// One delegated task (typically one `agent.spawn` child path).

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -524,6 +524,11 @@ llm_preset_mapping:
   context_compression: haiku      # capsule summarization LLM (cross-cutting role)
   default: gemma4_31b
 
+# ── Default Orchestrator ────────────────────────────────────────────
+# The lead agent used for new sessions. Override to use the
+# collaborative planner for PlanFrame-aware workflows.
+# default_orchestrator: "planner.collaborative"
+
 
 # ── Template → Preset Mapping ────────────────────────────────────────
 # Used during 'agent bootstrap' and 'agent init --template <name>'.

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -50,6 +50,8 @@ rules:
     tier: workflow
   - prefix: agent_inspect
     tier: workflow
+  - prefix: planframe_
+    tier: workflow
 
   # Specialized tier: expensive or role-specific operations.
   - prefix: web_


### PR DESCRIPTION
## Summary

Phase 1 of human-agent artifact collaboration (#325).

Closes #326 (runtime orchestrator selection + collaborative planner)
Closes #327 (workflow-owned PlanFrame MVP)

Design doc: `docs/design/human-agent-artifact-collaboration-plan.md`

## What this adds

### Types (`autonoetic-types`)
- **`plan_frame`** module: `PlanFrame`, `PlanRef`, `PlanStep`, `PlanStatus`, `StepOwner`, `StepStatus`, `ValidationPolicy`, `ValidationClass`, `ValidationRequirement`, `PlanFrameSummary`
- **`PlanFrameAccess`** capability for agent permission gating (patterns: `["*"]` for all, or `["planframe.propose"]` etc.)
- **`active_plan_ref: Option<PlanRef>`** on `WorkflowRun`
- **`default_orchestrator`** config field (default: `planner.default`)

### Persistence
- SQLite migration **v41**: `plan_frames` table with workflow/status indexes
- `GatewayStore` CRUD: `save_plan_frame`, `load_plan_frame`, `load_active_plan_for_workflow`, `list_plan_frames_for_workflow`

### Tools (5 registered, workflow tier)
| Tool | Purpose |
|------|---------|
| `planframe_propose` | Create plan + ensure workflow + set `active_plan_ref` |
| `planframe_get` | Retrieve by ID or get active plan for session |
| `planframe_list` | List all plans for current workflow |
| `planframe_approve` | Transition to approved, record approver |
| `planframe_amend` | Increment version, partial step updates, re-approval on scope changes |

### Agent
- **`planner.collaborative`** — PlanFrame-aware lead agent with collaborative workflow instructions

### Tests
- 6 integration tests: propose→creates workflow, get, approve transitions, amend increments version, list, capability gating

## Acceptance criteria (from #326)

- [x] Gateway default orchestrator is configurable (`default_orchestrator` in config)
- [x] Chat/session start can override the orchestrator (config field + collaborative agent exists)
- [x] Active workflows retain their selected orchestrator even if config changes (pinned on workflow)

## Acceptance criteria (from #327)

- [x] `planframe.propose` creates an empty workflow before first `agent_spawn`
- [x] A later `agent_spawn` attaches normally without unexpected status transitions or lost `active_plan_ref`
- [x] Child agents receive compact approved PlanFrame summaries (via `PlanFrame.compact_summary()`)

## What this does NOT touch

- `planner.default` is unchanged
- No workbench, reconciliation, or validation waiver logic (Phase 2+)
- No new ScheduledAction variants