### PR TITLE
feat(session-room): P3.a — session.timeline.list RPC + SSE stream (#391)

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -965,16 +965,30 @@ impl JsonRpcRouter {
                         );
                     }
                 };
-                let min_altitude = params
-                    .min_altitude
-                    .as_deref()
-                    .and_then(autonoetic_types::session_timeline::Altitude::parse_str);
+                // Per the type contract: omitted floor ⇒ Normal; an invalid floor
+                // is an error, not a silent "no filter".
+                let min_altitude = match params.min_altitude.as_deref() {
+                    None => autonoetic_types::session_timeline::Altitude::Normal,
+                    Some(s) => match autonoetic_types::session_timeline::Altitude::parse_str(s) {
+                        Some(a) => a,
+                        None => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32602,
+                                format!(
+                                    "invalid min_altitude '{}': expected detail | normal | attention | error",
+                                    s
+                                ),
+                            );
+                        }
+                    },
+                };
                 let limit = params.limit.clamp(1, 500);
                 match store.list_session_timeline(
                     &params.root_session_id,
                     params.after_event_id.as_deref(),
                     limit,
-                    min_altitude,
+                    Some(min_altitude),
                     params.principal_id.as_deref(),
                 ) {
                     Ok(result) => JsonRpcResponse::success(

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -934,6 +934,61 @@ impl JsonRpcRouter {
                 }
             }
 
+            "session.timeline.list" => {
+                // Canonical Session Room timeline over the gateway API (#391) so
+                // channels are clients, not direct store readers.
+                let params: autonoetic_types::session_timeline::SessionTimelineListParams =
+                    match serde_json::from_value(req.params) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32602,
+                                format!("Invalid params for session.timeline.list: {}", e),
+                            );
+                        }
+                    };
+                if params.root_session_id.trim().is_empty() {
+                    return JsonRpcResponse::error(
+                        req.id,
+                        -32602,
+                        "root_session_id is required".to_string(),
+                    );
+                }
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                let min_altitude = params
+                    .min_altitude
+                    .as_deref()
+                    .and_then(autonoetic_types::session_timeline::Altitude::parse_str);
+                let limit = params.limit.clamp(1, 500);
+                match store.list_session_timeline(
+                    &params.root_session_id,
+                    params.after_event_id.as_deref(),
+                    limit,
+                    min_altitude,
+                    params.principal_id.as_deref(),
+                ) {
+                    Ok(result) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("session.timeline.list failed: {}", e),
+                    ),
+                }
+            }
+
             "session.approval_resolved" => {
                 #[derive(Deserialize)]
                 struct ApprovalResolvedParams {

--- a/autonoetic-gateway/src/server/http.rs
+++ b/autonoetic-gateway/src/server/http.rs
@@ -293,6 +293,19 @@ struct OperatorActivityStreamQuery {
     after: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct SessionTimelineStreamQuery {
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    interval_ms: Option<u64>,
+    #[serde(default)]
+    after: Option<String>,
+    /// Altitude floor: detail | normal | attention | error. Default: normal.
+    #[serde(default)]
+    min_altitude: Option<String>,
+}
+
 /// Create the HTTP router for content API
 pub fn create_router(state: HttpState) -> Router {
     Router::new()
@@ -304,6 +317,10 @@ pub fn create_router(state: HttpState) -> Router {
         .route(
             "/api/operator/activity/stream/{root_session_id}",
             get(handle_operator_activity_stream_sse),
+        )
+        .route(
+            "/api/session/timeline/stream/{root_session_id}",
+            get(handle_session_timeline_stream_sse),
         )
         .route("/api/content/write", post(handle_write))
         .route(
@@ -505,6 +522,107 @@ async fn handle_operator_activity_stream_sse(
             Some((
                 Ok(Event::default()
                     .event("operator.activity")
+                    .data(batch.to_string())),
+                next_cursor,
+            ))
+        }
+    });
+
+    Ok(
+        Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15))),
+    )
+}
+
+async fn dispatch_session_timeline_list(
+    router: &JsonRpcRouter,
+    root_session_id: &str,
+    after_event_id: Option<&str>,
+    min_altitude: &str,
+    secret: &str,
+) -> JsonRpcResponse {
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: format!("http-tl-{}", uuid::Uuid::new_v4()),
+        method: "session.timeline.list".to_string(),
+        params: serde_json::json!({
+            "root_session_id": root_session_id,
+            "after_event_id": after_event_id,
+            "limit": 100,
+            "min_altitude": min_altitude,
+        }),
+        auth_token: Some(secret.to_string()),
+    };
+    router.dispatch(req).await
+}
+
+/// GET /api/session/timeline/stream/{root_session_id} — SSE stream of the
+/// canonical Session Room timeline (#391). Cursor-bootstrap then tail; the
+/// gateway owns the data, channels render it.
+async fn handle_session_timeline_stream_sse(
+    State(state): State<Arc<HttpState>>,
+    headers: HeaderMap,
+    Path(root_session_id): Path<String>,
+    Query(q): Query<SessionTimelineStreamQuery>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ErrorResponse> {
+    validate_bearer_or_query(&headers, q.token.as_deref(), &state.shared_secret)?;
+    validate_session_id(&root_session_id)?;
+
+    let Some(router) = state.router.clone() else {
+        return Err(ErrorResponse {
+            error: "HTTP ingress router not configured".to_string(),
+            code: 503,
+        });
+    };
+
+    let interval_ms = q.interval_ms.unwrap_or(500).clamp(100, 10_000);
+    let min_altitude = q.min_altitude.unwrap_or_else(|| "normal".to_string());
+    let secret = state.shared_secret.clone();
+
+    let stream = stream::unfold(q.after, move |cursor_state| {
+        let router = router.clone();
+        let root_session_id = root_session_id.clone();
+        let min_altitude = min_altitude.clone();
+        let secret = secret.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+            let resp = dispatch_session_timeline_list(
+                router.as_ref(),
+                &root_session_id,
+                cursor_state.as_deref(),
+                &min_altitude,
+                &secret,
+            )
+            .await;
+            if resp.error.is_some() {
+                let json = serde_json::to_string(&resp).unwrap_or_else(|_| "{}".to_string());
+                return Some((
+                    Ok(Event::default().event("session.timeline.error").data(json)),
+                    cursor_state,
+                ));
+            }
+            let entries = resp
+                .result
+                .as_ref()
+                .and_then(|v| v.get("entries"))
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let next_cursor = entries
+                .last()
+                .and_then(|e| e.get("event_id"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .or(cursor_state);
+            if entries.is_empty() {
+                return Some((
+                    Ok(Event::default().event("session.timeline.heartbeat").data("{}")),
+                    next_cursor,
+                ));
+            }
+            let batch = serde_json::json!({ "entries": entries });
+            Some((
+                Ok(Event::default()
+                    .event("session.timeline")
                     .data(batch.to_string())),
                 next_cursor,
             ))

--- a/autonoetic-gateway/src/server/http.rs
+++ b/autonoetic-gateway/src/server/http.rs
@@ -576,6 +576,17 @@ async fn handle_session_timeline_stream_sse(
 
     let interval_ms = q.interval_ms.unwrap_or(500).clamp(100, 10_000);
     let min_altitude = q.min_altitude.unwrap_or_else(|| "normal".to_string());
+    // Validate the floor up front so an invalid value is a 400, not a silently
+    // unfiltered stream.
+    if autonoetic_types::session_timeline::Altitude::parse_str(&min_altitude).is_none() {
+        return Err(ErrorResponse {
+            error: format!(
+                "invalid min_altitude '{}': expected detail | normal | attention | error",
+                min_altitude
+            ),
+            code: 400,
+        });
+    }
     let secret = state.shared_secret.clone();
 
     let stream = stream::unfold(q.after, move |cursor_state| {

--- a/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
+++ b/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
@@ -41,7 +41,12 @@ fn make_jsonrpc(method: &str, params: serde_json::Value) -> JsonRpcRequest {
     }
 }
 
-fn timeline_event(root: &str, event_type: &str, altitude: &str) -> LiveDigestEventRecord {
+fn timeline_event(
+    root: &str,
+    event_type: &str,
+    altitude: &str,
+    created_at: &str,
+) -> LiveDigestEventRecord {
     LiveDigestEventRecord {
         event_id: format!("ev-{}", uuid::Uuid::new_v4()),
         root_session_id: root.to_string(),
@@ -51,7 +56,8 @@ fn timeline_event(root: &str, event_type: &str, altitude: &str) -> LiveDigestEve
         source_node_id: "gateway".to_string(),
         event_type: event_type.to_string(),
         payload: Some(serde_json::json!({ "k": "v" }).to_string()),
-        created_at: chrono::Utc::now().to_rfc3339(),
+        // Deterministic timestamps so ordering never falls back to random UUIDs.
+        created_at: created_at.to_string(),
         principal_kind: Some("autonoetic_agent".to_string()),
         principal_id: Some("planner.default".to_string()),
         role: Some("planner".to_string()),
@@ -66,24 +72,35 @@ async fn session_timeline_list_returns_seeded_events_above_floor() {
     // Distinct root keeps this test isolated from others sharing the store.
     let root = "root-tl-floor";
     env.store
-        .create_live_digest_event(&timeline_event(root, "approval.pending", "attention"))
+        .create_live_digest_event(&timeline_event(
+            root,
+            "approval.pending",
+            "attention",
+            "2026-06-01T10:00:00+00:00",
+        ))
         .unwrap();
     env.store
-        .create_live_digest_event(&timeline_event(root, "turn.start", "detail"))
+        .create_live_digest_event(&timeline_event(
+            root,
+            "turn.start",
+            "detail",
+            "2026-06-01T10:00:01+00:00",
+        ))
         .unwrap();
 
+    // Omit min_altitude → defaults to `normal` (the type contract).
     let resp = env
         .router
         .dispatch(make_jsonrpc(
             "session.timeline.list",
-            serde_json::json!({ "root_session_id": root, "min_altitude": "normal", "limit": 50 }),
+            serde_json::json!({ "root_session_id": root, "limit": 50 }),
         ))
         .await;
 
     assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
     let result = resp.result.expect("result");
     let entries = result["entries"].as_array().expect("entries array");
-    // Only the Attention event clears the normal floor; the Detail one is filtered.
+    // Only the Attention event clears the default (normal) floor; Detail is filtered.
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0]["event_type"], "approval.pending");
     assert_eq!(entries[0]["principal"]["kind"], "autonoetic_agent");
@@ -112,5 +129,19 @@ async fn session_timeline_list_requires_root_session_id() {
         ))
         .await;
     let err = resp.error.expect("missing root_session_id must error");
+    assert_eq!(err.code, -32602);
+}
+
+#[tokio::test]
+async fn session_timeline_list_rejects_invalid_min_altitude() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "session.timeline.list",
+            serde_json::json!({ "root_session_id": "root-x", "min_altitude": "bogus" }),
+        ))
+        .await;
+    let err = resp.error.expect("invalid min_altitude must error, not silently disable filtering");
     assert_eq!(err.code, -32602);
 }

--- a/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
+++ b/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
@@ -1,0 +1,116 @@
+//! `session.timeline.list` JSON-RPC (#391) — the canonical Session Room timeline
+//! served over the gateway API so channels are clients, not direct store readers.
+
+mod support;
+
+use autonoetic_gateway::router::{JsonRpcRequest, JsonRpcRouter};
+use autonoetic_gateway::scheduler::gateway_store::{GatewayStore, LiveDigestEventRecord};
+use std::sync::{Arc, OnceLock};
+use support::TestWorkspace;
+
+struct SharedEnv {
+    _ws: TestWorkspace,
+    store: Arc<GatewayStore>,
+    router: JsonRpcRouter,
+}
+
+static SHARED: OnceLock<SharedEnv> = OnceLock::new();
+
+// One shared workspace/router — initializing TestWorkspace concurrently from
+// multiple tests races on global state, so all tests share a single env.
+fn shared() -> &'static SharedEnv {
+    SHARED.get_or_init(|| {
+        let ws = TestWorkspace::new().expect("workspace");
+        let store = Arc::new(GatewayStore::open(ws.path()).expect("store open"));
+        let router = JsonRpcRouter::new(ws.gateway_config(), Some(store.clone()));
+        SharedEnv {
+            _ws: ws,
+            store,
+            router,
+        }
+    })
+}
+
+fn make_jsonrpc(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: "tl-test".to_string(),
+        method: method.to_string(),
+        params,
+        auth_token: None,
+    }
+}
+
+fn timeline_event(root: &str, event_type: &str, altitude: &str) -> LiveDigestEventRecord {
+    LiveDigestEventRecord {
+        event_id: format!("ev-{}", uuid::Uuid::new_v4()),
+        root_session_id: root.to_string(),
+        source_session_id: root.to_string(),
+        turn_id: Some("turn-1".to_string()),
+        source_agent_id: Some("planner.default".to_string()),
+        source_node_id: "gateway".to_string(),
+        event_type: event_type.to_string(),
+        payload: Some(serde_json::json!({ "k": "v" }).to_string()),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        principal_kind: Some("autonoetic_agent".to_string()),
+        principal_id: Some("planner.default".to_string()),
+        role: Some("planner".to_string()),
+        altitude: Some(altitude.to_string()),
+        refs_json: None,
+    }
+}
+
+#[tokio::test]
+async fn session_timeline_list_returns_seeded_events_above_floor() {
+    let env = shared();
+    // Distinct root keeps this test isolated from others sharing the store.
+    let root = "root-tl-floor";
+    env.store
+        .create_live_digest_event(&timeline_event(root, "approval.pending", "attention"))
+        .unwrap();
+    env.store
+        .create_live_digest_event(&timeline_event(root, "turn.start", "detail"))
+        .unwrap();
+
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "session.timeline.list",
+            serde_json::json!({ "root_session_id": root, "min_altitude": "normal", "limit": 50 }),
+        ))
+        .await;
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let result = resp.result.expect("result");
+    let entries = result["entries"].as_array().expect("entries array");
+    // Only the Attention event clears the normal floor; the Detail one is filtered.
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["event_type"], "approval.pending");
+    assert_eq!(entries[0]["principal"]["kind"], "autonoetic_agent");
+    assert_eq!(entries[0]["role"]["role"], "planner");
+
+    // Dropping the floor to `detail` surfaces both.
+    let resp_all = env
+        .router
+        .dispatch(make_jsonrpc(
+            "session.timeline.list",
+            serde_json::json!({ "root_session_id": root, "min_altitude": "detail", "limit": 50 }),
+        ))
+        .await;
+    let all = resp_all.result.expect("result");
+    assert_eq!(all["entries"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn session_timeline_list_requires_root_session_id() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "session.timeline.list",
+            serde_json::json!({ "root_session_id": "  " }),
+        ))
+        .await;
+    let err = resp.error.expect("missing root_session_id must error");
+    assert_eq!(err.code, -32602);
+}


### PR DESCRIPTION
## Summary
First slice of **P3** (#390): serve the canonical Session Room timeline over the **gateway API**, so channels become *clients* instead of reaching into `gateway.db` directly (the Separation-of-Powers boundary you flagged). Mirrors the proven `operator.activity.list` RPC + SSE pattern (#358).

### What's here
- **`session.timeline.list` JSON-RPC** (router.rs) — wraps `GatewayStore::list_session_timeline` (`root_session_id`, `after_event_id`, `limit`, `min_altitude`, `principal_id`) → `SessionTimelineListResult`. `root_session_id` required; `limit` clamped 1..=500; store-absent → error.
- **`GET /api/session/timeline/stream/{root_session_id}`** SSE (http.rs) — Bearer / query-token auth, cursor-bootstrap then tail, `min_altitude` floor (default `normal`), `session.timeline.heartbeat` when idle, `session.timeline.error` on failure.

## Test plan
- [x] `cargo test -p autonoetic-gateway --test session_timeline_jsonrpc_integration` — 2 pass: floor filtering (Attention surfaces at `normal`, Detail filtered; dropping to `detail` surfaces both) + `root_session_id`-required validation
- [x] `cargo build -p autonoetic-gateway`

(Test uses a shared `OnceLock` env — concurrent `TestWorkspace::new()` races on global state, same pattern as `gate_messages_jsonrpc_integration`.)

## Next
**P3.b (#392)**: migrate the room TUI off direct `GatewayStore` access onto this API — which also unblocks **interaction answering** over `interaction.resolve_and_answer` RPC, and is the prerequisite for remote bridges (Discord, #394).

Tracks #390 · #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)