### PR TITLE
feat(session-room): P3.b-2 — interactive TUI becomes a gateway API client (#392)

### DIFF
--- a/autonoetic/src/cli/room/client.rs
+++ b/autonoetic/src/cli/room/client.rs
@@ -28,6 +28,16 @@ impl RoomClient {
         })
     }
 
+    /// A non-connecting client for unit tests of pure call sites (paths that
+    /// return before any RPC). Calling `.call()` on it will fail to connect.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self {
+            addr: "127.0.0.1:0".to_string(),
+            token: "test".to_string(),
+        }
+    }
+
     /// One JSON-RPC round-trip. Returns the `result` value, or an error carrying
     /// the gateway's message (connect failure, auth, or method error).
     pub async fn call(

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -1,10 +1,10 @@
 //! Session Room (#363) — read-only viewer + interactive shell.
 //!
-//! P3.b (#392): the room is a *gateway API client*, not a direct store reader.
-//! The non-interactive viewer here reads the canonical timeline over the
-//! `session.timeline.list` JSON-RPC. The interactive TUI still reads the store
-//! directly (its sync event loop needs an async restructure) — P3.b-2 migrates
-//! it (reads via RPC, writes via `approvals.*` / `interaction.resolve_and_answer`).
+//! P3.b (#392): the room is a *gateway API client*, not a direct store reader
+//! (Separation of Powers). Both the viewer and the interactive TUI read the
+//! canonical timeline over `session.timeline.list` and resolve gates over
+//! `approvals.approve`/`reject` + `interaction.resolve_and_answer` — no
+//! `GatewayStore` access.
 
 mod client;
 mod render;
@@ -28,16 +28,16 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
         ),
     };
 
-    // Interactive shell — still a direct store reader for now; P3.b-2 migrates
-    // it to the RPC client (its sync event loop needs an async restructure).
+    // The whole room is a gateway API client (#392) — no store access.
+    let client = RoomClient::from_config(&config)?;
+
+    // Interactive shell — reads via session.timeline.list, resolves gates via
+    // approvals.* / interaction.resolve_and_answer.
     if args.tui {
-        let gateway_dir = config.agents_dir.join(".gateway");
-        let store = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir)?;
-        return tui::run(&config, &store, &args.root_session_id, min_altitude, args.limit);
+        return tui::run(&client, &args.root_session_id, min_altitude, args.limit);
     }
 
-    // Read-only viewer: a pure gateway API client (#392) — no store access.
-    let client = RoomClient::from_config(&config)?;
+    // Read-only viewer.
     let mut cursor: Option<String> = None;
     let rendered_any = drain_new_rpc(
         &client,

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -43,7 +43,7 @@ struct GateInput {
     buffer: String,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 enum GateAction {
     Approve,
     Reject,
@@ -107,7 +107,12 @@ pub fn run(
                 "root_session_id": root_session_id,
                 "after_event_id": cursor,
                 "limit": limit,
-                "min_altitude": floor.as_str(),
+                // Always fetch at `detail` and filter for display below. Approval
+                // resolution events are `Normal` altitude, so fetching at the
+                // display floor (e.g. Attention) would drop them and leave
+                // `resolved` unpopulated — making already-decided gates look
+                // re-decidable. Fetch everything; filter is purely a view concern.
+                "min_altitude": "detail",
             }),
         ) {
             Ok(value) => match serde_json::from_value::<SessionTimelineListResult>(value) {
@@ -135,11 +140,16 @@ pub fn run(
             Err(e) => status = Some(format!("✗ gateway: {e}")),
         }
 
+        // `entries` holds everything (fetched at `detail`); the display floor is
+        // applied here as a pure view filter. RowSource indices below therefore
+        // index into `visible`, so gate selection and drill-down use it too.
+        let visible: Vec<SessionTimelineEntry> =
+            entries.iter().filter(|e| e.altitude >= floor).cloned().collect();
         // Rows + their source mapping (lets Enter drill into the underlying event).
         let indexed: Vec<(RenderedRow, RowSource)> = if squash {
-            render::coalesce_indexed(&entries)
+            render::coalesce_indexed(&visible)
         } else {
-            entries
+            visible
                 .iter()
                 .enumerate()
                 .map(|(i, e)| {
@@ -158,7 +168,7 @@ pub fn run(
             selected = selected.min(rows.len().saturating_sub(1));
         }
 
-        let gate = selectable_gate(&entries, indexed.get(selected), &resolved, &acted);
+        let gate = selectable_gate(&visible, indexed.get(selected), &resolved, &acted);
 
         terminal.draw(|f| {
             draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), status.as_deref(), gate.as_ref())
@@ -175,8 +185,20 @@ pub fn run(
                         KeyCode::Esc => input = None,
                         KeyCode::Enter => {
                             let gi = input.take().unwrap();
-                            acted.insert(gi.id.clone());
-                            status = Some(resolve_gate(client, &gi));
+                            match resolve_gate(client, &gi) {
+                                // Mark acted only on success — a failed RPC or an
+                                // empty answer leaves the gate offerable.
+                                Ok(msg) => {
+                                    acted.insert(gi.id.clone());
+                                    status = Some(msg);
+                                }
+                                // Reopen capture with the buffer intact so the
+                                // operator can fix the input and resubmit.
+                                Err(msg) => {
+                                    status = Some(msg);
+                                    input = Some(gi);
+                                }
+                            }
                         }
                         KeyCode::Backspace => {
                             gi.buffer.pop();
@@ -231,13 +253,13 @@ pub fn run(
                         detail = if detail.is_some() {
                             None
                         } else {
-                            indexed.get(selected).map(|(_, src)| detail_for(&entries, *src))
+                            indexed.get(selected).map(|(_, src)| detail_for(&visible, *src))
                         };
                     }
                     KeyCode::Char('a') => {
+                        // Pure view change now (we always fetch at `detail`) — no
+                        // reload, so already-fetched history re-filters instantly.
                         floor = cycle_floor(floor);
-                        entries.clear();
-                        cursor = None;
                         detail = None;
                     }
                     KeyCode::Char('s') => squash = !squash,
@@ -302,9 +324,19 @@ fn selectable_gate(
 /// Resolve a gate over the gateway API (the sanctioned path that unblocks the
 /// waiting agent + records the decision incl. decider kind, #361). Decider is
 /// the operator; `buffer` is the motivation (approvals) or answer (interactions).
-fn resolve_gate(client: &RoomClient, gi: &GateInput) -> String {
+///
+/// Returns `Ok(msg)` only when the gateway accepted the decision (the caller
+/// uses this to mark the gate acted); `Err(msg)` on validation or transport
+/// failure, leaving the gate offerable so the operator can retry.
+fn resolve_gate(client: &RoomClient, gi: &GateInput) -> Result<String, String> {
     let text = gi.buffer.trim();
     let reason = (!text.is_empty()).then(|| text.to_string());
+    // The gateway requires a non-empty answer for interactions; reject locally
+    // rather than round-trip a guaranteed server rejection (and so we never mark
+    // the gate acted on an empty submission).
+    if gi.action == GateAction::Answer && text.is_empty() {
+        return Err("✗ answer cannot be empty".to_string());
+    }
     let (result, verb) = match gi.action {
         GateAction::Approve => (
             rpc(
@@ -332,8 +364,8 @@ fn resolve_gate(client: &RoomClient, gi: &GateInput) -> String {
         ),
     };
     match result {
-        Ok(_) => format!("✓ {verb} {}", gi.id),
-        Err(e) => format!("✗ {e}"),
+        Ok(_) => Ok(format!("✓ {verb} {}", gi.id)),
+        Err(e) => Err(format!("✗ {e}")),
     }
 }
 
@@ -532,6 +564,20 @@ mod tests {
         // A non-gate event is not resolvable.
         let other = vec![gate_entry("tool.completed")];
         assert!(selectable_gate(&other, Some(&single), &empty, &empty).is_none());
+    }
+
+    #[test]
+    fn empty_interaction_answer_is_rejected_before_any_rpc() {
+        // An empty answer is rejected locally (the gateway requires non-empty),
+        // so the caller never marks the gate acted on a doomed submission.
+        let client = RoomClient::for_test();
+        let gi = GateInput {
+            action: GateAction::Answer,
+            id: "int-1".into(),
+            buffer: "   ".into(), // whitespace-only ⇒ empty after trim
+        };
+        let err = resolve_gate(&client, &gi).unwrap_err();
+        assert!(err.contains("empty"), "expected empty-answer rejection, got: {err}");
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -1,22 +1,14 @@
-//! Interactive Session Room shell (#363 P2) — the ratatui renderer.
+//! Interactive Session Room shell (#363) — the ratatui renderer.
 //!
 //! A scrollable, live-tailing view of the canonical timeline with an altitude
-//! dial and squash toggle. Greenfield (chat.rs untouched). Read-only for now —
-//! conversational gate *input* is a later slice. Built on the shared render
-//! core, so styling/summaries match the CLI viewer and future channel bridges.
+//! dial, squash, drill-down, and conversational gate resolution. P3.b-2 (#392):
+//! a **gateway API client** — reads via `session.timeline.list`, resolves gates
+//! via `approvals.approve`/`reject` and `interaction.resolve_and_answer`. No
+//! direct store access. chat.rs untouched.
 
+use super::client::RoomClient;
 use super::render::{self, RenderedRow, RowSource};
-use autonoetic_gateway::scheduler::GatewayStore;
-use autonoetic_types::config::GatewayConfig;
-use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry};
-
-/// An in-flight operator decision on a pending approval gate — captures an
-/// optional motivation before committing (§3.5 conversational gate).
-struct GateInput {
-    approve: bool,
-    request_id: String,
-    buffer: String,
-}
+use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry, SessionTimelineListResult};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     execute,
@@ -26,8 +18,37 @@ use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
+use std::collections::HashSet;
 use std::io;
 use std::time::Duration;
+
+/// A still-resolvable gate at the current selection.
+#[derive(Clone)]
+struct GateRef {
+    kind: GateKind,
+    id: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GateKind {
+    Approval,
+    Interaction,
+}
+
+/// An in-flight operator decision — captures an optional motivation (approvals,
+/// §3.5) or the answer text (interactions) before committing.
+struct GateInput {
+    action: GateAction,
+    id: String,
+    buffer: String,
+}
+
+#[derive(Clone, Copy)]
+enum GateAction {
+    Approve,
+    Reject,
+    Answer,
+}
 
 /// Restores the terminal on drop, even on early return / panic-unwind.
 struct TerminalRestore;
@@ -38,9 +59,18 @@ impl Drop for TerminalRestore {
     }
 }
 
+/// One JSON-RPC round-trip from the sync TUI loop. `block_in_place` keeps the
+/// multi-thread runtime healthy while we briefly block on the call.
+fn rpc(
+    client: &RoomClient,
+    method: &str,
+    params: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(client.call(method, params)))
+}
+
 pub fn run(
-    config: &GatewayConfig,
-    store: &GatewayStore,
+    client: &RoomClient,
     root_session_id: &str,
     initial_floor: Altitude,
     limit: u32,
@@ -60,16 +90,50 @@ pub fn run(
     let mut selected: usize = 0;
     let mut detail: Option<Vec<String>> = None; // drill-down pane content
     let mut input: Option<GateInput> = None; // in-flight gate decision
-    let mut status: Option<String> = None; // last action result
+    let mut status: Option<String> = None; // last action / connection result
+    // Gates no longer offerable: approvals resolved on the timeline, plus
+    // anything the operator just acted on (covers interactions, which have no
+    // timeline resolution event yet).
+    let mut resolved: HashSet<String> = HashSet::new();
+    let mut acted: HashSet<String> = HashSet::new();
 
     loop {
-        // Fetch at most one page per tick so a large backlog drains across ticks
-        // without ever blocking input (incl. quit). The 250ms poll paces catch-up.
-        let page = store.list_session_timeline(root_session_id, cursor.as_deref(), limit, Some(floor), None)?;
-        if let Some(last) = page.entries.last() {
-            cursor = Some(last.event_id.clone());
+        // Fetch at most one page per tick via the gateway API. On error (gateway
+        // down), surface it and keep retrying — don't crash the UI.
+        match rpc(
+            client,
+            "session.timeline.list",
+            serde_json::json!({
+                "root_session_id": root_session_id,
+                "after_event_id": cursor,
+                "limit": limit,
+                "min_altitude": floor.as_str(),
+            }),
+        ) {
+            Ok(value) => match serde_json::from_value::<SessionTimelineListResult>(value) {
+                Ok(page) => {
+                    if let Some(last) = page.entries.last() {
+                        cursor = Some(last.event_id.clone());
+                    }
+                    for e in &page.entries {
+                        if matches!(
+                            e.event_type.as_str(),
+                            "approval.approved" | "approval.rejected" | "approval.cancelled"
+                        ) {
+                            if let Some(id) = &e.refs.approval_request_id {
+                                resolved.insert(id.clone());
+                            }
+                        }
+                    }
+                    entries.extend(page.entries);
+                    if status.as_deref().map(|s| s.starts_with("✗ gateway")).unwrap_or(false) {
+                        status = None; // recovered
+                    }
+                }
+                Err(e) => status = Some(format!("✗ bad timeline response: {e}")),
+            },
+            Err(e) => status = Some(format!("✗ gateway: {e}")),
         }
-        entries.extend(page.entries);
 
         // Rows + their source mapping (lets Enter drill into the underlying event).
         let indexed: Vec<(RenderedRow, RowSource)> = if squash {
@@ -94,32 +158,10 @@ pub fn run(
             selected = selected.min(rows.len().saturating_sub(1));
         }
 
-        // Only offer resolution for an approval that is *still* pending in the
-        // store — a historical `approval.pending` row whose request was since
-        // decided must not show y/n (it would just hit the idempotency guard).
-        let pending_approval = pending_approval_id(&entries, indexed.get(selected)).filter(|id| {
-            store
-                .get_approval(id)
-                .ok()
-                .flatten()
-                .map(|a| a.status.is_none())
-                .unwrap_or(false)
-        });
+        let gate = selectable_gate(&entries, indexed.get(selected), &resolved, &acted);
 
         terminal.draw(|f| {
-            draw(
-                f,
-                root_session_id,
-                floor,
-                squash,
-                follow,
-                &rows,
-                selected,
-                detail.as_deref(),
-                input.as_ref(),
-                status.as_deref(),
-                pending_approval.is_some(),
-            )
+            draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), status.as_deref(), gate.as_ref())
         })?;
 
         if event::poll(Duration::from_millis(250))? {
@@ -127,17 +169,14 @@ pub fn run(
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
-                // Motivation-capture mode takes over all input while open.
+                // Text-capture mode takes over all input while open.
                 if let Some(gi) = input.as_mut() {
                     match key.code {
                         KeyCode::Esc => input = None,
                         KeyCode::Enter => {
                             let gi = input.take().unwrap();
-                            let reason = {
-                                let t = gi.buffer.trim();
-                                (!t.is_empty()).then(|| t.to_string())
-                            };
-                            status = Some(resolve_gate(config, store, &gi, reason));
+                            acted.insert(gi.id.clone());
+                            status = Some(resolve_gate(client, &gi));
                         }
                         KeyCode::Backspace => {
                             gi.buffer.pop();
@@ -153,7 +192,6 @@ pub fn run(
                 match key.code {
                     KeyCode::Char('q') => break,
                     _ if ctrl_c => break,
-                    // Esc closes the detail pane if open, otherwise quits.
                     KeyCode::Esc => {
                         if detail.is_some() {
                             detail = None;
@@ -161,33 +199,42 @@ pub fn run(
                             break;
                         }
                     }
-                    // y/n: resolve the selected pending approval (captures an
-                    // optional motivation first — §3.5; recording-only, no
-                    // BLOCKING enforcement yet).
+                    // y/n: approve/reject the selected pending approval.
                     KeyCode::Char('y') | KeyCode::Char('n') => {
-                        if let Some(request_id) = pending_approval.clone() {
-                            // Close the drill-down so the motivation prompt (footer)
-                            // is visible — otherwise input would be a hidden mode.
+                        if let Some(g) = gate.as_ref().filter(|g| g.kind == GateKind::Approval) {
                             detail = None;
                             input = Some(GateInput {
-                                approve: key.code == KeyCode::Char('y'),
-                                request_id,
+                                action: if key.code == KeyCode::Char('y') {
+                                    GateAction::Approve
+                                } else {
+                                    GateAction::Reject
+                                },
+                                id: g.id.clone(),
                                 buffer: String::new(),
                             });
                             status = None;
                         }
                     }
-                    // Enter toggles drill-down on the selected row.
+                    // r: reply to the selected pending interaction (user.ask).
+                    KeyCode::Char('r') => {
+                        if let Some(g) = gate.as_ref().filter(|g| g.kind == GateKind::Interaction) {
+                            detail = None;
+                            input = Some(GateInput {
+                                action: GateAction::Answer,
+                                id: g.id.clone(),
+                                buffer: String::new(),
+                            });
+                            status = None;
+                        }
+                    }
                     KeyCode::Enter => {
                         detail = if detail.is_some() {
                             None
                         } else {
-                            indexed.get(selected).map(|(_, src)| detail_for(store, &entries, *src))
+                            indexed.get(selected).map(|(_, src)| detail_for(&entries, *src))
                         };
                     }
                     KeyCode::Char('a') => {
-                        // Cycle the altitude floor; refetch from scratch since the
-                        // gateway filters server-side.
                         floor = cycle_floor(floor);
                         entries.clear();
                         cursor = None;
@@ -221,74 +268,82 @@ pub fn run(
     Ok(())
 }
 
-/// The approval request_id if the selected row is a single, still-`pending`
-/// approval gate (so it can be resolved in-flow).
-fn pending_approval_id(
+/// The still-resolvable gate at the selection (a single, not-yet-resolved
+/// `approval.pending` or `user.ask.pending` row).
+fn selectable_gate(
     entries: &[SessionTimelineEntry],
     src: Option<&(RenderedRow, RowSource)>,
-) -> Option<String> {
-    if let Some((_, RowSource::Single(i))) = src {
-        let e = entries.get(*i)?;
-        if e.event_type == "approval.pending" {
-            return e.refs.approval_request_id.clone();
+    resolved: &HashSet<String>,
+    acted: &HashSet<String>,
+) -> Option<GateRef> {
+    let (_, RowSource::Single(i)) = src? else {
+        return None;
+    };
+    let e = entries.get(*i)?;
+    match e.event_type.as_str() {
+        "approval.pending" => {
+            let id = e.refs.approval_request_id.clone()?;
+            (!resolved.contains(&id) && !acted.contains(&id)).then_some(GateRef {
+                kind: GateKind::Approval,
+                id,
+            })
         }
+        "user.ask.pending" => {
+            let id = e.refs.interaction_id.clone()?;
+            (!acted.contains(&id)).then_some(GateRef {
+                kind: GateKind::Interaction,
+                id,
+            })
+        }
+        _ => None,
     }
-    None
 }
 
-/// Resolve an approval through the sanctioned scheduler path (which records the
-/// decision — incl. decider kind via #361 — and queues the session-resume
-/// notification). Decider is the operator; the motivation is the optional reason.
-fn resolve_gate(
-    config: &GatewayConfig,
-    store: &GatewayStore,
-    gi: &GateInput,
-    reason: Option<String>,
-) -> String {
-    let result = if gi.approve {
-        autonoetic_gateway::scheduler::approve_request_with_options(
-            config,
-            Some(store),
-            &gi.request_id,
-            "operator",
-            reason,
-            None,
-            None,
-            None,
-            autonoetic_gateway::scheduler::ApproveOptions::default(),
-        )
-    } else {
-        autonoetic_gateway::scheduler::reject_request(
-            config,
-            Some(store),
-            &gi.request_id,
-            "operator",
-            reason,
-            None,
-        )
+/// Resolve a gate over the gateway API (the sanctioned path that unblocks the
+/// waiting agent + records the decision incl. decider kind, #361). Decider is
+/// the operator; `buffer` is the motivation (approvals) or answer (interactions).
+fn resolve_gate(client: &RoomClient, gi: &GateInput) -> String {
+    let text = gi.buffer.trim();
+    let reason = (!text.is_empty()).then(|| text.to_string());
+    let (result, verb) = match gi.action {
+        GateAction::Approve => (
+            rpc(
+                client,
+                "approvals.approve",
+                serde_json::json!({ "request_id": gi.id, "decided_by": "operator", "reason": reason }),
+            ),
+            "approved",
+        ),
+        GateAction::Reject => (
+            rpc(
+                client,
+                "approvals.reject",
+                serde_json::json!({ "request_id": gi.id, "decided_by": "operator", "reason": reason }),
+            ),
+            "rejected",
+        ),
+        GateAction::Answer => (
+            rpc(
+                client,
+                "interaction.resolve_and_answer",
+                serde_json::json!({ "interaction_id": gi.id, "answer_text": text, "answered_by": "operator" }),
+            ),
+            "answered",
+        ),
     };
     match result {
-        Ok(d) => format!(
-            "✓ {} {}",
-            if gi.approve { "approved" } else { "rejected" },
-            d.request_id
-        ),
+        Ok(_) => format!("✓ {verb} {}", gi.id),
         Err(e) => format!("✗ {e}"),
     }
 }
 
-/// Build the drill-down detail for a selected row's source. A single event
-/// shows its full metadata/payload; a collapsed run shows what it folds.
-fn detail_for(store: &GatewayStore, entries: &[SessionTimelineEntry], src: RowSource) -> Vec<String> {
+/// Drill-down detail for a selected row's source: a single event's full
+/// metadata/payload/refs, or what a collapsed run folds. (Deep ref-following —
+/// fetching the referenced approval/plan/workbench object — needs RPC read
+/// methods that don't exist yet; tracked as a follow-up.)
+fn detail_for(entries: &[SessionTimelineEntry], src: RowSource) -> Vec<String> {
     match src {
-        RowSource::Single(i) => {
-            let Some(e) = entries.get(i) else {
-                return Vec::new();
-            };
-            let mut lines = render::format_detail(e);
-            enrich_with_refs(store, e, &mut lines);
-            lines
-        }
+        RowSource::Single(i) => entries.get(i).map(render::format_detail).unwrap_or_default(),
         RowSource::Run { start, len } => {
             let mut lines = vec![
                 format!("collapsed run — {len} routine events"),
@@ -303,116 +358,12 @@ fn detail_for(store: &GatewayStore, entries: &[SessionTimelineEntry], src: RowSo
     }
 }
 
-/// Deep ref-following: fetch the object a gate event points at and append a
-/// summary, so drilling into a gate shows *what* it is about (the action you'd
-/// approve, the plan's shape, the workbench state). Best-effort/read-only.
-fn enrich_with_refs(store: &GatewayStore, entry: &SessionTimelineEntry, lines: &mut Vec<String>) {
-    if let Some(id) = &entry.refs.approval_request_id {
-        if let Ok(Some(a)) = store.get_approval(id) {
-            lines.push(String::new());
-            lines.push("approval request:".to_string());
-            lines.push(format!("  action:  {}", a.action.kind()));
-            lines.push(format!("  level:   {}", a.approval_level.to_config()));
-            lines.push(format!(
-                "  status:  {}",
-                a.status.map(|s| s.as_str()).unwrap_or("pending")
-            ));
-            if let Some(r) = &a.reason {
-                lines.push(format!("  reason:  {r}"));
-            }
-        }
-    }
-    if let Some(id) = &entry.refs.plan_id {
-        if let Ok(Some(p)) = store.load_plan_frame(id) {
-            lines.push(String::new());
-            lines.push("plan frame:".to_string());
-            lines.push(format!("  title:   {}", p.title));
-            lines.push(format!("  status:  {}  (v{})", p.status.as_str(), p.version));
-            lines.push(format!("  steps:   {}", p.steps.len()));
-        }
-    }
-    if let Some(id) = &entry.refs.workbench_id {
-        if let Ok(Some(w)) = store.load_workbench(id) {
-            lines.push(String::new());
-            lines.push("workbench:".to_string());
-            lines.push(format!("  status:  {}", w.status.as_str()));
-            lines.push(format!("  base:    {}", w.base_artifact_id));
-        }
-    }
-}
-
 fn cycle_floor(floor: Altitude) -> Altitude {
     match floor {
         Altitude::Detail => Altitude::Normal,
         Altitude::Normal => Altitude::Attention,
         Altitude::Attention => Altitude::Error,
         Altitude::Error => Altitude::Detail,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn approval_entry(event_type: &str) -> SessionTimelineEntry {
-        use autonoetic_types::principal::Principal;
-        use autonoetic_types::session_timeline::{SessionRole, TimelineRefs};
-        SessionTimelineEntry {
-            event_id: "ev".into(),
-            root_session_id: "r".into(),
-            source_session_id: "r".into(),
-            turn_id: None,
-            principal: Principal::agent("planner.default"),
-            role: SessionRole::Planner,
-            event_type: event_type.into(),
-            altitude: Altitude::Attention,
-            occurred_at: "t".into(),
-            payload: None,
-            refs: TimelineRefs {
-                approval_request_id: Some("apr-1".into()),
-                ..Default::default()
-            },
-        }
-    }
-
-    #[test]
-    fn pending_approval_id_only_for_selected_pending_gate() {
-        let row = (
-            RenderedRow::Line { text: "x".into(), altitude: Altitude::Attention },
-            RowSource::Single(0),
-        );
-        // A selected approval.pending row → its request id is resolvable.
-        let pending = vec![approval_entry("approval.pending")];
-        assert_eq!(pending_approval_id(&pending, Some(&row)), Some("apr-1".into()));
-        // Any other event (incl. an already-resolved approval) → not resolvable.
-        let resolved = vec![approval_entry("approval.approved")];
-        assert_eq!(pending_approval_id(&resolved, Some(&row)), None);
-        // A collapsed run is never a single resolvable gate.
-        let run = (
-            RenderedRow::Collapsed { count: 2, summary: "x".into() },
-            RowSource::Run { start: 0, len: 2 },
-        );
-        assert_eq!(pending_approval_id(&pending, Some(&run)), None);
-    }
-
-    #[test]
-    fn floor_cycles_through_all_levels() {
-        let mut a = Altitude::Detail;
-        let seq: Vec<Altitude> = (0..4)
-            .map(|_| {
-                a = cycle_floor(a);
-                a
-            })
-            .collect();
-        assert_eq!(
-            seq,
-            vec![
-                Altitude::Normal,
-                Altitude::Attention,
-                Altitude::Error,
-                Altitude::Detail
-            ]
-        );
     }
 }
 
@@ -437,7 +388,7 @@ fn draw(
     detail: Option<&[String]>,
     input: Option<&GateInput>,
     status: Option<&str>,
-    can_resolve: bool,
+    gate: Option<&GateRef>,
 ) {
     let chunks = Layout::vertical([
         Constraint::Length(1),
@@ -460,15 +411,13 @@ fn draw(
     );
 
     if let Some(lines) = detail {
-        // Drill-down pane replaces the list while open.
         let text: Vec<Line> = lines.iter().map(|l| Line::from(l.as_str())).collect();
         f.render_widget(
             Paragraph::new(text).block(Block::default().borders(Borders::ALL).title(" event detail ")),
             chunks[1],
         );
         f.render_widget(
-            Paragraph::new(" Esc/Enter close detail · q quit")
-                .style(Style::default().fg(Color::DarkGray)),
+            Paragraph::new(" Esc/Enter close detail · q quit").style(Style::default().fg(Color::DarkGray)),
             chunks[2],
         );
         return;
@@ -478,7 +427,6 @@ fn draw(
         .iter()
         .map(|row| {
             let style = altitude_style(render::row_altitude(row));
-            // Pass the Cow through — borrows for `Line` rows, allocates only for collapsed.
             ListItem::new(Line::from(Span::styled(render::row_text(row), style)))
         })
         .collect();
@@ -496,18 +444,108 @@ fn draw(
     );
 
     let footer = if let Some(gi) = input {
+        let label = match gi.action {
+            GateAction::Approve => "APPROVE — motivation (optional)",
+            GateAction::Reject => "REJECT — motivation (optional)",
+            GateAction::Answer => "ANSWER",
+        };
         Paragraph::new(format!(
-            " {} — motivation (optional): {}▏   [Enter submit · Esc cancel]",
-            if gi.approve { "APPROVE" } else { "REJECT" },
-            gi.buffer,
+            " {label}: {}▏   [Enter submit · Esc cancel]",
+            gi.buffer
         ))
         .style(Style::default().fg(Color::Cyan))
     } else {
-        let resolve_hint = if can_resolve { " · y/n approve/reject" } else { "" };
+        let gate_hint = match gate.map(|g| g.kind) {
+            Some(GateKind::Approval) => " · y/n approve/reject",
+            Some(GateKind::Interaction) => " · r reply",
+            None => "",
+        };
         Paragraph::new(format!(
-            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · ⏎ detail{resolve_hint}"
+            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · ⏎ detail{gate_hint}"
         ))
         .style(Style::default().fg(Color::DarkGray))
     };
     f.render_widget(footer, chunks[2]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gate_entry(event_type: &str) -> SessionTimelineEntry {
+        use autonoetic_types::principal::Principal;
+        use autonoetic_types::session_timeline::{SessionRole, TimelineRefs};
+        SessionTimelineEntry {
+            event_id: "ev".into(),
+            root_session_id: "r".into(),
+            source_session_id: "r".into(),
+            turn_id: None,
+            principal: Principal::agent("planner.default"),
+            role: SessionRole::Planner,
+            event_type: event_type.into(),
+            altitude: Altitude::Attention,
+            occurred_at: "t".into(),
+            payload: None,
+            refs: TimelineRefs {
+                approval_request_id: Some("apr-1".into()),
+                interaction_id: Some("int-1".into()),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn selectable_gate_classifies_and_respects_resolved() {
+        let single = (
+            RenderedRow::Line { text: "x".into(), altitude: Altitude::Attention },
+            RowSource::Single(0),
+        );
+        let empty = HashSet::new();
+
+        // approval.pending → resolvable Approval gate.
+        let appr = vec![gate_entry("approval.pending")];
+        let g = selectable_gate(&appr, Some(&single), &empty, &empty).unwrap();
+        assert!(g.kind == GateKind::Approval && g.id == "apr-1");
+
+        // user.ask.pending → resolvable Interaction gate.
+        let ask = vec![gate_entry("user.ask.pending")];
+        let g = selectable_gate(&ask, Some(&single), &empty, &empty).unwrap();
+        assert!(g.kind == GateKind::Interaction && g.id == "int-1");
+
+        // A resolved approval (its request id seen on the timeline) is not offered.
+        let mut resolved = HashSet::new();
+        resolved.insert("apr-1".to_string());
+        assert!(selectable_gate(&appr, Some(&single), &resolved, &empty).is_none());
+
+        // A locally-acted gate is not offered.
+        let mut acted = HashSet::new();
+        acted.insert("int-1".to_string());
+        assert!(selectable_gate(&ask, Some(&single), &empty, &acted).is_none());
+
+        // A collapsed run is never a single resolvable gate.
+        let run = (
+            RenderedRow::Collapsed { count: 2, summary: "x".into() },
+            RowSource::Run { start: 0, len: 2 },
+        );
+        assert!(selectable_gate(&appr, Some(&run), &empty, &empty).is_none());
+
+        // A non-gate event is not resolvable.
+        let other = vec![gate_entry("tool.completed")];
+        assert!(selectable_gate(&other, Some(&single), &empty, &empty).is_none());
+    }
+
+    #[test]
+    fn floor_cycles_through_all_levels() {
+        let mut a = Altitude::Detail;
+        let seq: Vec<Altitude> = (0..4)
+            .map(|_| {
+                a = cycle_floor(a);
+                a
+            })
+            .collect();
+        assert_eq!(
+            seq,
+            vec![Altitude::Normal, Altitude::Attention, Altitude::Error, Altitude::Detail]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
**Stacked on #401.** Completes #392: the interactive room TUI now reads + writes over the **gateway API** instead of `gateway.db`. With this, the **entire room is store-free** — a true channel-as-client (Separation of Powers, #390).

> ⚠️ Base is `feat/session-room-p3b-rpc-client` (#401), not `main` — review/merge **#401 first**; I'll retarget to `main` after.

### What changed
- **Reads** — the TUI drains the timeline via `session.timeline.list`, bridged from its sync event loop with `block_in_place` + `Handle::block_on` (the CLI runs on a multi-thread runtime). Gateway errors surface in the header and retry — they don't crash the UI.
- **Gate resolution over RPC** — approvals via `approvals.approve`/`reject`; and — **newly enabled** — **interaction answering** via `interaction.resolve_and_answer` (`r` to reply on a pending `user.ask`). This is the capability #392 set out to unlock.
- **Pending state from the timeline** — derived from `approval.{approved,rejected,cancelled}` events + a local just-acted set, replacing `store.get_approval`. A gate stops offering once resolved (by you or anyone).
- **Detail pane** — drops store ref-enrichment (there's no RPC read for the approval/plan/workbench *objects* yet); shows event metadata/payload/refs. Re-adding object enrichment via RPC is a tracked follow-up.

## Test plan
- [x] `cargo build -p autonoetic`
- [x] `cargo test -p autonoetic cli::room` — 8 pass (incl. `selectable_gate` across approval / interaction / resolved / acted / collapsed-run / non-gate)
- [ ] Manual (needs a live gateway): `autonoetic room <id> --tui` → scroll, drill-down, approve/reject with motivation, reply to a `user.ask`; confirm the resolution appears in the feed

## Follow-ups
- Detail object-enrichment over RPC (add `approval/plan/workbench` read methods or fold into timeline refs).
- `block_in_place` requires a multi-thread runtime (the CLI's default); noted for any future current-thread context.

Tracks #390 · #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)