### PR TITLE
feat(session-room): P3.c — channel trait + operator_channel_bindings (#393)

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1003,6 +1003,105 @@ impl JsonRpcRouter {
                 }
             }
 
+            "channel.bind" => {
+                // #393 (P3.c): bind an external conversation (Discord thread,
+                // WhatsApp chat) to a room so it survives reconnects and routes
+                // replies back as Operator-seat events. Channels are API clients,
+                // not direct store readers (#390).
+                let params: autonoetic_types::channel::ChannelBindParams =
+                    match serde_json::from_value(req.params) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32602,
+                                format!("Invalid params for channel.bind: {}", e),
+                            );
+                        }
+                    };
+                if params.channel.trim().is_empty()
+                    || params.external_id.trim().is_empty()
+                    || params.root_session_id.trim().is_empty()
+                {
+                    return JsonRpcResponse::error(
+                        req.id,
+                        -32602,
+                        "channel, external_id, and root_session_id are required".to_string(),
+                    );
+                }
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                match store.bind_channel(
+                    &params.channel,
+                    &params.external_id,
+                    &params.root_session_id,
+                ) {
+                    Ok(binding) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::to_value(binding).unwrap_or_else(|_| serde_json::json!({})),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("channel.bind failed: {}", e),
+                    ),
+                }
+            }
+
+            "channel.resolve" => {
+                // #393 (P3.c): look up which room a conversation is bound to.
+                let params: autonoetic_types::channel::ChannelResolveParams =
+                    match serde_json::from_value(req.params) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32602,
+                                format!("Invalid params for channel.resolve: {}", e),
+                            );
+                        }
+                    };
+                if params.channel.trim().is_empty() || params.external_id.trim().is_empty() {
+                    return JsonRpcResponse::error(
+                        req.id,
+                        -32602,
+                        "channel and external_id are required".to_string(),
+                    );
+                }
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                match store.resolve_channel_binding(&params.channel, &params.external_id) {
+                    Ok(binding) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::to_value(
+                            autonoetic_types::channel::ChannelResolveResult { binding },
+                        )
+                        .unwrap_or_else(|_| serde_json::json!({})),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("channel.resolve failed: {}", e),
+                    ),
+                }
+            }
+
             "session.approval_resolved" => {
                 #[derive(Deserialize)]
                 struct ApprovalResolvedParams {

--- a/autonoetic-gateway/src/scheduler/gateway_store/channel_bindings.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/channel_bindings.rs
@@ -1,0 +1,81 @@
+//! Store access for `operator_channel_bindings` (#393, P3.c).
+//!
+//! Maps an external channel conversation `(channel, external_id)` to a room
+//! (`root_session_id`) so a Discord thread / WhatsApp chat survives reconnects
+//! and routes replies back as `Operator`-seat events. Channels reach these over
+//! RPC (`channel.bind` / `channel.resolve`) — they are API clients, never direct
+//! store readers (Separation of Powers, #390).
+
+use anyhow::Result;
+use autonoetic_types::channel::ChannelBinding;
+use rusqlite::OptionalExtension;
+
+use super::GatewayStore;
+
+impl GatewayStore {
+    /// Upsert a binding (idempotent on the `(channel, external_id)` natural key).
+    /// Rebinding the same conversation to a new room updates `root_session_id`
+    /// and `updated_at` while preserving the original `created_at`. Returns the
+    /// resulting binding.
+    pub fn bind_channel(
+        &self,
+        channel: &str,
+        external_id: &str,
+        root_session_id: &str,
+    ) -> Result<ChannelBinding> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO operator_channel_bindings
+                (channel, external_id, root_session_id, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?4)
+             ON CONFLICT(channel, external_id) DO UPDATE SET
+                root_session_id = excluded.root_session_id,
+                updated_at = excluded.updated_at",
+            rusqlite::params![channel, external_id, root_session_id, now],
+        )?;
+        // Read back so the caller sees the persisted row (notably the original
+        // created_at on a rebind).
+        conn.query_row(
+            "SELECT channel, external_id, root_session_id, created_at, updated_at
+             FROM operator_channel_bindings WHERE channel = ?1 AND external_id = ?2",
+            rusqlite::params![channel, external_id],
+            |row| {
+                Ok(ChannelBinding {
+                    channel: row.get(0)?,
+                    external_id: row.get(1)?,
+                    root_session_id: row.get(2)?,
+                    created_at: row.get(3)?,
+                    updated_at: row.get(4)?,
+                })
+            },
+        )
+        .map_err(Into::into)
+    }
+
+    /// Look up the binding for a conversation, or `None` if it is unbound.
+    pub fn resolve_channel_binding(
+        &self,
+        channel: &str,
+        external_id: &str,
+    ) -> Result<Option<ChannelBinding>> {
+        let conn = self.conn.lock().unwrap();
+        let binding = conn
+            .query_row(
+                "SELECT channel, external_id, root_session_id, created_at, updated_at
+                 FROM operator_channel_bindings WHERE channel = ?1 AND external_id = ?2",
+                rusqlite::params![channel, external_id],
+                |row| {
+                    Ok(ChannelBinding {
+                        channel: row.get(0)?,
+                        external_id: row.get(1)?,
+                        root_session_id: row.get(2)?,
+                        created_at: row.get(3)?,
+                        updated_at: row.get(4)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(binding)
+    }
+}

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 47;
+const SCHEMA_VERSION_LATEST: i64 = 48;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -532,7 +532,48 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_operator_activity_v45(conn)?;
     apply_session_timeline_v46(conn)?;
     apply_decided_by_kind_v47(conn)?;
+    apply_operator_channel_bindings_v48(conn)?;
 
+    Ok(())
+}
+
+/// #393 (P3.c) — map an external channel conversation to a room. A Discord
+/// thread / WhatsApp chat binds to a `root_session_id` so it survives
+/// reconnects and routes replies back as `Operator`-seat events. `(channel,
+/// external_id)` is the natural key (one conversation ⇒ one room); rebinding
+/// the same conversation upserts. Channels reach this over RPC — they are API
+/// clients, never direct store readers (Separation of Powers, #390).
+fn apply_operator_channel_bindings_v48(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 48 {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS operator_channel_bindings (
+            channel          TEXT NOT NULL,
+            external_id      TEXT NOT NULL,
+            root_session_id  TEXT NOT NULL,
+            created_at       TEXT NOT NULL,
+            updated_at       TEXT NOT NULL,
+            PRIMARY KEY (channel, external_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_channel_bindings_root
+            ON operator_channel_bindings(root_session_id);",
+    )?;
+
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![
+            48_i64,
+            "operator_channel_bindings",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
     Ok(())
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/mod.rs
@@ -7,6 +7,7 @@ pub mod constitutional_proposals;
 mod credentials;
 mod escalations;
 mod evaluations;
+mod channel_bindings;
 mod gate_messages;
 mod hook_deliveries;
 mod improvement_cycles;

--- a/autonoetic-gateway/tests/channel_bindings_jsonrpc_integration.rs
+++ b/autonoetic-gateway/tests/channel_bindings_jsonrpc_integration.rs
@@ -1,0 +1,124 @@
+//! `channel.bind` / `channel.resolve` JSON-RPC (#393, P3.c) — external channel
+//! conversations bind to a room over the gateway API so channels are clients,
+//! not direct store readers (#390).
+
+mod support;
+
+use autonoetic_gateway::router::{JsonRpcRequest, JsonRpcRouter};
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use std::sync::{Arc, OnceLock};
+use support::TestWorkspace;
+
+struct SharedEnv {
+    _ws: TestWorkspace,
+    _store: Arc<GatewayStore>,
+    router: JsonRpcRouter,
+}
+
+static SHARED: OnceLock<SharedEnv> = OnceLock::new();
+
+// One shared workspace/router — initializing TestWorkspace concurrently from
+// multiple tests races on global state, so all tests share a single env.
+fn shared() -> &'static SharedEnv {
+    SHARED.get_or_init(|| {
+        let ws = TestWorkspace::new().expect("workspace");
+        let store = Arc::new(GatewayStore::open(ws.path()).expect("store open"));
+        let router = JsonRpcRouter::new(ws.gateway_config(), Some(store.clone()));
+        SharedEnv {
+            _ws: ws,
+            _store: store,
+            router,
+        }
+    })
+}
+
+fn make_jsonrpc(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: "ch-test".to_string(),
+        method: method.to_string(),
+        params,
+        auth_token: None,
+    }
+}
+
+#[tokio::test]
+async fn channel_bind_then_resolve_round_trips() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "channel.bind",
+            serde_json::json!({
+                "channel": "discord",
+                "external_id": "thread-100",
+                "root_session_id": "root-abc",
+            }),
+        ))
+        .await;
+    assert!(resp.error.is_none(), "bind errored: {:?}", resp.error);
+    let bound = resp.result.expect("bind result");
+    assert_eq!(bound["channel"], "discord");
+    assert_eq!(bound["root_session_id"], "root-abc");
+    let created_at = bound["created_at"].as_str().unwrap().to_string();
+
+    // Resolve returns the same binding.
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "channel.resolve",
+            serde_json::json!({ "channel": "discord", "external_id": "thread-100" }),
+        ))
+        .await;
+    let result = resp.result.expect("resolve result");
+    assert_eq!(result["binding"]["root_session_id"], "root-abc");
+
+    // Rebinding the same conversation upserts root_session_id, preserves created_at.
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "channel.bind",
+            serde_json::json!({
+                "channel": "discord",
+                "external_id": "thread-100",
+                "root_session_id": "root-xyz",
+            }),
+        ))
+        .await;
+    let rebound = resp.result.expect("rebind result");
+    assert_eq!(rebound["root_session_id"], "root-xyz");
+    assert_eq!(
+        rebound["created_at"].as_str().unwrap(),
+        created_at,
+        "rebind must preserve the original created_at"
+    );
+}
+
+#[tokio::test]
+async fn channel_resolve_unbound_returns_none() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "channel.resolve",
+            serde_json::json!({ "channel": "whatsapp", "external_id": "never-bound" }),
+        ))
+        .await;
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let result = resp.result.expect("resolve result");
+    assert!(result["binding"].is_null(), "unbound must resolve to null");
+}
+
+#[tokio::test]
+async fn channel_bind_requires_all_fields() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(make_jsonrpc(
+            "channel.bind",
+            serde_json::json!({ "channel": "discord", "external_id": "  ", "root_session_id": "r" }),
+        ))
+        .await;
+    let err = resp.error.expect("blank external_id must error");
+    assert_eq!(err.code, -32602);
+}

--- a/autonoetic-types/src/channel.rs
+++ b/autonoetic-types/src/channel.rs
@@ -24,15 +24,18 @@ pub struct ChannelBinding {
 }
 
 /// Params for `channel.bind` — upsert a binding (idempotent on the natural key).
-#[derive(Debug, Clone, Deserialize)]
+/// Derives `Serialize` too so channel clients can reuse it to *send* the request
+/// (not just the gateway to receive it).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelBindParams {
     pub channel: String,
     pub external_id: String,
     pub root_session_id: String,
 }
 
-/// Params for `channel.resolve` — look up the room for a conversation.
-#[derive(Debug, Clone, Deserialize)]
+/// Params for `channel.resolve` — look up the room for a conversation. Derives
+/// `Serialize` too so channel clients can reuse it to *send* the request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelResolveParams {
     pub channel: String,
     pub external_id: String,

--- a/autonoetic-types/src/channel.rs
+++ b/autonoetic-types/src/channel.rs
@@ -1,0 +1,45 @@
+//! Channel bindings (#393, P3.c) — map an external channel conversation to a
+//! Session Room.
+//!
+//! A channel (Discord, WhatsApp, the TUI, …) is a *client* of the gateway API,
+//! never a direct store reader (Separation of Powers, #390). A binding lets a
+//! channel-native conversation — a Discord thread, a WhatsApp chat — survive
+//! reconnects and route the operator's replies back into the right room as
+//! `Operator`-seat events. `(channel, external_id)` is the natural key: one
+//! external conversation maps to exactly one room.
+
+use serde::{Deserialize, Serialize};
+
+/// A persisted mapping from an external channel conversation to a room.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelBinding {
+    /// Channel kind, e.g. `"discord"`, `"whatsapp"`, `"tui"`.
+    pub channel: String,
+    /// The channel-native conversation id (thread / chat / room id).
+    pub external_id: String,
+    /// The room this conversation is bound to.
+    pub root_session_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Params for `channel.bind` — upsert a binding (idempotent on the natural key).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChannelBindParams {
+    pub channel: String,
+    pub external_id: String,
+    pub root_session_id: String,
+}
+
+/// Params for `channel.resolve` — look up the room for a conversation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChannelResolveParams {
+    pub channel: String,
+    pub external_id: String,
+}
+
+/// Result of `channel.resolve` — the binding if one exists, else `None`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelResolveResult {
+    pub binding: Option<ChannelBinding>,
+}

--- a/autonoetic-types/src/lib.rs
+++ b/autonoetic-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod background;
 pub mod capability;
 pub mod capsule;
 pub mod causal_chain;
+pub mod channel;
 pub mod config;
 pub mod disclosure;
 pub mod escalation;

--- a/autonoetic/src/cli/room/channel.rs
+++ b/autonoetic/src/cli/room/channel.rs
@@ -9,6 +9,7 @@
 //! `operator_channel_bindings` to route an external conversation back to a room.
 
 use super::render::{self, RenderedRow};
+use std::borrow::Cow;
 
 /// A still-resolvable gate at a selection — the channel-neutral primitive every
 /// surface resolves the same way (over `approvals.*` / `interaction.*`).
@@ -40,10 +41,11 @@ pub trait Channel {
     fn kind(&self) -> &'static str;
 
     /// Format a rendered row into this channel's native line. Defaults to the
-    /// channel-neutral text; a richer surface (styled TUI, Discord markdown)
-    /// overrides.
-    fn format_row(&self, row: &RenderedRow) -> String {
-        render::row_text(row).into_owned()
+    /// channel-neutral text, borrowing the existing line for `RenderedRow::Line`
+    /// (no allocation on the hot path — mirrors [`render::row_text`]); a richer
+    /// surface (styled TUI, Discord markdown) overrides and allocates as needed.
+    fn format_row<'r>(&self, row: &'r RenderedRow) -> Cow<'r, str> {
+        render::row_text(row)
     }
 
     /// The affordance hint for resolving a pending gate in this surface (TUI

--- a/autonoetic/src/cli/room/channel.rs
+++ b/autonoetic/src/cli/room/channel.rs
@@ -1,0 +1,103 @@
+//! Channel abstraction for the Session Room (#393, P3.c).
+//!
+//! A *channel* is a presentation + input surface over the shared, channel-neutral
+//! render core (`render.rs`). It owns **only** formatting and input affordances —
+//! never merge or importance logic, which are fixed gateway-side for every
+//! channel (#390). The interactive TUI is one impl, the non-interactive CLI
+//! viewer another; a Discord/WhatsApp bridge (P3.d, #394) will be a third. The
+//! `kind()` string is also the `channel` column value used in
+//! `operator_channel_bindings` to route an external conversation back to a room.
+
+use super::render::{self, RenderedRow};
+
+/// A still-resolvable gate at a selection — the channel-neutral primitive every
+/// surface resolves the same way (over `approvals.*` / `interaction.*`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GateRef {
+    pub kind: GateKind,
+    pub id: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum GateKind {
+    Approval,
+    Interaction,
+}
+
+/// A resolution action a gate affords — the operator's intent, independent of
+/// how any channel surfaces it (keypress, button, reaction).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum GateAction {
+    Approve,
+    Reject,
+    Answer,
+}
+
+/// A presentation + input surface over the shared render core.
+pub trait Channel {
+    /// Stable channel-kind identifier — also the `channel` column value in
+    /// `operator_channel_bindings`. e.g. `"tui"`, `"cli"`, `"discord"`.
+    fn kind(&self) -> &'static str;
+
+    /// Format a rendered row into this channel's native line. Defaults to the
+    /// channel-neutral text; a richer surface (styled TUI, Discord markdown)
+    /// overrides.
+    fn format_row(&self, row: &RenderedRow) -> String {
+        render::row_text(row).into_owned()
+    }
+
+    /// The affordance hint for resolving a pending gate in this surface (TUI
+    /// keybindings here; a rich channel would surface buttons/reactions).
+    fn gate_prompt(&self, gate: &GateRef) -> String;
+}
+
+/// The non-interactive CLI viewer channel: plain one-line-per-row text.
+pub struct CliChannel;
+
+impl Channel for CliChannel {
+    fn kind(&self) -> &'static str {
+        "cli"
+    }
+    fn gate_prompt(&self, gate: &GateRef) -> String {
+        // The read-only viewer cannot resolve gates; point at the interactive shell.
+        match gate.kind {
+            GateKind::Approval => "(pending approval — resolve in `room --tui`)".into(),
+            GateKind::Interaction => "(pending question — answer in `room --tui`)".into(),
+        }
+    }
+}
+
+/// The interactive ratatui shell channel. (Row styling is done live by the shell
+/// via ratatui spans; `format_row` keeps the plain-text fallback for parity.)
+pub struct TuiChannel;
+
+impl Channel for TuiChannel {
+    fn kind(&self) -> &'static str {
+        "tui"
+    }
+    fn gate_prompt(&self, gate: &GateRef) -> String {
+        match gate.kind {
+            GateKind::Approval => " · y/n approve/reject".into(),
+            GateKind::Interaction => " · r reply".into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channels_name_themselves_and_prompt_per_gate() {
+        let appr = GateRef { kind: GateKind::Approval, id: "apr-1".into() };
+        let ask = GateRef { kind: GateKind::Interaction, id: "int-1".into() };
+
+        assert_eq!(TuiChannel.kind(), "tui");
+        assert!(TuiChannel.gate_prompt(&appr).contains("approve/reject"));
+        assert!(TuiChannel.gate_prompt(&ask).contains("reply"));
+
+        assert_eq!(CliChannel.kind(), "cli");
+        // The viewer can't resolve; it points at the interactive shell.
+        assert!(CliChannel.gate_prompt(&appr).contains("--tui"));
+    }
+}

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -6,12 +6,14 @@
 //! `approvals.approve`/`reject` + `interaction.resolve_and_answer` — no
 //! `GatewayStore` access.
 
+mod channel;
 mod client;
 mod render;
 mod tui;
 
 use crate::cli::common::RoomArgs;
 use autonoetic_types::session_timeline::{Altitude, SessionTimelineListResult};
+use channel::{Channel, CliChannel};
 use client::RoomClient;
 use std::path::Path;
 use std::time::Duration;
@@ -59,8 +61,10 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
     }
 
     eprintln!(
-        "Following room '{}' (floor: {}) via gateway API. Press Ctrl+C to stop.",
-        args.root_session_id, args.min_altitude
+        "Following room '{}' (floor: {}) via the {} channel. Press Ctrl+C to stop.",
+        args.root_session_id,
+        args.min_altitude,
+        CliChannel.kind(),
     );
     let mut interval = tokio::time::interval(Duration::from_millis(800));
     loop {
@@ -104,7 +108,7 @@ async fn drain_new_rpc(
             break;
         }
         for row in render::coalesce(&page.entries) {
-            println!("{}", render::row_text(&row));
+            println!("{}", CliChannel.format_row(&row));
         }
         *cursor = page.entries.last().map(|e| e.event_id.clone());
         rendered_any = true;

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -6,6 +6,7 @@
 //! via `approvals.approve`/`reject` and `interaction.resolve_and_answer`. No
 //! direct store access. chat.rs untouched.
 
+use super::channel::{Channel, GateAction, GateKind, GateRef, TuiChannel};
 use super::client::RoomClient;
 use super::render::{self, RenderedRow, RowSource};
 use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry, SessionTimelineListResult};
@@ -22,32 +23,14 @@ use std::collections::HashSet;
 use std::io;
 use std::time::Duration;
 
-/// A still-resolvable gate at the current selection.
-#[derive(Clone)]
-struct GateRef {
-    kind: GateKind,
-    id: String,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum GateKind {
-    Approval,
-    Interaction,
-}
-
 /// An in-flight operator decision — captures an optional motivation (approvals,
-/// §3.5) or the answer text (interactions) before committing.
+/// §3.5) or the answer text (interactions) before committing. `GateRef`,
+/// `GateKind`, and `GateAction` are the channel-neutral primitives, shared from
+/// [`super::channel`].
 struct GateInput {
     action: GateAction,
     id: String,
     buffer: String,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-enum GateAction {
-    Approve,
-    Reject,
-    Answer,
 }
 
 /// Restores the terminal on drop, even on early return / panic-unwind.
@@ -430,7 +413,8 @@ fn draw(
     .split(f.area());
 
     let header = format!(
-        " Session Room — {root}   floor: {}   squash: {}   {} rows{}{}",
+        " Session Room [{}] — {root}   floor: {}   squash: {}   {} rows{}{}",
+        TuiChannel.kind(),
         floor.as_str(),
         if squash { "on" } else { "off" },
         rows.len(),
@@ -487,11 +471,9 @@ fn draw(
         ))
         .style(Style::default().fg(Color::Cyan))
     } else {
-        let gate_hint = match gate.map(|g| g.kind) {
-            Some(GateKind::Approval) => " · y/n approve/reject",
-            Some(GateKind::Interaction) => " · r reply",
-            None => "",
-        };
+        // The gate affordance hint is the channel's concern (#393) — route it
+        // through the channel so a Discord/WhatsApp bridge can render its own.
+        let gate_hint = gate.map(|g| TuiChannel.gate_prompt(g)).unwrap_or_default();
         Paragraph::new(format!(
             " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · ⏎ detail{gate_hint}"
         ))


### PR DESCRIPTION
## Summary
Closes #393 (part of #390). Generalizes the Session Room into a reusable **channel abstraction**, and revives the deferred #357 binding table — now with a real consumer ahead of the Discord bridge (P3.d, #394).

### Channel trait
`autonoetic/src/cli/room/channel.rs` — a **thin** trait over the shared, channel-neutral render core:
- `kind()` — stable channel id (also the `channel` column value in bindings), surfaced in the viewer banner + TUI header.
- `format_row()` — defaults to the neutral text; a rich surface (styled TUI, Discord markdown) overrides.
- `gate_prompt()` — the per-gate affordance hint (TUI keybindings; a rich channel would render buttons/reactions).

By design it owns **only** formatting + input affordances — never merge or importance logic, which stay gateway-side and identical for every channel. `CliChannel` (viewer) and `TuiChannel` (shell) are the first two impls. `GateRef`/`GateKind`/`GateAction` move here as the channel-neutral gate primitives.

### `operator_channel_bindings` (migration v48)
`(channel, external_id) → root_session_id`, so a Discord thread / WhatsApp chat survives reconnects and routes the operator's replies back into the right room as `Operator`-seat events.
- Store: `bind_channel` (upsert; **preserves `created_at` on rebind**) + `resolve_channel_binding`.
- **`channel.bind` / `channel.resolve` JSON-RPC** so channels reach bindings as API clients, never direct store readers (#390). Types in `autonoetic_types::channel`.

## Test plan
- [x] `cargo build` (workspace) — clean
- [x] `cargo test -p autonoetic` — 10 room unit tests (incl. new `channel` tests: `kind`/`gate_prompt` per gate)
- [x] `cargo test -p autonoetic-gateway --test channel_bindings_jsonrpc_integration` — 3 pass: bind→resolve round-trip, rebind-preserves-`created_at`, unbound→`null`, required-field validation (`-32602`)
- [x] `session_timeline_jsonrpc_integration` still green
- Note: the ~27 `--lib` failures are the pre-existing parallelism races (each passes in isolation — e.g. `test_dispatch_ping`); this PR is purely additive (two new match arms + an idempotent migration on a fresh table).

## Next
P3.d (#394) — Discord bridge: the first off-host channel client, consuming `channel.bind`/`resolve` + `session.timeline.list` and the `Channel` trait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)