### PR TITLE
feat(session-room): workbench events on the canonical timeline (P1 final)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -53,8 +53,11 @@ pub fn build_timeline_event(
 /// Base importance of a digest event type, before any role refinement.
 pub fn base_altitude(event_type: &str) -> Altitude {
     match event_type {
-        // Mechanics / poll-ish — hidden at the normal floor.
-        "turn.start" | "turn.end" | "llm.round" | "tool.requested" => Altitude::Detail,
+        // Mechanics / poll-ish / infra — hidden at the normal floor. Workbench
+        // lifecycle is plumbing around the real work (edits/artifacts), so it
+        // stays Detail and surfaces only when the operator dials down.
+        "turn.start" | "turn.end" | "llm.round" | "tool.requested"
+        | "workbench.created" | "workbench.reconciled" | "workbench.discarded" => Altitude::Detail,
         // Failures always surface.
         "llm.request_failed" | "tool.failed" => Altitude::Error,
         // Gates awaiting the operator (conversational asks, RFC §3.5).

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -38,6 +38,39 @@ fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
 }
 
+/// Emit a `workbench.{created,reconciled,discarded}` event onto the canonical
+/// Session Room timeline (#363 P1), attributed to the acting agent's seat and
+/// referencing the workbench surface. Best-effort — never fails the operation.
+fn emit_workbench_timeline_event(
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+    workbench_id: &str,
+    event_type: &str,
+    altitude: Option<autonoetic_types::session_timeline::Altitude>,
+) {
+    let role = crate::runtime::session_timeline::derive_role(agent_id);
+    let principal = autonoetic_types::principal::Principal::agent(agent_id);
+    let refs = autonoetic_types::session_timeline::TimelineRefs {
+        workbench_id: Some(workbench_id.to_string()),
+        ..Default::default()
+    };
+    let event = crate::runtime::session_timeline::build_timeline_event(
+        root_session_id.to_string(),
+        root_session_id.to_string(),
+        None,
+        &principal,
+        &role,
+        event_type,
+        altitude,
+        Some(serde_json::json!({ "workbench_id": workbench_id })),
+        refs,
+    );
+    if let Err(e) = store.create_live_digest_event(&event) {
+        tracing::debug!(target: "session_timeline", error = %e, "workbench timeline emit failed");
+    }
+}
+
 fn new_workbench_id() -> String {
     let bytes = uuid::Uuid::new_v4();
     format!("wb-{}", hex::encode(&bytes.as_bytes()[..6]))
@@ -373,6 +406,14 @@ impl NativeTool for ArtifactProjectTool {
         };
 
         store.save_workbench(&wb)?;
+        emit_workbench_timeline_event(
+            &store,
+            &wb.root_session_id,
+            &manifest.agent.id,
+            &wb.workbench_id,
+            "workbench.created",
+            None,
+        );
 
         // Issue #330: auto-checkpoint on projection so the operator has
         // a clean restore point before any edits. Best-effort — failure
@@ -1049,6 +1090,14 @@ impl NativeTool for WorkbenchReconcileTool {
 
         let now = now_rfc3339();
         store.update_workbench_status(&wb.workbench_id, WorkbenchStatus::Reconciled, &now)?;
+        emit_workbench_timeline_event(
+            &store,
+            &wb.root_session_id,
+            &manifest.agent.id,
+            &wb.workbench_id,
+            "workbench.reconciled",
+            None,
+        );
 
         let semantic_summary = build_semantic_summary(
             &store,
@@ -1255,6 +1304,14 @@ impl NativeTool for WorkbenchDiscardTool {
 
         let now = now_rfc3339();
         store.update_workbench_status(&wb.workbench_id, WorkbenchStatus::Discarded, &now)?;
+        emit_workbench_timeline_event(
+            &store,
+            &wb.root_session_id,
+            &_manifest.agent.id,
+            &wb.workbench_id,
+            "workbench.discarded",
+            Some(autonoetic_types::session_timeline::Altitude::Detail),
+        );
 
         Ok(serde_json::to_string(&serde_json::json!({
             "ok": true,

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -1310,7 +1310,7 @@ impl NativeTool for WorkbenchDiscardTool {
             &_manifest.agent.id,
             &wb.workbench_id,
             "workbench.discarded",
-            Some(autonoetic_types::session_timeline::Altitude::Detail),
+            None,
         );
 
         Ok(serde_json::to_string(&serde_json::json!({

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -176,6 +176,18 @@ fn artifact_project_creates_editable_workbench() {
     assert!(wb.base_artifact_id.starts_with("art_"), "base_artifact_id should be art_*: {}", wb.base_artifact_id);
     assert_eq!(wb.status.as_str(), "active");
 
+    // Session Room P1: projecting a workbench lands a `workbench.created` event
+    // on the canonical timeline, referencing the workbench surface.
+    let tl = store
+        .list_session_timeline("root-session-001", None, 100, None, None)
+        .unwrap();
+    let created = tl
+        .entries
+        .iter()
+        .find(|e| e.event_type == "workbench.created")
+        .expect("workbench.created event on the canonical timeline");
+    assert_eq!(created.refs.workbench_id.as_deref(), Some(workbench_id));
+
     std::fs::write(&main_py, "print('modified')").unwrap();
     let content_after = std::fs::read_to_string(&main_py).unwrap();
     assert_eq!(content_after, "print('modified')");

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -712,6 +712,19 @@ fn workbench_reconcile_creates_new_artifact() {
     let wb_after = store.load_workbench(&wb_id).unwrap().unwrap();
     assert_eq!(wb_after.status, autonoetic_types::workbench::WorkbenchStatus::Reconciled);
     assert!(wb_after.reconciled_at.is_some());
+
+    // Session Room P1: `workbench.reconciled` lands on the timeline at Detail
+    // altitude (min_altitude=None to include Detail), with the workbench ref.
+    let tl = store
+        .list_session_timeline("root-session-006", None, 100, None, None)
+        .unwrap();
+    let ev = tl
+        .entries
+        .iter()
+        .find(|e| e.event_type == "workbench.reconciled")
+        .expect("workbench.reconciled event on the canonical timeline");
+    assert_eq!(ev.refs.workbench_id.as_deref(), Some(wb_id.as_str()));
+    assert_eq!(ev.altitude, autonoetic_types::session_timeline::Altitude::Detail);
 }
 
 #[test]
@@ -856,6 +869,18 @@ fn workbench_discard_marks_discarded() {
     let wb = store.load_workbench(&wb_id).unwrap().unwrap();
     assert_eq!(wb.status, autonoetic_types::workbench::WorkbenchStatus::Discarded);
     assert!(wb.discarded_at.is_some());
+
+    // Session Room P1: `workbench.discarded` lands on the timeline at Detail.
+    let tl = store
+        .list_session_timeline("root-session-008", None, 100, None, None)
+        .unwrap();
+    let ev = tl
+        .entries
+        .iter()
+        .find(|e| e.event_type == "workbench.discarded")
+        .expect("workbench.discarded event on the canonical timeline");
+    assert_eq!(ev.refs.workbench_id.as_deref(), Some(wb_id.as_str()));
+    assert_eq!(ev.altitude, autonoetic_types::session_timeline::Altitude::Detail);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
The **last remaining-P1 producer** (#363 / #364). Workbench lifecycle now appears on the canonical timeline alongside gates (`approval.*`, `plan.*`), divergence, and the digest spine — so the room shows the full picture of what's happening.

- **`workbench.created`** (artifact_project), **`workbench.reconciled`**, **`workbench.discarded`** (Detail altitude — least notable) emitted from the workbench tools.
- Attributed to the **acting agent's seat** (`derive_role`), with a `workbench_id` ref for drill-down.
- Shared `emit_workbench_timeline_event` helper; **best-effort** — a timeline-emit failure never affects the workbench operation.

## Test plan
- [x] `cargo test -p autonoetic-gateway --test workbench_integration artifact_project_creates_editable_workbench` — asserts `workbench.created` lands with the `workbench_id` ref ✅
- [x] `cargo build -p autonoetic-gateway`

## Where this leaves P1
With this, **all P1 timeline producers are in**: digest spine (#371), gate opens (#372), gate resolutions (#375), and now workbench. The canonical `live_digest_events` timeline reflects the whole session. Next phase is **P2** — the greenfield renderer that consumes `list_session_timeline`.

Tracks #363 · #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)