### PR TITLE
feat(session-room): interaction polish — pre-digested choices + one-line rendering

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -657,6 +657,28 @@ impl JsonRpcRouter {
                         }
                     }
                 }
+                // Operator's own message onto the canonical timeline (#405) — so
+                // any channel (room, Discord) shows both sides of the conversation,
+                // not just the agent's replies. Written here, gateway-side and once,
+                // before dispatch so the operator line precedes the agent's response
+                // even under async_mode.
+                if params.event_type.trim() == "chat" && !params.message.trim().is_empty() {
+                    if let Some(store) = self.execution.gateway_store() {
+                        let event = crate::runtime::session_timeline::operator_message_event(
+                            &session_id,
+                            params.source_agent_id.as_deref(),
+                            &crate::log_redaction::redact_text_for_logs(&params.message),
+                        );
+                        if let Err(e) = store.create_live_digest_event(&event) {
+                            tracing::debug!(
+                                target: "session_timeline",
+                                error = %e,
+                                "operator.message timeline emit failed"
+                            );
+                        }
+                    }
+                }
+
                 let explicit_target = if ingest_rerouted_from_child {
                     reroute_lead.as_deref()
                 } else {

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -50,6 +50,36 @@ pub fn build_timeline_event(
     }
 }
 
+/// Build the `operator.message` timeline event for an operator-originated chat
+/// message into a session (#405) — so channels show both sides of the
+/// conversation, not just agent replies. Attribution: a human chat (no
+/// `source_agent_id`) is the **Operator seat / Human** principal; an
+/// agent-originated ingest is attributed to that agent's seat. Altitude is
+/// `Normal` (first-class conversation, visible at the default floor). The
+/// caller redacts the message text before passing it in.
+pub fn operator_message_event(
+    session_id: &str,
+    source_agent_id: Option<&str>,
+    redacted_message: &str,
+) -> LiveDigestEventRecord {
+    let (principal, role) = match source_agent_id {
+        None | Some("") => (Principal::human("operator"), SessionRole::Operator),
+        Some(agent_id) => (Principal::agent(agent_id), derive_role(agent_id)),
+    };
+    let root = crate::runtime::content_store::root_session_id(session_id);
+    build_timeline_event(
+        root.to_string(),
+        session_id.to_string(),
+        None,
+        &principal,
+        &role,
+        "operator.message",
+        Some(Altitude::Normal),
+        Some(serde_json::json!({ "message": redacted_message })),
+        TimelineRefs::default(),
+    )
+}
+
 /// Base importance of a digest event type, before any role refinement.
 pub fn base_altitude(event_type: &str) -> Altitude {
     match event_type {
@@ -123,6 +153,31 @@ pub fn decider_seat(decided_by: &str) -> (autonoetic_types::principal::Principal
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn operator_message_event_attributes_human_and_agent() {
+        // A human chat (no source_agent_id) ⇒ Operator seat / Human principal.
+        let human = operator_message_event("session-1", None, "hello there");
+        assert_eq!(human.event_type, "operator.message");
+        assert_eq!(human.altitude.as_deref(), Some("normal"));
+        assert_eq!(human.role, Some(SessionRole::Operator.to_storage()));
+        assert_eq!(
+            human.principal_kind,
+            Some(Principal::human("operator").kind_to_storage())
+        );
+        assert_eq!(human.principal_id.as_deref(), Some("operator"));
+        let payload: serde_json::Value =
+            serde_json::from_str(human.payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload["message"], "hello there");
+
+        // An agent-originated ingest is attributed to that agent, not the operator.
+        let agent = operator_message_event("session-1", Some("planner.default"), "ping");
+        assert_eq!(agent.principal_id.as_deref(), Some("planner.default"));
+        assert_ne!(
+            agent.principal_kind,
+            Some(Principal::human("operator").kind_to_storage())
+        );
+    }
 
     #[test]
     fn sentinel_floor_raises_mild_events() {

--- a/autonoetic-gateway/src/runtime/tools/user_interaction.rs
+++ b/autonoetic-gateway/src/runtime/tools/user_interaction.rs
@@ -222,6 +222,16 @@ impl NativeTool for UserAskTool {
             )
         };
         let options_count = options.len();
+        // Embed the pre-digested choices (id + label) in the timeline event so
+        // every channel can render one-tap options inline without an extra
+        // round-trip — the room is store-free and reads only the timeline (#393).
+        // Labels only (not `value`, which may be sensitive); freeform-allowed
+        // travels too so a channel knows whether to offer a text fallback.
+        let options_for_event: Vec<serde_json::Value> = options
+            .iter()
+            .map(|o| serde_json::json!({ "id": o.id, "label": o.label }))
+            .collect();
+        let allow_freeform_for_event = args.allow_freeform;
 
         let store = match gateway_store {
             Some(ref s) => s.clone(),
@@ -324,6 +334,8 @@ impl NativeTool for UserAskTool {
                                     "interaction_id": gate_id,
                                     "question": crate::log_redaction::redact_text_for_logs(&question_for_side_effects),
                                     "options_count": options_count,
+                                    "options": options_for_event,
+                                    "allow_freeform": allow_freeform_for_event,
                                 })
                                 .to_string(),
                             ),

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -44,6 +44,40 @@ fn role_label(role: &SessionRole) -> String {
     }
 }
 
+/// Collapse a possibly multi-line string into a single timeline line: runs of
+/// whitespace (incl. newlines) become one space, then truncate with an ellipsis.
+/// Keeps a rich `user.ask` question or any prose from breaking the one-line feed.
+fn one_line(s: &str, max: usize) -> String {
+    let flat = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = flat.chars();
+    let truncated: String = chars.by_ref().take(max).collect();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
+/// Render embedded pre-digested choices as a compact inline hint, e.g.
+/// ` — [1] Yes · [2] No`. Reads the `options` array (objects with a `label`)
+/// the gateway embeds in the `user.ask.pending` payload (#393). Empty ⇒ "".
+fn choices_hint(payload: Option<&serde_json::Value>) -> String {
+    let Some(opts) = payload.and_then(|v| v.get("options")).and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+    let parts: Vec<String> = opts
+        .iter()
+        .enumerate()
+        .filter_map(|(i, o)| o.get("label").and_then(|l| l.as_str()).map(|l| (i, l)))
+        .map(|(i, label)| format!("[{}] {}", i + 1, one_line(label, 24)))
+        .collect();
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" — {}", parts.join(" · "))
+    }
+}
+
 /// Human summary of an event, from its type + payload. Keeps the most useful
 /// field per known event type; falls back to the bare event type.
 pub fn summarize(entry: &SessionTimelineEntry) -> String {
@@ -77,10 +111,17 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
         "workbench.reconciled" => "workbench reconciled".into(),
         "workbench.discarded" => "workbench discarded".into(),
         "user.ask.pending" => format!(
-            "asks: {}",
-            field("question").unwrap_or_default()
+            "asks: {}{}",
+            one_line(&field("question").unwrap_or_default(), 100),
+            choices_hint(p.as_ref()),
         ),
-        "tool.completed" => format!("tool {}", field("tool").unwrap_or_else(|| "completed".into())),
+        // Payload key is `tool_name`; keep `tool` as a fallback for older rows.
+        "tool.completed" => format!(
+            "tool {}",
+            field("tool_name")
+                .or_else(|| field("tool"))
+                .unwrap_or_else(|| "completed".into())
+        ),
         "llm.request_failed" => format!("LLM error: {}", field("error").unwrap_or_default()),
         other => other.to_string(),
     }
@@ -394,6 +435,40 @@ mod tests {
         assert!(detail.contains("seat:      operator"));
         assert!(detail.contains("approval=apr-9"));
         assert!(detail.contains("\"request_id\": \"apr-9\""));
+    }
+
+    #[test]
+    fn multiline_question_flattens_and_truncates_with_choices() {
+        let long_q = "Pick a market:\n\n1. US equities\n2. Crypto\n".to_string() + &"x".repeat(200);
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "user.ask.pending",
+            Altitude::Attention,
+            serde_json::json!({
+                "question": long_q,
+                "options": [{"id": "o1", "label": "US equities"}, {"id": "o2", "label": "Crypto"}],
+            }),
+        );
+        let line = render_line(&e);
+        // One physical line: no embedded newlines, truncated with an ellipsis.
+        assert!(!line.contains('\n'));
+        assert!(line.contains('…'));
+        // Pre-digested choices rendered inline and numbered.
+        assert!(line.contains("[1] US equities"));
+        assert!(line.contains("[2] Crypto"));
+    }
+
+    #[test]
+    fn tool_completed_uses_tool_name_field() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({ "tool_name": "Edit", "result": "ok" }),
+        );
+        assert!(render_line(&e).contains("tool Edit"));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -114,6 +114,9 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
         "workbench.created" => "workbench projected".into(),
         "workbench.reconciled" => "workbench reconciled".into(),
         "workbench.discarded" => "workbench discarded".into(),
+        // The operator's (or any actor's) own message into the session (#405).
+        // The actor label already shows who; here we just show the text.
+        "operator.message" => one_line(&field("message").unwrap_or_default(), 120),
         "user.ask.pending" => format!(
             "asks: {}{}",
             one_line(&field("question").unwrap_or_default(), 100),
@@ -474,6 +477,22 @@ mod tests {
         // Whitespace (incl. newlines) collapses to single spaces.
         assert_eq!(one_line("a\n\n  b\tc", 50), "a b c");
         assert_eq!(one_line("anything", 0), "");
+    }
+
+    #[test]
+    fn operator_message_renders_with_human_label() {
+        let e = entry(
+            SessionRole::Operator,
+            Principal::human("operator"),
+            "operator.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "focus on US equities\nand crypto" }),
+        );
+        let line = render_line(&e);
+        assert!(line.contains("🧑 operator"));
+        // Flattened to one line, no embedded newline.
+        assert!(line.contains("focus on US equities and crypto"));
+        assert!(!line.contains('\n'));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -47,15 +47,19 @@ fn role_label(role: &SessionRole) -> String {
 /// Collapse a possibly multi-line string into a single timeline line: runs of
 /// whitespace (incl. newlines) become one space, then truncate with an ellipsis.
 /// Keeps a rich `user.ask` question or any prose from breaking the one-line feed.
-fn one_line(s: &str, max: usize) -> String {
+/// The result is a **hard cap** of `max` chars — the ellipsis counts toward it,
+/// so a truncated string keeps `max - 1` chars + `…`.
+pub(crate) fn one_line(s: &str, max: usize) -> String {
     let flat = s.split_whitespace().collect::<Vec<_>>().join(" ");
-    let mut chars = flat.chars();
-    let truncated: String = chars.by_ref().take(max).collect();
-    if chars.next().is_some() {
-        format!("{truncated}…")
-    } else {
-        truncated
+    if flat.chars().count() <= max {
+        return flat;
     }
+    if max == 0 {
+        return String::new();
+    }
+    // Reserve one char for the ellipsis so the total never exceeds `max`.
+    let truncated: String = flat.chars().take(max - 1).collect();
+    format!("{truncated}…")
 }
 
 /// Render embedded pre-digested choices as a compact inline hint, e.g.
@@ -457,6 +461,19 @@ mod tests {
         // Pre-digested choices rendered inline and numbered.
         assert!(line.contains("[1] US equities"));
         assert!(line.contains("[2] Crypto"));
+    }
+
+    #[test]
+    fn one_line_is_a_hard_cap_including_the_ellipsis() {
+        let long = "abcdefghijklmnopqrstuvwxyz";
+        let out = one_line(long, 10);
+        assert_eq!(out.chars().count(), 10, "must not exceed max incl. ellipsis");
+        assert!(out.ends_with('…'));
+        // A string within the cap is returned untouched (no ellipsis).
+        assert_eq!(one_line("short", 10), "short");
+        // Whitespace (incl. newlines) collapses to single spaces.
+        assert_eq!(one_line("a\n\n  b\tc", 50), "a b c");
+        assert_eq!(one_line("anything", 0), "");
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -24,13 +24,60 @@ use std::io;
 use std::time::Duration;
 
 /// An in-flight operator decision — captures an optional motivation (approvals,
-/// §3.5) or the answer text (interactions) before committing. `GateRef`,
-/// `GateKind`, and `GateAction` are the channel-neutral primitives, shared from
+/// §3.5) or the answer (interactions) before committing. `GateRef`, `GateKind`,
+/// and `GateAction` are the channel-neutral primitives, shared from
 /// [`super::channel`].
 struct GateInput {
     action: GateAction,
     id: String,
     buffer: String,
+    /// Pre-digested choices for an interaction answer (empty for approvals and
+    /// option-less asks). A number key picks one → `answer_option_id`.
+    options: Vec<GateOption>,
+    /// Whether free-text is accepted alongside any options (interactions).
+    allow_freeform: bool,
+}
+
+/// One pre-digested choice surfaced from a `user.ask.pending` event payload.
+#[derive(Clone)]
+struct GateOption {
+    id: String,
+    label: String,
+}
+
+/// Read the pre-digested choices + freeform policy for an interaction from its
+/// `user.ask.pending` timeline entry (the gateway embeds them, #393). Returns
+/// `(options, allow_freeform)`; missing `allow_freeform` defaults to permissive.
+fn interaction_choices(entries: &[SessionTimelineEntry], interaction_id: &str) -> (Vec<GateOption>, bool) {
+    let entry = entries.iter().find(|e| {
+        e.event_type == "user.ask.pending"
+            && e.refs.interaction_id.as_deref() == Some(interaction_id)
+    });
+    let Some(payload) = entry
+        .and_then(|e| e.payload.as_deref())
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+    else {
+        return (Vec::new(), true);
+    };
+    let options = payload
+        .get("options")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|o| {
+                    Some(GateOption {
+                        id: o.get("id")?.as_str()?.to_string(),
+                        label: o.get("label")?.as_str()?.to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let allow_freeform = payload
+        .get("allow_freeform")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    (options, allow_freeform)
 }
 
 /// Restores the terminal on drop, even on early return / panic-unwind.
@@ -164,25 +211,39 @@ pub fn run(
                 }
                 // Text-capture mode takes over all input while open.
                 if let Some(gi) = input.as_mut() {
-                    match key.code {
-                        KeyCode::Esc => input = None,
-                        KeyCode::Enter => {
-                            let gi = input.take().unwrap();
-                            match resolve_gate(client, &gi) {
-                                // Mark acted only on success — a failed RPC or an
-                                // empty answer leaves the gate offerable.
-                                Ok(msg) => {
-                                    acted.insert(gi.id.clone());
-                                    status = Some(msg);
-                                }
-                                // Reopen capture with the buffer intact so the
-                                // operator can fix the input and resubmit.
-                                Err(msg) => {
-                                    status = Some(msg);
-                                    input = Some(gi);
-                                }
+                    // A number key picks a pre-digested choice (interaction answer)
+                    // while the free-text buffer is still empty.
+                    let chosen = if gi.action == GateAction::Answer && gi.buffer.is_empty() {
+                        if let KeyCode::Char(c @ '1'..='9') = key.code {
+                            gi.options.get((c as usize) - ('1' as usize)).cloned()
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    // Number selection and Enter both commit; share the resolve path.
+                    let commit = chosen.is_some() || key.code == KeyCode::Enter;
+                    if commit {
+                        let gi = input.take().unwrap();
+                        match resolve_gate(client, &gi, chosen.as_ref()) {
+                            // Mark acted only on success — a failed RPC or an
+                            // invalid answer leaves the gate offerable.
+                            Ok(msg) => {
+                                acted.insert(gi.id.clone());
+                                status = Some(msg);
+                            }
+                            // Reopen capture with the buffer intact so the operator
+                            // can fix the input and resubmit.
+                            Err(msg) => {
+                                status = Some(msg);
+                                input = Some(gi);
                             }
                         }
+                        continue;
+                    }
+                    match key.code {
+                        KeyCode::Esc => input = None,
                         KeyCode::Backspace => {
                             gi.buffer.pop();
                         }
@@ -216,18 +277,24 @@ pub fn run(
                                 },
                                 id: g.id.clone(),
                                 buffer: String::new(),
+                                options: Vec::new(),
+                                allow_freeform: true,
                             });
                             status = None;
                         }
                     }
-                    // r: reply to the selected pending interaction (user.ask).
+                    // r: reply to the selected pending interaction (user.ask) —
+                    // load its pre-digested choices so a number key picks one.
                     KeyCode::Char('r') => {
                         if let Some(g) = gate.as_ref().filter(|g| g.kind == GateKind::Interaction) {
                             detail = None;
+                            let (options, allow_freeform) = interaction_choices(&visible, &g.id);
                             input = Some(GateInput {
                                 action: GateAction::Answer,
                                 id: g.id.clone(),
                                 buffer: String::new(),
+                                options,
+                                allow_freeform,
                             });
                             status = None;
                         }
@@ -306,20 +373,16 @@ fn selectable_gate(
 
 /// Resolve a gate over the gateway API (the sanctioned path that unblocks the
 /// waiting agent + records the decision incl. decider kind, #361). Decider is
-/// the operator; `buffer` is the motivation (approvals) or answer (interactions).
+/// the operator; `buffer` is the motivation (approvals) or free-text answer
+/// (interactions). `chosen` is a pre-digested choice picked by number, which
+/// resolves an interaction via `answer_option_id` instead of free text.
 ///
 /// Returns `Ok(msg)` only when the gateway accepted the decision (the caller
 /// uses this to mark the gate acted); `Err(msg)` on validation or transport
 /// failure, leaving the gate offerable so the operator can retry.
-fn resolve_gate(client: &RoomClient, gi: &GateInput) -> Result<String, String> {
+fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>) -> Result<String, String> {
     let text = gi.buffer.trim();
     let reason = (!text.is_empty()).then(|| text.to_string());
-    // The gateway requires a non-empty answer for interactions; reject locally
-    // rather than round-trip a guaranteed server rejection (and so we never mark
-    // the gate acted on an empty submission).
-    if gi.action == GateAction::Answer && text.is_empty() {
-        return Err("✗ answer cannot be empty".to_string());
-    }
     let (result, verb) = match gi.action {
         GateAction::Approve => (
             rpc(
@@ -337,14 +400,30 @@ fn resolve_gate(client: &RoomClient, gi: &GateInput) -> Result<String, String> {
             ),
             "rejected",
         ),
-        GateAction::Answer => (
-            rpc(
-                client,
-                "interaction.resolve_and_answer",
-                serde_json::json!({ "interaction_id": gi.id, "answer_text": text, "answered_by": "operator" }),
-            ),
-            "answered",
-        ),
+        GateAction::Answer => {
+            // Exactly one of answer_option_id / answer_text, per the gateway.
+            let params = if let Some(opt) = chosen {
+                serde_json::json!({ "interaction_id": gi.id, "answer_option_id": opt.id, "answered_by": "operator" })
+            } else {
+                // Reject locally rather than round-trip a guaranteed rejection
+                // (and so we never mark the gate acted on a doomed submission).
+                if text.is_empty() {
+                    return Err(if gi.options.is_empty() {
+                        "✗ answer cannot be empty".to_string()
+                    } else {
+                        "✗ press a number to choose, or type a reply".to_string()
+                    });
+                }
+                if !gi.allow_freeform {
+                    return Err("✗ this question requires choosing a numbered option".to_string());
+                }
+                serde_json::json!({ "interaction_id": gi.id, "answer_text": text, "answered_by": "operator" })
+            };
+            (
+                rpc(client, "interaction.resolve_and_answer", params),
+                "answered",
+            )
+        }
     };
     match result {
         Ok(_) => Ok(format!("✓ {verb} {}", gi.id)),
@@ -465,11 +544,25 @@ fn draw(
             GateAction::Reject => "REJECT — motivation (optional)",
             GateAction::Answer => "ANSWER",
         };
-        Paragraph::new(format!(
-            " {label}: {}▏   [Enter submit · Esc cancel]",
-            gi.buffer
-        ))
-        .style(Style::default().fg(Color::Cyan))
+        // For an interaction with pre-digested choices, list them so a number
+        // key picks one (the §3.5 one-tap path); free-text stays available when
+        // the question allows it.
+        let choices = gi
+            .options
+            .iter()
+            .enumerate()
+            .map(|(i, o)| format!("[{}] {}", i + 1, o.label))
+            .collect::<Vec<_>>()
+            .join(" · ");
+        let hint = if gi.options.is_empty() {
+            "[Enter submit · Esc cancel]".to_string()
+        } else if gi.allow_freeform {
+            format!("{choices}   [number choose · or type a reply · Esc cancel]")
+        } else {
+            format!("{choices}   [number choose · Esc cancel]")
+        };
+        Paragraph::new(format!(" {label}: {}▏   {hint}", gi.buffer))
+            .style(Style::default().fg(Color::Cyan))
     } else {
         // The gate affordance hint is the channel's concern (#393) — route it
         // through the channel so a Discord/WhatsApp bridge can render its own.
@@ -557,9 +650,56 @@ mod tests {
             action: GateAction::Answer,
             id: "int-1".into(),
             buffer: "   ".into(), // whitespace-only ⇒ empty after trim
+            options: Vec::new(),
+            allow_freeform: true,
         };
-        let err = resolve_gate(&client, &gi).unwrap_err();
+        let err = resolve_gate(&client, &gi, None).unwrap_err();
         assert!(err.contains("empty"), "expected empty-answer rejection, got: {err}");
+    }
+
+    #[test]
+    fn answer_validation_respects_options_and_freeform_policy() {
+        let client = RoomClient::for_test();
+        // Empty answer with options present ⇒ guidance to choose a number.
+        let with_opts = GateInput {
+            action: GateAction::Answer,
+            id: "int-1".into(),
+            buffer: String::new(),
+            options: vec![GateOption { id: "o1".into(), label: "Yes".into() }],
+            allow_freeform: true,
+        };
+        assert!(resolve_gate(&client, &with_opts, None).unwrap_err().contains("number"));
+
+        // Free-text typed where only options are allowed ⇒ rejected locally.
+        let no_freeform = GateInput {
+            action: GateAction::Answer,
+            id: "int-1".into(),
+            buffer: "typed answer".into(),
+            options: vec![GateOption { id: "o1".into(), label: "Yes".into() }],
+            allow_freeform: false,
+        };
+        assert!(resolve_gate(&client, &no_freeform, None).unwrap_err().contains("numbered option"));
+    }
+
+    #[test]
+    fn interaction_choices_reads_options_from_payload() {
+        let mut e = gate_entry("user.ask.pending");
+        e.payload = Some(
+            serde_json::json!({
+                "interaction_id": "int-1",
+                "options": [{"id": "o1", "label": "Yes"}, {"id": "o2", "label": "No"}],
+                "allow_freeform": false
+            })
+            .to_string(),
+        );
+        let (opts, freeform) = interaction_choices(std::slice::from_ref(&e), "int-1");
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].id, "o1");
+        assert_eq!(opts[1].label, "No");
+        assert!(!freeform);
+        // Unknown interaction ⇒ permissive default, no options.
+        let (none, ff) = interaction_choices(std::slice::from_ref(&e), "other");
+        assert!(none.is_empty() && ff);
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -120,6 +120,7 @@ pub fn run(
     let mut selected: usize = 0;
     let mut detail: Option<Vec<String>> = None; // drill-down pane content
     let mut input: Option<GateInput> = None; // in-flight gate decision
+    let mut compose: Option<String> = None; // in-flight free-form message to the session
     let mut status: Option<String> = None; // last action / connection result
     // Gates no longer offerable: approvals resolved on the timeline, plus
     // anything the operator just acted on (covers interactions, which have no
@@ -201,7 +202,7 @@ pub fn run(
         let gate = selectable_gate(&visible, indexed.get(selected), &resolved, &acted);
 
         terminal.draw(|f| {
-            draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), status.as_deref(), gate.as_ref())
+            draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), compose.as_deref(), status.as_deref(), gate.as_ref())
         })?;
 
         if event::poll(Duration::from_millis(250))? {
@@ -209,6 +210,31 @@ pub fn run(
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
+                // Compose mode: capturing a free-form message to the session (#405).
+                if let Some(buf) = compose.as_mut() {
+                    match key.code {
+                        KeyCode::Esc => compose = None,
+                        KeyCode::Enter => {
+                            let text = buf.trim().to_string();
+                            if text.is_empty() {
+                                compose = None; // nothing to send
+                            } else {
+                                // Async so the sync loop never blocks on the agent
+                                // turn; the operator line + reply stream in via polling.
+                                status = Some(send_message(client, root_session_id, &text));
+                                compose = None;
+                                follow = true; // jump to newest to watch the exchange
+                            }
+                        }
+                        KeyCode::Backspace => {
+                            buf.pop();
+                        }
+                        KeyCode::Char(c) => buf.push(c),
+                        _ => {}
+                    }
+                    continue;
+                }
+
                 // Text-capture mode takes over all input while open.
                 if let Some(gi) = input.as_mut() {
                     // Instant single-digit pick — only when it's unambiguous: a
@@ -320,6 +346,12 @@ pub fn run(
                         detail = None;
                     }
                     KeyCode::Char('s') => squash = !squash,
+                    // i: compose a free-form message into the session (#405).
+                    KeyCode::Char('i') => {
+                        detail = None;
+                        compose = Some(String::new());
+                        status = None;
+                    }
                     KeyCode::Down | KeyCode::Char('j') => {
                         follow = false;
                         detail = None;
@@ -453,6 +485,27 @@ fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>
     }
 }
 
+/// Send a free-form operator message into the session over the gateway API
+/// (#405) — the same `event.ingest` ingress `chat` uses. Async (`async_mode`)
+/// so the sync TUI loop never blocks on the agent turn; the operator's line
+/// (recorded gateway-side) and the agent's reply then stream in via polling.
+fn send_message(client: &RoomClient, root_session_id: &str, text: &str) -> String {
+    match rpc(
+        client,
+        "event.ingest",
+        serde_json::json!({
+            "event_type": "chat",
+            "message": text,
+            "session_id": root_session_id,
+            "async_mode": true,
+            "metadata": { "source": "session_room" },
+        }),
+    ) {
+        Ok(_) => "✓ sent".to_string(),
+        Err(e) => format!("✗ {e}"),
+    }
+}
+
 /// Drill-down detail for a selected row's source: a single event's full
 /// metadata/payload/refs, or what a collapsed run folds. (Deep ref-following —
 /// fetching the referenced approval/plan/workbench object — needs RPC read
@@ -503,6 +556,7 @@ fn draw(
     selected: usize,
     detail: Option<&[String]>,
     input: Option<&GateInput>,
+    compose: Option<&str>,
     status: Option<&str>,
     gate: Option<&GateRef>,
 ) {
@@ -560,7 +614,10 @@ fn draw(
         &mut state,
     );
 
-    let footer = if let Some(gi) = input {
+    let footer = if let Some(buf) = compose {
+        Paragraph::new(format!(" MESSAGE: {buf}▏   [Enter send · Esc cancel]"))
+            .style(Style::default().fg(Color::Green))
+    } else if let Some(gi) = input {
         let label = match gi.action {
             GateAction::Approve => "APPROVE — motivation (optional)",
             GateAction::Reject => "REJECT — motivation (optional)",
@@ -592,7 +649,7 @@ fn draw(
         // through the channel so a Discord/WhatsApp bridge can render its own.
         let gate_hint = gate.map(|g| TuiChannel.gate_prompt(g)).unwrap_or_default();
         Paragraph::new(format!(
-            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · ⏎ detail{gate_hint}"
+            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · i message · ⏎ detail{gate_hint}"
         ))
         .style(Style::default().fg(Color::DarkGray))
     };

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -211,9 +211,16 @@ pub fn run(
                 }
                 // Text-capture mode takes over all input while open.
                 if let Some(gi) = input.as_mut() {
-                    // A number key picks a pre-digested choice (interaction answer)
-                    // while the free-text buffer is still empty.
-                    let chosen = if gi.action == GateAction::Answer && gi.buffer.is_empty() {
+                    // Instant single-digit pick — only when it's unambiguous: a
+                    // pure-choice question (no free-text) with ≤9 options and an
+                    // empty buffer. Otherwise digits go into the buffer so multi-
+                    // digit ordinals (>9 options) and free-text starting with a
+                    // digit still work; Enter then resolves the ordinal.
+                    let chosen = if gi.action == GateAction::Answer
+                        && gi.buffer.is_empty()
+                        && !gi.allow_freeform
+                        && gi.options.len() <= 9
+                    {
                         if let KeyCode::Char(c @ '1'..='9') = key.code {
                             gi.options.get((c as usize) - ('1' as usize)).cloned()
                         } else {
@@ -371,6 +378,41 @@ fn selectable_gate(
     }
 }
 
+/// Decide the `interaction.resolve_and_answer` params for an interaction, or a
+/// local-rejection message. Pure (no RPC) so the branching is unit-testable.
+///
+/// A typed number selects the matching pre-digested option — so >9 options and
+/// the "type 2 ⏎" flow both work, even when free-text is disallowed. Falls back
+/// to a hotkey-`chosen` option, then to free-text (when the question allows it).
+/// Rejects locally rather than round-trip a guaranteed rejection (so a gate is
+/// never marked acted on a doomed submission).
+fn answer_params(gi: &GateInput, chosen: Option<&GateOption>) -> Result<serde_json::Value, String> {
+    let text = gi.buffer.trim();
+    let by_number = (!gi.options.is_empty())
+        .then(|| text.parse::<usize>().ok())
+        .flatten()
+        .filter(|n| (1..=gi.options.len()).contains(n))
+        .map(|n| &gi.options[n - 1]);
+    if let Some(opt) = chosen.or(by_number) {
+        return Ok(serde_json::json!({
+            "interaction_id": gi.id, "answer_option_id": opt.id, "answered_by": "operator"
+        }));
+    }
+    if text.is_empty() {
+        return Err(if gi.options.is_empty() {
+            "✗ answer cannot be empty".to_string()
+        } else {
+            "✗ type a number to choose, or type a reply".to_string()
+        });
+    }
+    if !gi.allow_freeform {
+        return Err("✗ this question requires choosing a numbered option".to_string());
+    }
+    Ok(serde_json::json!({
+        "interaction_id": gi.id, "answer_text": text, "answered_by": "operator"
+    }))
+}
+
 /// Resolve a gate over the gateway API (the sanctioned path that unblocks the
 /// waiting agent + records the decision incl. decider kind, #361). Decider is
 /// the operator; `buffer` is the motivation (approvals) or free-text answer
@@ -400,30 +442,10 @@ fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>
             ),
             "rejected",
         ),
-        GateAction::Answer => {
-            // Exactly one of answer_option_id / answer_text, per the gateway.
-            let params = if let Some(opt) = chosen {
-                serde_json::json!({ "interaction_id": gi.id, "answer_option_id": opt.id, "answered_by": "operator" })
-            } else {
-                // Reject locally rather than round-trip a guaranteed rejection
-                // (and so we never mark the gate acted on a doomed submission).
-                if text.is_empty() {
-                    return Err(if gi.options.is_empty() {
-                        "✗ answer cannot be empty".to_string()
-                    } else {
-                        "✗ press a number to choose, or type a reply".to_string()
-                    });
-                }
-                if !gi.allow_freeform {
-                    return Err("✗ this question requires choosing a numbered option".to_string());
-                }
-                serde_json::json!({ "interaction_id": gi.id, "answer_text": text, "answered_by": "operator" })
-            };
-            (
-                rpc(client, "interaction.resolve_and_answer", params),
-                "answered",
-            )
-        }
+        GateAction::Answer => (
+            rpc(client, "interaction.resolve_and_answer", answer_params(gi, chosen)?),
+            "answered",
+        ),
     };
     match result {
         Ok(_) => Ok(format!("✓ {verb} {}", gi.id)),
@@ -551,7 +573,9 @@ fn draw(
             .options
             .iter()
             .enumerate()
-            .map(|(i, o)| format!("[{}] {}", i + 1, o.label))
+            // Flatten/truncate labels so a multi-line or long label can't break
+            // the one-line footer.
+            .map(|(i, o)| format!("[{}] {}", i + 1, render::one_line(&o.label, 24)))
             .collect::<Vec<_>>()
             .join(" · ");
         let hint = if gi.options.is_empty() {
@@ -658,27 +682,46 @@ mod tests {
     }
 
     #[test]
-    fn answer_validation_respects_options_and_freeform_policy() {
-        let client = RoomClient::for_test();
-        // Empty answer with options present ⇒ guidance to choose a number.
-        let with_opts = GateInput {
+    fn answer_params_handles_numbers_options_and_freeform() {
+        let opts = || vec![
+            GateOption { id: "o1".into(), label: "Yes".into() },
+            GateOption { id: "o2".into(), label: "No".into() },
+        ];
+        let mk = |buffer: &str, options: Vec<GateOption>, allow_freeform: bool| GateInput {
             action: GateAction::Answer,
             id: "int-1".into(),
-            buffer: String::new(),
-            options: vec![GateOption { id: "o1".into(), label: "Yes".into() }],
-            allow_freeform: true,
+            buffer: buffer.into(),
+            options,
+            allow_freeform,
         };
-        assert!(resolve_gate(&client, &with_opts, None).unwrap_err().contains("number"));
 
-        // Free-text typed where only options are allowed ⇒ rejected locally.
-        let no_freeform = GateInput {
-            action: GateAction::Answer,
-            id: "int-1".into(),
-            buffer: "typed answer".into(),
-            options: vec![GateOption { id: "o1".into(), label: "Yes".into() }],
-            allow_freeform: false,
-        };
-        assert!(resolve_gate(&client, &no_freeform, None).unwrap_err().contains("numbered option"));
+        // A typed number selects the matching option — even when free-text is
+        // disallowed (the "type 2 ⏎" / >9-options flow the reviewer flagged).
+        let p = answer_params(&mk("2", opts(), false), None).unwrap();
+        assert_eq!(p["answer_option_id"], "o2");
+        assert!(p.get("answer_text").is_none());
+
+        // An out-of-range number is treated as free-text (when allowed).
+        let p = answer_params(&mk("99", opts(), true), None).unwrap();
+        assert_eq!(p["answer_text"], "99");
+
+        // A hotkey-chosen option wins regardless of buffer.
+        let chosen = GateOption { id: "o1".into(), label: "Yes".into() };
+        let p = answer_params(&mk("", opts(), false), Some(&chosen)).unwrap();
+        assert_eq!(p["answer_option_id"], "o1");
+
+        // Free-text where only options are allowed ⇒ rejected locally.
+        assert!(answer_params(&mk("maybe later", opts(), false), None)
+            .unwrap_err()
+            .contains("numbered option"));
+
+        // Empty with options ⇒ guidance to type a number; empty without ⇒ "empty".
+        assert!(answer_params(&mk("", opts(), true), None).unwrap_err().contains("number"));
+        assert!(answer_params(&mk("", Vec::new(), true), None).unwrap_err().contains("empty"));
+
+        // Plain free-text with no options ⇒ answer_text.
+        let p = answer_params(&mk("ship it", Vec::new(), true), None).unwrap();
+        assert_eq!(p["answer_text"], "ship it");
     }
 
     #[test]

--- a/docs/design/session-room-conversational-input.md
+++ b/docs/design/session-room-conversational-input.md
@@ -1,0 +1,106 @@
+# Session Room — Full Conversational Input (operator messages)
+
+Status: **proposed** (2026-06-04) · Part of the Session Room program (#363) ·
+Follows interaction polish (#404).
+
+## Problem
+
+The Session Room (`autonoetic/src/cli/room/`) is today a **read + gate-resolve**
+surface: it tails the canonical timeline and resolves approvals/clarifications,
+but the operator **cannot send a free-form message** into the session. To start
+or steer a conversation you still drop back to `chat.rs`. The goal is to make the
+room a true interaction surface so a session can be driven entirely from it — and,
+because the room is just one channel, so the same path works for Discord/WhatsApp
+later.
+
+## How operator input works today (findings)
+
+- **Ingress is `event.ingest`** (newline JSON-RPC over TCP, `AUTONOETIC_SHARED_SECRET`)
+  — the *same transport* the room's `RoomClient` already uses. `chat.rs` submits
+  every operator turn as `event.ingest { event_type: "chat", message, session_id,
+  target_agent_id?, metadata }` (`router.rs:583`). The handler already special-cases
+  `event_type == "chat"` (e.g. rerouting to an active workflow-child session,
+  `router.rs:632`).
+- **Session continuity**: the first message to a fresh `session_id` spawns; reusing
+  the same `session_id` continues (`is_message` flag → `can_message_agent` policy).
+- **Blocking vs async**: `event.ingest` blocks on the agent turn by default;
+  `async_mode: true` enqueues and returns immediately.
+- **The gap**: the operator's own message is pushed into the in-memory conversation
+  history (`execution.rs:3698`) and persisted to the content store, but **never
+  written to `live_digest_events`**. So a timeline reader (the room) sees the
+  agent's side but not the operator's. This is the foundational thing to fix.
+
+## Design
+
+Two slices. Slice A is gateway-side and benefits every channel; Slice B is the
+room UI.
+
+### Slice A — operator messages on the canonical timeline (gateway)
+
+In the `event.ingest` handler, for operator-originated chat, emit a
+`live_digest_events` row **before** dispatching to the agent (so the operator's
+line lands in the feed ahead of the agent's response, preserving conversational
+order):
+
+- `event_type`: `operator.message`
+- `principal` / `role`: derive — when there is **no `source_agent_id`** (a human
+  via room/chat), attribute to **`Human` + `Operator` seat**; when an agent
+  originated it, attribute to that agent. (v1 keys on `event_type == "chat"` with
+  no `source_agent_id` ⇒ operator. Foreign-channel attribution via `metadata`
+  sender is a follow-up.)
+- `altitude`: `Normal` (visible at the default floor; it's first-class conversation,
+  not plumbing).
+- `payload`: `{ "message": <redacted text> }` (reuse `redact_text_for_logs`, as the
+  `user.ask.pending` producer does).
+- `refs`: none required for v1.
+
+`render::summarize` gets an arm for `operator.message` (show the one-lined text;
+the actor label already renders 🧑/seat). This makes the operator visible in the
+room **and** in any future channel — no per-channel work.
+
+> Why gateway-side, not in the room: the timeline is the canonical, channel-neutral
+> spine (#390). Writing the operator event once in the gateway means the room,
+> Discord, and `chat.rs`-as-timeline all show the operator identically. A channel
+> writing its own "I sent this" row would fragment the source of truth.
+
+### Slice B — compose & send from the room (TUI)
+
+- A **compose** key (proposed `i` = "input", mirroring the gate-capture UX already
+  in `tui.rs`) opens a text buffer in the footer; `Enter` sends, `Esc` cancels.
+- Send via `RoomClient` → `event.ingest { event_type: "chat", message, session_id:
+  <root_session_id>, async_mode: true, metadata: { source: "session_room" } }`.
+  **Async** so the sync TUI loop never blocks on a full agent turn; the operator's
+  line (Slice A) and the agent's response then stream in through normal polling.
+- Status line reflects the outcome (`✓ sent` / `✗ <error>`); on a mid-turn/busy
+  rejection, surface it and keep the buffer so it can be resent.
+- Targeting v1: send to the room's `root_session_id` (omit `target_agent_id` →
+  gateway resolves the lead). The existing chat reroute logic handles workflow
+  children.
+
+### Non-goals (v1)
+
+- Starting a **brand-new** session from the room (attach-to-existing only; fresh
+  sessions stay with `chat`/CLI).
+- Rich/multi-line composer, history scrollback editing, attachments.
+- Per-occupant attribution for non-human channel senders (Slice A keys on the
+  operator case; richer attribution is a follow-up when the Discord bridge lands).
+
+## Open questions
+
+1. **Mid-turn sends** — does `async_mode: true` enqueue or reject while the agent
+   is mid-turn? Confirm and pick the UX (queue silently vs. "agent busy, resend").
+2. **Event-type name** — `operator.message` (Operator-seat framing) vs. a neutral
+   `chat.message`. Leaning `operator.message` to match the two-axis model (seat =
+   Operator, principal = Human *or* AI).
+3. **Echo timing** — emit the operator event synchronously in the handler before
+   enqueueing the turn (chosen), so order is deterministic even under async.
+
+## Test plan
+
+- Gateway: `event.ingest { event_type: "chat" }` writes one `operator.message`
+  timeline row attributed to Human/Operator; agent-originated ingest does not
+  mis-attribute. Integration test over the router (shared-env pattern).
+- Render: `operator.message` renders one-lined with the 🧑 operator label.
+- Room TUI: compose→send issues an async `event.ingest`; unit-test the param
+  shape and the busy/again handling (no live agent required).
+- Live smoke: drive a real session end-to-end from the room.


### PR DESCRIPTION
## Summary
Fosters the §3.5 conversational-gate experience and fixes the rough edges I found in a **live smoke test** of the room. First half of the reprioritized plan (interaction polish → full conversational input → Discord).

### Pre-digested choices (one-tap clarification answers)
The `user.ask` answering path was free-text only, even though interactions carry `options`. Now:
- **Gateway** embeds the option labels (`id` + `label`) and `allow_freeform` in the `user.ask.pending` timeline event — so every channel renders the choices inline with **no extra round-trip**, keeping the room store-free (#393).
- **TUI**: replying (`r`) loads the choices; a **number key picks one** → resolves via `interaction.resolve_and_answer { answer_option_id }`. Free-text stays available when the question allows it. Locally rejects an empty answer (guides to a number when options exist) and free-text where only options are permitted — never marks a gate acted on a doomed submission.

### Rendering fixes (shared render core → benefits all channels incl. the coming Discord bridge)
- **Multi-line / long questions** flatten to one feed line + ellipsis truncation. (Live, a 772-char markdown question dumped ~8 lines into the feed.)
- **`tool.completed`** reads the real `tool_name` payload key — was always showing "completed" (58 identical rows in the smoke test).
- Choices render inline as numbered `[1] … · [2] …`.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test -p autonoetic` — 14 room tests (render: multiline+choices, `tool_name`; tui: option/freeform validation, `interaction_choices` payload parsing)
- [x] `cargo test -p autonoetic-gateway user_interaction` — green (producer change is additive)

## Next
Full conversational input (operator-initiated messages — room as a true chat surface, needs session ingress routing), then the Discord bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)