### PR TITLE
P1.c — Map updated_by_type strings to PrincipalKind::tag() + document actor_id

### DIFF
--- a/autonoetic-gateway/src/capsule/import.rs
+++ b/autonoetic-gateway/src/capsule/import.rs
@@ -572,7 +572,7 @@ fn bind_alias(
         agent_id: agent_id.to_string(),
         revision_id: revision_id.to_string(),
         updated_at: now,
-        updated_by_type: "system".to_string(),
+        updated_by_type: autonoetic_types::principal::PrincipalKind::Script.tag().to_string(),
         updated_by_id: "capsule.import".to_string(),
         reason: Some("capsule import --activate".to_string()),
     };

--- a/autonoetic-types/src/causal_chain.rs
+++ b/autonoetic-types/src/causal_chain.rs
@@ -22,10 +22,17 @@ impl std::fmt::Display for EntryStatus {
 }
 
 /// A single entry in the append-only `.jsonl` Causal Chain log.
+///
+/// **Principal identity**: `actor_id` *is* the principal identity — it is
+/// bound into the entry hash alongside `session_id`, `turn_id`, and
+/// `event_seq`. No `agent_id` → `principal_id` rename is planned; the
+/// generic identity already lives at the ledger layer. See
+/// [`crate::principal`] for the typed principal model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CausalChainEntry {
     pub timestamp: String,
     pub log_id: String,
+    /// Principal identity — bound into the entry hash. See module doc.
     pub actor_id: String,
     #[serde(default)]
     pub session_id: String,

--- a/autonoetic/src/cli/agent.rs
+++ b/autonoetic/src/cli/agent.rs
@@ -2888,7 +2888,7 @@ metadata:
                 agent_id: "planner.default".to_string(),
                 revision_id: revision.revision_id.clone(),
                 updated_at: "2026-01-01T00:00:01Z".to_string(),
-                updated_by_type: "human".to_string(),
+                updated_by_type: autonoetic_types::principal::PrincipalKind::Human.tag().to_string(),
                 updated_by_id: "operator".to_string(),
                 reason: Some("initial seed".to_string()),
             })
@@ -2976,7 +2976,7 @@ metadata:
                 agent_id: "list.agent".to_string(),
                 revision_id: "rev_sha256:list123".to_string(),
                 updated_at: "2026-01-01T00:00:01Z".to_string(),
-                updated_by_type: "human".to_string(),
+                updated_by_type: autonoetic_types::principal::PrincipalKind::Human.tag().to_string(),
                 updated_by_id: "operator".to_string(),
                 reason: Some("seed".to_string()),
             })


### PR DESCRIPTION
Part of #359 / #362.

P1.a and P1.b landed in #371/#372 (session-room PRs). This PR picks up the remaining P1.c pieces:

- **`capsule/import.rs`**: `"system"` → `PrincipalKind::Script.tag()`
- **`cli/agent.rs`**: `"human"` → `PrincipalKind::Human.tag()` (2 sites)
- **`causal_chain.rs`**: Document that `actor_id` *is* the principal identity — no `agent_id` → `principal_id` rename is planned.

These are incremental type-safety improvements: the stringly-typed `updated_by_type` values now go through the typed `PrincipalKind::tag()` instead of raw literals.