### PR TITLE
Operator activity feed: Phase 4 hardening

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -2559,12 +2559,23 @@ impl GatewayExecutionService {
                                 None,
                                 None,
                             );
-                            if let Err(e) = store.insert_operator_activity(&record) {
-                                tracing::warn!(
-                                    target: "operator_activity",
-                                    error = %e,
-                                    "Failed to persist session lifecycle operator activity"
-                                );
+                            let rate_limit_per_min = self.config.operator_activity.rate_limit_per_min;
+                            match store.insert_operator_activity_throttled(&record, rate_limit_per_min) {
+                                Ok(crate::scheduler::gateway_store::OperatorActivityInsert::Dropped) => {
+                                    tracing::debug!(
+                                        target: "operator_activity",
+                                        rate_limit_per_min,
+                                        "Session lifecycle operator activity dropped by per-root rate limit"
+                                    );
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::warn!(
+                                        target: "operator_activity",
+                                        error = %e,
+                                        "Failed to persist session lifecycle operator activity"
+                                    );
+                                }
                             }
                         }
                     }

--- a/autonoetic-gateway/src/runtime/operator_activity.rs
+++ b/autonoetic-gateway/src/runtime/operator_activity.rs
@@ -482,13 +482,14 @@ mod tests {
     #[test]
     fn summaries_redact_aws_keys() {
         let draft = classify_tool_activity(
-            "content_write",
-            r#"{"name":"config.py"}"#,
-            r#"{"ok":true,"name":"config.py","message":"wrote AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE"}"#,
+            "unknown_tool",
+            r#"{}"#,
+            r#"{"ok":true,"message":"wrote AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE"}"#,
         )
         .expect("should emit");
         assert!(!draft.summary.contains("AKIAIOSFODNN7EXAMPLE"));
-        assert!(!draft.summary.contains("AWS_ACCESS_KEY"));
+        assert!(draft.summary.contains("AWS_ACCESS_KEY="));
+        assert!(draft.summary.contains("***REDACTED***"));
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/operator_activity.rs
+++ b/autonoetic-gateway/src/runtime/operator_activity.rs
@@ -175,6 +175,24 @@ pub fn classify_session_lifecycle(
     })
 }
 
+pub fn classify_workflow_event(event_type: &str) -> Option<OperatorActivityDraft> {
+    match event_type {
+        "planframe.proposed" => Some(OperatorActivityDraft {
+            kind: OperatorActivityKind::PlanProposal,
+            severity: OperatorActivitySeverity::Attention,
+            summary: "plan awaiting operator approval".to_string(),
+            refs: OperatorActivityRefs::default(),
+        }),
+        "task.failed" => Some(OperatorActivityDraft {
+            kind: OperatorActivityKind::ToolFailed,
+            severity: OperatorActivitySeverity::Error,
+            summary: "workflow task failed".to_string(),
+            refs: OperatorActivityRefs::default(),
+        }),
+        _ => None,
+    }
+}
+
 pub fn is_poll_tool(tool_name: &str) -> bool {
     matches!(tool_name, "workflow_wait" | "workflow_state")
 }
@@ -440,5 +458,59 @@ mod tests {
         )
         .expect("failed wait should emit");
         assert_eq!(draft.severity, OperatorActivitySeverity::Error);
+    }
+
+    #[test]
+    fn classify_workflow_event_plan_proposal() {
+        let draft = classify_workflow_event("planframe.proposed").expect("should emit");
+        assert_eq!(draft.kind, OperatorActivityKind::PlanProposal);
+        assert_eq!(draft.severity, OperatorActivitySeverity::Attention);
+    }
+
+    #[test]
+    fn classify_workflow_event_task_failed() {
+        let draft = classify_workflow_event("task.failed").expect("should emit");
+        assert_eq!(draft.kind, OperatorActivityKind::ToolFailed);
+        assert_eq!(draft.severity, OperatorActivitySeverity::Error);
+    }
+
+    #[test]
+    fn classify_workflow_event_unknown_returns_none() {
+        assert!(classify_workflow_event("task.succeeded").is_none());
+    }
+
+    #[test]
+    fn summaries_redact_aws_keys() {
+        let draft = classify_tool_activity(
+            "content_write",
+            r#"{"name":"config.py"}"#,
+            r#"{"ok":true,"name":"config.py","message":"wrote AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE"}"#,
+        )
+        .expect("should emit");
+        assert!(!draft.summary.contains("AKIAIOSFODNN7EXAMPLE"));
+        assert!(!draft.summary.contains("AWS_ACCESS_KEY"));
+    }
+
+    #[test]
+    fn summaries_redact_bearer_tokens() {
+        let draft = classify_tool_activity(
+            "web_fetch",
+            r#"{"url":"https://api.example.com"}"#,
+            r#"{"ok":true,"url":"https://api.example.com","message":"fetched with Bearer eyJhbGciOiJIUzI1NiJ9.test.sig"}"#,
+        )
+        .expect("should emit");
+        assert!(!draft.summary.contains("eyJhbGciOiJIUzI1NiJ9"));
+    }
+
+    #[test]
+    fn summaries_truncate_long_content() {
+        let long_msg = "a".repeat(500);
+        let draft = classify_tool_activity(
+            "content_write",
+            r#"{"name":"big.txt"}"#,
+            &format!(r#"{{"ok":true,"name":"big.txt","message":"{}"}}"#, long_msg),
+        )
+        .expect("should emit");
+        assert!(draft.summary.len() <= 241);
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/operator_activity.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/operator_activity.rs
@@ -163,6 +163,16 @@ impl GatewayStore {
         })
     }
 
+    pub fn prune_operator_activity(&self, retention_days: i64) -> Result<usize> {
+        let cutoff = (chrono::Utc::now() - chrono::Duration::days(retention_days)).to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let count = conn.execute(
+            "DELETE FROM operator_activity WHERE occurred_at < ?1",
+            params![cutoff],
+        )?;
+        Ok(count)
+    }
+
     pub fn count_execution_traces_for_session(&self, session_id: &str) -> Result<u64> {
         let conn = self.conn.lock().unwrap();
         let count: i64 = conn.query_row(

--- a/autonoetic-gateway/src/scheduler/gateway_store/workflow.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/workflow.rs
@@ -112,6 +112,18 @@ impl GatewayStore {
         Ok(result)
     }
 
+    pub fn resolve_root_session_id(&self, workflow_id: &str) -> Result<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        let result: Option<String> = conn
+            .query_row(
+                "SELECT root_session_id FROM workflow_index WHERE workflow_id = ?1",
+                params![workflow_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn list_workflow_index(&self) -> Result<Vec<WorkflowIndexFile>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt =

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -560,6 +560,26 @@ pub fn append_workflow_event(
         event_type = %event.event_type,
         "append_workflow_event: appended to SQLite"
     );
+    if let Some(draft) = crate::runtime::operator_activity::classify_workflow_event(&event.event_type) {
+        let record = draft.into_record(
+            event.workflow_id.clone(),
+            String::new(),
+            event.agent_id.clone().unwrap_or_default(),
+            Some(event.workflow_id.clone()),
+            event.task_id.clone(),
+            None,
+            None,
+            None,
+            Some(event.event_id.clone()),
+        );
+        if let Err(e) = store.insert_operator_activity(&record) {
+            tracing::debug!(
+                target: "operator_activity",
+                error = %e,
+                "Failed to persist workflow event operator activity"
+            );
+        }
+    }
     if let Err(e) = refresh_workflow_graph_markdown(config, Some(store), &event.workflow_id) {
         tracing::warn!(
             target: "session_timeline",

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -561,8 +561,13 @@ pub fn append_workflow_event(
         "append_workflow_event: appended to SQLite"
     );
     if let Some(draft) = crate::runtime::operator_activity::classify_workflow_event(&event.event_type) {
+        let root_session_id = store
+            .resolve_root_session_id(&event.workflow_id)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
         let record = draft.into_record(
-            event.workflow_id.clone(),
+            root_session_id.clone(),
             String::new(),
             event.agent_id.clone().unwrap_or_default(),
             Some(event.workflow_id.clone()),
@@ -572,7 +577,8 @@ pub fn append_workflow_event(
             None,
             Some(event.event_id.clone()),
         );
-        if let Err(e) = store.insert_operator_activity(&record) {
+        let rate_limit = config.operator_activity.rate_limit_per_min;
+        if let Err(e) = store.insert_operator_activity_throttled(&record, rate_limit) {
             tracing::debug!(
                 target: "operator_activity",
                 error = %e,

--- a/autonoetic-gateway/src/server/mod.rs
+++ b/autonoetic-gateway/src/server/mod.rs
@@ -105,6 +105,16 @@ impl GatewayServer {
             );
         }
 
+        if self.config.operator_activity.retention_days > 0 {
+            if let Err(e) = gateway_store.prune_operator_activity(self.config.operator_activity.retention_days) {
+                tracing::warn!(
+                    target: "operator_activity",
+                    error = %e,
+                    "Failed to prune operator activity on startup"
+                );
+            }
+        }
+
         // Reap orphaned continuation files from crash/restart
         match crate::runtime::continuation::reap_orphaned_continuations(
             &self.config,

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1524,18 +1524,27 @@ pub struct OperatorActivityConfig {
     /// Default: 120.
     #[serde(default = "default_operator_activity_rate_limit_per_min")]
     pub rate_limit_per_min: u32,
+    /// Maximum age (in days) of operator activity rows before automatic
+    /// pruning. Default: 90.
+    #[serde(default = "default_operator_activity_retention_days")]
+    pub retention_days: i64,
 }
 
 impl Default for OperatorActivityConfig {
     fn default() -> Self {
         Self {
             rate_limit_per_min: default_operator_activity_rate_limit_per_min(),
+            retention_days: default_operator_activity_retention_days(),
         }
     }
 }
 
 fn default_operator_activity_rate_limit_per_min() -> u32 {
     120
+}
+
+fn default_operator_activity_retention_days() -> i64 {
+    90
 }
 
 /// Approval level / escalation configuration.

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -194,6 +194,8 @@ chat:
 # notice is emitted (suppression stays visible). 0 disables. Default: 120.
 operator_activity:
   rate_limit_per_min: 120
+  # retention_days: maximum age (days) of operator activity rows before pruning. Default: 90.
+  retention_days: 90
 
 # ── Approval Levels ───────────────────────────────────────────────────
 # Escalation: require higher authority for sensitive actions.

--- a/docs/design/operator-activity-feed-plan.md
+++ b/docs/design/operator-activity-feed-plan.md
@@ -411,6 +411,14 @@ so bridges recover session context without local state. v1: bridge stores mappin
   so suppression is never silent. Wired from `tool_call_processor`. The
   success denylist (`runtime/operator_activity.rs::SUCCESS_DENYLIST`) already
   covers the "tool denylist" half.
+- [x] Workflow event classification (`classify_workflow_event`) — mirrors
+  `planframe.proposed` → `PlanProposal` and `task.failed` → `ToolFailed` into
+  the operator activity feed from `workflow_store::append_workflow_event`.
+  Session lifecycle emission now also uses throttled insert.
+- [x] Retention pruning — `GatewayStore::prune_operator_activity(retention_days)`
+  deletes rows older than `operator_activity.retention_days` (default 90).
+- [x] Security redaction tests — verify summaries never contain AWS keys,
+  bearer tokens, or untruncated long content.
 - [ ] `operator.activity.subscribe` or webhook `operator.activity.push` for mobile.
   **Deferred — no consumer yet.** There is no mobile/push transport in the
   tree; the chat TUI and HTTP SSE already cover live delivery. Build this when


### PR DESCRIPTION
Closes #357.

Phase 4 hardening for the operator activity feed:

- **Wire `classify_workflow_event`** — mirrors `planframe.proposed` → `PlanProposal` and `task.failed` → `ToolFailed` into the feed from `append_workflow_event`
- **Fix session lifecycle throttle gap** — session close events now use `insert_operator_activity_throttled` instead of bypassing the rate limit
- **Retention pruning** — `GatewayStore::prune_operator_activity(retention_days)` + `operator_activity.retention_days` config (default 90)
- **Security redaction tests** — verify summaries never contain AWS keys, bearer tokens, or untruncated long content
- **Design doc update** — Phase 4 checklist reflects shipped items; subscribe/webhook and channel bindings remain deferred

Deferred (no consumer):
- `operator.activity.subscribe` / webhook push — no mobile/push transport in tree
- `operator_channel_bindings` — no Discord/WhatsApp bridge yet