### PR TITLE
feat(session-room): P2 slice 1 — render core + read-only room viewer

### DIFF
--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -153,6 +153,8 @@ pub enum Commands {
     Chat(ChatArgs),
     /// Inspect causal chain traces
     Trace(TraceArgs),
+    /// Render a session's canonical activity timeline (Session Room, read-only)
+    Room(RoomArgs),
     /// Ecosystem and Skills management
     Skill(SkillArgs),
     /// Federation and Cluster management
@@ -942,6 +944,21 @@ pub struct ChatArgs {
 pub struct TraceArgs {
     #[command(subcommand)]
     pub command: TraceCommands,
+}
+
+#[derive(Args)]
+pub struct RoomArgs {
+    /// Root session id whose timeline to render.
+    pub root_session_id: String,
+    /// Altitude floor: detail | normal | attention | error. Default: normal.
+    #[arg(long, default_value = "normal")]
+    pub min_altitude: String,
+    /// Follow the timeline live (tail -f style) until Ctrl+C.
+    #[arg(long)]
+    pub follow: bool,
+    /// Max rows to fetch per read.
+    #[arg(long, default_value_t = 200)]
+    pub limit: u32,
 }
 
 #[derive(Subcommand)]

--- a/autonoetic/src/cli/mod.rs
+++ b/autonoetic/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod gateway;
 pub mod mcp;
 pub mod model_discovery;
 pub mod recording;
+pub mod room;
 pub mod run;
 pub mod security;
 pub mod sentinel_experiment;

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -18,29 +18,23 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
     let gateway_dir = config.agents_dir.join(".gateway");
     let store = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir)?;
 
-    let min_altitude = Altitude::parse_str(&args.min_altitude);
-    if min_altitude.is_none() && args.min_altitude != "detail" {
-        anyhow::bail!(
+    // `parse_str` returns `Some` for every valid floor (detail/normal/attention/
+    // error), so `None` here means the input was invalid.
+    let min_altitude = match Altitude::parse_str(&args.min_altitude) {
+        Some(a) => a,
+        None => anyhow::bail!(
             "invalid --min-altitude '{}': expected detail | normal | attention | error",
             args.min_altitude
-        );
-    }
+        ),
+    };
 
-    // Initial window: most recent `limit` rows at/above the floor.
-    let first = store.list_session_timeline(
-        &args.root_session_id,
-        None,
-        args.limit,
-        min_altitude,
-        None,
-    )?;
-    for entry in &first.entries {
-        println!("{}", render::render_line(entry));
-    }
-    let mut cursor = first.entries.last().map(|e| e.event_id.clone());
+    // Render the full timeline oldest-first, paging through *all* rows (not just
+    // the first `limit`, which would silently truncate long sessions).
+    let mut cursor: Option<String> = None;
+    let rendered_any = drain_new(&store, &args.root_session_id, &mut cursor, args.limit, min_altitude)?;
 
     if !args.follow {
-        if first.entries.is_empty() {
+        if !rendered_any {
             eprintln!(
                 "(no activity at or above '{}' for session '{}')",
                 args.min_altitude, args.root_session_id
@@ -56,25 +50,40 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
     let mut interval = tokio::time::interval(Duration::from_millis(800));
     loop {
         interval.tick().await;
-        // Drain everything newer than the cursor (page until caught up).
-        loop {
-            let page = store.list_session_timeline(
-                &args.root_session_id,
-                cursor.as_deref(),
-                args.limit,
-                min_altitude,
-                None,
-            )?;
-            if page.entries.is_empty() {
-                break;
-            }
-            for entry in &page.entries {
-                println!("{}", render::render_line(entry));
-                cursor = Some(entry.event_id.clone());
-            }
-            if !page.has_more {
-                break;
-            }
+        drain_new(&store, &args.root_session_id, &mut cursor, args.limit, min_altitude)?;
+    }
+}
+
+/// Render every timeline entry newer than `cursor`, paging (in `limit`-sized
+/// reads) until caught up, advancing `cursor`. Returns whether anything was
+/// rendered. Used for both the initial dump and each follow tick.
+fn drain_new(
+    store: &autonoetic_gateway::scheduler::GatewayStore,
+    root_session_id: &str,
+    cursor: &mut Option<String>,
+    limit: u32,
+    min_altitude: Altitude,
+) -> anyhow::Result<bool> {
+    let mut rendered_any = false;
+    loop {
+        let page = store.list_session_timeline(
+            root_session_id,
+            cursor.as_deref(),
+            limit,
+            Some(min_altitude),
+            None,
+        )?;
+        if page.entries.is_empty() {
+            break;
+        }
+        for entry in &page.entries {
+            println!("{}", render::render_line(entry));
+            *cursor = Some(entry.event_id.clone());
+            rendered_any = true;
+        }
+        if !page.has_more {
+            break;
         }
     }
+    Ok(rendered_any)
 }

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -1,0 +1,80 @@
+//! Session Room (#363 P2) — read-only renderer slice.
+//!
+//! `autonoetic room <root_session_id>` renders the gateway's canonical
+//! `live_digest_events` timeline for a root session, oldest-first, with an
+//! altitude floor and an optional `--follow` live tail. This is the first P2
+//! slice: it proves timeline consumption + the channel-neutral rendering core
+//! ([`render`]) before any interactive ratatui shell is built on top.
+
+mod render;
+
+use crate::cli::common::RoomArgs;
+use autonoetic_types::session_timeline::Altitude;
+use std::path::Path;
+use std::time::Duration;
+
+pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<()> {
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_dir = config.agents_dir.join(".gateway");
+    let store = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir)?;
+
+    let min_altitude = Altitude::parse_str(&args.min_altitude);
+    if min_altitude.is_none() && args.min_altitude != "detail" {
+        anyhow::bail!(
+            "invalid --min-altitude '{}': expected detail | normal | attention | error",
+            args.min_altitude
+        );
+    }
+
+    // Initial window: most recent `limit` rows at/above the floor.
+    let first = store.list_session_timeline(
+        &args.root_session_id,
+        None,
+        args.limit,
+        min_altitude,
+        None,
+    )?;
+    for entry in &first.entries {
+        println!("{}", render::render_line(entry));
+    }
+    let mut cursor = first.entries.last().map(|e| e.event_id.clone());
+
+    if !args.follow {
+        if first.entries.is_empty() {
+            eprintln!(
+                "(no activity at or above '{}' for session '{}')",
+                args.min_altitude, args.root_session_id
+            );
+        }
+        return Ok(());
+    }
+
+    eprintln!(
+        "Following room '{}' (floor: {}). Press Ctrl+C to stop.",
+        args.root_session_id, args.min_altitude
+    );
+    let mut interval = tokio::time::interval(Duration::from_millis(800));
+    loop {
+        interval.tick().await;
+        // Drain everything newer than the cursor (page until caught up).
+        loop {
+            let page = store.list_session_timeline(
+                &args.root_session_id,
+                cursor.as_deref(),
+                args.limit,
+                min_altitude,
+                None,
+            )?;
+            if page.entries.is_empty() {
+                break;
+            }
+            for entry in &page.entries {
+                println!("{}", render::render_line(entry));
+                cursor = Some(entry.event_id.clone());
+            }
+            if !page.has_more {
+                break;
+            }
+        }
+    }
+}

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -1,0 +1,169 @@
+//! Pure rendering core for the Session Room (#363 P2).
+//!
+//! Channel-neutral: turns a `SessionTimelineEntry` into a one-line human string.
+//! Deliberately free of any I/O or terminal state so the TUI shell, the CLI
+//! viewer, and (later) external channel bridges all share the *same* formatting.
+//! Presentation only — importance/altitude is decided gateway-side.
+
+use autonoetic_types::principal::PrincipalKind;
+use autonoetic_types::session_timeline::{Altitude, SessionRole, SessionTimelineEntry};
+
+/// Altitude glyph — the at-a-glance importance marker.
+pub fn altitude_glyph(altitude: Altitude) -> &'static str {
+    match altitude {
+        Altitude::Error => "✗",
+        Altitude::Attention => "⚠",
+        Altitude::Normal => "▸",
+        Altitude::Detail => "·",
+    }
+}
+
+/// A compact actor label: the seat, prefixed when the occupant is not a normal
+/// autonoetic agent (so a human operator or a foreign agent is obvious).
+pub fn actor_label(entry: &SessionTimelineEntry) -> String {
+    let seat = role_label(&entry.role);
+    match &entry.principal.kind {
+        PrincipalKind::Human => format!("🧑 {seat}"),
+        PrincipalKind::ForeignAgent { provider } => format!("🌐 {seat}·{provider}"),
+        PrincipalKind::Script => seat,
+        PrincipalKind::AutonoeticAgent => seat,
+    }
+}
+
+fn role_label(role: &SessionRole) -> String {
+    match role {
+        SessionRole::Operator => "operator".into(),
+        SessionRole::Planner => "planner".into(),
+        SessionRole::Specialist { kind } => kind.clone(),
+        SessionRole::Sentinel => "sentinel".into(),
+        SessionRole::Curator => "curator".into(),
+        SessionRole::Auditor => "auditor".into(),
+        SessionRole::Tool { surface } => surface.clone(),
+        SessionRole::ExternalSurface { surface } => surface.clone(),
+        SessionRole::Runtime => "runtime".into(),
+    }
+}
+
+/// Human summary of an event, from its type + payload. Keeps the most useful
+/// field per known event type; falls back to the bare event type.
+pub fn summarize(entry: &SessionTimelineEntry) -> String {
+    let p = entry
+        .payload
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+    let field = |key: &str| -> Option<String> {
+        p.as_ref()
+            .and_then(|v| v.get(key))
+            .and_then(|x| x.as_str())
+            .map(str::to_string)
+    };
+
+    match entry.event_type.as_str() {
+        "approval.pending" => format!(
+            "approval requested ({})",
+            field("request_id").unwrap_or_default()
+        ),
+        "approval.approved" => format!("approval granted ({})", field("request_id").unwrap_or_default()),
+        "approval.rejected" => format!("approval denied ({})", field("request_id").unwrap_or_default()),
+        "approval.cancelled" => format!("approval cancelled ({})", field("request_id").unwrap_or_default()),
+        "plan.pending" => format!("plan proposed: {}", field("title").unwrap_or_default()),
+        "plan.approved" => format!("plan approved ({})", field("plan_id").unwrap_or_default()),
+        "divergence.intervention" => format!(
+            "divergence: {} (turn {})",
+            field("level").unwrap_or_else(|| "?".into()),
+            p.as_ref().and_then(|v| v.get("turn")).and_then(|x| x.as_u64()).unwrap_or(0)
+        ),
+        "workbench.created" => "workbench projected".into(),
+        "workbench.reconciled" => "workbench reconciled".into(),
+        "workbench.discarded" => "workbench discarded".into(),
+        "user.ask.pending" => format!(
+            "asks: {}",
+            field("question").unwrap_or_default()
+        ),
+        "tool.completed" => format!("tool {}", field("tool").unwrap_or_else(|| "completed".into())),
+        "llm.request_failed" => format!("LLM error: {}", field("error").unwrap_or_default()),
+        other => other.to_string(),
+    }
+}
+
+/// Full one-line rendering: `<glyph> [<actor>] <summary>`.
+pub fn render_line(entry: &SessionTimelineEntry) -> String {
+    format!(
+        "{} [{}] {}",
+        altitude_glyph(entry.altitude),
+        actor_label(entry),
+        summarize(entry)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::principal::Principal;
+    use autonoetic_types::session_timeline::TimelineRefs;
+
+    fn entry(role: SessionRole, kind_principal: Principal, et: &str, alt: Altitude, payload: serde_json::Value) -> SessionTimelineEntry {
+        SessionTimelineEntry {
+            event_id: "ev-1".into(),
+            root_session_id: "r".into(),
+            source_session_id: "r".into(),
+            turn_id: None,
+            principal: kind_principal,
+            role,
+            event_type: et.into(),
+            altitude: alt,
+            occurred_at: "2026-06-01T00:00:00Z".into(),
+            payload: Some(payload.to_string()),
+            refs: TimelineRefs::default(),
+        }
+    }
+
+    #[test]
+    fn renders_human_operator_approval() {
+        let e = entry(
+            SessionRole::Operator,
+            Principal::human("operator"),
+            "approval.rejected",
+            Altitude::Attention,
+            serde_json::json!({ "request_id": "apr-9" }),
+        );
+        let line = render_line(&e);
+        assert!(line.starts_with("⚠"));
+        assert!(line.contains("🧑 operator"));
+        assert!(line.contains("approval denied (apr-9)"));
+    }
+
+    #[test]
+    fn renders_sentinel_divergence_and_foreign_agent() {
+        let s = entry(
+            SessionRole::Sentinel,
+            Principal::agent("sentinel"),
+            "divergence.intervention",
+            Altitude::Attention,
+            serde_json::json!({ "level": "diverging", "turn": 4 }),
+        );
+        assert!(render_line(&s).contains("sentinel"));
+        assert!(render_line(&s).contains("divergence: diverging (turn 4)"));
+
+        let f = entry(
+            SessionRole::Specialist { kind: "coder".into() },
+            Principal::foreign("claude-code", "fa-1"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({ "tool": "edit" }),
+        );
+        assert!(render_line(&f).contains("🌐 coder·claude-code"));
+    }
+
+    #[test]
+    fn unknown_event_falls_back_to_type() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "some.future.event",
+            Altitude::Normal,
+            serde_json::json!({}),
+        );
+        assert!(render_line(&e).contains("some.future.event"));
+    }
+}

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -379,6 +379,10 @@ async fn main() -> anyhow::Result<()> {
             }
         },
 
+        Commands::Room(args) => {
+            cli::room::handle_room(&config_path, args).await?;
+        }
+
         Commands::Skill(args) => match &args.command {
             cli::common::SkillCommands::Install { url_or_id, agent } => {
                 tracing::info!("Installing Skill {} (agent: {:?})", url_or_id, agent);


### PR DESCRIPTION
## Summary
Starts **P2** (#365), the greenfield Session Room renderer. `chat.rs` is **untouched** — this is the new path beside it. This first slice is the **read-only renderer**: the channel-neutral formatting core plus a CLI viewer that proves end-to-end timeline consumption.

### What's here
- **`cli/room/render.rs` — pure render core.** Turns a `SessionTimelineEntry` into a one-line string: `<altitude glyph> [<actor seat>] <summary>`, with 🧑 / 🌐 markers so a human operator or a foreign-agent occupant is obvious at a glance, and a per-event-type summary. **No I/O, no terminal state** — the same function will back the interactive TUI shell *and* future Discord/WhatsApp bridges. Presentation only; importance/altitude stays gateway-owned. Unit-tested (human approval, sentinel divergence, foreign agent, unknown-event fallback).
- **`autonoetic room <root_session_id>` command** — renders the canonical `live_digest_events` timeline oldest-first at an altitude floor (`--min-altitude detail|normal|attention|error`, default `normal`), with an optional `--follow` cursor-based live tail. Reads via `GatewayStore::list_session_timeline`.

### Why this shape first
Per the RFC's channel-agnostic thesis, the reusable part is the **render core**; the TUI is just one shell around it. Shipping the core + a thin viewer first de-risks the big interactive ratatui work and immediately makes the timeline inspectable (`autonoetic room <id> --follow`).

## Test plan
- [x] `cargo test -p autonoetic cli::room` — 3 render tests pass
- [x] `cargo build -p autonoetic`

## Next P2 slices (follow-ups)
Squashing of `Detail` runs · drill-down into refs (causal/trace/artifact) · the interactive ratatui shell (scroll, altitude dial keybind) · conversational gate input (needs the #361 decider recording, already merged).

Tracks #363 · #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)