### PR TITLE
feat(operator-activity): per-root rate limit (Phase 4, #357)

### DIFF
--- a/autonoetic-gateway/src/runtime/tool_call_processor.rs
+++ b/autonoetic-gateway/src/runtime/tool_call_processor.rs
@@ -363,6 +363,7 @@ impl<'a> ToolCallProcessor<'a> {
                 tracing::debug!(
                     target: "operator_activity",
                     session_id = %session_id,
+                    root_session_id = %record.root_session_id,
                     rate_limit_per_min,
                     "Operator activity dropped by per-root rate limit"
                 );

--- a/autonoetic-gateway/src/runtime/tool_call_processor.rs
+++ b/autonoetic-gateway/src/runtime/tool_call_processor.rs
@@ -352,13 +352,30 @@ impl<'a> ToolCallProcessor<'a> {
             causal_event_id,
             None,
         );
-        if let Err(e) = store.insert_operator_activity(&record) {
-            tracing::warn!(
-                target: "operator_activity",
-                error = %e,
-                session_id = %session_id,
-                "Failed to persist operator activity"
-            );
+        let rate_limit_per_min = self
+            .config
+            .map(|c| c.operator_activity.rate_limit_per_min)
+            .unwrap_or_else(|| {
+                autonoetic_types::config::OperatorActivityConfig::default().rate_limit_per_min
+            });
+        match store.insert_operator_activity_throttled(&record, rate_limit_per_min) {
+            Ok(crate::scheduler::gateway_store::OperatorActivityInsert::Dropped) => {
+                tracing::debug!(
+                    target: "operator_activity",
+                    session_id = %session_id,
+                    rate_limit_per_min,
+                    "Operator activity dropped by per-root rate limit"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    target: "operator_activity",
+                    error = %e,
+                    session_id = %session_id,
+                    "Failed to persist operator activity"
+                );
+            }
         }
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -15,6 +15,7 @@ mod messages;
 mod migrate;
 mod notifications;
 mod operator_activity;
+pub use operator_activity::OperatorActivityInsert;
 mod observability;
 pub mod plan_frames;
 pub mod post_promotion_reviews;

--- a/autonoetic-gateway/src/scheduler/gateway_store/operator_activity.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/operator_activity.rs
@@ -61,8 +61,10 @@ impl GatewayStore {
         // Notices don't consume budget — only real activity rows count.
         let count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM operator_activity
-             WHERE root_session_id = ?1 AND occurred_at >= ?2 AND kind != 'rate_limited'",
-            params![record.root_session_id, window_start],
+             WHERE root_session_id = ?1
+               AND occurred_at >= ?2 AND occurred_at <= ?3
+               AND kind != 'rate_limited'",
+            params![record.root_session_id, window_start, record.occurred_at],
             |row| row.get(0),
         )?;
 
@@ -73,8 +75,10 @@ impl GatewayStore {
 
         let notice_count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM operator_activity
-             WHERE root_session_id = ?1 AND occurred_at >= ?2 AND kind = 'rate_limited'",
-            params![record.root_session_id, window_start],
+             WHERE root_session_id = ?1
+               AND occurred_at >= ?2 AND occurred_at <= ?3
+               AND kind = 'rate_limited'",
+            params![record.root_session_id, window_start, record.occurred_at],
             |row| row.get(0),
         )?;
 
@@ -463,6 +467,30 @@ mod tests {
         later.occurred_at = "2026-06-01T10:02:00+00:00".to_string();
         assert_eq!(
             store.insert_operator_activity_throttled(&later, 1).unwrap(),
+            OperatorActivityInsert::Inserted
+        );
+    }
+
+    #[test]
+    fn rate_limit_window_has_upper_bound_for_out_of_order_inserts() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        let root = "session-out-of-order";
+
+        // A later-timestamped row lands first (e.g. concurrent emitter).
+        let mut later = sample_record(root);
+        later.occurred_at = "2026-06-01T10:02:00+00:00".to_string();
+        assert_eq!(
+            store.insert_operator_activity_throttled(&later, 1).unwrap(),
+            OperatorActivityInsert::Inserted
+        );
+
+        // An earlier row's window is [09:59:00, 10:00:00] — the later row sits
+        // past its upper bound and must NOT count against it, so it inserts.
+        let mut earlier = sample_record(root);
+        earlier.occurred_at = "2026-06-01T10:00:00+00:00".to_string();
+        assert_eq!(
+            store.insert_operator_activity_throttled(&earlier, 1).unwrap(),
             OperatorActivityInsert::Inserted
         );
     }

--- a/autonoetic-gateway/src/scheduler/gateway_store/operator_activity.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/operator_activity.rs
@@ -20,43 +20,71 @@ const SEVERITY_RANK_SQL: &str = "CASE severity
     ELSE 0
 END";
 
+/// Outcome of a rate-limited operator-activity insert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperatorActivityInsert {
+    /// The record was persisted.
+    Inserted,
+    /// The record was dropped, but a single `rate_limited` notice was emitted
+    /// for this window so the suppression is visible.
+    ThrottleNoticeEmitted,
+    /// The record was dropped; a notice for this window already existed.
+    Dropped,
+}
+
 impl GatewayStore {
     pub fn insert_operator_activity(&self, record: &OperatorActivityRecord) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        let kind = record.kind.as_str();
-        let severity = record.severity.as_str();
-        let refs_json = if record.refs == OperatorActivityRefs::default() {
-            None
-        } else {
-            Some(serde_json::to_string(&record.refs)?)
-        };
+        write_operator_activity(&conn, record)
+    }
 
-        conn.execute(
-            "INSERT OR IGNORE INTO operator_activity (
-                activity_id, root_session_id, session_id, agent_id,
-                workflow_id, task_id, turn_id, occurred_at,
-                kind, severity, summary, tool_name,
-                causal_event_id, workflow_event_id, refs_json
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
-            params![
-                record.activity_id,
-                record.root_session_id,
-                record.session_id,
-                record.agent_id,
-                record.workflow_id,
-                record.task_id,
-                record.turn_id,
-                record.occurred_at,
-                kind,
-                severity,
-                record.summary,
-                record.tool_name,
-                record.causal_event_id,
-                record.workflow_event_id,
-                refs_json,
-            ],
+    /// Insert an operator activity subject to a per-root rolling-window rate
+    /// limit. At most `rate_limit_per_min` real rows are persisted per root
+    /// session per 60 seconds; once the cap is reached a single
+    /// `rate_limited` notice is emitted and further rows in the window are
+    /// dropped. `rate_limit_per_min == 0` disables the limit. The count and
+    /// notice check run under the same connection lock as the insert, so the
+    /// cap holds even with concurrent emitters.
+    pub fn insert_operator_activity_throttled(
+        &self,
+        record: &OperatorActivityRecord,
+        rate_limit_per_min: u32,
+    ) -> Result<OperatorActivityInsert> {
+        if rate_limit_per_min == 0 {
+            self.insert_operator_activity(record)?;
+            return Ok(OperatorActivityInsert::Inserted);
+        }
+
+        let window_start = window_start_rfc3339(&record.occurred_at)?;
+        let conn = self.conn.lock().unwrap();
+
+        // Notices don't consume budget — only real activity rows count.
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM operator_activity
+             WHERE root_session_id = ?1 AND occurred_at >= ?2 AND kind != 'rate_limited'",
+            params![record.root_session_id, window_start],
+            |row| row.get(0),
         )?;
-        Ok(())
+
+        if (count as u64) < rate_limit_per_min as u64 {
+            write_operator_activity(&conn, record)?;
+            return Ok(OperatorActivityInsert::Inserted);
+        }
+
+        let notice_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM operator_activity
+             WHERE root_session_id = ?1 AND occurred_at >= ?2 AND kind = 'rate_limited'",
+            params![record.root_session_id, window_start],
+            |row| row.get(0),
+        )?;
+
+        if notice_count == 0 {
+            let notice = rate_limit_notice(record, rate_limit_per_min);
+            write_operator_activity(&conn, &notice)?;
+            return Ok(OperatorActivityInsert::ThrottleNoticeEmitted);
+        }
+
+        Ok(OperatorActivityInsert::Dropped)
     }
 
     pub fn list_operator_activity(
@@ -142,6 +170,76 @@ impl GatewayStore {
     }
 }
 
+fn write_operator_activity(
+    conn: &rusqlite::Connection,
+    record: &OperatorActivityRecord,
+) -> Result<()> {
+    let refs_json = if record.refs == OperatorActivityRefs::default() {
+        None
+    } else {
+        Some(serde_json::to_string(&record.refs)?)
+    };
+
+    conn.execute(
+        "INSERT OR IGNORE INTO operator_activity (
+            activity_id, root_session_id, session_id, agent_id,
+            workflow_id, task_id, turn_id, occurred_at,
+            kind, severity, summary, tool_name,
+            causal_event_id, workflow_event_id, refs_json
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+        params![
+            record.activity_id,
+            record.root_session_id,
+            record.session_id,
+            record.agent_id,
+            record.workflow_id,
+            record.task_id,
+            record.turn_id,
+            record.occurred_at,
+            record.kind.as_str(),
+            record.severity.as_str(),
+            record.summary,
+            record.tool_name,
+            record.causal_event_id,
+            record.workflow_event_id,
+            refs_json,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Start of the 60-second rate-limit window ending at `occurred_at`, as an
+/// RFC3339 string comparable (lexicographically) with stored `occurred_at`.
+fn window_start_rfc3339(occurred_at: &str) -> Result<String> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(occurred_at)
+        .map_err(|e| anyhow::anyhow!("invalid occurred_at `{occurred_at}`: {e}"))?;
+    Ok((parsed - chrono::Duration::seconds(60)).to_rfc3339())
+}
+
+/// Build the synthetic `rate_limited` notice that stands in for dropped rows,
+/// inheriting the source record's session/agent context.
+fn rate_limit_notice(src: &OperatorActivityRecord, cap: u32) -> OperatorActivityRecord {
+    OperatorActivityRecord {
+        activity_id: format!("oa-{}", uuid::Uuid::new_v4()),
+        root_session_id: src.root_session_id.clone(),
+        session_id: src.session_id.clone(),
+        agent_id: src.agent_id.clone(),
+        workflow_id: src.workflow_id.clone(),
+        task_id: src.task_id.clone(),
+        turn_id: src.turn_id.clone(),
+        occurred_at: src.occurred_at.clone(),
+        kind: OperatorActivityKind::RateLimited,
+        severity: OperatorActivitySeverity::Attention,
+        summary: format!(
+            "activity rate limit reached ({cap}/min) — further updates this minute are suppressed"
+        ),
+        tool_name: None,
+        causal_event_id: None,
+        workflow_event_id: None,
+        refs: OperatorActivityRefs::default(),
+    }
+}
+
 fn severity_rank(min: Option<OperatorActivitySeverity>) -> i64 {
     match min {
         None => 0,
@@ -187,6 +285,7 @@ fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<OperatorActivityRecord> 
         "plan_proposal" => OperatorActivityKind::PlanProposal,
         "human_gate" => OperatorActivityKind::HumanGate,
         "session_lifecycle" => OperatorActivityKind::SessionLifecycle,
+        "rate_limited" => OperatorActivityKind::RateLimited,
         other => {
             return Err(rusqlite::Error::InvalidColumnType(
                 8,
@@ -297,6 +396,94 @@ mod tests {
             .unwrap();
         assert_eq!(listed.activities.len(), 1);
         assert_eq!(listed.activities[0].summary, "visible");
+    }
+
+    #[test]
+    fn rate_limit_emits_single_notice_then_drops() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        let root = "session-rate-limit";
+        let at = "2026-06-01T10:00:00+00:00";
+
+        // Cap of 2: the first two real rows go through.
+        for i in 0..2 {
+            let mut r = sample_record(root);
+            r.summary = format!("row {i}");
+            r.occurred_at = at.to_string();
+            assert_eq!(
+                store.insert_operator_activity_throttled(&r, 2).unwrap(),
+                OperatorActivityInsert::Inserted
+            );
+        }
+
+        // The third row in the window is dropped but emits one notice.
+        let mut third = sample_record(root);
+        third.summary = "row 2".to_string();
+        third.occurred_at = at.to_string();
+        assert_eq!(
+            store.insert_operator_activity_throttled(&third, 2).unwrap(),
+            OperatorActivityInsert::ThrottleNoticeEmitted
+        );
+
+        // Subsequent rows in the same window are dropped with no extra notice.
+        let mut fourth = sample_record(root);
+        fourth.summary = "row 3".to_string();
+        fourth.occurred_at = at.to_string();
+        assert_eq!(
+            store.insert_operator_activity_throttled(&fourth, 2).unwrap(),
+            OperatorActivityInsert::Dropped
+        );
+
+        let listed = store.list_operator_activity(root, None, 50, None).unwrap();
+        // 2 real rows + exactly 1 notice.
+        assert_eq!(listed.activities.len(), 3);
+        let notices = listed
+            .activities
+            .iter()
+            .filter(|a| a.kind == OperatorActivityKind::RateLimited)
+            .count();
+        assert_eq!(notices, 1);
+    }
+
+    #[test]
+    fn rate_limit_window_resets_for_later_activity() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        let root = "session-rate-window";
+
+        let mut first = sample_record(root);
+        first.occurred_at = "2026-06-01T10:00:00+00:00".to_string();
+        assert_eq!(
+            store.insert_operator_activity_throttled(&first, 1).unwrap(),
+            OperatorActivityInsert::Inserted
+        );
+
+        // Two minutes later the window no longer contains the first row.
+        let mut later = sample_record(root);
+        later.occurred_at = "2026-06-01T10:02:00+00:00".to_string();
+        assert_eq!(
+            store.insert_operator_activity_throttled(&later, 1).unwrap(),
+            OperatorActivityInsert::Inserted
+        );
+    }
+
+    #[test]
+    fn rate_limit_zero_disables_throttle() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        let root = "session-rate-unlimited";
+
+        for i in 0..5 {
+            let mut r = sample_record(root);
+            r.summary = format!("row {i}");
+            r.occurred_at = "2026-06-01T10:00:00+00:00".to_string();
+            assert_eq!(
+                store.insert_operator_activity_throttled(&r, 0).unwrap(),
+                OperatorActivityInsert::Inserted
+            );
+        }
+        let listed = store.list_operator_activity(root, None, 50, None).unwrap();
+        assert_eq!(listed.activities.len(), 5);
     }
 
     #[test]

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1092,6 +1092,11 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub chat: ChatConfig,
 
+    /// Operator activity feed settings (rate limiting). See the operator
+    /// activity feed design (`docs/design/operator-activity-feed-plan.md`).
+    #[serde(default)]
+    pub operator_activity: OperatorActivityConfig,
+
     /// Approval level / escalation settings.
     #[serde(default)]
     pub approval_levels: ApprovalLevelConfig,
@@ -1507,6 +1512,30 @@ impl Default for ChatConfig {
             inline_approvals: default_chat_inline_approvals(),
         }
     }
+}
+
+/// Configuration for the operator activity feed (Phase 4 hardening).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorActivityConfig {
+    /// Maximum operator activity rows persisted per root session per rolling
+    /// 60-second window. When the cap is reached the gateway drops further
+    /// rows in that window but emits a single `rate_limited` notice so the
+    /// suppression is always visible (never silent). `0` disables the limit.
+    /// Default: 120.
+    #[serde(default = "default_operator_activity_rate_limit_per_min")]
+    pub rate_limit_per_min: u32,
+}
+
+impl Default for OperatorActivityConfig {
+    fn default() -> Self {
+        Self {
+            rate_limit_per_min: default_operator_activity_rate_limit_per_min(),
+        }
+    }
+}
+
+fn default_operator_activity_rate_limit_per_min() -> u32 {
+    120
 }
 
 /// Approval level / escalation configuration.
@@ -2557,6 +2586,7 @@ impl Default for GatewayConfig {
             trajectory: TrajectoryConfig::default(),
             llm_routing: None,
             chat: ChatConfig::default(),
+            operator_activity: OperatorActivityConfig::default(),
             approval_levels: ApprovalLevelConfig::default(),
             context_compression: ContextCompressionConfig::default(),
             signal_delivery_timeout_secs: default_signal_delivery_timeout_secs(),

--- a/autonoetic-types/src/operator_activity.rs
+++ b/autonoetic-types/src/operator_activity.rs
@@ -43,6 +43,9 @@ pub enum OperatorActivityKind {
     PlanProposal,
     HumanGate,
     SessionLifecycle,
+    /// Synthetic marker emitted when the per-root activity rate limit is hit,
+    /// so suppression of subsequent rows in the window is visible.
+    RateLimited,
 }
 
 impl OperatorActivityKind {
@@ -56,6 +59,7 @@ impl OperatorActivityKind {
             Self::PlanProposal => "plan_proposal",
             Self::HumanGate => "human_gate",
             Self::SessionLifecycle => "session_lifecycle",
+            Self::RateLimited => "rate_limited",
         }
     }
 }

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -187,6 +187,14 @@ approval_timeout_secs: 3600
 chat:
   inline_approvals: true
 
+# ── Operator Activity Feed ────────────────────────────────────────────
+# Channel-neutral live session visibility (chat TUI, HTTP SSE, future bridges).
+# rate_limit_per_min: max activity rows persisted per root session per rolling
+# 60s window. On the cap, further rows are dropped and one `rate_limited`
+# notice is emitted (suppression stays visible). 0 disables. Default: 120.
+operator_activity:
+  rate_limit_per_min: 120
+
 # ── Approval Levels ───────────────────────────────────────────────────
 # Escalation: require higher authority for sensitive actions.
 # Levels: operator (default) | admin | agent:<agent_id>

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -721,6 +721,23 @@ retention:
 
 ---
 
+## Operator Activity Feed
+
+Controls the channel-neutral operator activity feed (see [`docs/design/operator-activity-feed-plan.md`](design/operator-activity-feed-plan.md)). The gateway owns visibility rules once; every consumer (chat TUI, HTTP SSE, future bridges) reads the same feed.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `operator_activity.rate_limit_per_min` | u32 | `120` | Max activity rows persisted per root session per rolling 60s window. On reaching the cap, further rows in the window are dropped and a single `rate_limited` notice (severity `attention`) is emitted so the suppression is visible. `0` disables the limit. |
+
+Example:
+
+```yaml
+operator_activity:
+  rate_limit_per_min: 120
+```
+
+---
+
 ## Cognitive Capsules
 
 Controls export/import of portable agent snapshots. A Cognitive Capsule pins a specific `AgentRevisionRecord` together with its `runtime.lock`, layer references (or embedded layer content in hermetic mode), and optional memory / checkpoint snapshots. See [`docs/cognitive-capsule.md`](cognitive-capsule.md).

--- a/docs/design/operator-activity-feed-plan.md
+++ b/docs/design/operator-activity-feed-plan.md
@@ -1,6 +1,6 @@
 # Operator Activity Feed (Channel-Agnostic Session Visibility)
 
-**Status:** Partial — Phases 0–3 shipped in PR #358 (classifier, SQLite feed, JSON-RPC, chat TUI, HTTP SSE). Phase 4 hardening (#357) pending.
+**Status:** Phases 0–3 shipped in PR #358 (classifier, SQLite feed, JSON-RPC, chat TUI, HTTP SSE). Phase 4 (#357): per-root rate limit shipped; subscribe/webhook push and channel-binding table deferred until a push/external-channel bridge exists.
 
 **Problem surfaced by:** `session-46d65624` — planner wrote `news_fetcher.py`, `market_data.py`, and
 `sentiment.py`; `digest.md` and `session_overview.md` showed it; the chat TUI did not.
@@ -403,9 +403,24 @@ so bridges recover session context without local state. v1: bridge stores mappin
 
 ### Phase 4 — Hardening
 
-- [ ] Tool denylist / rate limit per root session (max N activities per minute).
+- [x] Tool denylist / rate limit per root session (max N activities per minute).
+  Shipped: `operator_activity.rate_limit_per_min` (default 120, `0` disables).
+  Enforced in `GatewayStore::insert_operator_activity_throttled` under the
+  connection lock (race-safe per-root 60s rolling window); on cap a single
+  `rate_limited` notice (kind `RateLimited`, severity `attention`) is emitted
+  so suppression is never silent. Wired from `tool_call_processor`. The
+  success denylist (`runtime/operator_activity.rs::SUCCESS_DENYLIST`) already
+  covers the "tool denylist" half.
 - [ ] `operator.activity.subscribe` or webhook `operator.activity.push` for mobile.
+  **Deferred — no consumer yet.** There is no mobile/push transport in the
+  tree; the chat TUI and HTTP SSE already cover live delivery. Build this when
+  a push-capable bridge lands, so the wire format is designed against a real
+  consumer rather than speculatively.
 - [ ] Channel binding table + `interaction.resolve_and_answer` correlation helpers.
+  **Deferred — no Discord/WhatsApp bridge yet.** An `operator_channel_bindings`
+  table would recover bridge sessions; with no such bridge in the tree it would
+  be unused scaffolding. `interaction_answer.rs` already correlates answers by
+  `interaction_id`. Revisit alongside the first external channel bridge.
 
 ---
 


### PR DESCRIPTION
## Summary
Phase 4 hardening for the operator activity feed (#357): a per-root-session rate limit so a busy session can't flood the feed.

- Caps activity rows per root session per rolling **60s window** (`operator_activity.rate_limit_per_min`, default **120**, `0` disables).
- On reaching the cap, drops further rows **but emits a single `rate_limited` notice** (kind `RateLimited`, severity `attention`) — suppression is never silent.
- Enforced in `GatewayStore::insert_operator_activity_throttled` **under the connection lock** (race-safe with concurrent emitters); wired from `tool_call_processor`.

## Test plan
- [x] `cargo test -p autonoetic-gateway operator_activity` — 9 pass (incl. notice-then-drop, window reset, `0` disables)
- [x] `cargo build` workspace

Part of #357. (The two remaining #357 items — subscribe/webhook push and channel bindings — are deferred; channel bindings get a real consumer in the Session Room work, #363/#366.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)