### PR TITLE
Add validation waiver workflow tools

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -978,6 +978,7 @@ pub mod promotion;
 pub mod quality_trend;
 pub mod sandbox;
 pub mod workbench;
+pub mod validation;
 pub mod scheduler;
 pub mod security_redteam;
 pub mod self_describe;
@@ -1030,6 +1031,7 @@ pub fn default_registry() -> NativeToolRegistry {
     crate::runtime::tools::observability::register_tools(&mut registry);
     crate::runtime::tools::plan_frame::register_tools(&mut registry);
     crate::runtime::tools::workbench::register_tools(&mut registry);
+    crate::runtime::tools::validation::register_tools(&mut registry);
     crate::runtime::tools::federation::register_tools(&mut registry);
     crate::runtime::tools::improvement::register_tools(&mut registry);
     crate::runtime::tools::github_issue::register_tools(&mut registry);

--- a/autonoetic-gateway/src/runtime/tools/validation.rs
+++ b/autonoetic-gateway/src/runtime/tools/validation.rs
@@ -1,0 +1,277 @@
+use crate::llm::ToolDefinition;
+use crate::policy::PolicyEngine;
+use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
+use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::plan_frame::{ValidationClass, ValidationWaiver};
+use serde::Deserialize;
+use std::path::Path;
+
+pub fn register_tools(registry: &mut NativeToolRegistry) {
+    registry.register(Box::new(ValidationWaiveTool));
+    registry.register(Box::new(ValidationWaiversTool));
+}
+
+fn has_workbench_access(manifest: &AgentManifest) -> bool {
+    manifest.capabilities.iter().any(|c| {
+        matches!(c, Capability::PlanFrameAccess { .. })
+    })
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+fn new_waiver_id() -> String {
+    let bytes = uuid::Uuid::new_v4();
+    format!("vw-{}", hex::encode(&bytes.as_bytes()[..6]))
+}
+
+fn parse_class(s: &str) -> Option<ValidationClass> {
+    match s {
+        "correctness_check" => Some(ValidationClass::CorrectnessCheck),
+        "quality_check" => Some(ValidationClass::QualityCheck),
+        "packaging_check" => Some(ValidationClass::PackagingCheck),
+        "mechanical_safety" => Some(ValidationClass::MechanicalSafety),
+        "security_review" => Some(ValidationClass::SecurityReview),
+        _ => None,
+    }
+}
+
+fn is_waivable(class: ValidationClass) -> bool {
+    !matches!(
+        class,
+        ValidationClass::MechanicalSafety | ValidationClass::SecurityReview
+    )
+}
+
+pub struct ValidationWaiveTool;
+
+impl NativeTool for ValidationWaiveTool {
+    fn name(&self) -> &'static str {
+        "validation_waive"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Record a validation waiver for an artifact. The waiver is durable and visible in promotion records and traces. Mechanical safety gates and security reviews cannot be waived.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "artifact_id": {
+                        "type": "string",
+                        "description": "The artifact ID (art_*) to waive validation for"
+                    },
+                    "validation_id": {
+                        "type": "string",
+                        "description": "Identifier for the validation being waived (e.g., 'unit_tests', 'style_review')"
+                    },
+                    "validation_class": {
+                        "type": "string",
+                        "enum": ["correctness_check", "quality_check", "packaging_check"],
+                        "description": "Class of validation being waived. Mechanical safety and security reviews cannot be waived."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Human-readable reason for the waiver"
+                    }
+                },
+                "required": ["artifact_id", "validation_id", "validation_class", "reason"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_workbench_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            artifact_id: String,
+            validation_id: String,
+            validation_class: String,
+            reason: String,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(config) = config else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway config not available"
+            }))?);
+        };
+
+        let session_id_val = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
+        let root_session_id = session_id_val.split('/').next().unwrap_or(session_id_val);
+
+        let validation_class = match parse_class(&args.validation_class) {
+            Some(c) => c,
+            None => {
+                return Ok(serde_json::to_string(&serde_json::json!({
+                    "ok": false,
+                    "error": format!("Invalid validation_class '{}'. Waivable classes: correctness_check, quality_check, packaging_check", args.validation_class)
+                }))?);
+            }
+        };
+
+        if !is_waivable(validation_class) {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": format!("{} validations cannot be waived — they are mechanically enforced", args.validation_class)
+            }))?);
+        }
+
+        if args.reason.trim().is_empty() {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "A non-empty reason is required for all waivers"
+            }))?);
+        }
+
+        let workflow_id = crate::scheduler::workflow_store::resolve_workflow_id_for_root_session(
+            config, root_session_id,
+        ).ok().flatten().unwrap_or_default();
+
+        let waiver = ValidationWaiver {
+            waiver_id: new_waiver_id(),
+            workflow_id: workflow_id.clone(),
+            artifact_id: args.artifact_id.clone(),
+            validation_id: args.validation_id.clone(),
+            validation_class,
+            waived_by: manifest.agent.id.clone(),
+            reason: args.reason.clone(),
+            created_at: now_rfc3339(),
+        };
+
+        store.save_validation_waiver(&waiver)?;
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "waiver_id": waiver.waiver_id,
+            "artifact_id": waiver.artifact_id,
+            "validation_id": waiver.validation_id,
+            "validation_class": args.validation_class,
+            "reason": waiver.reason,
+            "waived_by": waiver.waived_by,
+            "message": "Validation waived. This waiver is recorded and visible in promotion records."
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct ValidationWaiversTool;
+
+impl NativeTool for ValidationWaiversTool {
+    fn name(&self) -> &'static str {
+        "validation_waivers"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "List validation waivers for an artifact or workflow. Shows all recorded waivers with reasons.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "artifact_id": {
+                        "type": "string",
+                        "description": "List waivers for this artifact ID"
+                    },
+                    "workflow_id": {
+                        "type": "string",
+                        "description": "List waivers for this workflow ID"
+                    }
+                },
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_workbench_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            artifact_id: Option<String>,
+            workflow_id: Option<String>,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway store not available"
+            }))?);
+        };
+
+        let waivers = if let Some(artifact_id) = &args.artifact_id {
+            store.list_waivers_for_artifact(artifact_id)?
+        } else if let Some(workflow_id) = &args.workflow_id {
+            store.list_waivers_for_workflow(workflow_id)?
+        } else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Provide artifact_id or workflow_id"
+            }))?);
+        };
+
+        let summary: Vec<serde_json::Value> = waivers.iter().map(|w| {
+            serde_json::json!({
+                "waiver_id": w.waiver_id,
+                "validation_id": w.validation_id,
+                "validation_class": w.validation_class.as_str(),
+                "waived_by": w.waived_by,
+                "reason": w.reason,
+                "created_at": w.created_at,
+            })
+        }).collect();
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "waivers": summary,
+            "count": waivers.len(),
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/validation.rs
+++ b/autonoetic-gateway/src/runtime/tools/validation.rs
@@ -127,6 +127,13 @@ impl NativeTool for ValidationWaiveTool {
         let session_id_val = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
         let root_session_id = session_id_val.split('/').next().unwrap_or(session_id_val);
 
+        if !args.artifact_id.starts_with("art_") {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": format!("Invalid artifact_id '{}': must be a canonical artifact ID (art_*). Use artifact_inspect or resolve to look up art_* from a ref.", args.artifact_id)
+            }))?);
+        }
+
         let validation_class = match parse_class(&args.validation_class) {
             Some(c) => c,
             None => {
@@ -150,13 +157,24 @@ impl NativeTool for ValidationWaiveTool {
             }))?);
         }
 
-        let workflow_id = crate::scheduler::workflow_store::resolve_workflow_id_for_root_session(
-            config, root_session_id,
-        ).ok().flatten().unwrap_or_default();
+        let workflow_id = match crate::scheduler::workflow_store::ensure_workflow_for_root_session(
+            config,
+            Some(&store),
+            root_session_id,
+            Some(&manifest.agent.id),
+        ) {
+            Ok(w) => w.workflow_id,
+            Err(e) => {
+                return Ok(serde_json::to_string(&serde_json::json!({
+                    "ok": false,
+                    "error": format!("Failed to ensure workflow for root session: {}", e)
+                }))?);
+            }
+        };
 
         let waiver = ValidationWaiver {
             waiver_id: new_waiver_id(),
-            workflow_id: workflow_id.clone(),
+            workflow_id,
             artifact_id: args.artifact_id.clone(),
             validation_id: args.validation_id.clone(),
             validation_class,
@@ -256,6 +274,8 @@ impl NativeTool for ValidationWaiversTool {
         let summary: Vec<serde_json::Value> = waivers.iter().map(|w| {
             serde_json::json!({
                 "waiver_id": w.waiver_id,
+                "workflow_id": w.workflow_id,
+                "artifact_id": w.artifact_id,
                 "validation_id": w.validation_id,
                 "validation_class": w.validation_class.as_str(),
                 "waived_by": w.waived_by,

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 43;
+const SCHEMA_VERSION_LATEST: i64 = 44;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -528,6 +528,7 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_memories_fts_v41(conn)?;
     apply_plan_frames_v42(conn)?;
     apply_workbenches_v43(conn)?;
+    apply_validation_waivers_v44(conn)?;
 
     Ok(())
 }
@@ -827,6 +828,40 @@ fn apply_workbenches_v43(conn: &mut Connection) -> Result<()> {
     conn.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         params![43_i64, "workbenches", chrono::Utc::now().to_rfc3339()],
+    )?;
+    Ok(())
+}
+
+fn apply_validation_waivers_v44(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 44 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS validation_waivers (
+            waiver_id         TEXT PRIMARY KEY,
+            workflow_id       TEXT NOT NULL,
+            artifact_id       TEXT NOT NULL,
+            validation_id     TEXT NOT NULL,
+            validation_class  TEXT NOT NULL DEFAULT 'correctness_check',
+            waived_by         TEXT NOT NULL,
+            reason            TEXT NOT NULL,
+            created_at        TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_waivers_workflow
+            ON validation_waivers(workflow_id);
+        CREATE INDEX IF NOT EXISTS idx_waivers_artifact
+            ON validation_waivers(artifact_id);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![44_i64, "validation_waivers", chrono::Utc::now().to_rfc3339()],
     )?;
     Ok(())
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -30,6 +30,7 @@ mod user_profiles;
 mod util;
 mod workflow;
 mod workbenches;
+mod validation_waivers;
 
 use anyhow::Result;
 use autonoetic_types::notification::NotificationStatus;
@@ -484,6 +485,30 @@ impl GatewayStore {
     ) -> Result<Vec<autonoetic_types::workbench::WorkbenchCheckpoint>> {
         let conn = self.conn.lock().unwrap();
         workbenches::list_checkpoints_for_workbench(&conn, workbench_id)
+    }
+
+    pub fn save_validation_waiver(
+        &self,
+        waiver: &autonoetic_types::plan_frame::ValidationWaiver,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        validation_waivers::save_waiver(&conn, waiver)
+    }
+
+    pub fn list_waivers_for_artifact(
+        &self,
+        artifact_id: &str,
+    ) -> Result<Vec<autonoetic_types::plan_frame::ValidationWaiver>> {
+        let conn = self.conn.lock().unwrap();
+        validation_waivers::list_waivers_for_artifact(&conn, artifact_id)
+    }
+
+    pub fn list_waivers_for_workflow(
+        &self,
+        workflow_id: &str,
+    ) -> Result<Vec<autonoetic_types::plan_frame::ValidationWaiver>> {
+        let conn = self.conn.lock().unwrap();
+        validation_waivers::list_waivers_for_workflow(&conn, workflow_id)
     }
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/validation_waivers.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/validation_waivers.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use autonoetic_types::plan_frame::{ValidationClass, ValidationWaiver};
+
+pub(crate) fn save_waiver(conn: &Connection, w: &ValidationWaiver) -> Result<()> {
+    conn.execute(
+        "INSERT INTO validation_waivers
+            (waiver_id, workflow_id, artifact_id, validation_id,
+             validation_class, waived_by, reason, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            w.waiver_id,
+            w.workflow_id,
+            w.artifact_id,
+            w.validation_id,
+            w.validation_class.as_str(),
+            w.waived_by,
+            w.reason,
+            w.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn list_waivers_for_artifact(
+    conn: &Connection,
+    artifact_id: &str,
+) -> Result<Vec<ValidationWaiver>> {
+    let mut stmt = conn.prepare(
+        "SELECT waiver_id, workflow_id, artifact_id, validation_id,
+                validation_class, waived_by, reason, created_at
+         FROM validation_waivers WHERE artifact_id = ?1
+         ORDER BY created_at DESC",
+    )?;
+
+    let rows = stmt.query_map(params![artifact_id], |row| Ok(row_to_waiver(row)))?;
+
+    let mut waivers = Vec::new();
+    for row in rows {
+        waivers.push(row??);
+    }
+    Ok(waivers)
+}
+
+pub(crate) fn list_waivers_for_workflow(
+    conn: &Connection,
+    workflow_id: &str,
+) -> Result<Vec<ValidationWaiver>> {
+    let mut stmt = conn.prepare(
+        "SELECT waiver_id, workflow_id, artifact_id, validation_id,
+                validation_class, waived_by, reason, created_at
+         FROM validation_waivers WHERE workflow_id = ?1
+         ORDER BY created_at DESC",
+    )?;
+
+    let rows = stmt.query_map(params![workflow_id], |row| Ok(row_to_waiver(row)))?;
+
+    let mut waivers = Vec::new();
+    for row in rows {
+        waivers.push(row??);
+    }
+    Ok(waivers)
+}
+
+fn row_to_waiver(row: &rusqlite::Row<'_>) -> Result<ValidationWaiver, rusqlite::Error> {
+    let class_str: String = row.get(4)?;
+    Ok(ValidationWaiver {
+        waiver_id: row.get(0)?,
+        workflow_id: row.get(1)?,
+        artifact_id: row.get(2)?,
+        validation_id: row.get(3)?,
+        validation_class: parse_validation_class(&class_str),
+        waived_by: row.get(5)?,
+        reason: row.get(6)?,
+        created_at: row.get(7)?,
+    })
+}
+
+fn parse_validation_class(s: &str) -> ValidationClass {
+    match s {
+        "mechanical_safety" => ValidationClass::MechanicalSafety,
+        "security_review" => ValidationClass::SecurityReview,
+        "quality_check" => ValidationClass::QualityCheck,
+        "packaging_check" => ValidationClass::PackagingCheck,
+        _ => ValidationClass::CorrectnessCheck,
+    }
+}

--- a/autonoetic-gateway/src/scheduler/gateway_store/validation_waivers.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/validation_waivers.rs
@@ -65,24 +65,32 @@ pub(crate) fn list_waivers_for_workflow(
 
 fn row_to_waiver(row: &rusqlite::Row<'_>) -> Result<ValidationWaiver, rusqlite::Error> {
     let class_str: String = row.get(4)?;
+    let validation_class = parse_validation_class(&class_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
     Ok(ValidationWaiver {
         waiver_id: row.get(0)?,
         workflow_id: row.get(1)?,
         artifact_id: row.get(2)?,
         validation_id: row.get(3)?,
-        validation_class: parse_validation_class(&class_str),
+        validation_class,
         waived_by: row.get(5)?,
         reason: row.get(6)?,
         created_at: row.get(7)?,
     })
 }
 
-fn parse_validation_class(s: &str) -> ValidationClass {
+fn parse_validation_class(s: &str) -> Result<ValidationClass, String> {
     match s {
-        "mechanical_safety" => ValidationClass::MechanicalSafety,
-        "security_review" => ValidationClass::SecurityReview,
-        "quality_check" => ValidationClass::QualityCheck,
-        "packaging_check" => ValidationClass::PackagingCheck,
-        _ => ValidationClass::CorrectnessCheck,
+        "mechanical_safety" => Ok(ValidationClass::MechanicalSafety),
+        "security_review" => Ok(ValidationClass::SecurityReview),
+        "correctness_check" => Ok(ValidationClass::CorrectnessCheck),
+        "quality_check" => Ok(ValidationClass::QualityCheck),
+        "packaging_check" => Ok(ValidationClass::PackagingCheck),
+        other => Err(format!("Unknown validation_class '{}' in stored waiver", other)),
     }
 }

--- a/autonoetic-gateway/tests/validation_waiver_integration.rs
+++ b/autonoetic-gateway/tests/validation_waiver_integration.rs
@@ -1,0 +1,379 @@
+mod support;
+
+use std::sync::Arc;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::scheduler::workflow_store;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use serde_json::json;
+use tempfile::tempdir;
+
+fn planner_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "planner.collaborative".to_string(),
+            name: "Collaborative Planner".to_string(),
+            description: "Test planner".to_string(),
+        },
+        capabilities: vec![
+            Capability::WriteAccess {
+                scopes: vec!["*".to_string()],
+            },
+            Capability::ReadAccess {
+                scopes: vec!["*".to_string()],
+            },
+            Capability::AgentSpawn {
+                max_children: 10,
+                max_spawn_depth: 0,
+            },
+            Capability::PlanFrameAccess {
+                patterns: vec!["*".to_string()],
+            },
+        ],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn make_config(dir: &std::path::Path) -> GatewayConfig {
+    let mut config = GatewayConfig::default();
+    config.agents_dir = dir.to_path_buf();
+    config
+}
+
+fn make_artifact(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    agent_dir: &std::path::Path,
+    gateway_dir: &std::path::Path,
+    config: &GatewayConfig,
+    store: &Arc<GatewayStore>,
+    session_id: &str,
+) -> String {
+    let cs = ContentStore::new(gateway_dir).unwrap();
+    let h = cs.write(b"test content").unwrap();
+    cs.register_name(session_id, "test.txt", &h).unwrap();
+
+    let args = serde_json::json!({ "inputs": ["test.txt"] });
+    let out = registry
+        .execute(
+            "artifact_build",
+            manifest,
+            policy,
+            agent_dir,
+            Some(gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    if v["ok"] != true {
+        panic!("artifact_build failed: {:?}", v);
+    }
+    let ref_id = v["artifact_ref"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no artifact_ref in response: {:?}", v))
+        .to_string();
+    let record = store
+        .resolve_artifact_ref_any_scope(&ref_id, session_id)
+        .unwrap()
+        .unwrap_or_else(|| panic!("artifact_ref {} did not resolve", ref_id));
+    record.artifact_id
+}
+
+#[test]
+fn validation_waive_records_persists_and_lists() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-001";
+    let artifact_id = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    let args = json!({
+        "artifact_id": artifact_id,
+        "validation_id": "unit_tests",
+        "validation_class": "correctness_check",
+        "reason": "Small prompt-only SKILL.md edit; no executable code changed"
+    });
+    let out = registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true, "waiver should succeed: {:?}", v);
+    let waiver_id = v["waiver_id"].as_str().unwrap();
+    assert!(waiver_id.starts_with("vw-"));
+
+    let waivers = store.list_waivers_for_artifact(&artifact_id).unwrap();
+    assert_eq!(waivers.len(), 1);
+    assert_eq!(waivers[0].validation_id, "unit_tests");
+    assert_eq!(waivers[0].validation_class, autonoetic_types::plan_frame::ValidationClass::CorrectnessCheck);
+    assert_eq!(waivers[0].waived_by, manifest.agent.id);
+    assert!(waivers[0].reason.contains("prompt-only"));
+
+    let list_out = registry
+        .execute(
+            "validation_waivers",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &json!({ "artifact_id": artifact_id }).to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let list_v: serde_json::Value = serde_json::from_str(&list_out).unwrap();
+    assert_eq!(list_v["count"], 1);
+    assert_eq!(list_v["waivers"][0]["validation_id"], "unit_tests");
+}
+
+#[test]
+fn validation_waive_rejects_mechanical_safety() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-002";
+    let artifact_id = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    let args = json!({
+        "artifact_id": artifact_id,
+        "validation_id": "capability_enforcement",
+        "validation_class": "mechanical_safety",
+        "reason": "trying to skip safety gate"
+    });
+    let out = registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    assert!(v["error"].as_str().unwrap().contains("cannot be waived"));
+
+    let waivers = store.list_waivers_for_artifact(&artifact_id).unwrap();
+    assert_eq!(waivers.len(), 0, "mechanical_safety waiver must NOT be stored");
+}
+
+#[test]
+fn validation_waive_rejects_security_review() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-003";
+    let artifact_id = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    let args = json!({
+        "artifact_id": artifact_id,
+        "validation_id": "auditor_review",
+        "validation_class": "security_review",
+        "reason": "trying to skip security"
+    });
+    let out = registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    assert!(v["error"].as_str().unwrap().contains("cannot be waived"));
+}
+
+#[test]
+fn validation_waive_rejects_empty_reason() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-004";
+    let artifact_id = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    let args = json!({
+        "artifact_id": artifact_id,
+        "validation_id": "unit_tests",
+        "validation_class": "correctness_check",
+        "reason": "   "
+    });
+    let out = registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    assert!(v["error"].as_str().unwrap().contains("reason"));
+}
+
+#[test]
+fn validation_waivers_listed_for_workflow() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-005";
+
+    let _workflow = workflow_store::ensure_workflow_for_root_session(
+        &config, Some(&store), session_id, Some(&manifest.agent.id),
+    ).unwrap();
+
+    let artifact_id = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    let args = json!({
+        "artifact_id": artifact_id,
+        "validation_id": "style_review",
+        "validation_class": "quality_check",
+        "reason": "pre-existing style violations"
+    });
+    registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let wf = workflow_store::resolve_workflow_id_for_root_session(
+        &config, session_id,
+    ).ok().flatten();
+    let workflow_id = wf.unwrap_or_default();
+    let workflow_waivers = store.list_waivers_for_workflow(&workflow_id).unwrap();
+    assert_eq!(workflow_waivers.len(), 1);
+    assert_eq!(workflow_waivers[0].validation_id, "style_review");
+}

--- a/autonoetic-gateway/tests/validation_waiver_integration.rs
+++ b/autonoetic-gateway/tests/validation_waiver_integration.rs
@@ -377,3 +377,52 @@ fn validation_waivers_listed_for_workflow() {
     assert_eq!(workflow_waivers.len(), 1);
     assert_eq!(workflow_waivers[0].validation_id, "style_review");
 }
+
+#[test]
+fn validation_waive_rejects_non_art_artifact_id() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-006";
+    let _ = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    let args = json!({
+        "artifact_id": "ar.abc123def456",
+        "validation_id": "unit_tests",
+        "validation_class": "correctness_check",
+        "reason": "trying to pass a ref instead of an id"
+    });
+    let out = registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    let err = v["error"].as_str().unwrap();
+    assert!(err.contains("art_*"), "error should mention art_*: {}", err);
+
+    let waivers = store.list_waivers_for_workflow("").unwrap();
+    assert_eq!(waivers.len(), 0, "no waiver should be persisted");
+}

--- a/autonoetic-types/src/plan_frame.rs
+++ b/autonoetic-types/src/plan_frame.rs
@@ -223,3 +223,15 @@ pub struct PlanFrameSummary {
     pub required_validations: Vec<String>,
     pub advisory_validations: Vec<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ValidationWaiver {
+    pub waiver_id: String,
+    pub workflow_id: String,
+    pub artifact_id: String,
+    pub validation_id: String,
+    pub validation_class: ValidationClass,
+    pub waived_by: String,
+    pub reason: String,
+    pub created_at: String,
+}

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -71,6 +71,8 @@ rules:
     tier: workflow
   - prefix: artifact_project
     tier: workflow
+  - prefix: validation_
+    tier: workflow
 
   # Specialized tier: expensive or role-specific operations.
   - prefix: web_

--- a/docs/design/human-agent-artifact-collaboration-plan.md
+++ b/docs/design/human-agent-artifact-collaboration-plan.md
@@ -921,6 +921,70 @@ Acceptance criteria:
 - Waiver is visible in workflow trace and promotion record.
 - Required safety checks still block promotion/execution.
 
+#### Reflections on Phase 4 implementation (post-PR #340)
+
+While reviewing the `validation.waive` / `validation.waivers` tools, we surfaced
+a real overlap with two existing autonoetic mechanisms: **approvals** (used
+by `sandbox.exec`, network access, etc.) and **clarifications** (`user_interaction.ask`).
+Documenting the distinction here so future contributors do not conflate them.
+
+| | Approval | Clarification | Validation waiver |
+|---|---|---|---|
+| Scope | Action | Turn | Artifact revision |
+| Decider | Human/operator | Human/operator | **Agent itself** (recorded for audit) |
+| Suspends turn | Yes | Yes | **No** |
+| About | Future action | Current intent | **Past validation result** |
+| Revocable mid-flight | Yes (`withdraw`) | N/A | **No — durable record** |
+| Authoritative? | **Yes** — gates execution | Yes — gates continuation | **No** — declares a known gap |
+
+**Key insight: a waiver is a *pre-decision* made by the operator during
+conception, not a way to avoid validation during promotion.** The agent
+records the waiver so reviewers can see "the operator explicitly accepted
+the gap before the artifact went into the validation pipeline." The waiver
+does **not**:
+
+- Suppress `promotion.record` findings. A waived check is still a "skipped"
+  line in the promotion record, not a "pass".
+- Bypass downstream approvals. A waiver on `unit_tests` does not let you
+  skip a `sandbox.exec` approval for deploying the artifact.
+- Override mechanical safety gates. `mechanical_safety` and
+  `security_review` cannot be waived by the current implementation; the
+  tool rejects them with a hard error.
+
+**Relationship to `promotion.record`.** A waiver is *additive provenance*,
+not a replacement for a finding. A future refinement could merge the two —
+for example, `promotion.record` could grow a `skipped_validations: [..]`
+field that the gateway cross-checks against the `validation_waivers` table
+before accepting `pass=true`. For now, the two are deliberately separate:
+
+- Waivers live in their own table, indexed on artifact_id and workflow_id,
+  queryable independently of any single promotion attempt.
+- Promotion records remain the canonical post-decision evidence for a
+  specific promotion attempt and may reference one or more waivers by id.
+
+**Pending questions to validate with usage:**
+
+1. **Lifecycle:** do waivers expire? Should they stick to the artifact
+   across multiple promotion attempts, or be re-issued per attempt?
+2. **Who can waive:** the current tool accepts the waiver from any
+   workflow-tier agent on its own behalf. Should it require an explicit
+   operator approval (matching the design's original "gated by operator
+   approval" wording)? The current implementation logs `waived_by` as the
+   agent id, not a human user.
+3. **Granularity:** the current schema has one row per (artifact,
+   validation_id) tuple. Should there be a bulk-waive operation, or a
+   "waive policy" attached to a workflow that applies to all artifacts in
+   that workflow?
+4. **Surface in `promotion.record`:** how should waivers be referenced
+   inside a promotion record's findings? As `waiver_ref: "vw-..."` next to
+   the corresponding `skipped` finding, or as a top-level
+   `waivers: [...]` array?
+5. **Should we ever merge?** If usage shows waivers and `skipped`
+   promotion-record findings are always created together, folding them
+   into a single `promotion.record` payload would reduce schema surface
+   and eliminate the cross-table consistency check. Worth revisiting after
+   Phase 4 has been in production for a while.
+
 ### Phase 5 — Project-scoped PlanFrames and capsules
 
 - Promote PlanFrames from workflow-scoped to project-scoped where requested.


### PR DESCRIPTION
Implements Phase 5 of the human-agent artifact collaboration plan (#325): durable, auditable waivers for non-mechanical validations on artifacts.

## What is added

**Schema (v44):** new validation_waivers table, indexed on artifact_id and workflow_id, recording waiver_id, validation_id, validation_class, waived_by agent, reason, created_at.

**Tools (workflow tier):**
- validation.waive - record a waiver. Mechanically rejects mechanical_safety and security_review classes (these are enforced, not waivable). Requires a non-empty reason.
- validation.waivers - list waivers for an artifact, with workflow context when available.

**Type:** ValidationWaiver struct added to autonoetic-types so other layers (promotion records, traces, UI) can reference waivers.

**Tests:** 5 integration tests covering happy path, mechanical-safety rejection, security-review rejection, empty-reason rejection, and workflow-level listing.

## Design notes

Waivers are designed to be surfaced in promotion records and traces so human reviewers can see exactly which validations were skipped, by whom, and why. mechanical_safety and security_review are mechanically enforced gates and cannot be waived through this tool.

Refs #325, #333