### PR TITLE
feat(session-room): P2 slice 4 — drill-down detail pane

### DIFF
--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -115,42 +115,73 @@ pub fn row_altitude(row: &RenderedRow) -> Altitude {
     }
 }
 
+/// Where a rendered row came from in the input slice — lets an interactive
+/// consumer map a selected row back to the underlying event(s) for drill-down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowSource {
+    /// A single event at this index.
+    Single(usize),
+    /// A collapsed run covering `entries[start..start+len]`.
+    Run { start: usize, len: usize },
+}
+
 /// Fold consecutive `Detail` events into a single collapsed row so routine
 /// plumbing (turns, workbench bookkeeping, polls) doesn't flood the view when
 /// the floor is low. A lone Detail event renders normally — collapsing one is
 /// pointless. Higher altitudes always render individually. Coalescing is
 /// page-local; a run split across reads collapses per page.
 pub fn coalesce(entries: &[SessionTimelineEntry]) -> Vec<RenderedRow> {
+    coalesce_indexed(entries).into_iter().map(|(r, _)| r).collect()
+}
+
+/// Like [`coalesce`], but also returns each row's [`RowSource`] for drill-down.
+pub fn coalesce_indexed(entries: &[SessionTimelineEntry]) -> Vec<(RenderedRow, RowSource)> {
     let mut out = Vec::new();
-    let mut run: Vec<&SessionTimelineEntry> = Vec::new();
-    for e in entries {
+    let mut run_start: Option<usize> = None;
+    let mut run_len: usize = 0;
+    for (i, e) in entries.iter().enumerate() {
         if e.altitude == Altitude::Detail {
-            run.push(e);
+            if run_start.is_none() {
+                run_start = Some(i);
+            }
+            run_len += 1;
         } else {
-            flush_run(&mut run, &mut out);
-            out.push(RenderedRow::Line {
-                text: render_line(e),
-                altitude: e.altitude,
-            });
+            flush_run(entries, &mut run_start, &mut run_len, &mut out);
+            out.push((
+                RenderedRow::Line { text: render_line(e), altitude: e.altitude },
+                RowSource::Single(i),
+            ));
         }
     }
-    flush_run(&mut run, &mut out);
+    flush_run(entries, &mut run_start, &mut run_len, &mut out);
     out
 }
 
-fn flush_run<'a>(run: &mut Vec<&'a SessionTimelineEntry>, out: &mut Vec<RenderedRow>) {
-    match run.len() {
+fn flush_run(
+    entries: &[SessionTimelineEntry],
+    run_start: &mut Option<usize>,
+    run_len: &mut usize,
+    out: &mut Vec<(RenderedRow, RowSource)>,
+) {
+    let Some(start) = run_start.take() else { return };
+    let len = std::mem::take(run_len);
+    match len {
         0 => {}
-        1 => out.push(RenderedRow::Line {
-            text: render_line(run[0]),
-            altitude: run[0].altitude,
-        }),
-        n => out.push(RenderedRow::Collapsed {
-            count: n,
-            summary: collapsed_summary(run),
-        }),
+        1 => out.push((
+            RenderedRow::Line {
+                text: render_line(&entries[start]),
+                altitude: entries[start].altitude,
+            },
+            RowSource::Single(start),
+        )),
+        n => {
+            let run: Vec<&SessionTimelineEntry> = entries[start..start + n].iter().collect();
+            out.push((
+                RenderedRow::Collapsed { count: n, summary: collapsed_summary(&run) },
+                RowSource::Run { start, len: n },
+            ));
+        }
     }
-    run.clear();
 }
 
 /// Brief breakdown of a collapsed run: the top event types by count. Sorted by
@@ -169,6 +200,58 @@ fn collapsed_summary(run: &[&SessionTimelineEntry]) -> String {
         .collect();
     let more = if ordered.len() > 3 { ", …" } else { "" };
     format!("routine events ({}{})", parts.join(", "), more)
+}
+
+/// Multi-line detail view of a single event for the drill-down pane: metadata,
+/// refs, and the pretty-printed payload. Pure (no I/O) and channel-neutral.
+pub fn format_detail(entry: &SessionTimelineEntry) -> Vec<String> {
+    let mut lines = vec![
+        format!("event:     {}", entry.event_type),
+        format!("at:        {}", entry.occurred_at),
+        format!("altitude:  {}", entry.altitude.as_str()),
+        format!(
+            "actor:     {} ({})",
+            entry.principal.id,
+            entry.principal.kind.tag()
+        ),
+        format!("seat:      {}", role_label(&entry.role)),
+    ];
+    if let Some(turn) = &entry.turn_id {
+        lines.push(format!("turn:      {turn}"));
+    }
+    lines.push(format!("event_id:  {}", entry.event_id));
+
+    let refs = &entry.refs;
+    let mut ref_parts: Vec<String> = Vec::new();
+    let mut add = |label: &str, v: &Option<String>| {
+        if let Some(s) = v {
+            ref_parts.push(format!("{label}={s}"));
+        }
+    };
+    add("causal", &refs.causal_event_id);
+    add("trace", &refs.execution_trace_id);
+    add("artifact", &refs.artifact_id);
+    add("interaction", &refs.interaction_id);
+    add("approval", &refs.approval_request_id);
+    add("plan", &refs.plan_id);
+    add("workbench", &refs.workbench_id);
+    if !ref_parts.is_empty() {
+        lines.push(format!("refs:      {}", ref_parts.join("  ")));
+    }
+
+    if let Some(payload) = &entry.payload {
+        lines.push(String::new());
+        lines.push("payload:".to_string());
+        // Pretty-print if it parses as JSON; otherwise show raw.
+        match serde_json::from_str::<serde_json::Value>(payload)
+            .ok()
+            .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        {
+            Some(pretty) => lines.extend(pretty.lines().map(|l| format!("  {l}"))),
+            None => lines.push(format!("  {payload}")),
+        }
+    }
+    lines
 }
 
 /// Non-interactive rendering of a row. Borrows the existing line for `Line`
@@ -275,6 +358,42 @@ mod tests {
         // The trailing lone Detail event is a normal line, not collapsed.
         assert!(matches!(&rows[2], RenderedRow::Line { .. }));
         assert!(row_text(&rows[0]).contains("⟨3 routine events"));
+    }
+
+    #[test]
+    fn coalesce_indexed_maps_rows_to_sources() {
+        let mk = |et: &str, alt: Altitude| {
+            entry(SessionRole::Planner, Principal::agent("planner.default"), et, alt, serde_json::json!({}))
+        };
+        let entries = vec![
+            mk("turn.start", Altitude::Detail),   // 0 ┐ run
+            mk("turn.end", Altitude::Detail),     // 1 ┘
+            mk("approval.pending", Altitude::Attention), // 2 single
+            mk("turn.start", Altitude::Detail),   // 3 lone detail → single
+        ];
+        let rows = coalesce_indexed(&entries);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].1, RowSource::Run { start: 0, len: 2 });
+        assert_eq!(rows[1].1, RowSource::Single(2));
+        assert_eq!(rows[2].1, RowSource::Single(3));
+    }
+
+    #[test]
+    fn format_detail_includes_meta_refs_and_pretty_payload() {
+        let mut e = entry(
+            SessionRole::Operator,
+            Principal::human("operator"),
+            "approval.rejected",
+            Altitude::Attention,
+            serde_json::json!({ "request_id": "apr-9", "decided_by": "operator" }),
+        );
+        e.refs = TimelineRefs { approval_request_id: Some("apr-9".into()), ..Default::default() };
+        let detail = format_detail(&e).join("\n");
+        assert!(detail.contains("event:     approval.rejected"));
+        assert!(detail.contains("actor:     operator (human)"));
+        assert!(detail.contains("seat:      operator"));
+        assert!(detail.contains("approval=apr-9"));
+        assert!(detail.contains("\"request_id\": \"apr-9\""));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -5,7 +5,7 @@
 //! conversational gate *input* is a later slice. Built on the shared render
 //! core, so styling/summaries match the CLI viewer and future channel bridges.
 
-use super::render::{self, RenderedRow};
+use super::render::{self, RenderedRow, RowSource};
 use autonoetic_gateway::scheduler::GatewayStore;
 use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry};
 use crossterm::{
@@ -48,6 +48,7 @@ pub fn run(
     let mut squash = true;
     let mut follow = true; // pin to newest
     let mut selected: usize = 0;
+    let mut detail: Option<Vec<String>> = None; // drill-down pane content
 
     loop {
         // Fetch at most one page per tick so a large backlog drains across ticks
@@ -58,14 +59,22 @@ pub fn run(
         }
         entries.extend(page.entries);
 
-        let rows: Vec<RenderedRow> = if squash {
-            render::coalesce(&entries)
+        // Rows + their source mapping (lets Enter drill into the underlying event).
+        let indexed: Vec<(RenderedRow, RowSource)> = if squash {
+            render::coalesce_indexed(&entries)
         } else {
             entries
                 .iter()
-                .map(|e| RenderedRow::Line { text: render::render_line(e), altitude: e.altitude })
+                .enumerate()
+                .map(|(i, e)| {
+                    (
+                        RenderedRow::Line { text: render::render_line(e), altitude: e.altitude },
+                        RowSource::Single(i),
+                    )
+                })
                 .collect()
         };
+        let rows: Vec<RenderedRow> = indexed.iter().map(|(r, _)| r.clone()).collect();
 
         if follow {
             selected = rows.len().saturating_sub(1);
@@ -73,42 +82,87 @@ pub fn run(
             selected = selected.min(rows.len().saturating_sub(1));
         }
 
-        terminal.draw(|f| draw(f, root_session_id, floor, squash, follow, &rows, selected))?;
+        terminal.draw(|f| draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref()))?;
 
         if event::poll(Duration::from_millis(250))? {
             if let Event::Key(key) = event::read()? {
                 let ctrl_c = key.code == KeyCode::Char('c')
                     && key.modifiers.contains(KeyModifiers::CONTROL);
                 match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => break,
+                    KeyCode::Char('q') => break,
                     _ if ctrl_c => break,
+                    // Esc closes the detail pane if open, otherwise quits.
+                    KeyCode::Esc => {
+                        if detail.is_some() {
+                            detail = None;
+                        } else {
+                            break;
+                        }
+                    }
+                    // Enter toggles drill-down on the selected row.
+                    KeyCode::Enter => {
+                        detail = if detail.is_some() {
+                            None
+                        } else {
+                            indexed.get(selected).map(|(_, src)| detail_for(&entries, *src))
+                        };
+                    }
                     KeyCode::Char('a') => {
                         // Cycle the altitude floor; refetch from scratch since the
                         // gateway filters server-side.
                         floor = cycle_floor(floor);
                         entries.clear();
                         cursor = None;
+                        detail = None;
                     }
                     KeyCode::Char('s') => squash = !squash,
                     KeyCode::Down | KeyCode::Char('j') => {
                         follow = false;
+                        detail = None;
                         selected = (selected + 1).min(rows.len().saturating_sub(1));
                     }
                     KeyCode::Up | KeyCode::Char('k') => {
                         follow = false;
+                        detail = None;
                         selected = selected.saturating_sub(1);
                     }
                     KeyCode::Char('g') | KeyCode::Home => {
                         follow = false;
+                        detail = None;
                         selected = 0;
                     }
-                    KeyCode::Char('G') | KeyCode::End => follow = true,
+                    KeyCode::Char('G') | KeyCode::End => {
+                        follow = true;
+                        detail = None;
+                    }
                     _ => {}
                 }
             }
         }
     }
     Ok(())
+}
+
+/// Build the drill-down detail for a selected row's source. A single event
+/// shows its full metadata/payload; a collapsed run shows what it folds.
+fn detail_for(entries: &[SessionTimelineEntry], src: RowSource) -> Vec<String> {
+    match src {
+        RowSource::Single(i) => entries
+            .get(i)
+            .map(render::format_detail)
+            .unwrap_or_default(),
+        RowSource::Run { start, len } => {
+            let mut lines = vec![
+                format!("collapsed run — {len} routine events"),
+                "(press 's' to unsquash and inspect individually)".to_string(),
+                String::new(),
+            ];
+            for e in entries.iter().skip(start).take(len) {
+                lines.push(format!("  · {}", render::render_line(e)));
+            }
+            lines
+        }
+    }
 }
 
 fn cycle_floor(floor: Altitude) -> Altitude {
@@ -163,6 +217,7 @@ fn draw(
     follow: bool,
     rows: &[RenderedRow],
     selected: usize,
+    detail: Option<&[String]>,
 ) {
     let chunks = Layout::vertical([
         Constraint::Length(1),
@@ -182,6 +237,21 @@ fn draw(
         Paragraph::new(header).style(Style::default().add_modifier(Modifier::BOLD)),
         chunks[0],
     );
+
+    if let Some(lines) = detail {
+        // Drill-down pane replaces the list while open.
+        let text: Vec<Line> = lines.iter().map(|l| Line::from(l.as_str())).collect();
+        f.render_widget(
+            Paragraph::new(text).block(Block::default().borders(Borders::ALL).title(" event detail ")),
+            chunks[1],
+        );
+        f.render_widget(
+            Paragraph::new(" Esc/Enter close detail · q quit")
+                .style(Style::default().fg(Color::DarkGray)),
+            chunks[2],
+        );
+        return;
+    }
 
     let items: Vec<ListItem> = rows
         .iter()
@@ -205,7 +275,7 @@ fn draw(
     );
 
     f.render_widget(
-        Paragraph::new(" q quit · j/k scroll · g/G top/bottom · a altitude floor · s squash")
+        Paragraph::new(" q quit · j/k scroll · g/G top/bottom · a altitude · s squash · ⏎ detail")
             .style(Style::default().fg(Color::DarkGray)),
         chunks[2],
     );


### PR DESCRIPTION
## Summary
Fourth **P2** slice (#363/#365): select any timeline row in the interactive shell and press **⏎** to open a detail pane — full event metadata (type, time, altitude, actor + kind, seat, turn, event_id), refs, and the pretty-printed payload. ⏎/Esc closes the pane; Esc on the list still quits. Read-only.

### What's here
- **`coalesce_indexed`** in the render core returns each row's **`RowSource`** (`Single(idx)` | `Run{start,len}`) so a selected row maps back to the underlying event(s). `coalesce` is now a thin wrapper over it.
- **`format_detail(entry)`** — the pure, channel-neutral detail formatter (metadata + refs + pretty JSON payload), reusable by future channel bridges.
- A **collapsed run's** detail lists the folded events with a hint to press `s` to unsquash and inspect individually.

### Scope
Read-only. Deep ref-following (fetching the linked approval/plan/workbench *object*, or the causal event / execution-trace content) is a natural follow-up; this slice shows the event's own metadata + payload + ref ids. Conversational gate **input** remains a separate write slice (gated on the §B.4 motivation-enforcement go).

## Test plan
- [x] `cargo test -p autonoetic cli::room` — 7 pass (incl. `coalesce_indexed_maps_rows_to_sources`, `format_detail_includes_meta_refs_and_pretty_payload`)
- [x] `cargo build -p autonoetic`
- [ ] Manual: `--tui`, select a row, ⏎ (interactive; not automatable here)

Tracks #363 · #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)