### PR TITLE
feat(session-room): gate + divergence events on the canonical timeline (#363, #364)

### DIFF
--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -629,6 +629,37 @@ impl GateService {
         };
 
         self.store.create_approval(&mut approval_req)?;
+
+        // Surface the gate on the canonical timeline as an `attention` ask
+        // addressed to the operator (#363 P1, RFC §3.5).
+        let role = crate::runtime::session_timeline::derive_role(&approval_req.agent_id);
+        let principal = autonoetic_types::principal::Principal::agent(approval_req.agent_id.clone());
+        let refs = autonoetic_types::session_timeline::TimelineRefs {
+            approval_request_id: Some(request_id.clone()),
+            ..Default::default()
+        };
+        let event = crate::runtime::session_timeline::build_timeline_event(
+            approval_req
+                .root_session_id
+                .clone()
+                .unwrap_or_else(|| approval_req.session_id.clone()),
+            approval_req.session_id.clone(),
+            req.turn_id.map(str::to_string),
+            &principal,
+            &role,
+            "approval.pending",
+            None,
+            Some(serde_json::json!({
+                "request_id": request_id,
+                "approval_level": approval_req.approval_level.to_config(),
+                "action": action.kind(),
+            })),
+            refs,
+        );
+        if let Err(e) = self.store.create_live_digest_event(&event) {
+            tracing::debug!(target: "session_timeline", error = %e, "approval.pending timeline emit failed");
+        }
+
         Ok(request_id)
     }
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -2731,6 +2731,36 @@ impl AgentExecutor {
                                             &self.suppress_until_turn,
                                             cfg.map(|c| c.trajectory.notify_planner).unwrap_or(true),
                                         );
+
+                                        // The Sentinel is a participant in the room, not
+                                        // chrome: its intervention lands on the canonical
+                                        // timeline under the Sentinel seat (#363 P1, RFC §3.2).
+                                        let is_critical =
+                                            matches!(result.health, TrajectoryHealth::Critical { .. });
+                                        let principal =
+                                            autonoetic_types::principal::Principal::agent("sentinel");
+                                        let event = crate::runtime::session_timeline::build_timeline_event(
+                                            root_sid.clone(),
+                                            session_id.to_string(),
+                                            None,
+                                            &principal,
+                                            &autonoetic_types::session_timeline::SessionRole::Sentinel,
+                                            "divergence.intervention",
+                                            Some(if is_critical {
+                                                autonoetic_types::session_timeline::Altitude::Error
+                                            } else {
+                                                autonoetic_types::session_timeline::Altitude::Attention
+                                            }),
+                                            Some(serde_json::json!({
+                                                "monitored_agent": self.manifest.agent.id,
+                                                "level": result.health.level_str(),
+                                                "turn": self.turn_counter,
+                                            })),
+                                            autonoetic_types::session_timeline::TimelineRefs::default(),
+                                        );
+                                        if let Err(e) = store.create_live_digest_event(&event) {
+                                            tracing::debug!(target: "session_timeline", error = %e, "divergence timeline emit failed");
+                                        }
                                     }
 
                                     // Critical also escalates to the operator via the

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -2742,7 +2742,7 @@ impl AgentExecutor {
                                         let event = crate::runtime::session_timeline::build_timeline_event(
                                             root_sid.clone(),
                                             session_id.to_string(),
-                                            None,
+                                            Some(turn_id.clone()),
                                             &principal,
                                             &autonoetic_types::session_timeline::SessionRole::Sentinel,
                                             "divergence.intervention",

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -6,7 +6,49 @@
 //! critical seat (Sentinel) always surfaces. `role_floor` defaults live here and
 //! are config-tunable (don't-pin-tunables); base mapping is deterministic.
 
-use autonoetic_types::session_timeline::{Altitude, SessionRole};
+use autonoetic_types::principal::Principal;
+use autonoetic_types::session_timeline::{Altitude, SessionRole, TimelineRefs};
+
+use crate::scheduler::gateway_store::LiveDigestEventRecord;
+
+/// Build a canonical-timeline (`live_digest_events`) record with attribution.
+/// Centralizes the event_id / node_id / kind-storage boilerplate so every
+/// producer (digest tracer, gates, divergence) emits a consistent shape.
+/// `altitude = None` derives it from `(event_type, role)`.
+#[allow(clippy::too_many_arguments)]
+pub fn build_timeline_event(
+    root_session_id: String,
+    session_id: String,
+    turn_id: Option<String>,
+    principal: &Principal,
+    role: &SessionRole,
+    event_type: &str,
+    altitude: Option<Altitude>,
+    payload: Option<serde_json::Value>,
+    refs: TimelineRefs,
+) -> LiveDigestEventRecord {
+    let altitude = altitude.unwrap_or_else(|| altitude_for(event_type, role));
+    LiveDigestEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        root_session_id,
+        source_session_id: session_id,
+        turn_id,
+        source_agent_id: Some(principal.id.clone()),
+        source_node_id: std::env::var("AUTONOETIC_NODE_ID").unwrap_or_else(|_| "gateway".to_string()),
+        event_type: event_type.to_string(),
+        payload: payload.and_then(|v| serde_json::to_string(&v).ok()),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        principal_kind: Some(principal.kind_to_storage()),
+        principal_id: Some(principal.id.clone()),
+        role: Some(role.to_storage()),
+        altitude: Some(altitude.as_str().to_string()),
+        refs_json: if refs.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&refs).ok()
+        },
+    }
+}
 
 /// Base importance of a digest event type, before any role refinement.
 pub fn base_altitude(event_type: &str) -> Altitude {
@@ -71,6 +113,34 @@ mod tests {
             altitude_for("turn.start", &SessionRole::Planner),
             Altitude::Detail
         );
+    }
+
+    #[test]
+    fn build_timeline_event_populates_attribution_and_derives_altitude() {
+        let principal = autonoetic_types::principal::Principal::agent("planner.default");
+        let role = derive_role("planner.default");
+        let refs = autonoetic_types::session_timeline::TimelineRefs {
+            approval_request_id: Some("apr-abc".to_string()),
+            ..Default::default()
+        };
+        let ev = build_timeline_event(
+            "root-1".to_string(),
+            "root-1".to_string(),
+            None,
+            &principal,
+            &role,
+            "approval.pending",
+            None, // derive
+            Some(serde_json::json!({ "request_id": "apr-abc" })),
+            refs,
+        );
+        assert_eq!(ev.event_type, "approval.pending");
+        // approval.pending is a gate ⇒ Attention.
+        assert_eq!(ev.altitude.as_deref(), Some("attention"));
+        assert_eq!(ev.role.as_deref(), Some("planner"));
+        assert_eq!(ev.principal_kind.as_deref(), Some("autonoetic_agent"));
+        assert_eq!(ev.principal_id.as_deref(), Some("planner.default"));
+        assert!(ev.refs_json.as_deref().unwrap().contains("apr-abc"));
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -267,7 +267,7 @@ impl NativeTool for PlanFrameProposeTool {
             let event = crate::runtime::session_timeline::build_timeline_event(
                 root_session_id.to_string(),
                 session_id.to_string(),
-                None,
+                _turn_id.map(str::to_string),
                 &principal,
                 &role,
                 "plan.pending",

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -255,6 +255,35 @@ impl NativeTool for PlanFrameProposeTool {
 
         store.save_plan_frame(&plan)?;
 
+        // Canonical timeline: a plan proposal is an `attention` gate (#363 P1).
+        {
+            let role = crate::runtime::session_timeline::derive_role(&plan.created_by_agent_id);
+            let principal =
+                autonoetic_types::principal::Principal::agent(plan.created_by_agent_id.clone());
+            let refs = autonoetic_types::session_timeline::TimelineRefs {
+                plan_id: Some(plan_id.clone()),
+                ..Default::default()
+            };
+            let event = crate::runtime::session_timeline::build_timeline_event(
+                root_session_id.to_string(),
+                session_id.to_string(),
+                None,
+                &principal,
+                &role,
+                "plan.pending",
+                None,
+                Some(serde_json::json!({
+                    "plan_id": plan_id,
+                    "version": plan.version,
+                    "title": plan.title,
+                })),
+                refs,
+            );
+            if let Err(e) = store.create_live_digest_event(&event) {
+                tracing::debug!(target: "session_timeline", error = %e, "plan.pending timeline emit failed");
+            }
+        }
+
         let mut updated_workflow = workflow;
         updated_workflow.active_plan_ref = Some(PlanRef {
             plan_id: plan_id.clone(),

--- a/autonoetic-types/src/session_timeline.rs
+++ b/autonoetic-types/src/session_timeline.rs
@@ -119,6 +119,8 @@ pub struct TimelineRefs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interaction_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workbench_id: Option<String>,


### PR DESCRIPTION
## Summary
Continues **P1** (#364) of the Session Room (#363). P1's first PR (#371) made `live_digest_events` the canonical timeline and populated the *digest spine*. This PR adds the **gate-opening "attention" events** — the things that need the operator's eye — so the timeline reflects the room, not just routine progress.

New event types emitted onto the canonical timeline:
- **`approval.pending`** — at approval creation (`human_gate.rs`), carrying the `approval_request_id` ref, attributed to the requesting agent's seat. (RFC §3.5 conversational gate.)
- **`plan.pending`** — at plan proposal (`plan_frame.rs`), carrying the `plan_id` ref, Planner seat.
- **`divergence.intervention`** — at trajectory level-change (`lifecycle.rs`), attributed to the **`Sentinel` seat** — the divergence monitor appears as a *participant in the room*, not system chrome (RFC §3.2). `Error` for Critical, `Attention` otherwise.

### Mechanics
- New `build_timeline_event` helper centralizes the event_id / node_id / kind-storage boilerplate and derives `altitude` from `(event_type, role)` unless overridden — so every producer emits a consistent shape.
- Adds `TimelineRefs.approval_request_id`.
- All emits are **best-effort** (logged at debug on failure; never fail the gate itself).

## Test plan
- [x] `cargo test -p autonoetic-gateway session_timeline` — 9 pass (incl. new `build_timeline_event` attribution/altitude test)
- [x] Full `cargo test -p autonoetic-gateway --lib` — **1116 passed / 29 failed**, the 29 identical pre-existing failures (confirmed on clean `main`); **zero new regressions**

## Remaining in P1 (follow-up)
Resolve/approve transitions (`approval.approved/rejected`, `plan.approved`) and workbench create/reconcile/discard — these need minor context plumbing at the resolve sites.

Tracks #363 · #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)