### PR TITLE
feat(workbench): reconcile and discard — Phase 3

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -21,6 +21,8 @@ pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(WorkbenchCheckpointTool));
     registry.register(Box::new(WorkbenchCheckpointsTool));
     registry.register(Box::new(WorkbenchCheckoutTool));
+    registry.register(Box::new(WorkbenchReconcileTool));
+    registry.register(Box::new(WorkbenchDiscardTool));
 }
 
 fn has_workbench_access(manifest: &AgentManifest) -> bool {
@@ -48,6 +50,71 @@ fn file_sha256(path: &Path) -> anyhow::Result<String> {
     let mut hasher = Sha256::new();
     hasher.update(&data);
     Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+fn mint_artifact_ref_id() -> String {
+    let b = *uuid::Uuid::new_v4().as_bytes();
+    format!(
+        "ar.{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        b[0], b[1], b[2], b[3], b[4], b[5]
+    )
+}
+
+fn compute_diff(
+    source_dir: &Path,
+    base_digests: &std::collections::HashMap<String, String>,
+) -> anyhow::Result<Vec<WorkbenchFileDiff>> {
+    let current_files = collect_workbench_files(source_dir)?;
+    let current_names: std::collections::HashSet<&str> =
+        current_files.iter().map(|(n, _)| n.as_str()).collect();
+
+    let mut diffs: Vec<WorkbenchFileDiff> = Vec::new();
+
+    for name in base_digests.keys() {
+        if !current_names.contains(name.as_str()) {
+            diffs.push(WorkbenchFileDiff {
+                path: name.clone(),
+                change_type: FileChangeType::Deleted,
+                base_digest: Some(base_digests[name].clone()),
+                current_digest: None,
+            });
+        }
+    }
+
+    for (name, _) in &current_files {
+        match base_digests.get(name) {
+            Some(base) => {
+                let current = file_sha256(&source_dir.join(name))?;
+                if &current == base {
+                    diffs.push(WorkbenchFileDiff {
+                        path: name.clone(),
+                        change_type: FileChangeType::Unchanged,
+                        base_digest: Some(base.clone()),
+                        current_digest: Some(current),
+                    });
+                } else {
+                    diffs.push(WorkbenchFileDiff {
+                        path: name.clone(),
+                        change_type: FileChangeType::Modified,
+                        base_digest: Some(base.clone()),
+                        current_digest: Some(current),
+                    });
+                }
+            }
+            None => {
+                let current = file_sha256(&source_dir.join(name))?;
+                diffs.push(WorkbenchFileDiff {
+                    path: name.clone(),
+                    change_type: FileChangeType::Added,
+                    base_digest: None,
+                    current_digest: Some(current),
+                });
+            }
+        }
+    }
+
+    diffs.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(diffs)
 }
 
 fn validate_relative_path(name: &str) -> anyhow::Result<()> {
@@ -452,57 +519,7 @@ impl NativeTool for WorkbenchDiffTool {
             std::collections::HashMap::new()
         };
 
-        let current_files = collect_workbench_files(source_dir)?;
-        let mut current_names: std::collections::HashSet<&str> =
-            current_files.iter().map(|(n, _)| n.as_str()).collect();
-
-        let mut diffs: Vec<WorkbenchFileDiff> = Vec::new();
-
-        for (name, _) in &base_digests {
-            if !current_names.contains(name.as_str()) {
-                diffs.push(WorkbenchFileDiff {
-                    path: name.clone(),
-                    change_type: FileChangeType::Deleted,
-                    base_digest: Some(base_digests[name].clone()),
-                    current_digest: None,
-                });
-            }
-        }
-
-        for (name, _) in &current_files {
-            match base_digests.get(name) {
-                Some(base) => {
-                    let current = file_sha256(&source_dir.join(name))?;
-                    if &current == base {
-                        diffs.push(WorkbenchFileDiff {
-                            path: name.clone(),
-                            change_type: FileChangeType::Unchanged,
-                            base_digest: Some(base.clone()),
-                            current_digest: Some(current),
-                        });
-                    } else {
-                        diffs.push(WorkbenchFileDiff {
-                            path: name.clone(),
-                            change_type: FileChangeType::Modified,
-                            base_digest: Some(base.clone()),
-                            current_digest: Some(current),
-                        });
-                    }
-                }
-                None => {
-                    let current = file_sha256(&source_dir.join(name))?;
-                    diffs.push(WorkbenchFileDiff {
-                        path: name.clone(),
-                        change_type: FileChangeType::Added,
-                        base_digest: None,
-                        current_digest: Some(current),
-                    });
-                }
-            }
-        }
-
-        diffs.sort_by(|a, b| a.path.cmp(&b.path));
-
+        let diffs = compute_diff(source_dir, &base_digests)?;
         let changed = diffs.iter().filter(|d| d.change_type != FileChangeType::Unchanged).count();
 
         Ok(serde_json::to_string(&serde_json::json!({
@@ -823,6 +840,283 @@ impl NativeTool for WorkbenchCheckoutTool {
             "label": cp.label,
             "file_count": cp.file_count,
             "message": "Workbench restored to checkpoint."
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct WorkbenchReconcileTool;
+
+impl NativeTool for WorkbenchReconcileTool {
+    fn name(&self) -> &'static str {
+        "workbench_reconcile"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Reconcile workbench edits into a new immutable artifact revision. Reads current files from the workbench, classifies authorship (operator-modified vs agent-generated), builds a new artifact, and marks the workbench as reconciled.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "workbench_id": {
+                        "type": "string",
+                        "description": "The workbench ID to reconcile"
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Optional human-readable message describing the edits"
+                    }
+                },
+                "required": ["workbench_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_workbench_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            workbench_id: String,
+            message: Option<String>,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(gateway_dir) = gateway_dir else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway directory not available"
+            }))?);
+        };
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(config) = config else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway config not available"
+            }))?);
+        };
+
+        let session_id_val = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
+        let root_session_id = session_id_val.split('/').next().unwrap_or(session_id_val);
+
+        let Some(wb) = store.load_workbench(&args.workbench_id)? else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Workbench not found"
+            }))?);
+        };
+
+        if wb.status != WorkbenchStatus::Active {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": format!("Cannot reconcile a {} workbench", wb.status.as_str())
+            }))?);
+        }
+
+        let source_dir = Path::new(&wb.workspace_path);
+        if !source_dir.exists() {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Workbench source directory does not exist"
+            }))?);
+        }
+
+        let meta_dir = source_dir.parent().unwrap().join(".autonoetic");
+        let digests_path = meta_dir.join("base_digests.json");
+        let base_digests: std::collections::HashMap<String, String> = if digests_path.exists() {
+            serde_json::from_str(&std::fs::read_to_string(&digests_path)?)?
+        } else {
+            std::collections::HashMap::new()
+        };
+
+        let diffs = compute_diff(source_dir, &base_digests)?;
+
+        let current_files = collect_workbench_files(source_dir)?;
+        if current_files.is_empty() {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "No files in workbench to reconcile"
+            }))?);
+        }
+
+        let content_store = ContentStore::new(gateway_dir)?;
+        let mut input_names: Vec<String> = Vec::new();
+
+        for (name, _) in &current_files {
+            let file_path = source_dir.join(name);
+            let content = std::fs::read(&file_path)?;
+            let handle = content_store.write(&content)?;
+            content_store.register_name(root_session_id, name, &handle)?;
+            input_names.push(name.clone());
+        }
+
+        let artifact_store = ArtifactStore::new(gateway_dir)?;
+        let bundle = artifact_store.build(&input_names, None, None, root_session_id)?;
+
+        let root = crate::runtime::content_store::root_session_id(root_session_id);
+        let (scope_type, scope_id) =
+            match crate::scheduler::workflow_store::resolve_workflow_id_for_root_session(
+                config, root,
+            ) {
+                Ok(Some(wf_id)) => (
+                    autonoetic_types::artifact::ArtifactRefScopeType::Workflow,
+                    wf_id,
+                ),
+                _ => (
+                    autonoetic_types::artifact::ArtifactRefScopeType::Session,
+                    root.to_string(),
+                ),
+            };
+
+        let ref_id = mint_artifact_ref_id();
+        store.create_artifact_ref(&autonoetic_types::artifact::ArtifactRefRecord {
+            ref_id: ref_id.clone(),
+            scope_type,
+            scope_id: scope_id.clone(),
+            artifact_id: bundle.artifact_id.clone(),
+            artifact_manifest_digest: bundle.artifact_manifest_digest.clone(),
+            artifact_canonical_digest: bundle.artifact_canonical_digest.clone(),
+            created_by_agent_id: manifest.agent.id.clone(),
+            created_at: now_rfc3339(),
+            expires_at: None,
+            revoked_at: None,
+        })?;
+
+        let now = now_rfc3339();
+        store.update_workbench_status(&wb.workbench_id, WorkbenchStatus::Reconciled, &now)?;
+
+        let provenance = serde_json::json!({
+            "base_artifact_id": wb.base_artifact_id,
+            "new_artifact_id": bundle.artifact_id,
+            "new_artifact_ref": ref_id,
+            "operator_modified": diffs.iter().filter(|d| d.change_type == FileChangeType::Modified).map(|d| d.path.clone()).collect::<Vec<_>>(),
+            "operator_added": diffs.iter().filter(|d| d.change_type == FileChangeType::Added).map(|d| d.path.clone()).collect::<Vec<_>>(),
+            "deleted": diffs.iter().filter(|d| d.change_type == FileChangeType::Deleted).map(|d| d.path.clone()).collect::<Vec<_>>(),
+            "unchanged": diffs.iter().filter(|d| d.change_type == FileChangeType::Unchanged).count(),
+        });
+
+        let provenance_path = meta_dir.join("reconciliation.json");
+        std::fs::write(&provenance_path, serde_json::to_string_pretty(&provenance)?)?;
+
+        let changed = diffs.iter().filter(|d| d.change_type != FileChangeType::Unchanged).count();
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "workbench_id": wb.workbench_id,
+            "new_artifact_ref": ref_id,
+            "new_artifact_id": bundle.artifact_id,
+            "base_artifact_id": wb.base_artifact_id,
+            "total_files": current_files.len(),
+            "changed_files": changed,
+            "provenance": provenance,
+            "reconciled_at": now,
+            "message": args.message.unwrap_or_default(),
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct WorkbenchDiscardTool;
+
+impl NativeTool for WorkbenchDiscardTool {
+    fn name(&self) -> &'static str {
+        "workbench_discard"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Discard a workbench without reconciling. Marks the workbench as discarded. The workbench directory and checkpoints are preserved for audit but the workbench can no longer be edited or reconciled.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "workbench_id": {
+                        "type": "string",
+                        "description": "The workbench ID to discard"
+                    }
+                },
+                "required": ["workbench_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_workbench_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            workbench_id: String,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(wb) = store.load_workbench(&args.workbench_id)? else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Workbench not found"
+            }))?);
+        };
+
+        if wb.status != WorkbenchStatus::Active {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": format!("Cannot discard a {} workbench", wb.status.as_str())
+            }))?);
+        }
+
+        let now = now_rfc3339();
+        store.update_workbench_status(&wb.workbench_id, WorkbenchStatus::Discarded, &now)?;
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "workbench_id": wb.workbench_id,
+            "status": "discarded",
+            "discarded_at": now,
+            "message": "Workbench discarded. Files preserved for audit."
         }))?)
     }
 

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -572,3 +572,353 @@ fn artifact_project_rejects_path_traversal() {
         }
     }
 }
+
+fn project_artifact(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    agent_dir: &std::path::Path,
+    gateway_dir: &std::path::Path,
+    config: &GatewayConfig,
+    store: &Arc<GatewayStore>,
+    session_id: &str,
+    artifact_ref: &str,
+) -> String {
+    let out = registry
+        .execute(
+            "artifact_project",
+            manifest,
+            policy,
+            agent_dir,
+            Some(gateway_dir),
+            &serde_json::to_string(&json!({ "artifact_ref": artifact_ref })).unwrap(),
+            Some(session_id),
+            None,
+            Some(config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    if v["ok"] != true {
+        panic!("artifact_project failed: {:?}", v);
+    }
+    v["workbench_id"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn workbench_reconcile_creates_new_artifact() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-006";
+
+    let artifact_ref = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("hello.txt", b"hello world"), ("config.toml", b"[settings]\nkey = \"value\"")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_ref,
+    );
+
+    let wb = store.load_workbench(&wb_id).unwrap().unwrap();
+    let source_dir = std::path::Path::new(&wb.workspace_path);
+
+    let edited = std::fs::read_to_string(source_dir.join("hello.txt")).unwrap();
+    std::fs::write(source_dir.join("hello.txt"), format!("{} -- edited by operator", edited)).unwrap();
+    std::fs::write(source_dir.join("new_file.txt"), b"brand new content").unwrap();
+
+    let reconcile_args = serde_json::json!({
+        "workbench_id": wb_id,
+        "message": "operator edited hello.txt and added new_file.txt"
+    });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true, "reconcile should succeed: {:?}", v);
+    assert!(v["new_artifact_ref"].as_str().unwrap().starts_with("ar."));
+    assert!(v["new_artifact_id"].as_str().unwrap().starts_with("art_"));
+    assert_eq!(v["base_artifact_id"], v["base_artifact_id"]);
+    assert_eq!(v["changed_files"], 2);
+    assert_eq!(v["total_files"], 3);
+
+    let provenance = &v["provenance"];
+    let modified: Vec<&str> = provenance["operator_modified"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(modified.contains(&"hello.txt"));
+    let added: Vec<&str> = provenance["operator_added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(added.contains(&"new_file.txt"));
+    assert_eq!(provenance["unchanged"], 1);
+
+    let wb_after = store.load_workbench(&wb_id).unwrap().unwrap();
+    assert_eq!(wb_after.status, autonoetic_types::workbench::WorkbenchStatus::Reconciled);
+    assert!(wb_after.reconciled_at.is_some());
+}
+
+#[test]
+fn workbench_reconcile_rejects_non_active() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-007";
+
+    let artifact_ref = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("test.txt", b"test")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_ref,
+    );
+
+    let discard_args = serde_json::json!({ "workbench_id": wb_id });
+    registry
+        .execute(
+            "workbench_discard",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &discard_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let reconcile_args = serde_json::json!({ "workbench_id": wb_id });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    assert!(v["error"].as_str().unwrap().contains("discard"));
+}
+
+#[test]
+fn workbench_discard_marks_discarded() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-008";
+
+    let artifact_ref = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("test.txt", b"test")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_ref,
+    );
+
+    let args = serde_json::json!({ "workbench_id": wb_id });
+    let out = registry
+        .execute(
+            "workbench_discard",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["status"], "discarded");
+    assert!(v["discarded_at"].is_string());
+
+    let wb = store.load_workbench(&wb_id).unwrap().unwrap();
+    assert_eq!(wb.status, autonoetic_types::workbench::WorkbenchStatus::Discarded);
+    assert!(wb.discarded_at.is_some());
+}
+
+#[test]
+fn workbench_discard_rejects_already_discarded() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-009";
+
+    let artifact_ref = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("test.txt", b"test")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_ref,
+    );
+
+    let args = serde_json::json!({ "workbench_id": wb_id });
+    registry
+        .execute(
+            "workbench_discard",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let out = registry
+        .execute(
+            "workbench_discard",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    assert!(v["error"].as_str().unwrap().contains("discard"));
+}


### PR DESCRIPTION
Closes #331

## Summary

Implements Phase 3 of the human-agent artifact collaboration plan: **Reconcile workbench edits into immutable artifact revisions**.

Depends on PR #337 (Phase 2 — merge that first).

## Tools Added

| Tool | Description |
|------|-------------|
| `workbench_reconcile` | Build new immutable artifact from edited workbench files |
| `workbench_discard` | Discard workbench without reconciling (files preserved for audit) |

## Reconcile Flow

1. Load workbench, verify Active status
2. Read current files from workbench source dir
3. Compute diff against base digests for provenance classification
4. Write each file to ContentStore + register_name
5. Build new artifact via ArtifactStore
6. Create artifact ref
7. Update workbench status to Reconciled
8. Persist reconciliation.json with provenance metadata

## Provenance Classification

- `operator_modified` — files whose digest changed from base artifact
- `operator_added` — files not in the base artifact
- `deleted` — base files removed from workbench
- `unchanged` — count of files identical to base

## Tests

4 new integration tests (9 total with Phase 2):
1. Reconcile creates new artifact with provenance
2. Reconcile rejects non-active workbench
3. Discard marks workbench as discarded
4. Discard rejects already-discarded workbench

## Acceptance Criteria (from #331)

- [x] Human edits become a new artifact revision
- [x] Provenance distinguishes operator-modified files
- [x] Workbench lifecycle: Active → Reconciled or Active → Discarded