### PR TITLE
feat(session-room): P2 slice 3 — interactive ratatui shell

### DIFF
--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -956,6 +956,9 @@ pub struct RoomArgs {
     /// Follow the timeline live (tail -f style) until Ctrl+C.
     #[arg(long)]
     pub follow: bool,
+    /// Launch the interactive Session Room shell (scroll, altitude dial, squash).
+    #[arg(long)]
+    pub tui: bool,
     /// Max rows to fetch per read.
     #[arg(long, default_value_t = 200)]
     pub limit: u32,

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -7,6 +7,7 @@
 //! ([`render`]) before any interactive ratatui shell is built on top.
 
 mod render;
+mod tui;
 
 use crate::cli::common::RoomArgs;
 use autonoetic_types::session_timeline::Altitude;
@@ -27,6 +28,11 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
             args.min_altitude
         ),
     };
+
+    // Interactive shell — the Session Room proper.
+    if args.tui {
+        return tui::run(&store, &args.root_session_id, min_altitude);
+    }
 
     // Render the full timeline oldest-first, paging through *all* rows (not just
     // the first `limit`, which would silently truncate long sessions).

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -31,7 +31,7 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
 
     // Interactive shell — the Session Room proper.
     if args.tui {
-        return tui::run(&store, &args.root_session_id, min_altitude);
+        return tui::run(&store, &args.root_session_id, min_altitude, args.limit);
     }
 
     // Render the full timeline oldest-first, paging through *all* rows (not just

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -102,8 +102,17 @@ pub fn render_line(entry: &SessionTimelineEntry) -> String {
 /// non-interactive consumers render it via [`row_text`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RenderedRow {
-    Line(String),
+    /// A single event line, carrying its altitude so consumers can style it.
+    Line { text: String, altitude: Altitude },
     Collapsed { count: usize, summary: String },
+}
+
+/// The altitude a row renders at (collapsed runs are Detail by definition).
+pub fn row_altitude(row: &RenderedRow) -> Altitude {
+    match row {
+        RenderedRow::Line { altitude, .. } => *altitude,
+        RenderedRow::Collapsed { .. } => Altitude::Detail,
+    }
 }
 
 /// Fold consecutive `Detail` events into a single collapsed row so routine
@@ -119,7 +128,10 @@ pub fn coalesce(entries: &[SessionTimelineEntry]) -> Vec<RenderedRow> {
             run.push(e);
         } else {
             flush_run(&mut run, &mut out);
-            out.push(RenderedRow::Line(render_line(e)));
+            out.push(RenderedRow::Line {
+                text: render_line(e),
+                altitude: e.altitude,
+            });
         }
     }
     flush_run(&mut run, &mut out);
@@ -129,7 +141,10 @@ pub fn coalesce(entries: &[SessionTimelineEntry]) -> Vec<RenderedRow> {
 fn flush_run<'a>(run: &mut Vec<&'a SessionTimelineEntry>, out: &mut Vec<RenderedRow>) {
     match run.len() {
         0 => {}
-        1 => out.push(RenderedRow::Line(render_line(run[0]))),
+        1 => out.push(RenderedRow::Line {
+            text: render_line(run[0]),
+            altitude: run[0].altitude,
+        }),
         n => out.push(RenderedRow::Collapsed {
             count: n,
             summary: collapsed_summary(run),
@@ -160,7 +175,7 @@ fn collapsed_summary(run: &[&SessionTimelineEntry]) -> String {
 /// (no allocation on the hot path); only the collapsed form allocates.
 pub fn row_text(row: &RenderedRow) -> std::borrow::Cow<'_, str> {
     match row {
-        RenderedRow::Line(s) => std::borrow::Cow::Borrowed(s),
+        RenderedRow::Line { text, .. } => std::borrow::Cow::Borrowed(text),
         RenderedRow::Collapsed { count, summary } => std::borrow::Cow::Owned(format!(
             "{} ⟨{} {}⟩",
             altitude_glyph(Altitude::Detail),
@@ -256,9 +271,9 @@ mod tests {
             }
             other => panic!("expected collapsed run, got {other:?}"),
         }
-        assert!(matches!(&rows[1], RenderedRow::Line(s) if s.contains("approval requested")));
+        assert!(matches!(&rows[1], RenderedRow::Line { text, .. } if text.contains("approval requested")));
         // The trailing lone Detail event is a normal line, not collapsed.
-        assert!(matches!(&rows[2], RenderedRow::Line(_)));
+        assert!(matches!(&rows[2], RenderedRow::Line { .. }));
         assert!(row_text(&rows[0]).contains("⟨3 routine events"));
     }
 

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -1,0 +1,209 @@
+//! Interactive Session Room shell (#363 P2) — the ratatui renderer.
+//!
+//! A scrollable, live-tailing view of the canonical timeline with an altitude
+//! dial and squash toggle. Greenfield (chat.rs untouched). Read-only for now —
+//! conversational gate *input* is a later slice. Built on the shared render
+//! core, so styling/summaries match the CLI viewer and future channel bridges.
+
+use super::render::{self, RenderedRow};
+use autonoetic_gateway::scheduler::GatewayStore;
+use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::io;
+use std::time::Duration;
+
+/// Restores the terminal on drop, even on early return / panic-unwind.
+struct TerminalRestore;
+impl Drop for TerminalRestore {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+pub fn run(store: &GatewayStore, root_session_id: &str, initial_floor: Altitude) -> anyhow::Result<()> {
+    enable_raw_mode()?;
+    execute!(io::stdout(), EnterAlternateScreen)?;
+    let _restore = TerminalRestore;
+    let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+
+    let mut entries: Vec<SessionTimelineEntry> = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut floor = initial_floor;
+    let mut squash = true;
+    let mut follow = true; // pin to newest
+    let mut selected: usize = 0;
+
+    loop {
+        // Drain new events past the cursor (a floor change clears and refetches).
+        loop {
+            let page = store.list_session_timeline(root_session_id, cursor.as_deref(), 200, Some(floor), None)?;
+            if page.entries.is_empty() {
+                break;
+            }
+            cursor = page.entries.last().map(|e| e.event_id.clone());
+            entries.extend(page.entries);
+            if !page.has_more {
+                break;
+            }
+        }
+
+        let rows: Vec<RenderedRow> = if squash {
+            render::coalesce(&entries)
+        } else {
+            entries
+                .iter()
+                .map(|e| RenderedRow::Line { text: render::render_line(e), altitude: e.altitude })
+                .collect()
+        };
+
+        if follow {
+            selected = rows.len().saturating_sub(1);
+        } else {
+            selected = selected.min(rows.len().saturating_sub(1));
+        }
+
+        terminal.draw(|f| draw(f, root_session_id, floor, squash, follow, &rows, selected))?;
+
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(key) = event::read()? {
+                let ctrl_c = key.code == KeyCode::Char('c')
+                    && key.modifiers.contains(KeyModifiers::CONTROL);
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => break,
+                    _ if ctrl_c => break,
+                    KeyCode::Char('a') => {
+                        // Cycle the altitude floor; refetch from scratch since the
+                        // gateway filters server-side.
+                        floor = cycle_floor(floor);
+                        entries.clear();
+                        cursor = None;
+                    }
+                    KeyCode::Char('s') => squash = !squash,
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        follow = false;
+                        selected = (selected + 1).min(rows.len().saturating_sub(1));
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        follow = false;
+                        selected = selected.saturating_sub(1);
+                    }
+                    KeyCode::Char('g') | KeyCode::Home => {
+                        follow = false;
+                        selected = 0;
+                    }
+                    KeyCode::Char('G') | KeyCode::End => follow = true,
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cycle_floor(floor: Altitude) -> Altitude {
+    match floor {
+        Altitude::Detail => Altitude::Normal,
+        Altitude::Normal => Altitude::Attention,
+        Altitude::Attention => Altitude::Error,
+        Altitude::Error => Altitude::Detail,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_cycles_through_all_levels() {
+        let mut a = Altitude::Detail;
+        let seq: Vec<Altitude> = (0..4)
+            .map(|_| {
+                a = cycle_floor(a);
+                a
+            })
+            .collect();
+        assert_eq!(
+            seq,
+            vec![
+                Altitude::Normal,
+                Altitude::Attention,
+                Altitude::Error,
+                Altitude::Detail
+            ]
+        );
+    }
+}
+
+fn altitude_style(altitude: Altitude) -> Style {
+    match altitude {
+        Altitude::Error => Style::default().fg(Color::Red),
+        Altitude::Attention => Style::default().fg(Color::Yellow),
+        Altitude::Normal => Style::default(),
+        Altitude::Detail => Style::default().fg(Color::DarkGray),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw(
+    f: &mut Frame,
+    root: &str,
+    floor: Altitude,
+    squash: bool,
+    follow: bool,
+    rows: &[RenderedRow],
+    selected: usize,
+) {
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(f.area());
+
+    let header = format!(
+        " Session Room — {root}   floor: {}   squash: {}   {} rows{}",
+        floor.as_str(),
+        if squash { "on" } else { "off" },
+        rows.len(),
+        if follow { "   (following)" } else { "" },
+    );
+    f.render_widget(
+        Paragraph::new(header).style(Style::default().add_modifier(Modifier::BOLD)),
+        chunks[0],
+    );
+
+    let items: Vec<ListItem> = rows
+        .iter()
+        .map(|row| {
+            let style = altitude_style(render::row_altitude(row));
+            ListItem::new(Line::from(Span::styled(render::row_text(row).into_owned(), style)))
+        })
+        .collect();
+
+    let mut state = ListState::default();
+    if !rows.is_empty() {
+        state.select(Some(selected.min(rows.len() - 1)));
+    }
+    f.render_stateful_widget(
+        List::new(items)
+            .block(Block::default().borders(Borders::NONE))
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED)),
+        chunks[1],
+        &mut state,
+    );
+
+    f.render_widget(
+        Paragraph::new(" q quit · j/k scroll · g/G top/bottom · a altitude floor · s squash")
+            .style(Style::default().fg(Color::DarkGray)),
+        chunks[2],
+    );
+}

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -29,10 +29,17 @@ impl Drop for TerminalRestore {
     }
 }
 
-pub fn run(store: &GatewayStore, root_session_id: &str, initial_floor: Altitude) -> anyhow::Result<()> {
+pub fn run(
+    store: &GatewayStore,
+    root_session_id: &str,
+    initial_floor: Altitude,
+    limit: u32,
+) -> anyhow::Result<()> {
     enable_raw_mode()?;
-    execute!(io::stdout(), EnterAlternateScreen)?;
+    // Guard constructed before entering the alternate screen, so raw mode is
+    // restored even if `EnterAlternateScreen` (or anything after) fails.
     let _restore = TerminalRestore;
+    execute!(io::stdout(), EnterAlternateScreen)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
 
     let mut entries: Vec<SessionTimelineEntry> = Vec::new();
@@ -43,18 +50,13 @@ pub fn run(store: &GatewayStore, root_session_id: &str, initial_floor: Altitude)
     let mut selected: usize = 0;
 
     loop {
-        // Drain new events past the cursor (a floor change clears and refetches).
-        loop {
-            let page = store.list_session_timeline(root_session_id, cursor.as_deref(), 200, Some(floor), None)?;
-            if page.entries.is_empty() {
-                break;
-            }
-            cursor = page.entries.last().map(|e| e.event_id.clone());
-            entries.extend(page.entries);
-            if !page.has_more {
-                break;
-            }
+        // Fetch at most one page per tick so a large backlog drains across ticks
+        // without ever blocking input (incl. quit). The 250ms poll paces catch-up.
+        let page = store.list_session_timeline(root_session_id, cursor.as_deref(), limit, Some(floor), None)?;
+        if let Some(last) = page.entries.last() {
+            cursor = Some(last.event_id.clone());
         }
+        entries.extend(page.entries);
 
         let rows: Vec<RenderedRow> = if squash {
             render::coalesce(&entries)
@@ -185,7 +187,8 @@ fn draw(
         .iter()
         .map(|row| {
             let style = altitude_style(render::row_altitude(row));
-            ListItem::new(Line::from(Span::styled(render::row_text(row).into_owned(), style)))
+            // Pass the Cow through — borrows for `Line` rows, allocates only for collapsed.
+            ListItem::new(Line::from(Span::styled(render::row_text(row), style)))
         })
         .collect();
 


### PR DESCRIPTION
## Summary
The **Session Room proper** (#363/#365) — `autonoetic room <root_session_id> --tui` opens a scrollable, live-tailing ratatui view of the canonical timeline. `chat.rs` is **untouched**; this is the greenfield renderer, built on the shared render core from slices 1–2.

### What's here
- **Live tail** — drains new events past the cursor each tick (250ms), auto-follows the newest row.
- **Scroll** — `j/k` / `↑↓`, `g`/`Home` top, `G`/`End` bottom; scrolling up detaches follow, `G` reattaches.
- **Altitude dial** — `a` cycles the floor `detail→normal→attention→error→…`, refetching (the gateway filters server-side).
- **Squash toggle** — `s` folds/unfolds the `Detail` plumbing (reuses slice-2 `coalesce`).
- **Altitude-colored rows** — Error red, Attention yellow, Detail dim — via the shared core (`RenderedRow::Line` now carries its altitude; new `row_altitude` helper). Header shows session / floor / squash / follow; footer shows keybinds.
- **Terminal restored via a Drop guard** (raw mode + alternate screen) even on early return / panic.

Default `room` behavior (line dump / `--follow`) is unchanged; `--tui` opts into the interactive shell.

### Scope
Read-only — **conversational gate input** (resolving approvals/clarifications in-flow) is the next slice, and builds on #361 (merged). Per-run expand of a collapsed group is also deferred; the squash toggle + altitude dial cover the same need globally for now.

## Test plan
- [x] `cargo test -p autonoetic cli::room` — 5 pass (render core + `cycle_floor`)
- [x] `cargo build -p autonoetic`
- [ ] Manual: `autonoetic room <root_session_id> --tui` against a live session (interactive; not automatable here)

Tracks #363 · #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)