### PR TITLE
feat(session-room): gate-resolution events on the timeline (P1 step 2)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -97,6 +97,26 @@ pub fn derive_role(agent_id: &str) -> SessionRole {
     }
 }
 
+/// Attribute a gate decision to a `(principal, seat)` from its recorded
+/// `decided_by` string. Operator (human) ⇒ Operator seat; an agent decider
+/// (`auditor.default` or `agent:auditor.default`) ⇒ that agent's seat (the
+/// `agent:` prefix is stripped first); a mechanical/unknown decider
+/// (`gateway`, `emergency_stop:<id>`, …) ⇒ the hidable Runtime seat.
+pub fn decider_seat(decided_by: &str) -> (autonoetic_types::principal::Principal, SessionRole) {
+    use autonoetic_types::principal::{Principal, PrincipalKind};
+    match autonoetic_types::principal::decider_principal_kind(decided_by) {
+        Some(PrincipalKind::Human) => (Principal::human(decided_by), SessionRole::Operator),
+        Some(PrincipalKind::AutonoeticAgent) => {
+            let id = decided_by.strip_prefix("agent:").unwrap_or(decided_by);
+            (Principal::agent(id), derive_role(id))
+        }
+        _ => (
+            Principal { kind: PrincipalKind::Script, id: decided_by.to_string() },
+            SessionRole::Runtime,
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,6 +169,30 @@ mod tests {
             altitude_for("llm.request_failed", &SessionRole::Planner),
             Altitude::Error
         );
+    }
+
+    #[test]
+    fn decider_seat_attribution() {
+        use autonoetic_types::principal::PrincipalKind;
+
+        let (p, r) = decider_seat("operator");
+        assert_eq!(p.kind, PrincipalKind::Human);
+        assert_eq!(r, SessionRole::Operator);
+
+        // `agent:` prefix is stripped before deriving the seat (regression: #375 review).
+        let (p, r) = decider_seat("agent:auditor.default");
+        assert_eq!(p.kind, PrincipalKind::AutonoeticAgent);
+        assert_eq!(p.id, "auditor.default");
+        assert_eq!(r, SessionRole::Auditor);
+
+        let (_p, r) = decider_seat("coder.default");
+        assert_eq!(r, SessionRole::Specialist { kind: "coder".to_string() });
+
+        // Mechanical resolutions ⇒ hidable Runtime seat, never Specialist{emergency_stop:..}.
+        let (_p, r) = decider_seat("emergency_stop:estop-1a2b3c4d");
+        assert_eq!(r, SessionRole::Runtime);
+        let (_p, r) = decider_seat("gateway");
+        assert_eq!(r, SessionRole::Runtime);
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -596,6 +596,45 @@ impl NativeTool for PlanFrameApproveTool {
             Some(&now),
         )?;
 
+        // Canonical timeline: the plan gate closes (#363 P1), authored by the
+        // approver (Operator seat for a human, the agent's seat otherwise).
+        {
+            use autonoetic_types::principal::{Principal, PrincipalKind};
+            use autonoetic_types::session_timeline::{SessionRole, TimelineRefs};
+            let (principal, role) =
+                match autonoetic_types::principal::decider_principal_kind(&approver) {
+                    Some(PrincipalKind::Human) => {
+                        (Principal::human(approver.clone()), SessionRole::Operator)
+                    }
+                    _ => (
+                        Principal::agent(approver.clone()),
+                        crate::runtime::session_timeline::derive_role(&approver),
+                    ),
+                };
+            let refs = TimelineRefs {
+                plan_id: Some(plan.plan_id.clone()),
+                ..Default::default()
+            };
+            let event = crate::runtime::session_timeline::build_timeline_event(
+                plan.root_session_id.clone(),
+                plan.root_session_id.clone(),
+                None,
+                &principal,
+                &role,
+                "plan.approved",
+                None,
+                Some(serde_json::json!({
+                    "plan_id": plan.plan_id,
+                    "version": plan.version,
+                    "approved_by": approver,
+                })),
+                refs,
+            );
+            if let Err(e) = store.create_live_digest_event(&event) {
+                tracing::debug!(target: "session_timeline", error = %e, "plan.approved timeline emit failed");
+            }
+        }
+
         if let Some(config) = config {
             crate::scheduler::workflow_store::append_workflow_event(
                 config,

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -599,18 +599,8 @@ impl NativeTool for PlanFrameApproveTool {
         // Canonical timeline: the plan gate closes (#363 P1), authored by the
         // approver (Operator seat for a human, the agent's seat otherwise).
         {
-            use autonoetic_types::principal::{Principal, PrincipalKind};
-            use autonoetic_types::session_timeline::{SessionRole, TimelineRefs};
-            let (principal, role) =
-                match autonoetic_types::principal::decider_principal_kind(&approver) {
-                    Some(PrincipalKind::Human) => {
-                        (Principal::human(approver.clone()), SessionRole::Operator)
-                    }
-                    _ => (
-                        Principal::agent(approver.clone()),
-                        crate::runtime::session_timeline::derive_role(&approver),
-                    ),
-                };
+            use autonoetic_types::session_timeline::TimelineRefs;
+            let (principal, role) = crate::runtime::session_timeline::decider_seat(&approver);
             let refs = TimelineRefs {
                 plan_id: Some(plan.plan_id.clone()),
                 ..Default::default()

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -233,8 +233,7 @@ impl GatewayStore {
         decided_by: &str,
         ctx: Option<(Option<String>, String, String)>,
     ) {
-        use autonoetic_types::principal::{Principal, PrincipalKind};
-        use autonoetic_types::session_timeline::{Altitude, SessionRole, TimelineRefs};
+        use autonoetic_types::session_timeline::{Altitude, TimelineRefs};
 
         let Some((root, session, _agent)) = ctx else {
             return;
@@ -245,19 +244,9 @@ impl GatewayStore {
             "cancelled" => ("approval.cancelled", Altitude::Detail),
             _ => return,
         };
-        // Author = the decider. Operator seat for a human; the agent's seat for an
-        // agent-decider; Runtime (hidable) for mechanical resolutions.
-        let (principal, role) = match autonoetic_types::principal::decider_principal_kind(decided_by) {
-            Some(PrincipalKind::Human) => (Principal::human(decided_by), SessionRole::Operator),
-            Some(PrincipalKind::AutonoeticAgent) => (
-                Principal::agent(decided_by),
-                crate::runtime::session_timeline::derive_role(decided_by),
-            ),
-            _ => (
-                Principal { kind: PrincipalKind::Script, id: decided_by.to_string() },
-                SessionRole::Runtime,
-            ),
-        };
+        // Author = the decider: Operator seat (human), the agent's seat (stripping
+        // any `agent:` prefix), or Runtime (hidable) for mechanical resolutions.
+        let (principal, role) = crate::runtime::session_timeline::decider_seat(decided_by);
         let refs = TimelineRefs {
             approval_request_id: Some(request_id.to_string()),
             ..Default::default()
@@ -1066,5 +1055,39 @@ mod decided_by_kind_tests {
             autonoetic_types::session_timeline::Altitude::Attention
         );
         assert_eq!(ev.refs.approval_request_id.as_deref(), Some("apr-r"));
+    }
+
+    #[test]
+    fn resolution_attribution_for_agent_and_mechanical_branches() {
+        use autonoetic_types::principal::PrincipalKind;
+        use autonoetic_types::session_timeline::{Altitude, SessionRole};
+
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+
+        // Agent-decider (agent: prefix) approval.
+        let mut a = pending("apr-ag");
+        store.create_approval(&mut a).unwrap();
+        store
+            .record_decision("apr-ag", "approved", "agent:auditor.default", "2026-06-01T01:00:00Z", None)
+            .unwrap();
+
+        // Mechanical emergency-stop cancel via record_decision.
+        let mut m = pending("apr-mech");
+        store.create_approval(&mut m).unwrap();
+        store
+            .record_decision("apr-mech", "cancelled", "emergency_stop:estop-1a2b3c4d", "2026-06-01T01:00:01Z", None)
+            .unwrap();
+
+        let tl = store.list_session_timeline("s1", None, 50, None, None).unwrap();
+
+        let agent_ev = tl.entries.iter().find(|e| e.event_type == "approval.approved").unwrap();
+        assert_eq!(agent_ev.principal.kind, PrincipalKind::AutonoeticAgent);
+        assert_eq!(agent_ev.principal.id, "auditor.default"); // prefix stripped
+        assert_eq!(agent_ev.role, SessionRole::Auditor);
+
+        let mech_ev = tl.entries.iter().find(|e| e.event_type == "approval.cancelled").unwrap();
+        assert_eq!(mech_ev.role, SessionRole::Runtime);
+        assert_eq!(mech_ev.altitude, Altitude::Detail); // hidable
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -173,21 +173,26 @@ impl GatewayStore {
         decided_at: &str,
         decision_reason: Option<&str>,
     ) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
         // #361: record the decider's principal kind (derived from decided_by) so
         // §O symmetric-obligation checks are mechanically queryable in SQL.
         let decided_by_kind =
             autonoetic_types::principal::decider_principal_kind(decided_by).map(|k| k.tag());
-        let rows = conn.execute(
-            "UPDATE approvals SET status = ?1, decided_by = ?2, decided_at = ?3, decision_reason = ?4, decided_by_kind = ?5 WHERE request_id = ?6 AND status = 'pending'",
-            params![status, decided_by, decided_at, decision_reason, decided_by_kind, request_id],
-        )?;
-        if rows == 0 {
-            anyhow::bail!(
-                "Approval {} is no longer pending (already decided or not found)",
-                request_id
-            );
-        }
+        let ctx = {
+            let conn = self.conn.lock().unwrap();
+            let rows = conn.execute(
+                "UPDATE approvals SET status = ?1, decided_by = ?2, decided_at = ?3, decision_reason = ?4, decided_by_kind = ?5 WHERE request_id = ?6 AND status = 'pending'",
+                params![status, decided_by, decided_at, decision_reason, decided_by_kind, request_id],
+            )?;
+            if rows == 0 {
+                anyhow::bail!(
+                    "Approval {} is no longer pending (already decided or not found)",
+                    request_id
+                );
+            }
+            resolution_context(&conn, request_id)
+        };
+        // Session Room: the gate *closes* on the canonical timeline (#363 P1).
+        self.emit_gate_resolution(request_id, status, decided_by, ctx);
         Ok(())
     }
 
@@ -197,20 +202,80 @@ impl GatewayStore {
         cancelled_by: &str,
         cancelled_at: &str,
     ) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
         let decided_by_kind =
             autonoetic_types::principal::decider_principal_kind(cancelled_by).map(|k| k.tag());
-        let rows = conn.execute(
-            "UPDATE approvals SET status = 'cancelled', decided_by = ?1, decided_at = ?2, decided_by_kind = ?3 WHERE request_id = ?4 AND status = 'pending'",
-            params![cancelled_by, cancelled_at, decided_by_kind, request_id],
-        )?;
-        if rows == 0 {
-            anyhow::bail!(
-                "Approval {} is no longer pending (already decided or not found)",
-                request_id
-            );
-        }
+        let ctx = {
+            let conn = self.conn.lock().unwrap();
+            let rows = conn.execute(
+                "UPDATE approvals SET status = 'cancelled', decided_by = ?1, decided_at = ?2, decided_by_kind = ?3 WHERE request_id = ?4 AND status = 'pending'",
+                params![cancelled_by, cancelled_at, decided_by_kind, request_id],
+            )?;
+            if rows == 0 {
+                anyhow::bail!(
+                    "Approval {} is no longer pending (already decided or not found)",
+                    request_id
+                );
+            }
+            resolution_context(&conn, request_id)
+        };
+        self.emit_gate_resolution(request_id, "cancelled", cancelled_by, ctx);
         Ok(())
+    }
+
+    /// Emit an `approval.{approved,rejected,cancelled}` event onto the canonical
+    /// timeline, authored by the decider (#363 P1). Best-effort: a failure here
+    /// never affects the recorded decision. `ctx` is `(root_session_id,
+    /// session_id, agent_id)` of the original request.
+    fn emit_gate_resolution(
+        &self,
+        request_id: &str,
+        status: &str,
+        decided_by: &str,
+        ctx: Option<(Option<String>, String, String)>,
+    ) {
+        use autonoetic_types::principal::{Principal, PrincipalKind};
+        use autonoetic_types::session_timeline::{Altitude, SessionRole, TimelineRefs};
+
+        let Some((root, session, _agent)) = ctx else {
+            return;
+        };
+        let (event_type, altitude) = match status {
+            "approved" => ("approval.approved", Altitude::Normal),
+            "rejected" | "denied" => ("approval.rejected", Altitude::Attention),
+            "cancelled" => ("approval.cancelled", Altitude::Detail),
+            _ => return,
+        };
+        // Author = the decider. Operator seat for a human; the agent's seat for an
+        // agent-decider; Runtime (hidable) for mechanical resolutions.
+        let (principal, role) = match autonoetic_types::principal::decider_principal_kind(decided_by) {
+            Some(PrincipalKind::Human) => (Principal::human(decided_by), SessionRole::Operator),
+            Some(PrincipalKind::AutonoeticAgent) => (
+                Principal::agent(decided_by),
+                crate::runtime::session_timeline::derive_role(decided_by),
+            ),
+            _ => (
+                Principal { kind: PrincipalKind::Script, id: decided_by.to_string() },
+                SessionRole::Runtime,
+            ),
+        };
+        let refs = TimelineRefs {
+            approval_request_id: Some(request_id.to_string()),
+            ..Default::default()
+        };
+        let event = crate::runtime::session_timeline::build_timeline_event(
+            root.unwrap_or_else(|| session.clone()),
+            session,
+            None,
+            &principal,
+            &role,
+            event_type,
+            Some(altitude),
+            Some(serde_json::json!({ "request_id": request_id, "decided_by": decided_by })),
+            refs,
+        );
+        if let Err(e) = self.create_live_digest_event(&event) {
+            tracing::debug!(target: "session_timeline", error = %e, "gate resolution timeline emit failed");
+        }
     }
 
     pub fn get_pending_approvals(&self) -> Result<Vec<ApprovalRequest>> {
@@ -853,6 +918,27 @@ impl GatewayStore {
     }
 }
 
+/// Fetch `(root_session_id, session_id, agent_id)` for a resolved approval so
+/// the timeline event can be attributed to the requesting session. Returns
+/// `None` (skipping emission) if the row can't be read.
+fn resolution_context(
+    conn: &rusqlite::Connection,
+    request_id: &str,
+) -> Option<(Option<String>, String, String)> {
+    conn.query_row(
+        "SELECT root_session_id, session_id, agent_id FROM approvals WHERE request_id = ?1",
+        params![request_id],
+        |r| {
+            Ok((
+                r.get::<_, Option<String>>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        },
+    )
+    .ok()
+}
+
 #[cfg(test)]
 mod decided_by_kind_tests {
     use super::GatewayStore;
@@ -934,5 +1020,36 @@ mod decided_by_kind_tests {
             .cancel_approval("apr-g", "gateway", "2026-06-01T01:00:00Z")
             .unwrap();
         assert_eq!(stored_kind(&store, "apr-g"), None);
+    }
+
+    #[test]
+    fn record_decision_emits_resolution_onto_timeline() {
+        use autonoetic_types::principal::PrincipalKind;
+        use autonoetic_types::session_timeline::SessionRole;
+
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+
+        let mut a = pending("apr-r");
+        store.create_approval(&mut a).unwrap();
+        store
+            .record_decision("apr-r", "rejected", "operator", "2026-06-01T01:00:00Z", Some("out of scope"))
+            .unwrap();
+
+        // session_id "s1" is the root (pending() leaves root_session_id None).
+        let tl = store.list_session_timeline("s1", None, 50, None, None).unwrap();
+        let ev = tl
+            .entries
+            .iter()
+            .find(|e| e.event_type == "approval.rejected")
+            .expect("resolution event on timeline");
+        assert_eq!(ev.principal.kind, PrincipalKind::Human);
+        assert_eq!(ev.role, SessionRole::Operator);
+        // A rejection draws attention.
+        assert_eq!(
+            ev.altitude,
+            autonoetic_types::session_timeline::Altitude::Attention
+        );
+        assert_eq!(ev.refs.approval_request_id.as_deref(), Some("apr-r"));
     }
 }

--- a/autonoetic-gateway/tests/plan_frame_integration.rs
+++ b/autonoetic-gateway/tests/plan_frame_integration.rs
@@ -338,6 +338,22 @@ fn planframe_approve_transitions_status() {
     let plan = store.load_plan_frame(&plan_id).unwrap().unwrap();
     assert_eq!(plan.status, PlanStatus::Approved);
     assert_eq!(plan.approved_by.as_deref(), Some("operator"));
+
+    // Session Room P1: the approval lands on the canonical timeline as a
+    // `plan.approved` event with the plan_id ref, authored by the Operator seat.
+    let tl = store
+        .list_session_timeline("root-session-003", None, 100, None, None)
+        .unwrap();
+    let approved = tl
+        .entries
+        .iter()
+        .find(|e| e.event_type == "plan.approved")
+        .expect("plan.approved event on the canonical timeline");
+    assert_eq!(approved.refs.plan_id.as_deref(), Some(plan_id.as_str()));
+    assert_eq!(
+        approved.role,
+        autonoetic_types::session_timeline::SessionRole::Operator
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
**Stacked on #374** (#361 decider-kind). Completes the **approval + plan gate lifecycle** on the canonical timeline (#363 P1): the room already showed gates *opening* (`approval.pending`, `plan.pending`); now it shows them *closing*, authored by the decider.

> ⚠️ Base is `feat/decider-kind-361`, not `main` — review/merge **#374 first**, then I'll retarget this to `main`. (It uses #361's `decider_principal_kind` for decider attribution.)

### What's emitted
- **`approval.approved` / `approval.rejected` / `approval.cancelled`** — from the **store chokepoint** (`record_decision` / `cancel_approval`), so *every* resolution path is covered uniformly (operator, agent-decider, scheduler, mechanical cancel) without instrumenting each of the ~5 callers. Authored by the decider: **Operator** seat (human), the agent's seat (agent-decider), or **Runtime** (hidable, for mechanical cancels). Rejection ⇒ `Attention`, cancel ⇒ `Detail`.
- **`plan.approved`** — at the plan-approve tool, authored by the approver.
- Both carry `approval_request_id` / `plan_id` refs for drill-down.

### Safety
- Best-effort: a timeline-emit failure never affects the recorded decision (logged at debug).
- The connection lock is released before emitting (no re-entrant lock).

## Test plan
- [x] `cargo test -p autonoetic-gateway decided_by_kind` — resolution lands on timeline with correct seat / altitude / refs
- [x] Full `cargo test -p autonoetic-gateway --lib` — **1118 passed / 29 failed** (same pre-existing 29; zero new regressions)

## Remaining in P1 (final follow-up)
Workbench create/reconcile/discard events — a small separate PR.

Tracks #363 · #364. Step 2 of 3 (→ P2 renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)