### PR TITLE
context-governor: use active PlanFrame as relevance lens for delta extraction

### DIFF
--- a/autonoetic-gateway/src/runtime/context_governor/capsule.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/capsule.rs
@@ -148,9 +148,9 @@ Respond ONLY with a JSON object matching this schema:
 
 /// Render the "Active Plan" block that anchors the delta-extraction prompt
 /// to the session's current PlanFrame. The LLM uses this as a relevance
-/// lens: plan-advancing decisions, artifacts, and identifiers should land
-/// in `decisions_and_rationale` / `stable_identifiers`, while abandoned
-/// detours can be safely dropped.
+/// lens: plan-advancing items should be captured in the resulting delta
+/// (under `new_decisions` / `new_identifiers` in the delta-extraction
+/// schema), while abandoned detours can be safely dropped.
 fn render_plan_anchor_block(p: &PlanFrameSummary) -> String {
     let mut s = String::from("Active Plan (use as a relevance lens — prefer plan-advancing items):\n");
     s.push_str(&format!(
@@ -166,6 +166,11 @@ fn render_plan_anchor_block(p: &PlanFrameSummary) -> String {
     if !p.operator_steps.is_empty() {
         s.push_str("- operator/shared steps: ");
         s.push_str(&p.operator_steps.join(", "));
+        s.push('\n');
+    }
+    if !p.agent_steps.is_empty() {
+        s.push_str("- agent steps: ");
+        s.push_str(&p.agent_steps.join(", "));
         s.push('\n');
     }
     if !p.required_validations.is_empty() {
@@ -923,6 +928,7 @@ mod tests {
             title: "Add OAuth login".into(),
             step_count: 5,
             operator_steps: vec!["op_login".into(), "op_logout".into()],
+            agent_steps: vec!["agent_oauth".into(), "agent_logout".into()],
             required_validations: vec!["security_review".into()],
             advisory_validations: vec!["unit_tests".into()],
         }
@@ -960,6 +966,7 @@ mod tests {
         assert!(prompt.contains("plan_abc"), "expected plan_id in prompt");
         assert!(prompt.contains("Add OAuth login"), "expected title in prompt");
         assert!(prompt.contains("op_login, op_logout"), "expected operator steps in prompt");
+        assert!(prompt.contains("agent_oauth, agent_logout"), "expected agent steps in prompt");
         assert!(prompt.contains("security_review"), "expected required validations");
         assert!(prompt.contains("unit_tests"), "expected advisory validations");
         assert!(prompt.contains("relevance lens"), "expected framing as relevance lens");
@@ -975,6 +982,7 @@ mod tests {
             title: String::new(),
             step_count: 0,
             operator_steps: vec![],
+            agent_steps: vec![],
             required_validations: vec![],
             advisory_validations: vec![],
         };

--- a/autonoetic-gateway/src/runtime/context_governor/capsule.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/capsule.rs
@@ -2,6 +2,7 @@ use crate::runtime::compression::{self, resolve_compression_llm_config, split_co
 use crate::runtime::context_governor::strategies::{GovernorContext, ReductionOutcome};
 use crate::runtime::content_store::{ContentStore, ContentVisibility};
 use autonoetic_types::config::LlmPreset;
+use autonoetic_types::plan_frame::PlanFrameSummary;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -91,11 +92,16 @@ impl CapsuleStrategy {
 fn build_delta_extraction_prompt(
     compressible_messages: &[crate::llm::Message],
     capsule_json: &str,
+    plan_anchor: Option<&PlanFrameSummary>,
 ) -> String {
+    let plan_block = match plan_anchor {
+        Some(p) => render_plan_anchor_block(p),
+        None => String::new(),
+    };
     format!(
         r#"You are a state capsule update extractor. Given the current session state capsule and recent conversation turns, produce a structured delta describing what changed.
 
-Current State Capsule (JSON):
+{plan_block}Current State Capsule (JSON):
 {capsule_json}
 
 Recent Conversation Turns:
@@ -138,6 +144,42 @@ Respond ONLY with a JSON object matching this schema:
             .collect::<Vec<_>>()
             .join("\n")
     )
+}
+
+/// Render the "Active Plan" block that anchors the delta-extraction prompt
+/// to the session's current PlanFrame. The LLM uses this as a relevance
+/// lens: plan-advancing decisions, artifacts, and identifiers should land
+/// in `decisions_and_rationale` / `stable_identifiers`, while abandoned
+/// detours can be safely dropped.
+fn render_plan_anchor_block(p: &PlanFrameSummary) -> String {
+    let mut s = String::from("Active Plan (use as a relevance lens — prefer plan-advancing items):\n");
+    s.push_str(&format!(
+        "- plan_id: {} v{} (status: {})\n",
+        p.plan_id, p.version, p.status.as_str()
+    ));
+    if !p.title.is_empty() {
+        s.push_str(&format!("- title: {}\n", p.title));
+    }
+    if p.step_count > 0 {
+        s.push_str(&format!("- step_count: {}\n", p.step_count));
+    }
+    if !p.operator_steps.is_empty() {
+        s.push_str("- operator/shared steps: ");
+        s.push_str(&p.operator_steps.join(", "));
+        s.push('\n');
+    }
+    if !p.required_validations.is_empty() {
+        s.push_str("- required validations: ");
+        s.push_str(&p.required_validations.join(", "));
+        s.push('\n');
+    }
+    if !p.advisory_validations.is_empty() {
+        s.push_str("- advisory validations: ");
+        s.push_str(&p.advisory_validations.join(", "));
+        s.push('\n');
+    }
+    s.push('\n');
+    s
 }
 
 fn compile_capsule_injection(capsule: &StateCapsule) -> String {
@@ -336,6 +378,7 @@ pub(crate) async fn extract_delta(
     agent_cfg: Option<&autonoetic_types::agent::CompressionConfig>,
     presets: &HashMap<String, LlmPreset>,
     http_client: &reqwest::Client,
+    plan_anchor: Option<&PlanFrameSummary>,
 ) -> anyhow::Result<CapsuleDelta> {
     let llm_config = match resolve_compression_llm_config(gateway_cfg, agent_cfg, presets) {
         Some(c) => c,
@@ -344,7 +387,7 @@ pub(crate) async fn extract_delta(
 
     let driver = crate::llm::build_driver(llm_config.clone(), http_client.clone())?;
     let capsule_json = serde_json::to_string(capsule)?;
-    let prompt = build_delta_extraction_prompt(compressible, &capsule_json);
+    let prompt = build_delta_extraction_prompt(compressible, &capsule_json, plan_anchor);
 
     let system_msg = crate::llm::Message::system(
         "You are a state capsule extractor. Output ONLY valid JSON matching the schema.",
@@ -463,6 +506,7 @@ impl super::ReductionStrategy for CapsuleStrategy {
             ctx.agent_compression.as_ref(),
             &self.presets,
             &self.http_client,
+            ctx.plan_anchor.as_ref(),
         )
         .await?;
 
@@ -868,5 +912,76 @@ mod tests {
 
         let result = bootstrap_capsule_from_compressed_markers("sess-1", &history, 10);
         assert!(result.is_none());
+    }
+
+    fn make_plan_summary() -> PlanFrameSummary {
+        PlanFrameSummary {
+            plan_id: "plan_abc".into(),
+            version: 3,
+            parent_version: Some(2),
+            status: autonoetic_types::plan_frame::PlanStatus::Approved,
+            title: "Add OAuth login".into(),
+            step_count: 5,
+            operator_steps: vec!["op_login".into(), "op_logout".into()],
+            required_validations: vec!["security_review".into()],
+            advisory_validations: vec!["unit_tests".into()],
+        }
+    }
+
+    #[test]
+    fn delta_prompt_without_plan_omits_anchor_block() {
+        let messages = vec![crate::llm::Message {
+            role: crate::llm::Role::User,
+            content: "Discuss the auth flow".into(),
+            tool_calls: vec![],
+            tool_call_id: None,
+            reasoning_content: None,
+            reasoning_details: None,
+        }];
+        let prompt = build_delta_extraction_prompt(&messages, "{}", None);
+        assert!(!prompt.contains("Active Plan"));
+        assert!(!prompt.contains("plan_id"));
+        assert!(prompt.contains("Recent Conversation Turns"));
+    }
+
+    #[test]
+    fn delta_prompt_with_plan_includes_anchor_block() {
+        let messages = vec![crate::llm::Message {
+            role: crate::llm::Role::User,
+            content: "Discuss the auth flow".into(),
+            tool_calls: vec![],
+            tool_call_id: None,
+            reasoning_content: None,
+            reasoning_details: None,
+        }];
+        let plan = make_plan_summary();
+        let prompt = build_delta_extraction_prompt(&messages, "{}", Some(&plan));
+        assert!(prompt.contains("Active Plan"), "expected 'Active Plan' in prompt");
+        assert!(prompt.contains("plan_abc"), "expected plan_id in prompt");
+        assert!(prompt.contains("Add OAuth login"), "expected title in prompt");
+        assert!(prompt.contains("op_login, op_logout"), "expected operator steps in prompt");
+        assert!(prompt.contains("security_review"), "expected required validations");
+        assert!(prompt.contains("unit_tests"), "expected advisory validations");
+        assert!(prompt.contains("relevance lens"), "expected framing as relevance lens");
+    }
+
+    #[test]
+    fn delta_prompt_with_minimal_plan_omits_empty_sections() {
+        let plan = PlanFrameSummary {
+            plan_id: "plan_min".into(),
+            version: 1,
+            parent_version: None,
+            status: autonoetic_types::plan_frame::PlanStatus::AwaitingApproval,
+            title: String::new(),
+            step_count: 0,
+            operator_steps: vec![],
+            required_validations: vec![],
+            advisory_validations: vec![],
+        };
+        let prompt = build_delta_extraction_prompt(&[], "{}", Some(&plan));
+        assert!(prompt.contains("plan_min"));
+        assert!(!prompt.contains("operator/shared steps"));
+        assert!(!prompt.contains("required validations"));
+        assert!(!prompt.contains("advisory validations"));
     }
 }

--- a/autonoetic-gateway/src/runtime/context_governor/strategies.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/strategies.rs
@@ -5,6 +5,7 @@ use crate::runtime::context_governor::error::GovernorAction;
 use crate::runtime::prompt_budget::PromptBudgetBreakdown;
 use autonoetic_types::agent::CompressionConfig;
 use autonoetic_types::config::{ContextCompressionConfig, PromptBudgetConfig};
+use autonoetic_types::plan_frame::PlanFrameSummary;
 
 /// Shared mutable state passed through the reduction pipeline.
 pub struct GovernorContext {
@@ -19,6 +20,13 @@ pub struct GovernorContext {
     pub compression_config: Option<ContextCompressionConfig>,
     pub agent_compression: Option<CompressionConfig>,
     pub capsule_state: Option<StateCapsule>,
+    /// Active PlanFrame summary, used as a relevance lens by the capsule
+    /// strategy. `None` when the session has no plan or no active plan.
+    /// When set, the capsule strategy prepends a "## Active Plan" block to
+    /// its delta-extraction prompt so the LLM knows which decisions,
+    /// artifacts, and identifiers are plan-advancing (and which detours
+    /// can be compressed more aggressively).
+    pub plan_anchor: Option<PlanFrameSummary>,
 }
 
 impl GovernorContext {
@@ -34,6 +42,7 @@ impl GovernorContext {
         budget_config: PromptBudgetConfig,
         compression_config: Option<ContextCompressionConfig>,
         agent_compression: Option<CompressionConfig>,
+        plan_anchor: Option<PlanFrameSummary>,
     ) -> Self {
         Self {
             history,
@@ -47,6 +56,7 @@ impl GovernorContext {
             compression_config,
             agent_compression,
             capsule_state: None,
+            plan_anchor,
         }
     }
 }
@@ -140,6 +150,7 @@ mod tests {
             compression_config: None,
             agent_compression: None,
             capsule_state: None,
+            plan_anchor: None,
         }
     }
 

--- a/autonoetic-gateway/src/runtime/context_governor/strategies.rs
+++ b/autonoetic-gateway/src/runtime/context_governor/strategies.rs
@@ -22,10 +22,10 @@ pub struct GovernorContext {
     pub capsule_state: Option<StateCapsule>,
     /// Active PlanFrame summary, used as a relevance lens by the capsule
     /// strategy. `None` when the session has no plan or no active plan.
-    /// When set, the capsule strategy prepends a "## Active Plan" block to
-    /// its delta-extraction prompt so the LLM knows which decisions,
-    /// artifacts, and identifiers are plan-advancing (and which detours
-    /// can be compressed more aggressively).
+    /// When set, the capsule strategy prepends an "Active Plan (...)"
+    /// block to its delta-extraction prompt so the LLM knows which
+    /// decisions, artifacts, and identifiers are plan-advancing (and
+    /// which detours can be compressed more aggressively).
     pub plan_anchor: Option<PlanFrameSummary>,
 }
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1544,6 +1544,21 @@ impl AgentExecutor {
                         default_window.saturating_sub(margin)
                     });
                 let compression_cfg = self.config.as_ref().map(|c| &c.context_compression);
+                let plan_anchor = self
+                    .gateway_store
+                    .as_ref()
+                    .and_then(|store| {
+                        let wf_id = self.workflow_id.clone().or_else(|| {
+                            crate::scheduler::resolve_workflow_id_for_root_session(
+                                self.config.as_ref()?,
+                                &session_id,
+                            )
+                            .ok()
+                            .flatten()
+                        })?;
+                        let plan = store.load_active_plan_for_workflow(&wf_id).ok().flatten()?;
+                        Some(plan.compact_summary())
+                    });
                 let mut ctx = crate::runtime::context_governor::strategies::GovernorContext::new(
                     history.clone(),
                     tools.clone(),
@@ -1556,6 +1571,7 @@ impl AgentExecutor {
                         .unwrap_or_default(),
                     compression_cfg.cloned(),
                     self.manifest.compression.clone(),
+                    plan_anchor,
                 );
                 let governor = if self.overflow_recovery {
                     tracing::info!(

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1548,10 +1548,15 @@ impl AgentExecutor {
                     .gateway_store
                     .as_ref()
                     .and_then(|store| {
+                        // `session_id` may be a child/forked id ("root/x"); the
+                        // workflow index is keyed on the *root* id.
+                        let root_session_id =
+                            crate::runtime::content_store::root_session_id(&session_id)
+                                .to_string();
                         let wf_id = self.workflow_id.clone().or_else(|| {
                             crate::scheduler::resolve_workflow_id_for_root_session(
                                 self.config.as_ref()?,
-                                &session_id,
+                                &root_session_id,
                             )
                             .ok()
                             .flatten()

--- a/autonoetic-gateway/tests/plan_anchor_lens_integration.rs
+++ b/autonoetic-gateway/tests/plan_anchor_lens_integration.rs
@@ -1,0 +1,234 @@
+mod support;
+
+use std::sync::Arc;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::scheduler::workflow_store;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, ExecutionMode, RuntimeDeclaration, ScriptInputMode};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::plan_frame::{
+    PlanFrame, PlanStatus, PlanStep, StepOwner, ValidationClass, ValidationEntry,
+    ValidationPolicy, ValidationRequirement,
+};
+use tempfile::tempdir;
+
+fn planner_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "planner.collaborative".to_string(),
+            name: "Collaborative Planner".to_string(),
+            description: "Test planner".to_string(),
+        },
+        capabilities: vec![
+            Capability::ReadAccess { scopes: vec!["*".to_string()] },
+            Capability::WriteAccess { scopes: vec!["*".to_string()] },
+            Capability::PlanFrameAccess { patterns: vec!["*".to_string()] },
+        ],
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        execution_mode: ExecutionMode::default(),
+        script_entry: None,
+        script_input_mode: ScriptInputMode::default(),
+        gateway_url: None,
+        gateway_token: None,
+        middleware: None,
+        agentskills_import: None,
+        allowed_tool_tiers: vec![],
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn make_plan(workflow_id: &str, root_session: &str) -> PlanFrame {
+    PlanFrame {
+        plan_id: format!("plan_{}", workflow_id),
+        version: 1,
+        parent_version: None,
+        workflow_id: workflow_id.to_string(),
+        root_session_id: root_session.to_string(),
+        title: "Add OAuth login".to_string(),
+        objective: "Replace legacy auth with OAuth".to_string(),
+        status: PlanStatus::Approved,
+        steps: vec![
+            PlanStep {
+                step_id: "op_login".to_string(),
+                title: "Operator designs login flow".to_string(),
+                owner: StepOwner::Operator,
+                depends_on: vec![],
+                agent_id: None,
+                notes: None,
+            },
+            PlanStep {
+                step_id: "agent_oauth".to_string(),
+                title: "Agent implements OAuth".to_string(),
+                owner: StepOwner::Agent,
+                depends_on: vec!["op_login".to_string()],
+                agent_id: None,
+                notes: None,
+            },
+        ],
+        validation_policy: ValidationPolicy {
+            entries: vec![
+                ValidationEntry {
+                    validation_id: "unit_tests".to_string(),
+                    title: "Unit Tests".to_string(),
+                    class: ValidationClass::CorrectnessCheck,
+                    requirement: ValidationRequirement::Advisory,
+                },
+                ValidationEntry {
+                    validation_id: "security_review".to_string(),
+                    title: "Security Review".to_string(),
+                    class: ValidationClass::SecurityReview,
+                    requirement: ValidationRequirement::Required,
+                },
+            ],
+        },
+        approved_by: Some("operator".to_string()),
+        approved_at: Some("2026-06-01T00:00:00Z".to_string()),
+        created_by_agent_id: "planner.collaborative".to_string(),
+        reason: Some("initial draft".to_string()),
+        created_at: "2026-06-01T00:00:00Z".to_string(),
+    }
+}
+
+fn bootstrap_workflow_and_plan(
+    config: &GatewayConfig,
+    store: &Arc<GatewayStore>,
+    manifest: &AgentManifest,
+    session_id: &str,
+) -> String {
+    let _ = workflow_store::ensure_workflow_for_root_session(
+        config,
+        Some(store),
+        session_id,
+        Some(&manifest.agent.id),
+    )
+    .unwrap();
+    let workflow_id = workflow_store::resolve_workflow_id_for_root_session(config, session_id)
+        .ok()
+        .flatten()
+        .expect("workflow id");
+    let plan = make_plan(&workflow_id, session_id);
+    store.save_plan_frame(&plan).unwrap();
+    workflow_id
+}
+
+#[test]
+fn plan_anchor_loads_from_store_with_expected_summary() {
+    let dir = tempdir().unwrap();
+    let mut config = GatewayConfig::default();
+    config.agents_dir = dir.path().to_path_buf();
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let _registry = default_registry();
+    let manifest = planner_manifest();
+    let _policy = PolicyEngine::new(manifest.clone());
+    let _agent_dir = dir.path().join("planner.collaborative");
+    let _cs = ContentStore::new(&gateway_dir).unwrap();
+
+    let session_id = "root-session-plan-anchor-1";
+    let workflow_id = bootstrap_workflow_and_plan(&config, &store, &manifest, session_id);
+
+    let loaded = store
+        .load_active_plan_for_workflow(&workflow_id)
+        .unwrap()
+        .expect("plan should load");
+    let summary = loaded.compact_summary();
+
+    assert_eq!(summary.plan_id, loaded.plan_id);
+    assert_eq!(summary.version, 1);
+    assert_eq!(summary.title, "Add OAuth login");
+    assert_eq!(summary.step_count, 2);
+    assert_eq!(summary.operator_steps, vec!["op_login".to_string()]);
+    assert_eq!(summary.required_validations, vec!["security_review".to_string()]);
+    assert_eq!(summary.advisory_validations, vec!["unit_tests".to_string()]);
+}
+
+#[test]
+fn plan_anchor_missing_when_workflow_has_no_plan() {
+    let dir = tempdir().unwrap();
+    let mut config = GatewayConfig::default();
+    config.agents_dir = dir.path().to_path_buf();
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let _registry = default_registry();
+    let manifest = planner_manifest();
+    let _policy = PolicyEngine::new(manifest.clone());
+    let _cs = ContentStore::new(&gateway_dir).unwrap();
+
+    let session_id = "root-session-plan-anchor-2";
+    let _ = workflow_store::ensure_workflow_for_root_session(
+        &config,
+        Some(&store),
+        session_id,
+        Some(&manifest.agent.id),
+    )
+    .unwrap();
+    let workflow_id = workflow_store::resolve_workflow_id_for_root_session(&config, session_id)
+        .ok()
+        .flatten()
+        .expect("workflow id");
+
+    let loaded = store.load_active_plan_for_workflow(&workflow_id).unwrap();
+    assert!(loaded.is_none(), "no plan saved, so load should return None");
+}
+
+#[test]
+fn plan_anchor_awaiting_approval_is_loaded() {
+    // Both 'awaiting_approval' and 'approved' plans should be loaded
+    // as the "active" plan, so the LLM can see the plan even before
+    // operator approval has been recorded.
+    let dir = tempdir().unwrap();
+    let mut config = GatewayConfig::default();
+    config.agents_dir = dir.path().to_path_buf();
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let _registry = default_registry();
+    let manifest = planner_manifest();
+    let _policy = PolicyEngine::new(manifest.clone());
+    let _cs = ContentStore::new(&gateway_dir).unwrap();
+
+    let session_id = "root-session-plan-anchor-3";
+    let _ = workflow_store::ensure_workflow_for_root_session(
+        &config,
+        Some(&store),
+        session_id,
+        Some(&manifest.agent.id),
+    )
+    .unwrap();
+    let workflow_id = workflow_store::resolve_workflow_id_for_root_session(&config, session_id)
+        .ok()
+        .flatten()
+        .expect("workflow id");
+    let mut plan = make_plan(&workflow_id, session_id);
+    plan.status = PlanStatus::AwaitingApproval;
+    store.save_plan_frame(&plan).unwrap();
+
+    let loaded = store
+        .load_active_plan_for_workflow(&workflow_id)
+        .unwrap()
+        .expect("awaiting_approval plan should load");
+    assert_eq!(loaded.status, PlanStatus::AwaitingApproval);
+}

--- a/autonoetic-gateway/tests/plan_anchor_lens_integration.rs
+++ b/autonoetic-gateway/tests/plan_anchor_lens_integration.rs
@@ -158,6 +158,7 @@ fn plan_anchor_loads_from_store_with_expected_summary() {
     assert_eq!(summary.title, "Add OAuth login");
     assert_eq!(summary.step_count, 2);
     assert_eq!(summary.operator_steps, vec!["op_login".to_string()]);
+    assert_eq!(summary.agent_steps, vec!["agent_oauth".to_string()]);
     assert_eq!(summary.required_validations, vec!["security_review".to_string()]);
     assert_eq!(summary.advisory_validations, vec!["unit_tests".to_string()]);
 }

--- a/autonoetic-types/src/plan_frame.rs
+++ b/autonoetic-types/src/plan_frame.rs
@@ -181,6 +181,13 @@ impl PlanFrame {
             .map(|s| s.step_id.clone())
             .collect();
 
+        let agent_steps: Vec<String> = self
+            .steps
+            .iter()
+            .filter(|s| s.owner == StepOwner::Agent)
+            .map(|s| s.step_id.clone())
+            .collect();
+
         let required_validations: Vec<String> = self
             .validation_policy
             .entries
@@ -205,6 +212,7 @@ impl PlanFrame {
             title: self.title.clone(),
             step_count: self.steps.len(),
             operator_steps,
+            agent_steps,
             required_validations,
             advisory_validations,
         }
@@ -220,6 +228,7 @@ pub struct PlanFrameSummary {
     pub title: String,
     pub step_count: usize,
     pub operator_steps: Vec<String>,
+    pub agent_steps: Vec<String>,
     pub required_validations: Vec<String>,
     pub advisory_validations: Vec<String>,
 }


### PR DESCRIPTION
Implements Phase 5 of the human-agent artifact collaboration plan (#325).

## Problem

When the LLM needs to compress history to fit the context budget, it sees a flat transcript. It may discard items that are still relevant to the current plan (e.g. operator decisions, validation outcomes) because it has no visibility into the plan structure.

## Solution

Load the active `PlanFrame` (if any) and include a compact `Active Plan` block in the delta-extraction prompt. The block frames the plan as a *relevance lens* — 'prefer plan-advancing items' — and surfaces:
- title
- step count
- operator step ids (signals the LLM to preserve operator work)
- agent step ids
- required validation ids (high-stakes items to keep)
- advisory validation ids

Empty optional sections are omitted to keep the prompt small.

## Changes

- `PlanFrameSummary` flows into `GovernorContext` as `plan_anchor`
- `build_delta_extraction_prompt` renders the anchor block via new `render_plan_anchor_block` helper
- `CapsuleStrategy::reduce` threads `plan_anchor` through to `extract_delta`
- `lifecycle.rs` loads the active plan before constructing `GovernorContext`. Missing store, workflow_id, or plan all degrade gracefully to no anchor.
- 3 unit tests cover prompt construction (presence, content, empty-section handling)
- 3 integration tests cover store-level plan loading (`Approved`, `AwaitingApproval`, missing plan)

Closes #334.