### PR TITLE
feat(#361): record decider principal kind on gate decisions

### DIFF
--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -174,9 +174,13 @@ impl GatewayStore {
         decision_reason: Option<&str>,
     ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
+        // #361: record the decider's principal kind (derived from decided_by) so
+        // §O symmetric-obligation checks are mechanically queryable in SQL.
+        let decided_by_kind =
+            autonoetic_types::principal::decider_principal_kind(decided_by).map(|k| k.tag());
         let rows = conn.execute(
-            "UPDATE approvals SET status = ?1, decided_by = ?2, decided_at = ?3, decision_reason = ?4 WHERE request_id = ?5 AND status = 'pending'",
-            params![status, decided_by, decided_at, decision_reason, request_id],
+            "UPDATE approvals SET status = ?1, decided_by = ?2, decided_at = ?3, decision_reason = ?4, decided_by_kind = ?5 WHERE request_id = ?6 AND status = 'pending'",
+            params![status, decided_by, decided_at, decision_reason, decided_by_kind, request_id],
         )?;
         if rows == 0 {
             anyhow::bail!(
@@ -194,9 +198,11 @@ impl GatewayStore {
         cancelled_at: &str,
     ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
+        let decided_by_kind =
+            autonoetic_types::principal::decider_principal_kind(cancelled_by).map(|k| k.tag());
         let rows = conn.execute(
-            "UPDATE approvals SET status = 'cancelled', decided_by = ?1, decided_at = ?2 WHERE request_id = ?3 AND status = 'pending'",
-            params![cancelled_by, cancelled_at, request_id],
+            "UPDATE approvals SET status = 'cancelled', decided_by = ?1, decided_at = ?2, decided_by_kind = ?3 WHERE request_id = ?4 AND status = 'pending'",
+            params![cancelled_by, cancelled_at, decided_by_kind, request_id],
         )?;
         if rows == 0 {
             anyhow::bail!(
@@ -844,5 +850,89 @@ impl GatewayStore {
             "rejection_rate": if total > 0 { format!("{:.1}%", (rejected as f64 / total as f64) * 100.0) } else { "N/A".to_string() },
             "top_agents": top_agents,
         }))
+    }
+}
+
+#[cfg(test)]
+mod decided_by_kind_tests {
+    use super::GatewayStore;
+    use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
+    use tempfile::tempdir;
+
+    fn pending(id: &str) -> ApprovalRequest {
+        ApprovalRequest {
+            request_id: id.to_string(),
+            agent_id: "coder.default".to_string(),
+            session_id: "s1".to_string(),
+            action: ScheduledAction::SandboxExec {
+                command: "echo hi".to_string(),
+                dependencies: None,
+                requires_approval: true,
+                evidence_ref: None,
+                detected_hosts: None,
+            },
+            approval_level: ApprovalLevel::Operator,
+            created_at: "2026-06-01T00:00:00Z".to_string(),
+            reason: None,
+            evidence_ref: None,
+            workflow_id: None,
+            task_id: None,
+            root_session_id: None,
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            decision_reason: None,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+            code_excerpts: None,
+            risk_summary: None,
+        }
+    }
+
+    fn stored_kind(store: &GatewayStore, id: &str) -> Option<String> {
+        store
+            .with_conn(|c| {
+                Ok(c.query_row(
+                    "SELECT decided_by_kind FROM approvals WHERE request_id = ?1",
+                    [id],
+                    |r| r.get::<_, Option<String>>(0),
+                )?)
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn record_decision_persists_derived_decider_kind() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+
+        // Operator (human) decision.
+        let mut a = pending("apr-h");
+        store.create_approval(&mut a).unwrap();
+        store
+            .record_decision("apr-h", "approved", "operator", "2026-06-01T01:00:00Z", None)
+            .unwrap();
+        assert_eq!(stored_kind(&store, "apr-h").as_deref(), Some("human"));
+
+        // Agent-decider decision.
+        let mut b = pending("apr-a");
+        store.create_approval(&mut b).unwrap();
+        store
+            .record_decision("apr-a", "approved", "auditor.default", "2026-06-01T01:00:00Z", None)
+            .unwrap();
+        assert_eq!(
+            stored_kind(&store, "apr-a").as_deref(),
+            Some("autonoetic_agent")
+        );
+
+        // Mechanical cancel ⇒ no principal kind.
+        let mut c = pending("apr-g");
+        store.create_approval(&mut c).unwrap();
+        store
+            .cancel_approval("apr-g", "gateway", "2026-06-01T01:00:00Z")
+            .unwrap();
+        assert_eq!(stored_kind(&store, "apr-g"), None);
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -934,5 +934,20 @@ mod decided_by_kind_tests {
             .cancel_approval("apr-g", "gateway", "2026-06-01T01:00:00Z")
             .unwrap();
         assert_eq!(stored_kind(&store, "apr-g"), None);
+
+        // Production emergency-stop cascade resolves via record_decision with a
+        // "emergency_stop:<id>" decider — mechanical, must NOT be an agent (#374 review).
+        let mut d = pending("apr-es");
+        store.create_approval(&mut d).unwrap();
+        store
+            .record_decision(
+                "apr-es",
+                "cancelled",
+                "emergency_stop:estop-1a2b3c4d",
+                "2026-06-01T01:00:00Z",
+                None,
+            )
+            .unwrap();
+        assert_eq!(stored_kind(&store, "apr-es"), None);
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -552,6 +552,23 @@ fn apply_decided_by_kind_v47(conn: &mut Connection) -> Result<()> {
 
     conn.execute("ALTER TABLE approvals ADD COLUMN decided_by_kind TEXT", [])?;
 
+    // Backfill already-decided rows so SQL accountability queries cover history.
+    // Mirrors `principal::decider_principal_kind` exactly: operator⇒human,
+    // agent-id-shaped (`agent:` or contains `.`)⇒autonoetic_agent, and
+    // gateway/system/emergency_stop/unknown⇒NULL (mechanical, no obligation).
+    conn.execute(
+        "UPDATE approvals SET decided_by_kind = CASE
+            WHEN trim(decided_by) = 'operator' THEN 'human'
+            WHEN decided_by LIKE 'agent:%' OR decided_by LIKE '%.%' THEN 'autonoetic_agent'
+            ELSE NULL
+         END
+         WHERE decided_by IS NOT NULL
+           AND trim(decided_by) <> ''
+           AND trim(decided_by) NOT IN ('gateway', 'system')
+           AND decided_by NOT LIKE 'emergency_stop:%'",
+        [],
+    )?;
+
     conn.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         params![47_i64, "decided_by_kind", chrono::Utc::now().to_rfc3339()],

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 46;
+const SCHEMA_VERSION_LATEST: i64 = 47;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -531,7 +531,31 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_validation_waivers_v44(conn)?;
     apply_operator_activity_v45(conn)?;
     apply_session_timeline_v46(conn)?;
+    apply_decided_by_kind_v47(conn)?;
 
+    Ok(())
+}
+
+/// #361 / #359 P1.b — record the decider's principal kind on gate decisions so
+/// symmetric-obligation (§O) checks can be made mechanically in SQL. Derived
+/// from `decided_by` at decision time (`operator`⇒human, agent id⇒autonoetic_agent,
+/// gateway/system⇒NULL). Additive column.
+fn apply_decided_by_kind_v47(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 47 {
+        return Ok(());
+    }
+
+    conn.execute("ALTER TABLE approvals ADD COLUMN decided_by_kind TEXT", [])?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![47_i64, "decided_by_kind", chrono::Utc::now().to_rfc3339()],
+    )?;
     Ok(())
 }
 

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -638,6 +638,15 @@ pub struct ApprovalRequest {
 }
 
 impl ApprovalRequest {
+    /// Principal kind of whoever decided this gate (#359 P1.b / #361), derived
+    /// from `decided_by`. `None` while pending or for executor-mechanical
+    /// resolutions. Mirrors the persisted `decided_by_kind` column.
+    pub fn decided_by_kind(&self) -> Option<crate::principal::PrincipalKind> {
+        self.decided_by
+            .as_deref()
+            .and_then(crate::principal::decider_principal_kind)
+    }
+
     pub fn into_decision(self) -> anyhow::Result<ApprovalDecision> {
         let status = self
             .status

--- a/autonoetic-types/src/principal.rs
+++ b/autonoetic-types/src/principal.rs
@@ -51,6 +51,20 @@ impl PrincipalKind {
 /// `kind` is flattened so the wire shape is flat — `{"kind":"human","id":...}`,
 /// or `{"kind":"foreign_agent","provider":"…","id":…}` — rather than the nested
 /// `{"kind":{"kind":"human"},…}` the internally-tagged enum would otherwise give.
+/// Best-effort principal kind of a gate *decider*, derived from the recorded
+/// `decided_by` string (#359 P1.b / #361). Deterministic and mechanically
+/// checkable: `"operator"` ⇒ Human; `"gateway"`/`"system"`/empty ⇒ `None`
+/// (executor mechanics — not a principal decision, so no §O obligation attaches);
+/// anything else (an agent id) ⇒ AutonoeticAgent. Foreign agents never decide
+/// gates (they hold no authority), so they are not produced here.
+pub fn decider_principal_kind(decided_by: &str) -> Option<PrincipalKind> {
+    match decided_by.trim() {
+        "" | "gateway" | "system" => None,
+        "operator" => Some(PrincipalKind::Human),
+        _ => Some(PrincipalKind::AutonoeticAgent),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Principal {
     #[serde(flatten)]
@@ -127,6 +141,19 @@ mod tests {
         // Round-trips back.
         let back: Principal = serde_json::from_value(foreign).unwrap();
         assert_eq!(back, Principal::foreign("claude-code", "fa-1"));
+    }
+
+    #[test]
+    fn decider_kind_derivation() {
+        assert_eq!(decider_principal_kind("operator"), Some(PrincipalKind::Human));
+        assert_eq!(
+            decider_principal_kind("auditor.default"),
+            Some(PrincipalKind::AutonoeticAgent)
+        );
+        // Executor mechanics are not principal decisions.
+        assert_eq!(decider_principal_kind("gateway"), None);
+        assert_eq!(decider_principal_kind("system"), None);
+        assert_eq!(decider_principal_kind("  "), None);
     }
 
     #[test]

--- a/autonoetic-types/src/principal.rs
+++ b/autonoetic-types/src/principal.rs
@@ -53,16 +53,30 @@ impl PrincipalKind {
 /// `{"kind":{"kind":"human"},…}` the internally-tagged enum would otherwise give.
 /// Best-effort principal kind of a gate *decider*, derived from the recorded
 /// `decided_by` string (#359 P1.b / #361). Deterministic and mechanically
-/// checkable: `"operator"` ⇒ Human; `"gateway"`/`"system"`/empty ⇒ `None`
-/// (executor mechanics — not a principal decision, so no §O obligation attaches);
-/// anything else (an agent id) ⇒ AutonoeticAgent. Foreign agents never decide
-/// gates (they hold no authority), so they are not produced here.
+/// checkable, and **fail-safe**: an unrecognized token is never claimed as an
+/// accountable agent.
+///
+/// - `"operator"` ⇒ Human.
+/// - Mechanical / executor resolutions ⇒ `None` (no §O obligation attaches):
+///   empty, `"gateway"`, `"system"`, and the `"emergency_stop:<id>"` cascade.
+/// - An agent decider ⇒ AutonoeticAgent, recognized positively by an agent-id
+///   shape (contains `.`, e.g. `auditor.default`) or the `"agent:<id>"` form.
+/// - Anything else ⇒ `None` (fail-safe, not AutonoeticAgent).
+///
+/// Foreign agents never decide gates (they hold no authority), so they are not
+/// produced here.
 pub fn decider_principal_kind(decided_by: &str) -> Option<PrincipalKind> {
-    match decided_by.trim() {
-        "" | "gateway" | "system" => None,
-        "operator" => Some(PrincipalKind::Human),
-        _ => Some(PrincipalKind::AutonoeticAgent),
+    let s = decided_by.trim();
+    if s == "operator" {
+        return Some(PrincipalKind::Human);
     }
+    if s.is_empty() || s == "gateway" || s == "system" || s.starts_with("emergency_stop:") {
+        return None;
+    }
+    if s.starts_with("agent:") || s.contains('.') {
+        return Some(PrincipalKind::AutonoeticAgent);
+    }
+    None
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -146,14 +160,23 @@ mod tests {
     #[test]
     fn decider_kind_derivation() {
         assert_eq!(decider_principal_kind("operator"), Some(PrincipalKind::Human));
+        // Agent deciders, both shapes.
         assert_eq!(
             decider_principal_kind("auditor.default"),
+            Some(PrincipalKind::AutonoeticAgent)
+        );
+        assert_eq!(
+            decider_principal_kind("agent:auditor.default"),
             Some(PrincipalKind::AutonoeticAgent)
         );
         // Executor mechanics are not principal decisions.
         assert_eq!(decider_principal_kind("gateway"), None);
         assert_eq!(decider_principal_kind("system"), None);
         assert_eq!(decider_principal_kind("  "), None);
+        // Emergency-stop cascade is mechanical, not an agent (regression: #374 review).
+        assert_eq!(decider_principal_kind("emergency_stop:estop-1a2b3c4d"), None);
+        // Fail-safe: an unrecognized bare token is not claimed as an agent.
+        assert_eq!(decider_principal_kind("mystery"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Implements **#361** (#359 P1.b): persist *who decided* a gate — human vs. autonoetic agent — so the symmetric-obligation (§O) checks of #359 Part B become mechanically queryable in SQL. This is the accountability foundation that makes "deciders owe reasons" (mirroring agents' `Ri-0.3`) enforceable, and it unblocks the Session Room P2 gate UX (#365).

### Approach — derived, not threaded
The decider kind is **fully determined by the already-recorded `decided_by`** string, so I derive it centrally rather than threading a new field through the ~28 `ApprovalRequest` construction sites:

- `principal::decider_principal_kind(decided_by)` — deterministic: `"operator"`⇒Human, agent id⇒AutonoeticAgent, `"gateway"`/`"system"`/empty⇒`None` (executor mechanics, not a principal decision — no §O obligation attaches).
- **migration v47**: additive `approvals.decided_by_kind` column (`SCHEMA_VERSION_LATEST` 46→47).
- `record_decision` / `cancel_approval` persist the derived kind — **no caller churn**.
- `ApprovalRequest::decided_by_kind()` exposes it (derived, consistent with the persisted column).

Foreign agents never decide gates (they hold no authority), so they are not produced here.

## What this is NOT (held for your explicit go)
This PR only **records** the decider kind. It does **not** implement the BLOCKING/DEFERRED motivation-enforcement tiers (§B.4) — that's the constitution-adjacent §O work (prepared unsigned, your authority ratifies). Recording is the mechanical P1.b primitive; enforcement is a separate, deliberate step.

## Test plan
- [x] `cargo test -p autonoetic-types principal` — 4 pass (incl. `decider_kind_derivation`)
- [x] `cargo test -p autonoetic-gateway decided_by_kind` — store round-trip (human / agent / mechanical-cancel) passes
- [x] Full `cargo test -p autonoetic-gateway --lib` — **1117 passed / 29 failed** (same pre-existing 29; zero new regressions)

Tracks #361 · #359. First of a 3-PR sequence → remaining-P1 resolve events → P2 renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)