### PR TITLE
feat: workbench auto-checkpoints, cleanup tool, and workflow completion warning (#330)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -66,8 +66,11 @@ fn mint_artifact_ref_id() -> String {
 /// Create a checkpoint of the workbench's current files. Used for both
 /// manual checkpoints (the `workbench_checkpoint` tool) and automatic
 /// checkpoints (on projection and before reconcile). Returns the
-/// checkpoint id on success. Failures are non-fatal to the caller —
-/// the checkpoint is best-effort, not a gate.
+/// checkpoint id on success.
+///
+/// For **automatic** callers the result is discarded (`let _ = …`) so
+/// a checkpoint failure is non-fatal.  The **manual** `workbench_checkpoint`
+/// tool propagates the error so the operator gets feedback.
 fn create_auto_checkpoint(
     store: &crate::scheduler::gateway_store::GatewayStore,
     wb: &WorkbenchProjection,
@@ -673,7 +676,14 @@ impl NativeTool for WorkbenchCheckpointTool {
         }
 
         let label = args.label.as_deref().unwrap_or("manual");
-        let cp_id = create_auto_checkpoint(&store, &wb, label)?;
+        let cp_id = match create_auto_checkpoint(&store, &wb, label) {
+            Ok(id) => id,
+            Err(e) => {
+                return Ok(serde_json::to_string(&serde_json::json!({
+                    "ok": false, "error": format!("Checkpoint failed: {e}")
+                }))?);
+            }
+        };
 
         Ok(serde_json::to_string(&serde_json::json!({
             "ok": true,
@@ -1031,8 +1041,6 @@ impl NativeTool for WorkbenchReconcileTool {
             revoked_at: None,
         })?;
 
-        let now = now_rfc3339();
-
         // Issue #330: auto-checkpoint before reconcile so the operator
         // can restore the pre-reconcile state if needed. Best-effort.
         if let Ok(_cp_id) = create_auto_checkpoint(&store, &wb, "auto: pre-reconcile") {
@@ -1334,29 +1342,48 @@ impl NativeTool for WorkbenchCleanupTool {
         let parent = workspace_path.parent().unwrap();
         let meta_dir = parent.join(".autonoetic");
 
+        let mut warnings: Vec<String> = Vec::new();
+
         let checkpoints_dir = meta_dir.join("checkpoints");
         if checkpoints_dir.exists() {
-            let _ = std::fs::remove_dir_all(&checkpoints_dir);
+            if let Err(e) = std::fs::remove_dir_all(&checkpoints_dir) {
+                warnings.push(format!("Failed to remove checkpoints dir: {e}"));
+            }
         }
 
         if workspace_path.exists() {
-            let _ = std::fs::remove_dir_all(workspace_path);
+            if let Err(e) = std::fs::remove_dir_all(workspace_path) {
+                warnings.push(format!("Failed to remove workspace dir: {e}"));
+            }
         }
 
         if meta_dir.exists() {
             for stem in &["projection", "base_digests", "reconciliation", "semantic_summary"] {
                 let p = meta_dir.join(format!("{stem}.json"));
-                let _ = std::fs::remove_file(p);
+                let _ = std::fs::remove_file(&p);
+            }
+            if std::fs::read_dir(&meta_dir).map_or(true, |mut d| d.next().is_none()) {
+                let _ = std::fs::remove_dir(&meta_dir);
+            }
+        }
+
+        if parent.exists() {
+            if std::fs::read_dir(parent).map_or(true, |mut d| d.next().is_none()) {
+                let _ = std::fs::remove_dir(parent);
             }
         }
 
         store.delete_workbench(&wb.workbench_id)?;
 
-        Ok(serde_json::to_string(&serde_json::json!({
+        let mut response = serde_json::json!({
             "ok": true,
             "workbench_id": wb.workbench_id,
             "message": format!("Cleaned up {} workbench.", wb.status.as_str())
-        }))?)
+        });
+        if !warnings.is_empty() {
+            response["warnings"] = serde_json::json!(warnings);
+        }
+        Ok(serde_json::to_string(&response)?)
     }
 
     fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -25,6 +25,7 @@ pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(WorkbenchCheckoutTool));
     registry.register(Box::new(WorkbenchReconcileTool));
     registry.register(Box::new(WorkbenchDiscardTool));
+    registry.register(Box::new(WorkbenchCleanupTool));
 }
 
 fn has_workbench_access(manifest: &AgentManifest) -> bool {
@@ -60,6 +61,61 @@ fn mint_artifact_ref_id() -> String {
         "ar.{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
         b[0], b[1], b[2], b[3], b[4], b[5]
     )
+}
+
+/// Create a checkpoint of the workbench's current files. Used for both
+/// manual checkpoints (the `workbench_checkpoint` tool) and automatic
+/// checkpoints (on projection and before reconcile). Returns the
+/// checkpoint id on success. Failures are non-fatal to the caller —
+/// the checkpoint is best-effort, not a gate.
+fn create_auto_checkpoint(
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    wb: &WorkbenchProjection,
+    label: &str,
+) -> Result<String, anyhow::Error> {
+    let source_dir = Path::new(&wb.workspace_path);
+    if !source_dir.exists() {
+        return Err(anyhow::anyhow!("workbench directory gone"));
+    }
+    let files = collect_workbench_files(source_dir)?;
+    if files.is_empty() {
+        return Err(anyhow::anyhow!("no files to checkpoint"));
+    }
+    let total_bytes: u64 = files.iter().map(|(_, sz)| *sz).sum();
+
+    let checkpoint_id = new_checkpoint_id();
+    let now = now_rfc3339();
+
+    let checkpoint_dir = source_dir
+        .parent()
+        .unwrap()
+        .join(".autonoetic")
+        .join("checkpoints")
+        .join(&checkpoint_id);
+    std::fs::create_dir_all(&checkpoint_dir)?;
+
+    for (name, _) in &files {
+        let src = source_dir.join(name);
+        let dst = checkpoint_dir.join(name);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&src, &dst)?;
+    }
+
+    let cp = WorkbenchCheckpoint {
+        checkpoint_id: checkpoint_id.clone(),
+        workbench_id: wb.workbench_id.clone(),
+        label: Some(label.to_string()),
+        file_count: files.len(),
+        total_bytes,
+        created_at: now.clone(),
+    };
+
+    store.save_checkpoint(&cp)?;
+    store.update_workbench_last_checkpoint(&wb.workbench_id, &now)?;
+
+    Ok(checkpoint_id)
 }
 
 fn compute_diff(
@@ -314,6 +370,11 @@ impl NativeTool for ArtifactProjectTool {
         };
 
         store.save_workbench(&wb)?;
+
+        // Issue #330: auto-checkpoint on projection so the operator has
+        // a clean restore point before any edits. Best-effort — failure
+        // does not block the projection.
+        let _ = create_auto_checkpoint(&store, &wb, "auto: projection");
 
         let file_names: Vec<&str> = bundle.files.iter().map(|f| f.name.as_str()).collect();
 
@@ -611,48 +672,13 @@ impl NativeTool for WorkbenchCheckpointTool {
             }))?);
         }
 
-        let source_dir = Path::new(&wb.workspace_path);
-        let files = collect_workbench_files(source_dir)?;
-        let total_bytes: u64 = files.iter().map(|(_, sz)| *sz).sum();
-
-        let checkpoint_id = new_checkpoint_id();
-        let now = now_rfc3339();
-
-        let checkpoint_dir = source_dir
-            .parent()
-            .unwrap()
-            .join(".autonoetic")
-            .join("checkpoints")
-            .join(&checkpoint_id);
-        std::fs::create_dir_all(&checkpoint_dir)?;
-
-        for (name, _) in &files {
-            let src = source_dir.join(name);
-            let dst = checkpoint_dir.join(name);
-            if let Some(parent) = dst.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::copy(&src, &dst)?;
-        }
-
-        let cp = WorkbenchCheckpoint {
-            checkpoint_id: checkpoint_id.clone(),
-            workbench_id: wb.workbench_id.clone(),
-            label: args.label,
-            file_count: files.len(),
-            total_bytes,
-            created_at: now.clone(),
-        };
-
-        store.save_checkpoint(&cp)?;
-        store.update_workbench_last_checkpoint(&wb.workbench_id, &now)?;
+        let label = args.label.as_deref().unwrap_or("manual");
+        let cp_id = create_auto_checkpoint(&store, &wb, label)?;
 
         Ok(serde_json::to_string(&serde_json::json!({
             "ok": true,
-            "checkpoint_id": checkpoint_id,
+            "checkpoint_id": cp_id,
             "workbench_id": wb.workbench_id,
-            "file_count": files.len(),
-            "total_bytes": total_bytes,
             "message": "Checkpoint created."
         }))?)
     }
@@ -1006,6 +1032,14 @@ impl NativeTool for WorkbenchReconcileTool {
         })?;
 
         let now = now_rfc3339();
+
+        // Issue #330: auto-checkpoint before reconcile so the operator
+        // can restore the pre-reconcile state if needed. Best-effort.
+        if let Ok(_cp_id) = create_auto_checkpoint(&store, &wb, "auto: pre-reconcile") {
+            // last_checkpoint_at updated inside create_auto_checkpoint
+        }
+
+        let now = now_rfc3339();
         store.update_workbench_status(&wb.workbench_id, WorkbenchStatus::Reconciled, &now)?;
 
         let semantic_summary = build_semantic_summary(
@@ -1220,6 +1254,108 @@ impl NativeTool for WorkbenchDiscardTool {
             "status": "discarded",
             "discarded_at": now,
             "message": "Workbench discarded. Files preserved for audit."
+        }))?)
+    }
+
+    fn extract_metadata(&self, _arguments_json: &str) -> ToolMetadata {
+        ToolMetadata::default()
+    }
+}
+
+pub struct WorkbenchCleanupTool;
+
+impl NativeTool for WorkbenchCleanupTool {
+    fn name(&self) -> &'static str {
+        "workbench_cleanup"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Clean up a reconciled or discarded workbench. Deletes the workbench directory, all checkpoints, and the SQLite record. Active workbenches are refused — they must be reconciled or discarded first.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "workbench_id": {
+                        "type": "string",
+                        "description": "The workbench ID to clean up"
+                    }
+                },
+                "required": ["workbench_id"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        has_workbench_access(manifest)
+    }
+
+    fn execute(
+        &self,
+        _manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        _gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        _session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        _config: Option<&GatewayConfig>,
+        gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+        _run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct Args {
+            workbench_id: String,
+        }
+        let args: Args = serde_json::from_str(arguments_json)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
+
+        let Some(store) = gateway_store else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Gateway store not available"
+            }))?);
+        };
+
+        let Some(wb) = store.load_workbench(&args.workbench_id)? else {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false, "error": "Workbench not found"
+            }))?);
+        };
+
+        if wb.status == WorkbenchStatus::Active {
+            return Ok(serde_json::to_string(&serde_json::json!({
+                "ok": false,
+                "error": "Cannot clean up an active workbench. Reconcile or discard first."
+            }))?);
+        }
+
+        let workspace_path = Path::new(&wb.workspace_path);
+        let parent = workspace_path.parent().unwrap();
+        let meta_dir = parent.join(".autonoetic");
+
+        let checkpoints_dir = meta_dir.join("checkpoints");
+        if checkpoints_dir.exists() {
+            let _ = std::fs::remove_dir_all(&checkpoints_dir);
+        }
+
+        if workspace_path.exists() {
+            let _ = std::fs::remove_dir_all(workspace_path);
+        }
+
+        if meta_dir.exists() {
+            for stem in &["projection", "base_digests", "reconciliation", "semantic_summary"] {
+                let p = meta_dir.join(format!("{stem}.json"));
+                let _ = std::fs::remove_file(p);
+            }
+        }
+
+        store.delete_workbench(&wb.workbench_id)?;
+
+        Ok(serde_json::to_string(&serde_json::json!({
+            "ok": true,
+            "workbench_id": wb.workbench_id,
+            "message": format!("Cleaned up {} workbench.", wb.status.as_str())
         }))?)
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -488,8 +488,8 @@ impl GatewayStore {
     }
 
     pub fn delete_workbench(&self, workbench_id: &str) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        workbenches::delete_workbench(&conn, workbench_id)
+        let mut conn = self.conn.lock().unwrap();
+        workbenches::delete_workbench(&mut conn, workbench_id)
     }
 
     pub fn save_validation_waiver(

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -487,6 +487,11 @@ impl GatewayStore {
         workbenches::list_checkpoints_for_workbench(&conn, workbench_id)
     }
 
+    pub fn delete_workbench(&self, workbench_id: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        workbenches::delete_workbench(&conn, workbench_id)
+    }
+
     pub fn save_validation_waiver(
         &self,
         waiver: &autonoetic_types::plan_frame::ValidationWaiver,

--- a/autonoetic-gateway/src/scheduler/gateway_store/workbenches.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/workbenches.rs
@@ -226,14 +226,16 @@ fn parse_workbench_status(s: &str) -> WorkbenchStatus {
     }
 }
 
-pub(crate) fn delete_workbench(conn: &Connection, workbench_id: &str) -> Result<()> {
-    conn.execute(
+pub(crate) fn delete_workbench(conn: &mut Connection, workbench_id: &str) -> Result<()> {
+    let tx = conn.transaction()?;
+    tx.execute(
         "DELETE FROM workbench_checkpoints WHERE workbench_id = ?1",
         params![workbench_id],
     )?;
-    conn.execute(
+    tx.execute(
         "DELETE FROM workbenches WHERE workbench_id = ?1",
         params![workbench_id],
     )?;
+    tx.commit()?;
     Ok(())
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/workbenches.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/workbenches.rs
@@ -225,3 +225,15 @@ fn parse_workbench_status(s: &str) -> WorkbenchStatus {
         _ => WorkbenchStatus::Active,
     }
 }
+
+pub(crate) fn delete_workbench(conn: &Connection, workbench_id: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM workbench_checkpoints WHERE workbench_id = ?1",
+        params![workbench_id],
+    )?;
+    conn.execute(
+        "DELETE FROM workbenches WHERE workbench_id = ?1",
+        params![workbench_id],
+    )?;
+    Ok(())
+}

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -1150,6 +1150,52 @@ pub fn try_complete_workflow(
         return Ok(false);
     }
 
+    // Issue #330: warn if the workflow has active workbenches with
+    // local edits that haven't been reconciled yet. The workflow still
+    // completes, but the warning event surfaces the unreconciled edits
+    // so the operator can decide whether to reconcile, discard, or
+    // archive before starting a new workflow.
+    if let Some(gw_store) = store {
+        if let Ok(workbenches) = gw_store.list_workbenches_for_workflow(&wf_id) {
+            let unreconciled: Vec<_> = workbenches
+                .iter()
+                .filter(|wb| wb.status == autonoetic_types::workbench::WorkbenchStatus::Active)
+                .map(|wb| wb.workbench_id.clone())
+                .collect();
+            if !unreconciled.is_empty() {
+                tracing::warn!(
+                    target: "workflow",
+                    workflow_id = %wf_id,
+                    count = unreconciled.len(),
+                    workbench_ids = ?unreconciled,
+                    "Workflow completing with {} unreconciled active workbench(es)",
+                    unreconciled.len()
+                );
+                let _ = append_workflow_event(
+                    config,
+                    Some(gw_store),
+                    &WorkflowEventRecord {
+                        event_id: new_event_id(),
+                        workflow_id: wf_id.clone(),
+                        task_id: None,
+                        event_type: "workflow.unreconciled_workbenches".to_string(),
+                        agent_id: None,
+                        payload: serde_json::json!({
+                            "root_session_id": root_session_id,
+                            "unreconciled_workbench_ids": unreconciled,
+                            "message": format!(
+                                "Workflow completed with {} unreconciled active workbench(es). \
+                                 Reconcile, discard, or archive before starting a new workflow.",
+                                unreconciled.len()
+                            ),
+                        }),
+                        occurred_at: now_rfc3339(),
+                    },
+                );
+            }
+        }
+    }
+
     let mut wf = run;
     wf.status = WorkflowRunStatus::Completed;
     wf.updated_at = now_rfc3339();

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -1156,41 +1156,58 @@ pub fn try_complete_workflow(
     // so the operator can decide whether to reconcile, discard, or
     // archive before starting a new workflow.
     if let Some(gw_store) = store {
-        if let Ok(workbenches) = gw_store.list_workbenches_for_workflow(&wf_id) {
-            let unreconciled: Vec<_> = workbenches
-                .iter()
-                .filter(|wb| wb.status == autonoetic_types::workbench::WorkbenchStatus::Active)
-                .map(|wb| wb.workbench_id.clone())
-                .collect();
-            if !unreconciled.is_empty() {
-                tracing::warn!(
+        match gw_store.list_workbenches_for_workflow(&wf_id) {
+            Ok(workbenches) => {
+                let unreconciled: Vec<_> = workbenches
+                    .iter()
+                    .filter(|wb| wb.status == autonoetic_types::workbench::WorkbenchStatus::Active)
+                    .map(|wb| wb.workbench_id.clone())
+                    .collect();
+                if !unreconciled.is_empty() {
+                    tracing::warn!(
+                        target: "workflow",
+                        workflow_id = %wf_id,
+                        count = unreconciled.len(),
+                        workbench_ids = ?unreconciled,
+                        "Workflow completing with {} unreconciled active workbench(es)",
+                        unreconciled.len()
+                    );
+                    if let Err(e) = append_workflow_event(
+                        config,
+                        Some(gw_store),
+                        &WorkflowEventRecord {
+                            event_id: new_event_id(),
+                            workflow_id: wf_id.clone(),
+                            task_id: None,
+                            event_type: "workflow.unreconciled_workbenches".to_string(),
+                            agent_id: None,
+                            payload: serde_json::json!({
+                                "root_session_id": root_session_id,
+                                "unreconciled_workbench_ids": unreconciled,
+                                "message": format!(
+                                    "Workflow completed with {} unreconciled active workbench(es). \
+                                     Reconcile, discard, or archive before starting a new workflow.",
+                                    unreconciled.len()
+                                ),
+                            }),
+                            occurred_at: now_rfc3339(),
+                        },
+                    ) {
+                        tracing::error!(
+                            target: "workflow",
+                            workflow_id = %wf_id,
+                            error = %e,
+                            "Failed to append workflow.unreconciled_workbenches event"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!(
                     target: "workflow",
                     workflow_id = %wf_id,
-                    count = unreconciled.len(),
-                    workbench_ids = ?unreconciled,
-                    "Workflow completing with {} unreconciled active workbench(es)",
-                    unreconciled.len()
-                );
-                let _ = append_workflow_event(
-                    config,
-                    Some(gw_store),
-                    &WorkflowEventRecord {
-                        event_id: new_event_id(),
-                        workflow_id: wf_id.clone(),
-                        task_id: None,
-                        event_type: "workflow.unreconciled_workbenches".to_string(),
-                        agent_id: None,
-                        payload: serde_json::json!({
-                            "root_session_id": root_session_id,
-                            "unreconciled_workbench_ids": unreconciled,
-                            "message": format!(
-                                "Workflow completed with {} unreconciled active workbench(es). \
-                                 Reconcile, discard, or archive before starting a new workflow.",
-                                unreconciled.len()
-                            ),
-                        }),
-                        occurred_at: now_rfc3339(),
-                    },
+                    error = %e,
+                    "Failed to list workbenches for workflow completion warning"
                 );
             }
         }

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -483,7 +483,7 @@ fn workbench_checkpoints_lists_history() {
 
     let list_v: serde_json::Value = serde_json::from_str(&list_result).unwrap();
     assert_eq!(list_v["ok"], true);
-    assert_eq!(list_v["count"], 3);
+    assert_eq!(list_v["count"], 4, "expected 3 manual + 1 auto-projection checkpoint");
 }
 
 fn has_artifact_project_tool(
@@ -1107,4 +1107,409 @@ fn workbench_reconcile_semantic_summary_no_contract_changes_for_source_edit() {
     assert_eq!(summary["summarizer_id"], "rule_based_v1");
     assert_eq!(summary["contract_changes"].as_array().unwrap().len(), 0);
     assert_eq!(summary["changed_files"], 1);
+}
+
+// Issue #330 (a): auto-checkpoint on projection.
+#[test]
+fn artifact_project_creates_auto_checkpoint() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-auto-cp-001";
+
+    let artifact_id = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("x.txt", b"hello")],
+    );
+
+    let result = registry
+        .execute(
+            "artifact_project",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "artifact_ref": artifact_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(v["ok"], true);
+    let wb_id = v["workbench_id"].as_str().unwrap();
+
+    // The auto-checkpoint should be listed.
+    let list_out = registry
+        .execute(
+            "workbench_checkpoints",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "workbench_id": wb_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let list_v: serde_json::Value = serde_json::from_str(&list_out).unwrap();
+    assert_eq!(list_v["ok"], true);
+    assert!(list_v["count"].as_u64().unwrap() >= 1, "expected at least 1 auto-checkpoint");
+
+    let cps = list_v["checkpoints"].as_array().unwrap();
+    let labels: Vec<&str> = cps.iter()
+        .filter_map(|c| c["label"].as_str())
+        .collect();
+    assert!(labels.contains(&"auto: projection"), "expected auto: projection label");
+}
+
+// Issue #330 (b): auto-checkpoint before reconcile.
+#[test]
+fn workbench_reconcile_creates_auto_checkpoint_before_reconcile() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-auto-cp-002";
+
+    let artifact_id = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("hello.txt", b"hello world")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_id,
+    );
+
+    let wb = store.load_workbench(&wb_id).unwrap().unwrap();
+    let source_dir = std::path::Path::new(&wb.workspace_path);
+    std::fs::write(source_dir.join("hello.txt"), b"edited").unwrap();
+
+    let reconcile_args = json!({ "workbench_id": wb_id });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true);
+
+    // After reconcile, the workbench should have the auto: pre-reconcile
+    // checkpoint in addition to the auto: projection checkpoint.
+    let list_out = registry
+        .execute(
+            "workbench_checkpoints",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "workbench_id": wb_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let list_v: serde_json::Value = serde_json::from_str(&list_out).unwrap();
+    assert_eq!(list_v["ok"], true);
+    let cps = list_v["checkpoints"].as_array().unwrap();
+    let labels: Vec<&str> = cps.iter()
+        .filter_map(|c| c["label"].as_str())
+        .collect();
+    assert!(labels.contains(&"auto: pre-reconcile"), "expected auto: pre-reconcile label");
+    assert!(labels.contains(&"auto: projection"), "expected auto: projection label");
+}
+
+// Issue #330 (c): cleanup rejects active, cleans up reconciled.
+#[test]
+fn workbench_cleanup_rejects_active() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-cleanup-001";
+
+    let artifact_id = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("x.txt", b"hello")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_id,
+    );
+
+    let out = registry
+        .execute(
+            "workbench_cleanup",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "workbench_id": wb_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    assert!(v["error"].as_str().unwrap().contains("Cannot clean up an active"));
+}
+
+// Issue #330 (c): cleanup succeeds on reconciled workbench.
+#[test]
+fn workbench_cleanup_succeeds_on_reconciled() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-cleanup-002";
+
+    let artifact_id = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("x.txt", b"hello")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_id,
+    );
+
+    let wb = store.load_workbench(&wb_id).unwrap().unwrap();
+    let source_dir = std::path::Path::new(&wb.workspace_path);
+
+    // Reconcile first.
+    let reconcile_args = json!({ "workbench_id": wb_id });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true);
+
+    // Now cleanup.
+    let cleanup_out = registry
+        .execute(
+            "workbench_cleanup",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "workbench_id": wb_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let cv: serde_json::Value = serde_json::from_str(&cleanup_out).unwrap();
+    assert_eq!(cv["ok"], true, "cleanup failed: {:?}", cv);
+    assert!(cv["message"].as_str().unwrap().contains("reconciled"));
+
+    // Workbench record should be gone.
+    let after = store.load_workbench(&wb_id).unwrap();
+    assert!(after.is_none(), "workbench record should be deleted after cleanup");
+
+    // Checkpoint records should be gone too.
+    let cps = store.list_checkpoints_for_workbench(&wb_id).unwrap();
+    assert!(cps.is_empty(), "checkpoint records should be deleted after cleanup");
+
+    // Disk artifacts should be removed.
+    let workspace_exists = source_dir.exists();
+    let checkpoints_dir = source_dir.parent().unwrap().join(".autonoetic").join("checkpoints");
+    assert!(!workspace_exists || !checkpoints_dir.exists(),
+        "workbench disk artifacts should be cleaned up");
+}
+
+// Issue #330 (c): cleanup succeeds on discarded workbench.
+#[test]
+fn workbench_cleanup_succeeds_on_discarded() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-cleanup-003";
+
+    let artifact_id = build_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &[("x.txt", b"hello")],
+    );
+
+    let wb_id = project_artifact(
+        &registry,
+        &manifest,
+        &policy,
+        &agent_dir,
+        &gateway_dir,
+        &config,
+        &store,
+        session_id,
+        &artifact_id,
+    );
+
+    // Discard first.
+    let discard_out = registry
+        .execute(
+            "workbench_discard",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "workbench_id": wb_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let dv: serde_json::Value = serde_json::from_str(&discard_out).unwrap();
+    assert_eq!(dv["ok"], true, "discard should succeed: {:?}", dv);
+
+    // Now cleanup.
+    let cleanup_out = registry
+        .execute(
+            "workbench_cleanup",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&json!({ "workbench_id": wb_id })).unwrap(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let cv: serde_json::Value = serde_json::from_str(&cleanup_out).unwrap();
+    assert_eq!(cv["ok"], true, "cleanup failed: {:?}", cv);
+    assert!(cv["message"].as_str().unwrap().contains("discarded"));
+
+    let after = store.load_workbench(&wb_id).unwrap();
+    assert!(after.is_none(), "workbench record should be deleted after cleanup");
 }

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -1425,10 +1425,9 @@ fn workbench_cleanup_succeeds_on_reconciled() {
     assert!(cps.is_empty(), "checkpoint records should be deleted after cleanup");
 
     // Disk artifacts should be removed.
-    let workspace_exists = source_dir.exists();
+    assert!(!source_dir.exists(), "workspace directory should be removed");
     let checkpoints_dir = source_dir.parent().unwrap().join(".autonoetic").join("checkpoints");
-    assert!(!workspace_exists || !checkpoints_dir.exists(),
-        "workbench disk artifacts should be cleaned up");
+    assert!(!checkpoints_dir.exists(), "checkpoints directory should be removed");
 }
 
 // Issue #330 (c): cleanup succeeds on discarded workbench.


### PR DESCRIPTION
Closes #330

## Summary

Auto-checkpoints on projection/before-reconcile, a cleanup tool for reconciled/discarded workbenches, and a workflow completion warning so unreconciled edits are never silently dropped.

## What changed

### Auto-checkpoints
- Extracted `create_auto_checkpoint()` helper — the manual `workbench_checkpoint` tool was refactored to reuse it.
- `ArtifactProjectTool` auto-creates `auto: projection` checkpoint on successful projection.
- `WorkbenchReconcileTool` auto-creates `auto: pre-reconcile` checkpoint before marking reconciled.
- Both best-effort; non-fatal to the parent operation.

### Cleanup tool
- New `WorkbenchCleanupTool` (`workbench_cleanup`) — deletes workbench directory, checkpoint snapshots, `.autonoetic` metadata files, and the SQLite record.
- Refuses `Active` workbenches with a hard error.
- `GatewayStore::delete_workbench()` added with cascading deletes.

### Workflow completion warning
- `try_complete_workflow()` now queries for active workbenches before completing. If any exist, emits a `workflow.unreconciled_workbenches` causal event with IDs and a message urging reconcile/discard/archive.
- The workflow still completes; the event is a warning, not a block.

### Tests (5 new, 1 updated)
- `artifact_project_creates_auto_checkpoint`
- `workbench_reconcile_creates_auto_checkpoint_before_reconcile`
- `workbench_cleanup_rejects_active`
- `workbench_cleanup_succeeds_on_reconciled`
- `workbench_cleanup_succeeds_on_discarded`
- `workbench_checkpoints_lists_history` — count updated 3→4

## Acceptance criteria

- [x] Auto-checkpoint on projection
- [x] Auto-checkpoint before reconcile
- [x] Cleanup tool for reconciled/discarded; refuses active
- [x] Workflow completion warning if unreconciled workbenches exist