### PR TITLE
feat(session-room): P3.b-1 — room viewer becomes a gateway API client (#392)

### DIFF
--- a/autonoetic/src/cli/room/client.rs
+++ b/autonoetic/src/cli/room/client.rs
@@ -1,0 +1,65 @@
+//! Minimal JSON-RPC client to the running gateway (#392, P3.b).
+//!
+//! The Session Room is a *channel* — a client of the gateway API, not a direct
+//! reader of `gateway.db` (Separation of Powers). This is the same newline-
+//! delimited JSON-RPC-over-TCP transport the chat TUI uses.
+
+use autonoetic_gateway::router::{JsonRpcRequest, JsonRpcResponse};
+use autonoetic_types::config::GatewayConfig;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+
+pub struct RoomClient {
+    addr: String,
+    token: String,
+}
+
+impl RoomClient {
+    pub fn from_config(config: &GatewayConfig) -> anyhow::Result<Self> {
+        let token = std::env::var("AUTONOETIC_SHARED_SECRET").map_err(|_| {
+            anyhow::anyhow!(
+                "Missing AUTONOETIC_SHARED_SECRET — the Session Room reaches the gateway over \
+                 JSON-RPC and needs the ingress auth token (start the gateway first)."
+            )
+        })?;
+        Ok(Self {
+            addr: format!("127.0.0.1:{}", config.port),
+            token,
+        })
+    }
+
+    /// One JSON-RPC round-trip. Returns the `result` value, or an error carrying
+    /// the gateway's message (connect failure, auth, or method error).
+    pub async fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let mut stream = TcpStream::connect(&self.addr)
+            .await
+            .map_err(|e| anyhow::anyhow!("cannot reach gateway at {}: {}", self.addr, e))?;
+
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: format!("room-{}", uuid::Uuid::new_v4()),
+            method: method.to_string(),
+            params,
+            auth_token: Some(self.token.clone()),
+        };
+        let encoded = serde_json::to_string(&request)?;
+        stream.write_all(encoded.as_bytes()).await?;
+        stream.write_all(b"\n").await?;
+        stream.flush().await?;
+
+        let mut line = String::new();
+        let mut reader = BufReader::new(stream);
+        if reader.read_line(&mut line).await? == 0 {
+            anyhow::bail!("gateway closed the connection with no response to {method}");
+        }
+        let response: JsonRpcResponse = serde_json::from_str(line.trim_end())?;
+        if let Some(err) = response.error {
+            anyhow::bail!("{method} failed: {}", err.message);
+        }
+        Ok(response.result.unwrap_or_else(|| serde_json::json!({})))
+    }
+}

--- a/autonoetic/src/cli/room/client.rs
+++ b/autonoetic/src/cli/room/client.rs
@@ -60,6 +60,8 @@ impl RoomClient {
         if let Some(err) = response.error {
             anyhow::bail!("{method} failed: {}", err.message);
         }
-        Ok(response.result.unwrap_or_else(|| serde_json::json!({})))
+        // A JSON `null` result deserializes to `None`; preserve null-vs-empty-object
+        // semantics by returning `Value::Null` rather than substituting `{}`.
+        Ok(response.result.unwrap_or(serde_json::Value::Null))
     }
 }

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -1,26 +1,25 @@
-//! Session Room (#363 P2) — read-only renderer slice.
+//! Session Room (#363) — read-only viewer + interactive shell.
 //!
-//! `autonoetic room <root_session_id>` renders the gateway's canonical
-//! `live_digest_events` timeline for a root session, oldest-first, with an
-//! altitude floor and an optional `--follow` live tail. This is the first P2
-//! slice: it proves timeline consumption + the channel-neutral rendering core
-//! ([`render`]) before any interactive ratatui shell is built on top.
+//! P3.b (#392): the room is a *gateway API client*, not a direct store reader.
+//! The non-interactive viewer here reads the canonical timeline over the
+//! `session.timeline.list` JSON-RPC. The interactive TUI still reads the store
+//! directly (its sync event loop needs an async restructure) — P3.b-2 migrates
+//! it (reads via RPC, writes via `approvals.*` / `interaction.resolve_and_answer`).
 
+mod client;
 mod render;
 mod tui;
 
 use crate::cli::common::RoomArgs;
-use autonoetic_types::session_timeline::Altitude;
+use autonoetic_types::session_timeline::{Altitude, SessionTimelineListResult};
+use client::RoomClient;
 use std::path::Path;
 use std::time::Duration;
 
 pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<()> {
     let config = autonoetic_gateway::config::load_config(config_path)?;
-    let gateway_dir = config.agents_dir.join(".gateway");
-    let store = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir)?;
 
-    // `parse_str` returns `Some` for every valid floor (detail/normal/attention/
-    // error), so `None` here means the input was invalid.
+    // `parse_str` returns `Some` for every valid floor — `None` means invalid.
     let min_altitude = match Altitude::parse_str(&args.min_altitude) {
         Some(a) => a,
         None => anyhow::bail!(
@@ -29,15 +28,25 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
         ),
     };
 
-    // Interactive shell — the Session Room proper.
+    // Interactive shell — still a direct store reader for now; P3.b-2 migrates
+    // it to the RPC client (its sync event loop needs an async restructure).
     if args.tui {
+        let gateway_dir = config.agents_dir.join(".gateway");
+        let store = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir)?;
         return tui::run(&config, &store, &args.root_session_id, min_altitude, args.limit);
     }
 
-    // Render the full timeline oldest-first, paging through *all* rows (not just
-    // the first `limit`, which would silently truncate long sessions).
+    // Read-only viewer: a pure gateway API client (#392) — no store access.
+    let client = RoomClient::from_config(&config)?;
     let mut cursor: Option<String> = None;
-    let rendered_any = drain_new(&store, &args.root_session_id, &mut cursor, args.limit, min_altitude)?;
+    let rendered_any = drain_new_rpc(
+        &client,
+        &args.root_session_id,
+        &mut cursor,
+        args.limit,
+        &args.min_altitude,
+    )
+    .await?;
 
     if !args.follow {
         if !rendered_any {
@@ -50,39 +59,50 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
     }
 
     eprintln!(
-        "Following room '{}' (floor: {}). Press Ctrl+C to stop.",
+        "Following room '{}' (floor: {}) via gateway API. Press Ctrl+C to stop.",
         args.root_session_id, args.min_altitude
     );
     let mut interval = tokio::time::interval(Duration::from_millis(800));
     loop {
         interval.tick().await;
-        drain_new(&store, &args.root_session_id, &mut cursor, args.limit, min_altitude)?;
+        drain_new_rpc(
+            &client,
+            &args.root_session_id,
+            &mut cursor,
+            args.limit,
+            &args.min_altitude,
+        )
+        .await?;
     }
 }
 
-/// Render every timeline entry newer than `cursor`, paging (in `limit`-sized
-/// reads) until caught up, advancing `cursor`. Returns whether anything was
-/// rendered. Used for both the initial dump and each follow tick.
-fn drain_new(
-    store: &autonoetic_gateway::scheduler::GatewayStore,
+/// Render every timeline entry newer than `cursor` via `session.timeline.list`,
+/// paging until caught up and advancing `cursor`. Returns whether anything was
+/// rendered.
+async fn drain_new_rpc(
+    client: &RoomClient,
     root_session_id: &str,
     cursor: &mut Option<String>,
     limit: u32,
-    min_altitude: Altitude,
+    min_altitude: &str,
 ) -> anyhow::Result<bool> {
     let mut rendered_any = false;
     loop {
-        let page = store.list_session_timeline(
-            root_session_id,
-            cursor.as_deref(),
-            limit,
-            Some(min_altitude),
-            None,
-        )?;
+        let result = client
+            .call(
+                "session.timeline.list",
+                serde_json::json!({
+                    "root_session_id": root_session_id,
+                    "after_event_id": *cursor,
+                    "limit": limit,
+                    "min_altitude": min_altitude,
+                }),
+            )
+            .await?;
+        let page: SessionTimelineListResult = serde_json::from_value(result)?;
         if page.entries.is_empty() {
             break;
         }
-        // Fold low-altitude plumbing into collapsed rows (page-local).
         for row in render::coalesce(&page.entries) {
             println!("{}", render::row_text(&row));
         }

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -93,7 +93,7 @@ async fn drain_new_rpc(
                 "session.timeline.list",
                 serde_json::json!({
                     "root_session_id": root_session_id,
-                    "after_event_id": *cursor,
+                    "after_event_id": cursor.clone(),
                     "limit": limit,
                     "min_altitude": min_altitude,
                 }),


### PR DESCRIPTION
## Summary
First slice of **P3.b** (#392): the non-interactive room viewer now reads the canonical timeline over the **`session.timeline.list` JSON-RPC** instead of opening `gateway.db` directly. This realizes the Separation-of-Powers boundary (#390) — a channel is a *client*, not a store reader.

### What's here
- **`cli/room/client.rs`** — a minimal `RoomClient`: newline-delimited JSON-RPC over TCP to `127.0.0.1:{port}`, `AUTONOETIC_SHARED_SECRET` auth (the same transport the chat TUI uses).
- **Viewer** (`autonoetic room <id>` / `--follow`) now drains via `session.timeline.list` and renders through the shared render core — **no `GatewayStore`** on this path. Like chat, it now requires a running gateway.

### Staging (why not the whole room at once)
The **interactive TUI** still opens the store. Migrating it means converting its **sync** event loop to **async** (RPC calls must `.await`) plus moving gate resolution to `approvals.approve`/`reject` and adding `interaction.resolve_and_answer` — a sizeable, gateway-dependent restructure. That's **P3.b-2**, kept separate so this stays reviewable and low-risk.

## Test plan
- [x] `cargo build -p autonoetic`
- [x] `cargo test -p autonoetic cli::room` — 8 pass (render core unchanged; only the viewer's data source moved)
- [ ] Manual: `autonoetic room <root_session_id> [--follow]` against a running gateway (RPC path needs a live daemon; not unit-testable here)

Tracks #390 · #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)