### PR TITLE
feat(#395): §O motivation enforcement — block unmotivated gate decisions

### DIFF
--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -1049,6 +1049,77 @@ fn unblock_task_on_approval(
     }
 }
 
+/// Whether an approval's action introduces an external effect or is hard to
+/// undo — used by the §O classifier to make a principal's *approval* of such an
+/// action BLOCKING (must carry a reason). Non-exhaustive: unknown/new actions
+/// are treated as local (DEFERRED), failing toward less friction.
+fn action_is_external_or_irreversible(action: &ScheduledAction) -> bool {
+    use ScheduledAction::*;
+    matches!(
+        action,
+        AgentInstall { .. }
+            | CredentialPrompt { .. }
+            | CredentialRequest { .. }
+            | WebFetch { .. }
+            | WebCall { .. }
+            | ProfileShare { .. }
+            | LayerMount { .. }
+            | RevisionPromote { .. }
+    )
+}
+
+/// §O motivation tier for a gate decision. `true` = BLOCKING (a motivation is
+/// required). A rejection/abort by a principal always blocks (the symmetric
+/// mirror of `Ri-0.3`); a principal's approval blocks only when the action is
+/// elevated-authority or external/irreversible. Mechanical resolutions (no
+/// principal — `gateway`/`system`/`emergency_stop:…`) never block. Reversible
+/// operator-level approvals are DEFERRED (not enforced here yet — "block now,
+/// refine later").
+fn decision_is_blocking(
+    request: &ApprovalRequest,
+    decided_by: &str,
+    status: &ApprovalStatus,
+) -> bool {
+    if autonoetic_types::principal::decider_principal_kind(decided_by).is_none() {
+        return false;
+    }
+    match status {
+        ApprovalStatus::Rejected | ApprovalStatus::Cancelled => true,
+        ApprovalStatus::Approved => {
+            request.approval_level != ApprovalLevel::Operator
+                || action_is_external_or_irreversible(&request.action)
+        }
+    }
+}
+
+/// Enforce the §O decider obligation: refuse a BLOCKING-tier decision with no
+/// motivation. Presence-only check (never judges the reason's quality —
+/// Lawful Executor). Disabled via `decider_obligations.enabled = false`.
+fn enforce_decider_motivation(
+    config: &GatewayConfig,
+    request: &ApprovalRequest,
+    decided_by: &str,
+    status: &ApprovalStatus,
+    reason: Option<&str>,
+) -> anyhow::Result<()> {
+    if !config.decider_obligations.enabled {
+        return Ok(());
+    }
+    if decision_is_blocking(request, decided_by, status) {
+        let has_reason = reason.map(|r| !r.trim().is_empty()).unwrap_or(false);
+        if !has_reason {
+            anyhow::bail!(
+                "§O decider obligation: a {} of approval '{}' (level {}) must record a \
+                 motivation. Provide a non-empty reason and retry.",
+                status.as_str(),
+                request.request_id,
+                request.approval_level.to_config()
+            );
+        }
+    }
+    Ok(())
+}
+
 fn decide_request(
     config: &GatewayConfig,
     gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
@@ -1095,6 +1166,11 @@ fn decide_request_with_options(
             request.decided_by.as_deref().unwrap_or("unknown")
         );
     }
+
+    // §O symmetric obligation (#359 / #395): a principal decider owes a
+    // motivation for a BLOCKING-tier decision (reject/abort, or approval of an
+    // elevated-authority / external-irreversible action). Checked before commit.
+    enforce_decider_motivation(config, &request, decided_by, &status, reason.as_deref())?;
 
     let decision = ApprovalDecision {
         request_id: request.request_id,
@@ -1314,6 +1390,76 @@ mod tests {
         let loaded = super::load_approval_requests(&cfg, Some(&store)).unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].request_id, "apr-test1234");
+    }
+
+    #[test]
+    fn decider_obligation_blocks_unmotivated_blocking_decisions() {
+        use autonoetic_types::background::ApprovalStatus;
+
+        let mk = |level: ApprovalLevel, action: ScheduledAction| ApprovalRequest {
+            request_id: "apr".to_string(),
+            agent_id: "coder.default".to_string(),
+            session_id: "s".to_string(),
+            action,
+            created_at: "2020-01-01T00:00:00Z".to_string(),
+            reason: None,
+            evidence_ref: None,
+            workflow_id: None,
+            task_id: None,
+            root_session_id: None,
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            decision_reason: None,
+            approval_level: level,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+            code_excerpts: None,
+            risk_summary: None,
+        };
+        let sandbox = || ScheduledAction::SandboxExec {
+            command: "x".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        };
+        let install = || ScheduledAction::AgentInstall {
+            agent_id: "a".to_string(),
+            summary: "s".to_string(),
+            requested_by_agent_id: "r".to_string(),
+            install_fingerprint: "fp".to_string(),
+            payload: None,
+        };
+        let cfg = GatewayConfig::default(); // decider_obligations.enabled = true
+        let local = mk(ApprovalLevel::Operator, sandbox());
+
+        // Operator rejection without a reason → blocked (mirror of Ri-0.3).
+        assert!(super::enforce_decider_motivation(&cfg, &local, "operator", &ApprovalStatus::Rejected, None).is_err());
+        // …with a reason → allowed.
+        assert!(super::enforce_decider_motivation(&cfg, &local, "operator", &ApprovalStatus::Rejected, Some("out of scope")).is_ok());
+        // Whitespace-only reason doesn't count.
+        assert!(super::enforce_decider_motivation(&cfg, &local, "operator", &ApprovalStatus::Rejected, Some("   ")).is_err());
+        // Approving a reversible, operator-level action without a reason → allowed (DEFERRED).
+        assert!(super::enforce_decider_motivation(&cfg, &local, "operator", &ApprovalStatus::Approved, None).is_ok());
+        // Mechanical decider (no principal) is exempt even on rejection.
+        assert!(super::enforce_decider_motivation(&cfg, &local, "gateway", &ApprovalStatus::Rejected, None).is_ok());
+        assert!(super::enforce_decider_motivation(&cfg, &local, "emergency_stop:estop-1", &ApprovalStatus::Cancelled, None).is_ok());
+        // Approving an external/irreversible action without a reason → blocked.
+        let ext = mk(ApprovalLevel::Operator, install());
+        assert!(super::enforce_decider_motivation(&cfg, &ext, "operator", &ApprovalStatus::Approved, None).is_err());
+        // Approving an elevated-authority gate without a reason → blocked.
+        let elevated = mk(ApprovalLevel::Admin, sandbox());
+        assert!(super::enforce_decider_motivation(&cfg, &elevated, "operator", &ApprovalStatus::Approved, None).is_err());
+
+        // Disabled config → no enforcement at all.
+        let cfg_off = GatewayConfig {
+            decider_obligations: autonoetic_types::config::DeciderObligationsConfig { enabled: false },
+            ..Default::default()
+        };
+        assert!(super::enforce_decider_motivation(&cfg_off, &local, "operator", &ApprovalStatus::Rejected, None).is_ok());
     }
 
     #[test]

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -1062,6 +1062,7 @@ fn action_is_external_or_irreversible(action: &ScheduledAction) -> bool {
             | CredentialRequest { .. }
             | WebFetch { .. }
             | WebCall { .. }
+            | WebSearch { .. }
             | ProfileShare { .. }
             | LayerMount { .. }
             | RevisionPromote { .. }
@@ -1109,11 +1110,11 @@ fn enforce_decider_motivation(
         let has_reason = reason.map(|r| !r.trim().is_empty()).unwrap_or(false);
         if !has_reason {
             anyhow::bail!(
-                "§O decider obligation: a {} of approval '{}' (level {}) must record a \
+                "§O decider obligation: recording approval '{}' (level {}) as '{}' requires a \
                  motivation. Provide a non-empty reason and retry.",
-                status.as_str(),
                 request.request_id,
-                request.approval_level.to_config()
+                request.approval_level.to_config(),
+                status.as_str()
             );
         }
     }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1097,6 +1097,10 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub operator_activity: OperatorActivityConfig,
 
+    /// Symmetric decider-obligation enforcement (#359 §O / #395).
+    #[serde(default)]
+    pub decider_obligations: DeciderObligationsConfig,
+
     /// Approval level / escalation settings.
     #[serde(default)]
     pub approval_levels: ApprovalLevelConfig,
@@ -1512,6 +1516,31 @@ impl Default for ChatConfig {
             inline_approvals: default_chat_inline_approvals(),
         }
     }
+}
+
+/// Symmetric decider obligations (#359 §O / #395). When enabled, the gateway
+/// refuses a BLOCKING-tier gate decision that carries no motivation — a
+/// rejection, or a principal's approval of an elevated-authority or
+/// external/irreversible action. Mechanical resolutions (no principal) and
+/// reversible operator-level approvals are exempt. The gateway checks only the
+/// *presence* of a reason, never its quality (Lawful Executor).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeciderObligationsConfig {
+    /// Require a motivation for BLOCKING-tier decisions. Default: true.
+    #[serde(default = "default_decider_obligations_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for DeciderObligationsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_decider_obligations_enabled(),
+        }
+    }
+}
+
+fn default_decider_obligations_enabled() -> bool {
+    true
 }
 
 /// Configuration for the operator activity feed (Phase 4 hardening).
@@ -2596,6 +2625,7 @@ impl Default for GatewayConfig {
             llm_routing: None,
             chat: ChatConfig::default(),
             operator_activity: OperatorActivityConfig::default(),
+            decider_obligations: DeciderObligationsConfig::default(),
             approval_levels: ApprovalLevelConfig::default(),
             context_compression: ContextCompressionConfig::default(),
             signal_delivery_timeout_secs: default_signal_delivery_timeout_secs(),

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -200,8 +200,9 @@ operator_activity:
 # ── Decider Obligations (symmetric obligations, #359 §O) ──────────────
 # When enabled, the gateway refuses a BLOCKING-tier gate decision with no
 # motivation: a principal's rejection/abort, or approval of an elevated-authority
-# or external/irreversible action. Mirrors the agent's Ri-0.3 duty. The gateway
-# checks only that a reason is present, never its quality. Default: enabled.
+# (any level above operator — admin or agent:<id>) or external/irreversible
+# action. Mirrors the agent's Ri-0.3 duty. The gateway checks only that a reason
+# is present, never its quality. Default: enabled.
 decider_obligations:
   enabled: true
 

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -197,6 +197,14 @@ operator_activity:
   # retention_days: maximum age (days) of operator activity rows before pruning. Default: 90.
   retention_days: 90
 
+# ── Decider Obligations (symmetric obligations, #359 §O) ──────────────
+# When enabled, the gateway refuses a BLOCKING-tier gate decision with no
+# motivation: a principal's rejection/abort, or approval of an elevated-authority
+# or external/irreversible action. Mirrors the agent's Ri-0.3 duty. The gateway
+# checks only that a reason is present, never its quality. Default: enabled.
+decider_obligations:
+  enabled: true
+
 # ── Approval Levels ───────────────────────────────────────────────────
 # Escalation: require higher authority for sensitive actions.
 # Levels: operator (default) | admin | agent:<agent_id>

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -742,7 +742,7 @@ operator_activity:
 
 Symmetric-obligation enforcement (#359 §O). When enabled, the gateway refuses a **BLOCKING-tier** gate decision that carries no motivation — mirroring how an agent owes a reason for every rejection (`Ri-0.3`). The gateway checks only that a reason is *present*, never its quality (Lawful Executor).
 
-A decision is BLOCKING when made by a *principal* (operator / agent — mechanical `gateway`/`system`/`emergency_stop:…` resolutions are exempt) **and** it is a rejection/abort, **or** an approval of an elevated-authority (`admin`+) or external/irreversible action. Approvals of reversible operator-level actions are DEFERRED (not enforced).
+A decision is BLOCKING when made by a *principal* (operator / agent — mechanical `gateway`/`system`/`emergency_stop:…` resolutions are exempt) **and** it is a rejection/abort, **or** an approval of an **elevated-authority** (any level above `operator` — i.e. `admin` or `agent:<id>`) or **external/irreversible** action (install, credential, web fetch/call/search, profile-share, layer-mount, revision-promote). Approvals of reversible operator-level actions are DEFERRED (not enforced).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -738,6 +738,25 @@ operator_activity:
 
 ---
 
+## Decider Obligations
+
+Symmetric-obligation enforcement (#359 §O). When enabled, the gateway refuses a **BLOCKING-tier** gate decision that carries no motivation — mirroring how an agent owes a reason for every rejection (`Ri-0.3`). The gateway checks only that a reason is *present*, never its quality (Lawful Executor).
+
+A decision is BLOCKING when made by a *principal* (operator / agent — mechanical `gateway`/`system`/`emergency_stop:…` resolutions are exempt) **and** it is a rejection/abort, **or** an approval of an elevated-authority (`admin`+) or external/irreversible action. Approvals of reversible operator-level actions are DEFERRED (not enforced).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `decider_obligations.enabled` | bool | `true` | Require a motivation for BLOCKING-tier decisions. `false` disables enforcement (decisions may be recorded without a reason). |
+
+Example:
+
+```yaml
+decider_obligations:
+  enabled: true
+```
+
+---
+
 ## Cognitive Capsules
 
 Controls export/import of portable agent snapshots. A Cognitive Capsule pins a specific `AgentRevisionRecord` together with its `runtime.lock`, layer references (or embedded layer content in hermetic mode), and optional memory / checkpoint snapshots. See [`docs/cognitive-capsule.md`](cognitive-capsule.md).


### PR DESCRIPTION
## Summary
Enacts the **symmetric decider obligation** (#359 §O): the gateway now **refuses a BLOCKING-tier gate decision that carries no motivation**. Today an agent owes a reason for every rejection (`Ri-0.3`); this makes a human/agent *decider* owe the same — closing the asymmetry. Per your go-ahead ("we can block unmotivated decisions").

### Classifier (§B.4)
At the common decision chokepoint (`decide_request_with_options`), a decision is **BLOCKING** when made by a *principal* decider **and**:
- it's a **reject/abort** (the exact mirror of `Ri-0.3`), **or**
- it **approves** an **elevated-authority** (`admin`+) or **external/irreversible** action (install, credential, web, profile-share, layer-mount, revision-promote).

Exempt: **mechanical resolutions** (`gateway` / `system` / `emergency_stop:…` — no principal, no §O obligation) and **reversible operator-level approvals** (DEFERRED — "block now, refine later").

- **Presence-only** check — the gateway never judges the reason's *quality* (Lawful Executor).
- Config `decider_obligations.enabled` (default **true**); set `false` to opt out.
- Recording of the decision + decider kind already lands via #361; this PR adds the *refusal*.

### Ordering note (important)
This enacts **enforcement ahead of the constitution clause**, per your "block now, sign after." The §O constitution text (`O-1a..d`, already drafted in `principal-model-and-symmetric-obligations.md` §B.4) will be prepared as a **new, unsigned constitution version** for the configured authority to recompute + sign — **the agent never signs the lock**. The mechanism is here; the formal law is the follow-up you ratify.

## Test plan
- [x] `cargo test -p autonoetic-gateway --lib scheduler::approval::tests::decider_obligation_blocks_unmotivated_blocking_decisions` — covers reject (blocked) / reject-with-reason (ok) / whitespace-only (blocked) / reversible-approve (ok) / mechanical-exempt / external-approve (blocked) / elevated-approve (blocked) / disabled-config (ok)
- [x] `cargo test -p autonoetic-gateway --lib` — **1129 passed / 29 failed**, the 29 identical pre-existing failures; **zero new regressions** (legacy CLI uses `decided_by="cli"` ⇒ exempt)
- [x] `cargo build` (workspace)

## Follow-ups
- Prepare the §O constitution version (unsigned) + enforcement_register mapping → you sign.
- Room UX: a BLOCKING reject with empty motivation surfaces the §O error in the status line (retry with a reason); §3.5 labeled choices would make it one-keystroke.
- DEFERRED-debt tracking (the "refine later" half).

Tracks #395 · #359.

⚠️ Heads-up unrelated to this PR: `tests/knowledge_revision_provenance_integration.rs` currently fails to **compile** on `main` (missing `use autonoetic_types::agent_revision::SessionAgentBinding;`) — pre-existing, not touched here, but it breaks full `cargo test` for the gateway crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)