### PR TITLE
feat(session-room): P2 slice 2 — squash runs of Detail plumbing

### DIFF
--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -76,11 +76,12 @@ fn drain_new(
         if page.entries.is_empty() {
             break;
         }
-        for entry in &page.entries {
-            println!("{}", render::render_line(entry));
-            *cursor = Some(entry.event_id.clone());
-            rendered_any = true;
+        // Fold low-altitude plumbing into collapsed rows (page-local).
+        for row in render::coalesce(&page.entries) {
+            println!("{}", render::row_text(&row));
         }
+        *cursor = page.entries.last().map(|e| e.event_id.clone());
+        rendered_any = true;
         if !page.has_more {
             break;
         }

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -138,32 +138,35 @@ fn flush_run<'a>(run: &mut Vec<&'a SessionTimelineEntry>, out: &mut Vec<Rendered
     run.clear();
 }
 
-/// Brief breakdown of a collapsed run: the top event types by count.
+/// Brief breakdown of a collapsed run: the top event types by count. Sorted by
+/// count desc, then name asc for deterministic output.
 fn collapsed_summary(run: &[&SessionTimelineEntry]) -> String {
-    let mut counts: Vec<(&str, usize)> = Vec::new();
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
     for e in run {
-        match counts.iter_mut().find(|(k, _)| *k == e.event_type) {
-            Some((_, c)) => *c += 1,
-            None => counts.push((e.event_type.as_str(), 1)),
-        }
+        *counts.entry(e.event_type.as_str()).or_insert(0) += 1;
     }
-    counts.sort_by(|a, b| b.1.cmp(&a.1));
-    let parts: Vec<String> = counts
+    let mut ordered: Vec<(&str, usize)> = counts.into_iter().collect();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let parts: Vec<String> = ordered
         .iter()
         .take(3)
         .map(|(k, c)| format!("{k}×{c}"))
         .collect();
-    let more = if counts.len() > 3 { ", …" } else { "" };
+    let more = if ordered.len() > 3 { ", …" } else { "" };
     format!("routine events ({}{})", parts.join(", "), more)
 }
 
-/// Non-interactive rendering of a row (the collapsed form shows the count).
-pub fn row_text(row: &RenderedRow) -> String {
+/// Non-interactive rendering of a row. Borrows the existing line for `Line`
+/// (no allocation on the hot path); only the collapsed form allocates.
+pub fn row_text(row: &RenderedRow) -> std::borrow::Cow<'_, str> {
     match row {
-        RenderedRow::Line(s) => s.clone(),
-        RenderedRow::Collapsed { count, summary } => {
-            format!("{} ⟨{} {}⟩", altitude_glyph(Altitude::Detail), count, summary)
-        }
+        RenderedRow::Line(s) => std::borrow::Cow::Borrowed(s),
+        RenderedRow::Collapsed { count, summary } => std::borrow::Cow::Owned(format!(
+            "{} ⟨{} {}⟩",
+            altitude_glyph(Altitude::Detail),
+            count,
+            summary
+        )),
     }
 }
 

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -96,6 +96,77 @@ pub fn render_line(entry: &SessionTimelineEntry) -> String {
     )
 }
 
+/// A rendered timeline row: either a single event line, or a *collapsed* run of
+/// consecutive low-altitude (Detail) plumbing folded into one count row. The
+/// structured form lets the interactive shell expand a collapsed run on demand;
+/// non-interactive consumers render it via [`row_text`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenderedRow {
+    Line(String),
+    Collapsed { count: usize, summary: String },
+}
+
+/// Fold consecutive `Detail` events into a single collapsed row so routine
+/// plumbing (turns, workbench bookkeeping, polls) doesn't flood the view when
+/// the floor is low. A lone Detail event renders normally — collapsing one is
+/// pointless. Higher altitudes always render individually. Coalescing is
+/// page-local; a run split across reads collapses per page.
+pub fn coalesce(entries: &[SessionTimelineEntry]) -> Vec<RenderedRow> {
+    let mut out = Vec::new();
+    let mut run: Vec<&SessionTimelineEntry> = Vec::new();
+    for e in entries {
+        if e.altitude == Altitude::Detail {
+            run.push(e);
+        } else {
+            flush_run(&mut run, &mut out);
+            out.push(RenderedRow::Line(render_line(e)));
+        }
+    }
+    flush_run(&mut run, &mut out);
+    out
+}
+
+fn flush_run<'a>(run: &mut Vec<&'a SessionTimelineEntry>, out: &mut Vec<RenderedRow>) {
+    match run.len() {
+        0 => {}
+        1 => out.push(RenderedRow::Line(render_line(run[0]))),
+        n => out.push(RenderedRow::Collapsed {
+            count: n,
+            summary: collapsed_summary(run),
+        }),
+    }
+    run.clear();
+}
+
+/// Brief breakdown of a collapsed run: the top event types by count.
+fn collapsed_summary(run: &[&SessionTimelineEntry]) -> String {
+    let mut counts: Vec<(&str, usize)> = Vec::new();
+    for e in run {
+        match counts.iter_mut().find(|(k, _)| *k == e.event_type) {
+            Some((_, c)) => *c += 1,
+            None => counts.push((e.event_type.as_str(), 1)),
+        }
+    }
+    counts.sort_by(|a, b| b.1.cmp(&a.1));
+    let parts: Vec<String> = counts
+        .iter()
+        .take(3)
+        .map(|(k, c)| format!("{k}×{c}"))
+        .collect();
+    let more = if counts.len() > 3 { ", …" } else { "" };
+    format!("routine events ({}{})", parts.join(", "), more)
+}
+
+/// Non-interactive rendering of a row (the collapsed form shows the count).
+pub fn row_text(row: &RenderedRow) -> String {
+    match row {
+        RenderedRow::Line(s) => s.clone(),
+        RenderedRow::Collapsed { count, summary } => {
+            format!("{} ⟨{} {}⟩", altitude_glyph(Altitude::Detail), count, summary)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,6 +224,39 @@ mod tests {
             serde_json::json!({ "tool": "edit" }),
         );
         assert!(render_line(&f).contains("🌐 coder·claude-code"));
+    }
+
+    #[test]
+    fn coalesce_folds_detail_runs_but_keeps_higher_altitudes() {
+        let mk = |et: &str, alt: Altitude| {
+            entry(
+                SessionRole::Planner,
+                Principal::agent("planner.default"),
+                et,
+                alt,
+                serde_json::json!({}),
+            )
+        };
+        let entries = vec![
+            mk("turn.start", Altitude::Detail),
+            mk("workbench.created", Altitude::Detail),
+            mk("turn.start", Altitude::Detail),
+            mk("approval.pending", Altitude::Attention), // breaks the run
+            mk("turn.end", Altitude::Detail),            // lone detail ⇒ normal line
+        ];
+        let rows = coalesce(&entries);
+        assert_eq!(rows.len(), 3);
+        match &rows[0] {
+            RenderedRow::Collapsed { count, summary } => {
+                assert_eq!(*count, 3);
+                assert!(summary.contains("turn.start×2"));
+            }
+            other => panic!("expected collapsed run, got {other:?}"),
+        }
+        assert!(matches!(&rows[1], RenderedRow::Line(s) if s.contains("approval requested")));
+        // The trailing lone Detail event is a normal line, not collapsed.
+        assert!(matches!(&rows[2], RenderedRow::Line(_)));
+        assert!(row_text(&rows[0]).contains("⟨3 routine events"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Second **P2** slice (#363/#365), extending the pure render core: fold consecutive low-altitude (`Detail`) plumbing — turns, workbench bookkeeping, polls — into a single collapsed count row, so viewing with a low floor (`--min-altitude detail`) doesn't flood the operator.

### What's here
- **`coalesce(entries) -> Vec<RenderedRow>`** in the render core. Consecutive `Detail` events collapse into `RenderedRow::Collapsed { count, summary }` with a top-event-type breakdown (`turn.start×6, workbench.created×3, …`). Higher altitudes always render individually; a *lone* Detail event stays a normal line (collapsing one is pointless).
- **`RenderedRow`** is structured (Line | Collapsed) so the future interactive shell can **expand** a collapsed run on demand; `row_text` renders the non-interactive form (`· ⟨12 routine events (…)⟩`).
- The `room` viewer renders each page through `coalesce` / `row_text`.

### Note
Coalescing is **page-local** for the streaming CLI (a run split across reads collapses per page) — fine for a tail viewer; the interactive TUI will coalesce over its full buffer.

## Test plan
- [x] `cargo test -p autonoetic cli::room` — 4 pass (incl. `coalesce_folds_detail_runs_but_keeps_higher_altitudes`)
- [x] `cargo build -p autonoetic`

## Next P2 slices
Drill-down into an event's refs · the interactive ratatui shell (scroll, altitude-dial keybind, expand collapsed runs) · conversational gate input.

Tracks #363 · #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)