### PR TITLE
feat: structured semantic summaries for reconciled workbench diffs (#332)

### DIFF
--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -44,6 +44,7 @@ pub mod prompt_budget;
 pub mod quality_signal;
 pub mod reevaluation_state;
 pub mod remote_access;
+pub mod semantic_diff;
 pub mod sealed_network;
 pub mod sealed_network_proxy;
 pub mod response_validation;

--- a/autonoetic-gateway/src/runtime/semantic_diff.rs
+++ b/autonoetic-gateway/src/runtime/semantic_diff.rs
@@ -125,7 +125,10 @@ impl SemanticSummarizer for RuleBasedSemanticSummarizer {
                 FileChangeType::Unchanged => continue,
             }
 
-            let content = inputs.current_files.get(&d.path);
+            let content = match d.change_type {
+                FileChangeType::Deleted => inputs.base_files.get(&d.path),
+                _ => inputs.current_files.get(&d.path),
+            };
             let role = classify_role(&d.path, content, &self.network_check_extensions);
             let impact = role_to_impact(role);
             let rationale = rationale_for(&d.path, role, impact, content);
@@ -427,6 +430,9 @@ mod tests {
         }
     }
 
+    static EMPTY_FILES: std::sync::LazyLock<HashMap<String, Vec<u8>>> =
+        std::sync::LazyLock::new(HashMap::new);
+
     #[test]
     fn classifies_capability_yaml() {
         let summarizer = RuleBasedSemanticSummarizer::default();
@@ -439,6 +445,7 @@ mod tests {
             new_artifact_id: "ar.b",
             diffs: &diffs,
             current_files: &files,
+            base_files: &EMPTY_FILES,
             plan: None,
             waivers_by_validation: &HashMap::new(),
             generated_at: "2026-06-01T00:00:00Z",
@@ -468,6 +475,7 @@ mod tests {
             new_artifact_id: "ar.b",
             diffs: &diffs,
             current_files: &files,
+            base_files: &EMPTY_FILES,
             plan: None,
             waivers_by_validation: &HashMap::new(),
             generated_at: "2026-06-01T00:00:00Z",
@@ -496,6 +504,7 @@ mod tests {
             new_artifact_id: "ar.b",
             diffs: &diffs,
             current_files: &files,
+            base_files: &EMPTY_FILES,
             plan: None,
             waivers_by_validation: &HashMap::new(),
             generated_at: "2026-06-01T00:00:00Z",
@@ -522,6 +531,7 @@ mod tests {
             new_artifact_id: "ar.b",
             diffs: &diffs,
             current_files: &files,
+            base_files: &EMPTY_FILES,
             plan: None,
             waivers_by_validation: &HashMap::new(),
             generated_at: "2026-06-01T00:00:00Z",
@@ -547,6 +557,7 @@ mod tests {
             new_artifact_id: "ar.b",
             diffs: &diffs,
             current_files: &files,
+            base_files: &EMPTY_FILES,
             plan: Some(&plan),
             waivers_by_validation: &waivers,
             generated_at: "2026-06-01T00:00:00Z",
@@ -579,6 +590,7 @@ mod tests {
             new_artifact_id: "ar.b",
             diffs: &diffs,
             current_files: &files,
+            base_files: &EMPTY_FILES,
             plan: None,
             waivers_by_validation: &HashMap::new(),
             generated_at: "2026-06-01T00:00:00Z",
@@ -588,5 +600,31 @@ mod tests {
         assert_eq!(s.changed_files, 1);
         assert_eq!(s.file_classifications.len(), 1);
         assert_eq!(s.file_classifications[0].path, "b.rs");
+    }
+
+    #[test]
+    fn deleted_file_with_network_pattern_uses_base_content() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![diff("src/lib.rs", FileChangeType::Deleted)];
+        let mut base = HashMap::new();
+        base.insert(
+            "src/lib.rs".to_string(),
+            b"fn fetch() { let _ = reqwest::get(\"https://example.com\"); }".to_vec(),
+        );
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &HashMap::new(),
+            base_files: &base,
+            plan: None,
+            waivers_by_validation: &HashMap::new(),
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        let c = &s.file_classifications[0];
+        assert_eq!(c.role, FileRole::NetworkAccess);
+        assert_eq!(c.impact, ContractImpact::NetworkAccessChange);
     }
 }

--- a/autonoetic-gateway/src/runtime/semantic_diff.rs
+++ b/autonoetic-gateway/src/runtime/semantic_diff.rs
@@ -1,0 +1,592 @@
+//! Rule-based [`SemanticSummarizer`] implementation.
+//!
+//! This is the default impl for issue #332. It is deliberately
+//! deterministic, no-LLM, and **pluggable** — swap the `summarizer`
+//! field on a `WorkbenchReconcileTool` call site (or any future wiring
+//! point) to use a different impl without touching the rest of the
+//! pipeline.
+//!
+//! ## Classification rules
+//!
+//! Each non-unchanged diff entry is classified into a [`FileRole`]
+//! based on path and content:
+//!
+//! - `capability`: filename is `capabilities.yaml`, `capabilities.yml`,
+//!   `agent.toml`, or path segment `capabilities/`, `agents/<id>/capability*`.
+//! - `skill_manifest`: filename is `SKILL.md` or path segment `skills/`.
+//! - `runtime_lock`: filename is `runtime_lock.json` or in `.autonoetic/`.
+//! - `config_schema`: filename is `config-template.yaml` or path
+//!   segment `config/`, `schemas/`.
+//! - `entry_point`: filename is `main.rs`, `lib.rs`, `main.py`, `__init__.py`,
+//!   `mod.rs`, `agent.toml` (also capability), or path segment `bin/`,
+//!   `src/bin/`, `agents/<id>/agent.toml`.
+//! - `network_access`: file content matches the
+//!   `RemoteAccessAnalyzer::analyze_code` patterns. Only applied to
+//!   source-code files to avoid false positives on config schemas.
+//! - `credential`: filename is `credentials.yaml`, `*.pem`, `*.key`,
+//!   `*.crt`, `*.p12`, `*.pfx`, or path segment `secrets/`.
+//! - `documentation`: `*.md`.
+//! - `test`: path segment `tests/`, `_test.rs`, `_test.py`, `test_*.py`,
+//!   `*.test.ts`, `*.spec.ts`.
+//! - `build`: filename is `Cargo.toml`, `Cargo.lock`, `package.json`,
+//!   `pyproject.toml`, `poetry.lock`, `requirements.txt`.
+//! - `source_code`: extension `*.rs`, `*.py`, `*.ts`, `*.tsx`, `*.js`,
+//!   `*.go`, `*.java`, `*.c`, `*.cpp`, `*.h`, `*.hpp`, `*.rb`, `*.sh`.
+//! - `unknown`: anything else.
+//!
+//! ## Contract-impact mapping
+//!
+//! Each role maps to a [`ContractImpact`]:
+//!
+//! - `Capability`         → `CapabilityChange`
+//! - `SkillManifest`      → `SkillManifestChange`
+//! - `RuntimeLock`        → `RuntimeLockChange`
+//! - `ConfigSchema`       → `ConfigSchemaChange`
+//! - `EntryPoint`         → `EntryPointChange`
+//! - `NetworkAccess`      → `NetworkAccessChange`
+//! - `Credential`         → `CredentialShapeChange`
+//! - `SourceCode`,
+//!   `Test`,
+//!   `Documentation`,
+//!   `Build`,
+//!   `Unknown`            → `None`
+//!
+//! ## Validation state
+//!
+//! - `waiver_count` and `waivers_present` mirror the inputs.
+//! - `required_validations` / `advisory_validations` come from the
+//!   active plan (empty when no plan is active).
+//! - `unsatisfied_required` is the set of `required_validations` not
+//!   covered by a waiver, sorted lexicographically. The orchestrator
+//!   uses this to know which validations are still owed.
+
+use std::collections::HashMap;
+
+use autonoetic_types::plan_frame::PlanFrameSummary;
+use autonoetic_types::semantic_diff::{
+    ContractChange, ContractImpact, FileClassification, FileRole, SemanticSummarizer,
+    SemanticSummary, SemanticSummaryInputs, ValidationState,
+};
+use autonoetic_types::workbench::{FileChangeType, WorkbenchFileDiff};
+
+use crate::runtime::remote_access::RemoteAccessAnalyzer;
+
+const ID: &str = "rule_based_v1";
+
+/// Rule-based semantic summarizer. Stateless and `Clone`-cheap (one
+/// small `Vec<String>` of extension sets), so callers can hold an
+/// instance in a `static` and pass it everywhere.
+#[derive(Debug, Clone)]
+pub struct RuleBasedSemanticSummarizer {
+    /// Source-code extensions eligible for the network-access check.
+    /// Defaults to a sensible cross-language set; override to narrow
+    /// the check.
+    pub network_check_extensions: Vec<String>,
+}
+
+impl Default for RuleBasedSemanticSummarizer {
+    fn default() -> Self {
+        Self {
+            network_check_extensions: vec![
+                "rs".into(),
+                "py".into(),
+                "ts".into(),
+                "tsx".into(),
+                "js".into(),
+                "go".into(),
+                "java".into(),
+                "c".into(),
+                "cpp".into(),
+                "h".into(),
+                "hpp".into(),
+                "rb".into(),
+                "sh".into(),
+            ],
+        }
+    }
+}
+
+impl SemanticSummarizer for RuleBasedSemanticSummarizer {
+    fn id(&self) -> &'static str {
+        ID
+    }
+
+    fn summarize(&self, inputs: &SemanticSummaryInputs<'_>) -> SemanticSummary {
+        let mut file_classifications: Vec<FileClassification> = Vec::new();
+
+        let mut added = 0usize;
+        let mut modified = 0usize;
+        let mut deleted = 0usize;
+        for d in inputs.diffs {
+            match d.change_type {
+                FileChangeType::Added => added += 1,
+                FileChangeType::Modified => modified += 1,
+                FileChangeType::Deleted => deleted += 1,
+                FileChangeType::Unchanged => continue,
+            }
+
+            let content = inputs.current_files.get(&d.path);
+            let role = classify_role(&d.path, content, &self.network_check_extensions);
+            let impact = role_to_impact(role);
+            let rationale = rationale_for(&d.path, role, impact, content);
+
+            file_classifications.push(FileClassification {
+                path: d.path.clone(),
+                change_type: d.change_type,
+                role,
+                impact,
+                rationale,
+            });
+        }
+
+        file_classifications.sort_by(|a, b| a.path.cmp(&b.path));
+
+        let mut contract_changes: Vec<ContractChange> = file_classifications
+            .iter()
+            .filter(|c| c.impact != ContractImpact::None)
+            .map(|c| ContractChange {
+                path: c.path.clone(),
+                change_type: c.change_type,
+                impact: c.impact,
+                rationale: c.rationale.clone(),
+            })
+            .collect();
+        contract_changes.sort_by(|a, b| {
+            impact_rank(b.impact)
+                .cmp(&impact_rank(a.impact))
+                .then_with(|| a.path.cmp(&b.path))
+        });
+
+        let validation_state =
+            build_validation_state(inputs.plan, inputs.waivers_by_validation);
+
+        let total_files = inputs.diffs.len();
+        let changed_files = added + modified + deleted;
+
+        SemanticSummary {
+            workbench_id: inputs.workbench_id.to_string(),
+            base_artifact_id: inputs.base_artifact_id.to_string(),
+            new_artifact_id: inputs.new_artifact_id.to_string(),
+            plan_id: inputs.plan.map(|p| p.plan_id.clone()),
+            plan_version: inputs.plan.map(|p| p.version),
+            total_files,
+            changed_files,
+            added_files: added,
+            modified_files: modified,
+            deleted_files: deleted,
+            contract_changes,
+            file_classifications,
+            validation_state,
+            summarizer_id: self.id().to_string(),
+            generated_at: inputs.generated_at.to_string(),
+        }
+    }
+}
+
+fn classify_role(
+    path: &str,
+    content: Option<&Vec<u8>>,
+    network_check_extensions: &[String],
+) -> FileRole {
+    let normalized = path.replace('\\', "/");
+    let name = normalized
+        .rsplit('/')
+        .next()
+        .unwrap_or(&normalized)
+        .to_ascii_lowercase();
+    let lower = normalized.to_ascii_lowercase();
+    let ext = extension(&name).unwrap_or("");
+
+    // Capability: explicit filenames / directories.
+    if name == "capabilities.yaml"
+        || name == "capabilities.yml"
+        || name == "capabilities.json"
+        || name == "agent.toml"
+        || lower.contains("/capabilities/")
+        || lower.contains("/capability/")
+    {
+        return FileRole::Capability;
+    }
+
+    // Skill manifest: SKILL.md at any depth, or `skills/` directory.
+    if name == "skill.md" || lower.contains("/skills/") {
+        return FileRole::SkillManifest;
+    }
+
+    // Runtime lock: explicit filename or under .autonoetic/.
+    if name == "runtime_lock.json" || lower.contains("/.autonoetic/") {
+        return FileRole::RuntimeLock;
+    }
+
+    // Config schema: well-known template / schemas directory.
+    if name == "config-template.yaml"
+        || name == "config-template.yml"
+        || name == "config_schema.json"
+        || lower.contains("/schemas/")
+        || lower.contains("/config/")
+    {
+        return FileRole::ConfigSchema;
+    }
+
+    // Credential: well-known secret-shape filenames.
+    if name == "credentials.yaml"
+        || name == "credentials.yml"
+        || name == "credentials.json"
+        || ext == "pem"
+        || ext == "key"
+        || ext == "crt"
+        || ext == "p12"
+        || ext == "pfx"
+        || lower.contains("/secrets/")
+    {
+        return FileRole::Credential;
+    }
+
+    // Entry point. `lib.rs`/`mod.rs` are library/module roots, not
+    // contract boundaries on their own; only binary entry points and
+    // agent manifests count.
+    if name == "main.rs"
+        || name == "main.py"
+        || name == "__init__.py"
+        || name == "agent.toml"
+        || lower.contains("/bin/")
+    {
+        return FileRole::EntryPoint;
+    }
+
+    // Test.
+    if lower.contains("/tests/")
+        || name.starts_with("test_")
+        || name.ends_with("_test.rs")
+        || name.ends_with("_test.py")
+        || name.ends_with(".test.ts")
+        || name.ends_with(".spec.ts")
+        || lower.contains("/__tests__/")
+    {
+        return FileRole::Test;
+    }
+
+    // Build.
+    if name == "cargo.toml"
+        || name == "cargo.lock"
+        || name == "package.json"
+        || name == "package-lock.json"
+        || name == "pyproject.toml"
+        || name == "poetry.lock"
+        || name == "requirements.txt"
+    {
+        return FileRole::Build;
+    }
+
+    // Documentation.
+    if ext == "md" || ext == "rst" || ext == "adoc" {
+        return FileRole::Documentation;
+    }
+
+    // Source code → run the network-access check.
+    if network_check_extensions.iter().any(|e| e == ext) {
+        if let Some(bytes) = content {
+            if let Ok(text) = std::str::from_utf8(bytes) {
+                if !RemoteAccessAnalyzer::analyze_code(text).detected_patterns.is_empty() {
+                    return FileRole::NetworkAccess;
+                }
+            }
+        }
+        return FileRole::SourceCode;
+    }
+
+    FileRole::Unknown
+}
+
+fn role_to_impact(role: FileRole) -> ContractImpact {
+    match role {
+        FileRole::Capability => ContractImpact::CapabilityChange,
+        FileRole::SkillManifest => ContractImpact::SkillManifestChange,
+        FileRole::RuntimeLock => ContractImpact::RuntimeLockChange,
+        FileRole::ConfigSchema => ContractImpact::ConfigSchemaChange,
+        FileRole::EntryPoint => ContractImpact::EntryPointChange,
+        FileRole::NetworkAccess => ContractImpact::NetworkAccessChange,
+        FileRole::Credential => ContractImpact::CredentialShapeChange,
+        FileRole::SourceCode
+        | FileRole::Test
+        | FileRole::Documentation
+        | FileRole::Build
+        | FileRole::Unknown => ContractImpact::None,
+    }
+}
+
+fn rationale_for(
+    path: &str,
+    role: FileRole,
+    impact: ContractImpact,
+    content: Option<&Vec<u8>>,
+) -> String {
+    if impact == ContractImpact::None {
+        return String::new();
+    }
+    let name = path
+        .rsplit('/')
+        .next()
+        .unwrap_or(path)
+        .to_ascii_lowercase();
+    match role {
+        FileRole::Capability => format!("matches capability contract ({name})"),
+        FileRole::SkillManifest => format!("matches skill manifest ({name})"),
+        FileRole::RuntimeLock => format!("runtime lock update ({name})"),
+        FileRole::ConfigSchema => format!("config schema update ({name})"),
+        FileRole::EntryPoint => format!("entry point update ({name})"),
+        FileRole::NetworkAccess => {
+            let n = content
+                .and_then(|b| std::str::from_utf8(b).ok())
+                .map(RemoteAccessAnalyzer::analyze_code)
+                .map(|a| a.detected_patterns.len())
+                .unwrap_or(0);
+            format!("source file with {n} remote-access pattern(s) ({name})")
+        }
+        FileRole::Credential => format!("credential-shape file ({name})"),
+        _ => String::new(),
+    }
+}
+
+fn impact_rank(impact: ContractImpact) -> u8 {
+    match impact {
+        ContractImpact::RuntimeLockChange => 9,
+        ContractImpact::CapabilityChange => 8,
+        ContractImpact::SkillManifestChange => 7,
+        ContractImpact::EntryPointChange => 6,
+        ContractImpact::NetworkAccessChange => 5,
+        ContractImpact::CredentialShapeChange => 4,
+        ContractImpact::ConfigSchemaChange => 3,
+        ContractImpact::UnknownContract => 2,
+        ContractImpact::None => 0,
+    }
+}
+
+fn build_validation_state(
+    plan: Option<&PlanFrameSummary>,
+    waivers_by_validation: &HashMap<String, Vec<String>>,
+) -> ValidationState {
+    let waiver_count: usize = waivers_by_validation.values().map(|v| v.len()).sum();
+    let (required, advisory, unsatisfied) = match plan {
+        Some(p) => {
+            let mut unsatisfied: Vec<String> = p
+                .required_validations
+                .iter()
+                .filter(|v| !waivers_by_validation.contains_key(*v))
+                .cloned()
+                .collect();
+            unsatisfied.sort();
+            (p.required_validations.clone(), p.advisory_validations.clone(), unsatisfied)
+        }
+        None => (Vec::new(), Vec::new(), Vec::new()),
+    };
+    ValidationState {
+        waiver_count,
+        waivers_present: waiver_count > 0,
+        required_validations: required,
+        advisory_validations: advisory,
+        unsatisfied_required: unsatisfied,
+    }
+}
+
+fn extension(name: &str) -> Option<&str> {
+    let idx = name.rfind('.')?;
+    if idx == 0 || idx + 1 == name.len() {
+        return None;
+    }
+    Some(&name[idx + 1..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::plan_frame::{PlanFrameSummary, PlanStatus};
+    use autonoetic_types::workbench::{FileChangeType, WorkbenchFileDiff};
+
+    fn diff(path: &str, kind: FileChangeType) -> WorkbenchFileDiff {
+        WorkbenchFileDiff {
+            path: path.to_string(),
+            change_type: kind,
+            base_digest: None,
+            current_digest: None,
+        }
+    }
+
+    fn plan_with_required(required: &[&str]) -> PlanFrameSummary {
+        PlanFrameSummary {
+            plan_id: "plan-1".into(),
+            version: 1,
+            parent_version: None,
+            status: PlanStatus::Approved,
+            title: "test plan".into(),
+            step_count: 0,
+            operator_steps: vec![],
+            agent_steps: vec![],
+            required_validations: required.iter().map(|s| s.to_string()).collect(),
+            advisory_validations: vec![],
+        }
+    }
+
+    #[test]
+    fn classifies_capability_yaml() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![diff("capabilities.yaml", FileChangeType::Modified)];
+        let mut files = HashMap::new();
+        files.insert("capabilities.yaml".to_string(), b"[]".to_vec());
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &files,
+            plan: None,
+            waivers_by_validation: &HashMap::new(),
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        assert_eq!(s.contract_changes.len(), 1);
+        assert_eq!(s.contract_changes[0].impact, ContractImpact::CapabilityChange);
+        assert!(s.contract_changes[0].rationale.contains("capability contract"));
+    }
+
+    #[test]
+    fn classifies_skill_manifest_and_runtime_lock_separately() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![
+            diff("agents/lead/SKILL.md", FileChangeType::Modified),
+            diff(".autonoetic/runtime_lock.json", FileChangeType::Modified),
+        ];
+        let mut files = HashMap::new();
+        files.insert("agents/lead/SKILL.md".to_string(), b"# skill".to_vec());
+        files.insert(
+            ".autonoetic/runtime_lock.json".to_string(),
+            b"{}".to_vec(),
+        );
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &files,
+            plan: None,
+            waivers_by_validation: &HashMap::new(),
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        assert_eq!(s.contract_changes.len(), 2);
+        let impacts: Vec<_> = s.contract_changes.iter().map(|c| c.impact).collect();
+        assert!(impacts.contains(&ContractImpact::SkillManifestChange));
+        assert!(impacts.contains(&ContractImpact::RuntimeLockChange));
+        // Runtime lock should be ranked first.
+        assert_eq!(s.contract_changes[0].impact, ContractImpact::RuntimeLockChange);
+    }
+
+    #[test]
+    fn detects_network_access_pattern_in_source_file() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![diff("src/lib.rs", FileChangeType::Modified)];
+        let mut files = HashMap::new();
+        files.insert(
+            "src/lib.rs".to_string(),
+            b"fn fetch() { let _ = reqwest::get(\"https://example.com\"); }".to_vec(),
+        );
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &files,
+            plan: None,
+            waivers_by_validation: &HashMap::new(),
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        let c = &s.file_classifications[0];
+        assert_eq!(c.role, FileRole::NetworkAccess);
+        assert_eq!(c.impact, ContractImpact::NetworkAccessChange);
+        assert!(c.rationale.contains("remote-access pattern"));
+    }
+
+    #[test]
+    fn source_without_network_pattern_is_pure_source() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![diff("src/lib.rs", FileChangeType::Modified)];
+        let mut files = HashMap::new();
+        files.insert(
+            "src/lib.rs".to_string(),
+            b"fn add(a: i32, b: i32) -> i32 { a + b }".to_vec(),
+        );
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &files,
+            plan: None,
+            waivers_by_validation: &HashMap::new(),
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        assert_eq!(s.file_classifications[0].role, FileRole::SourceCode);
+        assert_eq!(s.file_classifications[0].impact, ContractImpact::None);
+        assert!(s.contract_changes.is_empty());
+    }
+
+    #[test]
+    fn validation_state_marks_unsatisfied_required() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![diff("src/lib.rs", FileChangeType::Modified)];
+        let mut files = HashMap::new();
+        files.insert("src/lib.rs".to_string(), b"fn x() {}".to_vec());
+        let plan = plan_with_required(&["unit_tests", "security_review", "lint"]);
+        let mut waivers = HashMap::new();
+        waivers.insert("unit_tests".to_string(), vec!["vw-1".to_string()]);
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &files,
+            plan: Some(&plan),
+            waivers_by_validation: &waivers,
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        assert_eq!(s.validation_state.waiver_count, 1);
+        assert!(s.validation_state.waivers_present);
+        assert_eq!(
+            s.validation_state.required_validations,
+            vec!["unit_tests", "security_review", "lint"]
+        );
+        assert_eq!(
+            s.validation_state.unsatisfied_required,
+            vec!["lint", "security_review"]
+        );
+    }
+
+    #[test]
+    fn file_classifications_omit_unchanged_entries() {
+        let summarizer = RuleBasedSemanticSummarizer::default();
+        let diffs = vec![
+            diff("a.rs", FileChangeType::Unchanged),
+            diff("b.rs", FileChangeType::Modified),
+        ];
+        let mut files = HashMap::new();
+        files.insert("b.rs".to_string(), b"fn x() {}".to_vec());
+        let inputs = SemanticSummaryInputs {
+            workbench_id: "wb-1",
+            base_artifact_id: "ar.a",
+            new_artifact_id: "ar.b",
+            diffs: &diffs,
+            current_files: &files,
+            plan: None,
+            waivers_by_validation: &HashMap::new(),
+            generated_at: "2026-06-01T00:00:00Z",
+        };
+        let s = summarizer.summarize(&inputs);
+        assert_eq!(s.total_files, 2);
+        assert_eq!(s.changed_files, 1);
+        assert_eq!(s.file_classifications.len(), 1);
+        assert_eq!(s.file_classifications[0].path, "b.rs");
+    }
+}

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -3,10 +3,12 @@ use crate::llm::ToolDefinition;
 use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::content_store::ContentStore;
+use crate::runtime::semantic_diff::RuleBasedSemanticSummarizer;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::semantic_diff::{SemanticSummary, SemanticSummaryInputs, SemanticSummarizer};
 use autonoetic_types::workbench::{
     FileChangeType, WorkbenchCheckpoint, WorkbenchFileDiff, WorkbenchProjection, WorkbenchStatus,
 };
@@ -1006,6 +1008,16 @@ impl NativeTool for WorkbenchReconcileTool {
         let now = now_rfc3339();
         store.update_workbench_status(&wb.workbench_id, WorkbenchStatus::Reconciled, &now)?;
 
+        let semantic_summary = build_semantic_summary(
+            &store,
+            &wb,
+            &scope_id,
+            &bundle.artifact_id,
+            &diffs,
+            source_dir,
+            &now,
+        )?;
+
         let provenance = serde_json::json!({
             "base_artifact_id": wb.base_artifact_id,
             "new_artifact_id": bundle.artifact_id,
@@ -1019,6 +1031,12 @@ impl NativeTool for WorkbenchReconcileTool {
         let provenance_path = meta_dir.join("reconciliation.json");
         std::fs::write(&provenance_path, serde_json::to_string_pretty(&provenance)?)?;
 
+        let summary_path = meta_dir.join("semantic_summary.json");
+        std::fs::write(
+            &summary_path,
+            serde_json::to_string_pretty(&semantic_summary)?,
+        )?;
+
         let changed = diffs.iter().filter(|d| d.change_type != FileChangeType::Unchanged).count();
 
         Ok(serde_json::to_string(&serde_json::json!({
@@ -1030,6 +1048,7 @@ impl NativeTool for WorkbenchReconcileTool {
             "total_files": current_files.len(),
             "changed_files": changed,
             "provenance": provenance,
+            "semantic_summary": semantic_summary,
             "reconciled_at": now,
             "message": args.message.unwrap_or_default(),
         }))?)
@@ -1038,6 +1057,78 @@ impl NativeTool for WorkbenchReconcileTool {
     fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
         ToolMetadata::default()
     }
+}
+
+/// Build a [`SemanticSummary`] for the workbench's reconciled diff.
+///
+/// The summarizer is the deterministic rule-based default; callers can
+/// swap in a different `SemanticSummarizer` impl later without changing
+/// the rest of the reconcile path. Failures here are *not* fatal to the
+/// reconcile itself — the raw provenance in `reconciliation.json`
+/// remains the source of truth, and a missing `semantic_summary.json`
+/// just means the wake-up payload will not carry a summary.
+fn build_semantic_summary(
+    store: &std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>,
+    wb: &WorkbenchProjection,
+    scope_id: &str,
+    new_artifact_id: &str,
+    diffs: &[WorkbenchFileDiff],
+    source_dir: &Path,
+    generated_at: &str,
+) -> anyhow::Result<SemanticSummary> {
+    let summarizer = RuleBasedSemanticSummarizer::default();
+
+    let mut current_files: std::collections::HashMap<String, Vec<u8>> =
+        std::collections::HashMap::new();
+    for d in diffs {
+        if d.change_type == FileChangeType::Added
+            || d.change_type == FileChangeType::Modified
+        {
+            let path = source_dir.join(&d.path);
+            if let Ok(bytes) = std::fs::read(&path) {
+                current_files.insert(d.path.clone(), bytes);
+            }
+        }
+    }
+
+    let plan_summary = if wb.workflow_id.is_empty() {
+        None
+    } else {
+        store
+            .load_active_plan_for_workflow(&wb.workflow_id)
+            .ok()
+            .flatten()
+            .map(|p| p.compact_summary())
+    };
+    let _ = scope_id;
+
+    let waivers_by_validation: std::collections::HashMap<String, Vec<String>> =
+        match store.list_waivers_for_artifact(&wb.base_artifact_id) {
+            Ok(rows) => {
+                let mut map: std::collections::HashMap<String, Vec<String>> =
+                    std::collections::HashMap::new();
+                for w in rows {
+                    map.entry(w.validation_id)
+                        .or_default()
+                        .push(w.waiver_id);
+                }
+                map
+            }
+            Err(_) => std::collections::HashMap::new(),
+        };
+
+    let inputs = SemanticSummaryInputs {
+        workbench_id: &wb.workbench_id,
+        base_artifact_id: &wb.base_artifact_id,
+        new_artifact_id,
+        diffs,
+        current_files: &current_files,
+        plan: plan_summary.as_ref(),
+        waivers_by_validation: &waivers_by_validation,
+        generated_at,
+    };
+
+    Ok(summarizer.summarize(&inputs))
 }
 
 pub struct WorkbenchDiscardTool;

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -1015,6 +1015,7 @@ impl NativeTool for WorkbenchReconcileTool {
             &bundle.artifact_id,
             &diffs,
             source_dir,
+            &content_store,
             &now,
         )?;
 
@@ -1032,10 +1033,9 @@ impl NativeTool for WorkbenchReconcileTool {
         std::fs::write(&provenance_path, serde_json::to_string_pretty(&provenance)?)?;
 
         let summary_path = meta_dir.join("semantic_summary.json");
-        std::fs::write(
-            &summary_path,
-            serde_json::to_string_pretty(&semantic_summary)?,
-        )?;
+        if let Ok(json) = serde_json::to_string_pretty(&semantic_summary) {
+            let _ = std::fs::write(&summary_path, json);
+        }
 
         let changed = diffs.iter().filter(|d| d.change_type != FileChangeType::Unchanged).count();
 
@@ -1074,20 +1074,31 @@ fn build_semantic_summary(
     new_artifact_id: &str,
     diffs: &[WorkbenchFileDiff],
     source_dir: &Path,
+    content_store: &ContentStore,
     generated_at: &str,
 ) -> anyhow::Result<SemanticSummary> {
     let summarizer = RuleBasedSemanticSummarizer::default();
 
     let mut current_files: std::collections::HashMap<String, Vec<u8>> =
         std::collections::HashMap::new();
+    let mut base_files: std::collections::HashMap<String, Vec<u8>> =
+        std::collections::HashMap::new();
     for d in diffs {
-        if d.change_type == FileChangeType::Added
-            || d.change_type == FileChangeType::Modified
-        {
-            let path = source_dir.join(&d.path);
-            if let Ok(bytes) = std::fs::read(&path) {
-                current_files.insert(d.path.clone(), bytes);
+        match d.change_type {
+            FileChangeType::Added | FileChangeType::Modified => {
+                let path = source_dir.join(&d.path);
+                if let Ok(bytes) = std::fs::read(&path) {
+                    current_files.insert(d.path.clone(), bytes);
+                }
             }
+            FileChangeType::Deleted => {
+                if let Some(digest) = &d.base_digest {
+                    if let Ok(bytes) = content_store.read(digest) {
+                        base_files.insert(d.path.clone(), bytes);
+                    }
+                }
+            }
+            FileChangeType::Unchanged => {}
         }
     }
 
@@ -1123,6 +1134,7 @@ fn build_semantic_summary(
         new_artifact_id,
         diffs,
         current_files: &current_files,
+        base_files: &base_files,
         plan: plan_summary.as_ref(),
         waivers_by_validation: &waivers_by_validation,
         generated_at,

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -922,3 +922,189 @@ fn workbench_discard_rejects_already_discarded() {
     assert_eq!(v["ok"], false);
     assert!(v["error"].as_str().unwrap().contains("discard"));
 }
+
+// Issue #332: reconcile must produce a semantic_summary that flags
+// capability changes and store the summary in
+// `.autonoetic/semantic_summary.json` next to `reconciliation.json`.
+#[test]
+fn workbench_reconcile_writes_semantic_summary_with_capability_flag() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-sem";
+
+    let artifact_ref = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[
+            ("capabilities.yaml", b"[]"),
+            ("src/lib.rs", b"pub fn x() { 1 + 1 }"),
+        ],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_ref,
+    );
+
+    let wb = store.load_workbench(&wb_id).unwrap().unwrap();
+    let source_dir = std::path::Path::new(&wb.workspace_path);
+
+    std::fs::write(
+        source_dir.join("capabilities.yaml"),
+        b"- network\n- shell\n",
+    )
+    .unwrap();
+    std::fs::write(
+        source_dir.join("src/lib.rs"),
+        b"pub fn fetch() { let _ = reqwest::get(\"https://example.com\"); }",
+    )
+    .unwrap();
+
+    let reconcile_args = json!({
+        "workbench_id": wb_id,
+    });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true, "reconcile failed: {:?}", v);
+
+    let summary = &v["semantic_summary"];
+    assert_eq!(summary["summarizer_id"], "rule_based_v1");
+    assert_eq!(summary["workbench_id"], wb_id);
+
+    let contract_changes = summary["contract_changes"].as_array().unwrap();
+    let impacts: Vec<&str> = contract_changes
+        .iter()
+        .map(|c| c["impact"].as_str().unwrap())
+        .collect();
+    assert!(
+        impacts.contains(&"capability_change"),
+        "expected capability_change in contract_changes, got {:?}",
+        impacts
+    );
+    assert!(
+        impacts.contains(&"network_access_change"),
+        "expected network_access_change in contract_changes, got {:?}",
+        impacts
+    );
+
+    let summary_path = source_dir
+        .parent()
+        .unwrap()
+        .join(".autonoetic")
+        .join("semantic_summary.json");
+    assert!(
+        summary_path.exists(),
+        "semantic_summary.json not written to disk at {:?}",
+        summary_path
+    );
+    let on_disk: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&summary_path).unwrap()).unwrap();
+    assert_eq!(on_disk["summarizer_id"], "rule_based_v1");
+    assert_eq!(on_disk["workbench_id"], wb_id);
+}
+
+#[test]
+fn workbench_reconcile_semantic_summary_no_contract_changes_for_source_edit() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-sem-src-edit";
+
+    let artifact_ref = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("hello.txt", b"hello world"), ("readme.md", b"# readme")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_ref,
+    );
+
+    let wb = store.load_workbench(&wb_id).unwrap().unwrap();
+    let source_dir = std::path::Path::new(&wb.workspace_path);
+
+    // Modify a plain text file (no contract impact).
+    let edited = std::fs::read_to_string(source_dir.join("hello.txt")).unwrap();
+    std::fs::write(source_dir.join("hello.txt"), format!("{} -- edited", edited)).unwrap();
+
+    let reconcile_args = json!({ "workbench_id": wb_id });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true);
+    let summary = &v["semantic_summary"];
+    assert_eq!(summary["summarizer_id"], "rule_based_v1");
+    assert_eq!(summary["contract_changes"].as_array().unwrap().len(), 0);
+    assert_eq!(summary["changed_files"], 1);
+}

--- a/autonoetic-types/src/lib.rs
+++ b/autonoetic-types/src/lib.rs
@@ -27,6 +27,7 @@ pub mod redaction;
 pub mod runtime_lock;
 pub mod scheduled_job;
 pub mod schema_enforcement;
+pub mod semantic_diff;
 pub mod security;
 pub mod session_outcome;
 pub mod task_board;

--- a/autonoetic-types/src/semantic_diff.rs
+++ b/autonoetic-types/src/semantic_diff.rs
@@ -1,0 +1,269 @@
+//! Semantic summaries for reconciled workbench diffs.
+//!
+//! Issue #332: when an operator returns a workbench to the orchestrator,
+//! the wake-up payload should carry both the raw diff (file lists) and a
+//! higher-level orientation that calls out potential agent I/O contract
+//! changes (capability additions/removals, skill manifest edits, runtime
+//! lock changes, etc.). This module defines the data types and the trait
+//! used to produce those summaries.
+//!
+//! The default implementation (in `autonoetic-gateway/src/runtime/semantic_diff.rs`)
+//! is a rule-based classifier keyed on file path and content patterns. It
+//! is deliberately pluggable: any type that implements
+//! [`SemanticSummarizer`] can be wired in later (e.g. an LLM-based
+//! summarizer behind a feature flag) without changing the
+//! reconcile → `/return` wake-up contract.
+//!
+//! Design constraints:
+//!
+//! - No new LLM infrastructure. The default impl does not call a model.
+//! - The summary is **additive** to the raw diff, never a replacement.
+//!   The orchestrator should be able to ground on the raw file lists if
+//!   the summary is wrong or stale.
+//! - The summary is persisted next to `reconciliation.json` so it can be
+//!   reread by `/return` and by audit consumers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::plan_frame::PlanFrameSummary;
+use crate::workbench::{FileChangeType, WorkbenchFileDiff};
+
+/// The contract-impact classification of a single file change.
+///
+/// The variants are ordered roughly from highest blast-radius to lowest.
+/// `None` is the default for files that don't match any known contract.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractImpact {
+    /// No contract impact (regular source / doc change).
+    None,
+    /// A capability declaration file was changed. The agent may have
+    /// gained or lost capabilities.
+    CapabilityChange,
+    /// A skill manifest was added / modified / removed. The orchestrator
+    /// may need to re-resolve agent routing.
+    SkillManifestChange,
+    /// The runtime lock was changed. The orchestrator may need to
+    /// re-evaluate which decisions were inherited.
+    RuntimeLockChange,
+    /// A config schema or template was changed. Other artifacts depending
+    /// on this config may need to be re-validated.
+    ConfigSchemaChange,
+    /// An entry point (main.rs, agent.toml) was changed.
+    EntryPointChange,
+    /// Code matching the remote-access / network patterns was changed.
+    /// The orchestrator may need to re-issue approvals.
+    NetworkAccessChange,
+    /// A credential-shape file was changed (the file is referenced from
+    /// the credential vault, not that the secret is in the diff).
+    CredentialShapeChange,
+    /// The file is in a directory that *could* be a contract but doesn't
+    /// match any specific known shape. Surfaced for manual review.
+    UnknownContract,
+}
+
+impl ContractImpact {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContractImpact::None => "none",
+            ContractImpact::CapabilityChange => "capability_change",
+            ContractImpact::SkillManifestChange => "skill_manifest_change",
+            ContractImpact::RuntimeLockChange => "runtime_lock_change",
+            ContractImpact::ConfigSchemaChange => "config_schema_change",
+            ContractImpact::EntryPointChange => "entry_point_change",
+            ContractImpact::NetworkAccessChange => "network_access_change",
+            ContractImpact::CredentialShapeChange => "credential_shape_change",
+            ContractImpact::UnknownContract => "unknown_contract",
+        }
+    }
+}
+
+/// The role of a file in the workbench. Used to feed the
+/// `ContractImpact` classifier and to label each entry in
+/// `file_classifications` so consumers can group by role.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum FileRole {
+    Capability,
+    SkillManifest,
+    RuntimeLock,
+    ConfigSchema,
+    EntryPoint,
+    NetworkAccess,
+    Credential,
+    SourceCode,
+    Documentation,
+    Build,
+    Test,
+    Unknown,
+}
+
+impl FileRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FileRole::Capability => "capability",
+            FileRole::SkillManifest => "skill_manifest",
+            FileRole::RuntimeLock => "runtime_lock",
+            FileRole::ConfigSchema => "config_schema",
+            FileRole::EntryPoint => "entry_point",
+            FileRole::NetworkAccess => "network_access",
+            FileRole::Credential => "credential",
+            FileRole::SourceCode => "source_code",
+            FileRole::Documentation => "documentation",
+            FileRole::Build => "build",
+            FileRole::Test => "test",
+            FileRole::Unknown => "unknown",
+        }
+    }
+}
+
+/// One per-file classification. Stable, ordered by path, mirrors
+/// `WorkbenchFileDiff` 1:1 (filtered to non-unchanged entries).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileClassification {
+    pub path: String,
+    pub change_type: FileChangeType,
+    pub role: FileRole,
+    pub impact: ContractImpact,
+    /// Short human-readable rationale, e.g. "matches capabilities.yaml".
+    /// Empty string when the classifier has nothing useful to say.
+    pub rationale: String,
+}
+
+/// One detected contract-level change. This is a filtered view of
+/// `FileClassification` keeping only entries where `impact != None`.
+///
+/// The list is sorted by `impact` then `path` for deterministic output.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContractChange {
+    pub path: String,
+    pub change_type: FileChangeType,
+    pub impact: ContractImpact,
+    pub rationale: String,
+}
+
+/// Validation state at reconcile time, derived from the gateway store
+/// (waivers on the base artifact) and the active plan (required
+/// validations). The summary reports *what the orchestrator should know*
+/// about validation; it does not produce validation findings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ValidationState {
+    /// Total waivers on the base artifact.
+    pub waiver_count: usize,
+    /// Whether at least one waiver is present. Mirrors `waiver_count > 0`
+    /// for ergonomic JSON consumers.
+    pub waivers_present: bool,
+    /// Validation ids the active plan marked as required.
+    pub required_validations: Vec<String>,
+    /// Validation ids the active plan marked as advisory.
+    pub advisory_validations: Vec<String>,
+    /// Validation ids required by the plan that are *not* covered by a
+    /// waiver. Empty when the plan is absent or all required validations
+    /// are satisfied/waived.
+    pub unsatisfied_required: Vec<String>,
+}
+
+/// Top-level semantic summary persisted in
+/// `<workbench>/.autonoetic/semantic_summary.json` and inlined into the
+/// `/return` wake-up metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SemanticSummary {
+    pub workbench_id: String,
+    pub base_artifact_id: String,
+    pub new_artifact_id: String,
+    pub plan_id: Option<String>,
+    pub plan_version: Option<u32>,
+    pub total_files: usize,
+    pub changed_files: usize,
+    pub added_files: usize,
+    pub modified_files: usize,
+    pub deleted_files: usize,
+    /// Only entries where `impact != None`. Sorted by impact then path.
+    pub contract_changes: Vec<ContractChange>,
+    /// All non-unchanged entries classified by role. Sorted by path.
+    pub file_classifications: Vec<FileClassification>,
+    pub validation_state: ValidationState,
+    /// Implementation id, e.g. `rule_based_v1`. Free-form so future
+    /// impls (LLM-based, etc.) can self-describe.
+    pub summarizer_id: String,
+    pub generated_at: String,
+}
+
+/// Inputs the summarizer needs. Held by reference so the gateway can
+/// reuse file buffers it already loaded.
+pub struct SemanticSummaryInputs<'a> {
+    pub workbench_id: &'a str,
+    pub base_artifact_id: &'a str,
+    pub new_artifact_id: &'a str,
+    pub diffs: &'a [WorkbenchFileDiff],
+    /// Map from relative path → file content. Caller is responsible for
+    /// loading only the files that appear in `diffs`.
+    pub current_files: &'a std::collections::HashMap<String, Vec<u8>>,
+    pub plan: Option<&'a PlanFrameSummary>,
+    /// Waiver ids on the base artifact, indexed by validation id.
+    pub waivers_by_validation: &'a std::collections::HashMap<String, Vec<String>>,
+    pub generated_at: &'a str,
+}
+
+/// Pluggable summarizer trait. Implementations must be deterministic
+/// (no wall-clock-dependent ordering) so persisted summaries can be
+/// re-derived and compared.
+pub trait SemanticSummarizer: Send + Sync {
+    /// Stable id used in [`SemanticSummary::summarizer_id`].
+    fn id(&self) -> &'static str;
+
+    /// Build a [`SemanticSummary`] from the given inputs. Implementations
+    /// should treat empty / missing optional fields as legitimate and
+    /// return `None` for any derived value they cannot produce, rather
+    /// than erroring.
+    fn summarize(&self, inputs: &SemanticSummaryInputs<'_>) -> SemanticSummary;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_impact_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ContractImpact::CapabilityChange).unwrap(),
+            "\"capability_change\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ContractImpact::NetworkAccessChange).unwrap(),
+            "\"network_access_change\""
+        );
+    }
+
+    #[test]
+    fn file_role_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&FileRole::SkillManifest).unwrap(),
+            "\"skill_manifest\""
+        );
+    }
+
+    #[test]
+    fn semantic_summary_round_trip_empty() {
+        let s = SemanticSummary {
+            workbench_id: "wb-x".into(),
+            base_artifact_id: "ar.abc".into(),
+            new_artifact_id: "ar.def".into(),
+            plan_id: None,
+            plan_version: None,
+            total_files: 0,
+            changed_files: 0,
+            added_files: 0,
+            modified_files: 0,
+            deleted_files: 0,
+            contract_changes: vec![],
+            file_classifications: vec![],
+            validation_state: ValidationState::default(),
+            summarizer_id: "test".into(),
+            generated_at: "2026-06-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: SemanticSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
+    }
+}

--- a/autonoetic-types/src/semantic_diff.rs
+++ b/autonoetic-types/src/semantic_diff.rs
@@ -196,9 +196,15 @@ pub struct SemanticSummaryInputs<'a> {
     pub base_artifact_id: &'a str,
     pub new_artifact_id: &'a str,
     pub diffs: &'a [WorkbenchFileDiff],
-    /// Map from relative path → file content. Caller is responsible for
-    /// loading only the files that appear in `diffs`.
+    /// Map from relative path → file content for the current (new)
+    /// version of each file. Populated for Added and Modified entries;
+    /// empty for Deleted entries (use `base_files` instead).
     pub current_files: &'a std::collections::HashMap<String, Vec<u8>>,
+    /// Map from relative path → file content for the base (original)
+    /// version of each file. Populated for Modified and Deleted entries
+    /// so the classifier can inspect the *old* content (e.g. detect
+    /// network-access patterns in a deleted source file).
+    pub base_files: &'a std::collections::HashMap<String, Vec<u8>>,
     pub plan: Option<&'a PlanFrameSummary>,
     /// Waiver ids on the base artifact, indexed by validation id.
     pub waivers_by_validation: &'a std::collections::HashMap<String, Vec<String>>,

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -36,6 +36,7 @@ use autonoetic_types::background::{
     UserInteractionStatus,
 };
 use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::semantic_diff::SemanticSummary;
 
 // ============================================================================
 // Constants
@@ -2049,7 +2050,8 @@ struct ReturnToAgentInput {
     /// impact, validation state, file-role classifications). Loaded
     /// from `.autonoetic/semantic_summary.json` for reconciled
     /// workbenches; `None` when missing or for active workbenches.
-    semantic_summary: Option<serde_json::Value>,
+    /// Uses the typed struct so `ReturnToAgentInput` preserves `Eq`.
+    semantic_summary: Option<SemanticSummary>,
 }
 
 /// Output of `build_return_to_agent_wakeup`. The `message` is the natural
@@ -2108,12 +2110,8 @@ fn build_return_to_agent_wakeup(input: &ReturnToAgentInput) -> ReturnToAgentWake
         );
     }
     if let Some(semantic_summary) = &input.semantic_summary {
-        // Issue #332: surface the rule-based semantic summary (contract
-        // impacts, file-role classifications, validation state) so the
-        // orchestrator gets both raw precision and high-level
-        // orientation. The summary is *additive* — the file lists above
-        // remain the source of truth for grounding.
-        structured["semantic_summary"] = semantic_summary.clone();
+        structured["semantic_summary"] = serde_json::to_value(semantic_summary)
+            .unwrap_or(serde_json::Value::Null);
     }
 
     let artifact_ref_label = input
@@ -2159,23 +2157,20 @@ fn build_return_to_agent_wakeup(input: &ReturnToAgentInput) -> ReturnToAgentWake
 
 /// Render a one-line summary of the contract-impact changes recorded in
 /// the semantic summary. Returns `None` when there are no
-/// `contract_changes` to call out, or when the summary is malformed.
+/// `contract_changes` to call out.
 ///
 /// Format: a comma-separated list of `"<impact> on <path>"` items,
 /// truncated to the first three to keep the wake-up message compact.
-fn summarize_contract_changes(summary: &serde_json::Value) -> Option<String> {
-    let changes = summary.get("contract_changes")?.as_array()?;
-    if changes.is_empty() {
+fn summarize_contract_changes(summary: &SemanticSummary) -> Option<String> {
+    if summary.contract_changes.is_empty() {
         return None;
     }
     let mut labels: Vec<String> = Vec::new();
-    for c in changes.iter().take(3) {
-        let path = c.get("path").and_then(|v| v.as_str()).unwrap_or("?");
-        let impact = c.get("impact").and_then(|v| v.as_str()).unwrap_or("?");
-        labels.push(format!("{impact} on {path}"));
+    for c in summary.contract_changes.iter().take(3) {
+        labels.push(format!("{} on {}", c.impact.as_str(), c.path));
     }
-    let suffix = if changes.len() > 3 {
-        format!(" (+{} more)", changes.len() - 3)
+    let suffix = if summary.contract_changes.len() > 3 {
+        format!(" (+{} more)", summary.contract_changes.len() - 3)
     } else {
         String::new()
     };

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -2045,6 +2045,11 @@ struct ReturnToAgentInput {
     operator_added_files: Vec<String>,
     /// IDs of files deleted by the operator since the projection.
     deleted_files: Vec<String>,
+    /// Issue #332: high-level semantic summary of the diff (contract
+    /// impact, validation state, file-role classifications). Loaded
+    /// from `.autonoetic/semantic_summary.json` for reconciled
+    /// workbenches; `None` when missing or for active workbenches.
+    semantic_summary: Option<serde_json::Value>,
 }
 
 /// Output of `build_return_to_agent_wakeup`. The `message` is the natural
@@ -2102,6 +2107,14 @@ fn build_return_to_agent_wakeup(input: &ReturnToAgentInput) -> ReturnToAgentWake
                 .collect(),
         );
     }
+    if let Some(semantic_summary) = &input.semantic_summary {
+        // Issue #332: surface the rule-based semantic summary (contract
+        // impacts, file-role classifications, validation state) so the
+        // orchestrator gets both raw precision and high-level
+        // orientation. The summary is *additive* — the file lists above
+        // remain the source of truth for grounding.
+        structured["semantic_summary"] = semantic_summary.clone();
+    }
 
     let artifact_ref_label = input
         .new_artifact_ref
@@ -2129,6 +2142,11 @@ fn build_return_to_agent_wakeup(input: &ReturnToAgentInput) -> ReturnToAgentWake
             message.push_str(&format!(" Operator note: {}.", note.trim()));
         }
     }
+    if let Some(semantic_summary) = &input.semantic_summary {
+        if let Some(label) = summarize_contract_changes(semantic_summary) {
+            message.push_str(&format!(" Contract impact: {label}."));
+        }
+    }
     message.push_str(" Please continue the workflow.");
 
     ReturnToAgentWakeup {
@@ -2137,6 +2155,31 @@ fn build_return_to_agent_wakeup(input: &ReturnToAgentInput) -> ReturnToAgentWake
             "workbench_reconciled": structured,
         }),
     }
+}
+
+/// Render a one-line summary of the contract-impact changes recorded in
+/// the semantic summary. Returns `None` when there are no
+/// `contract_changes` to call out, or when the summary is malformed.
+///
+/// Format: a comma-separated list of `"<impact> on <path>"` items,
+/// truncated to the first three to keep the wake-up message compact.
+fn summarize_contract_changes(summary: &serde_json::Value) -> Option<String> {
+    let changes = summary.get("contract_changes")?.as_array()?;
+    if changes.is_empty() {
+        return None;
+    }
+    let mut labels: Vec<String> = Vec::new();
+    for c in changes.iter().take(3) {
+        let path = c.get("path").and_then(|v| v.as_str()).unwrap_or("?");
+        let impact = c.get("impact").and_then(|v| v.as_str()).unwrap_or("?");
+        labels.push(format!("{impact} on {path}"));
+    }
+    let suffix = if changes.len() > 3 {
+        format!(" (+{} more)", changes.len() - 3)
+    } else {
+        String::new()
+    };
+    Some(format!("{}{suffix}", labels.join(", ")))
 }
 
 /// Read the active workbench's operator-edited file lists from the gateway
@@ -2216,6 +2259,11 @@ fn read_return_to_agent_input(
             .unwrap_or_default();
 
         let unsaved_change_count = modified.len() + added.len() + deleted.len();
+        let semantic_summary = meta_dir
+            .as_ref()
+            .map(|d| d.join("semantic_summary.json"))
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|raw| serde_json::from_str(&raw).ok());
         return Some(ReturnToAgentInput {
             workbench_id: wb.workbench_id,
             base_artifact_id: wb.base_artifact_id,
@@ -2227,6 +2275,7 @@ fn read_return_to_agent_input(
             operator_modified_files: modified,
             operator_added_files: added,
             deleted_files: deleted,
+            semantic_summary,
         });
     }
 
@@ -2243,6 +2292,7 @@ fn read_return_to_agent_input(
             operator_modified_files: Vec::new(),
             operator_added_files: Vec::new(),
             deleted_files: Vec::new(),
+            semantic_summary: None,
         });
     }
 
@@ -2308,6 +2358,7 @@ fn read_return_to_agent_input(
         operator_modified_files: modified,
         operator_added_files: added,
         deleted_files: deleted,
+        semantic_summary: None,
     })
 }
 
@@ -8304,6 +8355,7 @@ mod tests {
             operator_modified_files: modified,
             operator_added_files: added,
             deleted_files: deleted,
+            semantic_summary: None,
         }
     }
 

--- a/docs/design/human-agent-artifact-collaboration-plan.md
+++ b/docs/design/human-agent-artifact-collaboration-plan.md
@@ -1017,6 +1017,141 @@ Acceptance criteria:
   runtime-lock, and entrypoint changes before reconcile.
 - `return to agent` refuses to silently drop local edits.
 
+#### Reflections on Phase 5 + 6 implementation (post-PR #341, #342)
+
+After shipping Phases 0–4 (PlanFrame MVP, projection, reconcile, validation
+waivers, TUI cockpit, `/wb`), the two remaining slices (Phase 5 context
+lens, Phase 6 return-to-agent) were implemented as PR #341 and PR #342.
+Below: what matched the plan, what didn't, and what was learned.
+
+**Phase 5 — PlanFrame as context-compression lens** shipped a thin slice of
+the original design.
+
+| | Plan | Shipped | Gap |
+|---|---|---|---|
+| PlanFrame as relevance lens for context compression | ✓ | ✓ — `plan_anchor` plumbed through `GovernorContext` → `extract_delta`; `build_delta_extraction_prompt` renders an "Active Plan (...)" block | None — works for delta extraction |
+| PlanFrame as relevance lens for **State Capsule** generation | ✓ | ✗ — capsule rendering still doesn't reference the plan | Deferred — would mean re-rendering the capsule body when a plan changes; bigger design call |
+| Promote PlanFrame from workflow-scoped to project-scoped | ✓ | ✗ | Deferred — multi-workflow plan reuse is a larger surface |
+| `capsule.project` into a workbench | ✓ | ✗ | Not started |
+| Capsule export of reconciled workbench + plan as a draft | ✓ | ✗ | Not started |
+| Cross-machine workbench transfer (provenance preserved) | ✓ | ✗ | Not started |
+
+The one shipped slice is small but high-leverage: when the LLM is asked
+to compress history, it now sees the active plan's title, operator and
+agent step ids, and required/advisory validation ids framed as
+*"prefer plan-advancing items"*. Empty optional sections are omitted
+to keep the prompt small. The active plan is loaded in `lifecycle.rs`
+via `load_active_plan_for_workflow(workflow_id)?.compact_summary()`,
+with graceful fallback to no anchor when the store, workflow_id, or
+plan is missing.
+
+Two real bugs caught at review (worth keeping in mind for similar plumbing):
+
+1. **`PlanFrameSummary` initially had only `operator_steps`, not `agent_steps`.**
+   The plan called for both, but the first cut only surfaced operator/shared
+   steps. Copilot flagged the gap during PR #341 review; `agent_steps` was
+   added to the struct, `compact_summary` was updated to populate it, and the
+   prompt was extended with a `- agent steps:` line.
+
+2. **Child session ids of the form `root/x` silently disabled the plan anchor.**
+   `resolve_workflow_id_for_root_session` is keyed on the *root* id; the
+   `lifecycle.rs` call site was passing the child id directly. Fix: wrap
+   `session_id` in `content_store::root_session_id(&session_id).to_string()`
+   before the workflow lookup. This is the same pattern the rest of the
+   codebase already uses (`workflow_store.rs:2985` and
+   `lifecycle.rs:2823`) — copying it cost one line.
+
+**Phase 6 — Return-to-agent flow** shipped the TUI `return to agent` action
+and most of the wake-up contract, with a few items deferred.
+
+| | Plan | Shipped | Gap |
+|---|---|---|---|
+| `return to agent` TUI action | ✓ | ✓ — `/return [--force\|-f] [note...]` slash command | None |
+| Refuses to silently drop local edits | ✓ | ✓ — by default; `--force` overrides | None |
+| Wake the **selected** orchestrator | ✓ | ✗ — hard-coded to `planner.default` | Deferred — requires #326 (orchestrator selection) |
+| `workbench.ask` for operator questions | ✓ | ✗ | Not started — could be a small follow-up tool |
+| `workbench.open` one-command edit mode | ✓ | ✗ | Not started — projection tool already covers the use case |
+| File watcher warnings for risky changes | ✓ | ✗ | Not started — separate surface (TUI status bar / hook) |
+| Semantic summary in the wake-up | ✓ | ✗ | Tracked by #332 — the wake-up currently carries raw file lists; an LLM-generated summary would let the planner orient faster |
+
+The shipped action is `ChatOutbound::ReturnToAgent`, which dispatches via
+`event.ingest` with `event_type: "workbench_reconciled"`. The structured
+metadata now includes `workbench_id`, `base_artifact_id`, `new_artifact_ref/id`
+when present, `reconciled` (bool), `unsaved_change_count`, and the
+operator/added/deleted file lists. The orchestrator wakes with both
+raw precision (the file lists) and high-level orientation
+(operator note, status, "in sync" / "unsaved --force" / "reconciled"
+label in the natural-language message).
+
+Three real bugs / surprises caught at review:
+
+1. **The reconciled path needed to read `.autonoetic/reconciliation.json`.**
+   First cut always set `new_artifact_ref`/`new_artifact_id` to `None`, which
+   would have made `/return` on a *reconciled* workbench incorrectly tell the
+   orchestrator to use the *base* artifact. Fix: `read_return_to_agent_input`
+   now branches on status — `Reconciled` reads the provenance file
+   (authoritative at reconcile time), `Active` computes live from
+   `base_digests.json` + the current files.
+
+2. **`event.ingest` only reroutes child→root for `event_type == "chat"`.**
+   The first dispatch sent `app.session_id` as the ingest `session_id`,
+   which on a child session would wake the orchestrator *on the child* —
+   the opposite of the user-visible "return-to-orchestrator" intent.
+   Fix: resolve the root session id via `get_root_session_id(app)` and
+   send that. The merge-with-envelope step then attaches
+   `metadata.root_session_id` so downstream consumers can still tell
+   which chat the request originated from.
+
+3. **The unsaved-edits safety check should not apply to reconciled workbenches.**
+   Reconciled workbenches have already committed their changes to a new
+   artifact, so `unsaved_change_count > 0` from provenance is *informational*
+   (e.g. "12 files were touched during the reconcile") not a drop risk.
+   First cut refused on any `unsaved_change_count > 0` regardless of
+   `reconciled`; the check is now `!reconciled && unsaved_change_count > 0`.
+
+**Cross-phase observations.**
+
+The structured `workbench_reconciled` payload that PR #342 puts on the
+wire is now the contract between the TUI and the orchestrator. It
+already has enough surface to be useful: workbench/artifact identifiers,
+operator/added/deleted file lists, reconciled flag, unsaved_change_count,
+and operator note. The natural next enrichment is **semantic summary
+generation** (#332) — the wake-up should tell the planner *what the
+operator changed and why it matters*, not just *which files were touched*.
+That converts the current "agent re-discovers context from raw diff"
+into "agent gets a curated brief plus the raw diff for grounding."
+
+The wake-up also currently targets `planner.default` because the
+runtime orchestrator selection mechanism (#326) does not exist yet.
+Once that lands, the TUI should resolve the wake-up target from the
+workflow's pinned orchestrator rather than hard-coding it. A
+collaborative-planner agent that knows about PlanFrame and workbenches
+would also be the natural recipient of the future semantic summary.
+
+**Open questions for the post-Phase-6 era.**
+
+1. **Should `/return` block until the orchestrator acknowledges the wake-up?**
+   Current implementation dispatches and returns to the chat loop
+   immediately; the user sees the assistant's next reply when the
+   orchestrator's first turn completes. An optional sync mode (e.g.
+   `/return --wait`) could be useful when the operator wants to know
+   the orchestrator has resumed before they keep typing.
+2. **What happens to a workbench the orchestrator *rejects*?**
+   Right now the orchestrator can either accept the edits (continue)
+   or push back (ask the operator to re-edit). There's no explicit
+   "rejected" event; the operator would have to infer it from the
+   orchestrator's message. A `workbench.rejected` event in the same
+   shape as `workbench_reconciled` would close the loop.
+3. **Does the operator need a way to **cancel** a wake-up after
+   dispatching it?** Currently once the event is on the wire, it
+   can't be unsent. A short cancellation window (e.g. 30 s) would
+   be a safety net for "oh wait, I sent that to the wrong session."
+4. **Should `workbench.ask` be a single tool or a family?** The plan
+   lists it as a single thing, but a one-shot operator question
+   ("summarize the current state") and a structured multi-step
+   Q&A ("walk me through how `auth.rs` changed") feel like different
+   surfaces. Worth scoping before implementation.
+
 ---
 
 ## 11. Planner policy changes


### PR DESCRIPTION
Closes #332

## Summary

Generate a semantic change summary when reconciling a workbench, so the orchestrator receives both raw diff precision and high-level contract-impact orientation.

## What changed

### New types (`autonoetic-types/src/semantic_diff.rs`)
- `SemanticSummary` — persisted alongside `reconciliation.json`
- `ContractImpact` — enum of blast-radius levels (capability, skill, runtime_lock, network_access, etc.)
- `FileRole` — how each changed file is classified
- `SemanticSummarizer` trait — pluggable; the rule-based default can be swapped for an LLM-based impl later

### Rule-based classifier (`autonoetic-gateway/src/runtime/semantic_diff.rs`)
- Path-based role detection (`capabilities.yaml`, `SKILL.md`, `runtime_lock.json`, etc.)
- Content-based network-access detection via `RemoteAccessAnalyzer`
- Validation state: cross-references active plan `required_validations` with waivers on the base artifact

### Wiring
- `workbench_reconcile` calls `build_semantic_summary()`, persists `.autonoetic/semantic_summary.json`, includes summary in tool response
- `/return` reads `semantic_summary.json` for reconciled workbenches and includes it in wake-up metadata
- Natural-language wake-up message includes one-line contract impact when contract changes are present

### Tests
- 3 unit tests (types: serialization round-trip)
- 6 unit tests (classifier: capability, skill+runtime lock, network access, pure source, validation state, unchanged filtering)
- 2 integration tests (capability+network flag, no-contract-changes for source edit)
- All existing tests pass (11 workbench, 24 chat)

## Acceptance criteria

- [x] Planner receives both raw precision and high-level orientation
- [x] Summary calls out potential agent I/O contract changes
- [x] No new LLM infrastructure — uses rule-based classifier

## Design decision

The `SemanticSummarizer` trait is deliberately pluggable. The current `RuleBasedSemanticSummarizer` uses path patterns and the existing `RemoteAccessAnalyzer` — no model calls. A future impl can swap in an LLM-based summarizer behind a config flag without touching the reconcile → `/return` wake-up contract.