### PR TITLE
feat(session-room): operator messages — send into the session + show both sides (#405)

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -657,6 +657,28 @@ impl JsonRpcRouter {
                         }
                     }
                 }
+                // Operator's own message onto the canonical timeline (#405) — so
+                // any channel (room, Discord) shows both sides of the conversation,
+                // not just the agent's replies. Written here, gateway-side and once,
+                // before dispatch so the operator line precedes the agent's response
+                // even under async_mode.
+                if params.event_type.trim() == "chat" && !params.message.trim().is_empty() {
+                    if let Some(store) = self.execution.gateway_store() {
+                        let event = crate::runtime::session_timeline::operator_message_event(
+                            &session_id,
+                            params.source_agent_id.as_deref(),
+                            &crate::log_redaction::redact_text_for_logs(&params.message),
+                        );
+                        if let Err(e) = store.create_live_digest_event(&event) {
+                            tracing::debug!(
+                                target: "session_timeline",
+                                error = %e,
+                                "operator.message timeline emit failed"
+                            );
+                        }
+                    }
+                }
+
                 let explicit_target = if ingest_rerouted_from_child {
                     reroute_lead.as_deref()
                 } else {

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -50,6 +50,36 @@ pub fn build_timeline_event(
     }
 }
 
+/// Build the `operator.message` timeline event for an operator-originated chat
+/// message into a session (#405) — so channels show both sides of the
+/// conversation, not just agent replies. Attribution: a human chat (no
+/// `source_agent_id`) is the **Operator seat / Human** principal; an
+/// agent-originated ingest is attributed to that agent's seat. Altitude is
+/// `Normal` (first-class conversation, visible at the default floor). The
+/// caller redacts the message text before passing it in.
+pub fn operator_message_event(
+    session_id: &str,
+    source_agent_id: Option<&str>,
+    redacted_message: &str,
+) -> LiveDigestEventRecord {
+    let (principal, role) = match source_agent_id {
+        None | Some("") => (Principal::human("operator"), SessionRole::Operator),
+        Some(agent_id) => (Principal::agent(agent_id), derive_role(agent_id)),
+    };
+    let root = crate::runtime::content_store::root_session_id(session_id);
+    build_timeline_event(
+        root.to_string(),
+        session_id.to_string(),
+        None,
+        &principal,
+        &role,
+        "operator.message",
+        Some(Altitude::Normal),
+        Some(serde_json::json!({ "message": redacted_message })),
+        TimelineRefs::default(),
+    )
+}
+
 /// Base importance of a digest event type, before any role refinement.
 pub fn base_altitude(event_type: &str) -> Altitude {
     match event_type {
@@ -123,6 +153,31 @@ pub fn decider_seat(decided_by: &str) -> (autonoetic_types::principal::Principal
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn operator_message_event_attributes_human_and_agent() {
+        // A human chat (no source_agent_id) ⇒ Operator seat / Human principal.
+        let human = operator_message_event("session-1", None, "hello there");
+        assert_eq!(human.event_type, "operator.message");
+        assert_eq!(human.altitude.as_deref(), Some("normal"));
+        assert_eq!(human.role, Some(SessionRole::Operator.to_storage()));
+        assert_eq!(
+            human.principal_kind,
+            Some(Principal::human("operator").kind_to_storage())
+        );
+        assert_eq!(human.principal_id.as_deref(), Some("operator"));
+        let payload: serde_json::Value =
+            serde_json::from_str(human.payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload["message"], "hello there");
+
+        // An agent-originated ingest is attributed to that agent, not the operator.
+        let agent = operator_message_event("session-1", Some("planner.default"), "ping");
+        assert_eq!(agent.principal_id.as_deref(), Some("planner.default"));
+        assert_ne!(
+            agent.principal_kind,
+            Some(Principal::human("operator").kind_to_storage())
+        );
+    }
 
     #[test]
     fn sentinel_floor_raises_mild_events() {

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -114,6 +114,9 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
         "workbench.created" => "workbench projected".into(),
         "workbench.reconciled" => "workbench reconciled".into(),
         "workbench.discarded" => "workbench discarded".into(),
+        // The operator's (or any actor's) own message into the session (#405).
+        // The actor label already shows who; here we just show the text.
+        "operator.message" => one_line(&field("message").unwrap_or_default(), 120),
         "user.ask.pending" => format!(
             "asks: {}{}",
             one_line(&field("question").unwrap_or_default(), 100),
@@ -474,6 +477,22 @@ mod tests {
         // Whitespace (incl. newlines) collapses to single spaces.
         assert_eq!(one_line("a\n\n  b\tc", 50), "a b c");
         assert_eq!(one_line("anything", 0), "");
+    }
+
+    #[test]
+    fn operator_message_renders_with_human_label() {
+        let e = entry(
+            SessionRole::Operator,
+            Principal::human("operator"),
+            "operator.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "focus on US equities\nand crypto" }),
+        );
+        let line = render_line(&e);
+        assert!(line.contains("🧑 operator"));
+        // Flattened to one line, no embedded newline.
+        assert!(line.contains("focus on US equities and crypto"));
+        assert!(!line.contains('\n'));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -120,6 +120,7 @@ pub fn run(
     let mut selected: usize = 0;
     let mut detail: Option<Vec<String>> = None; // drill-down pane content
     let mut input: Option<GateInput> = None; // in-flight gate decision
+    let mut compose: Option<String> = None; // in-flight free-form message to the session
     let mut status: Option<String> = None; // last action / connection result
     // Gates no longer offerable: approvals resolved on the timeline, plus
     // anything the operator just acted on (covers interactions, which have no
@@ -201,7 +202,7 @@ pub fn run(
         let gate = selectable_gate(&visible, indexed.get(selected), &resolved, &acted);
 
         terminal.draw(|f| {
-            draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), status.as_deref(), gate.as_ref())
+            draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), compose.as_deref(), status.as_deref(), gate.as_ref())
         })?;
 
         if event::poll(Duration::from_millis(250))? {
@@ -209,6 +210,31 @@ pub fn run(
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
+                // Compose mode: capturing a free-form message to the session (#405).
+                if let Some(buf) = compose.as_mut() {
+                    match key.code {
+                        KeyCode::Esc => compose = None,
+                        KeyCode::Enter => {
+                            let text = buf.trim().to_string();
+                            if text.is_empty() {
+                                compose = None; // nothing to send
+                            } else {
+                                // Async so the sync loop never blocks on the agent
+                                // turn; the operator line + reply stream in via polling.
+                                status = Some(send_message(client, root_session_id, &text));
+                                compose = None;
+                                follow = true; // jump to newest to watch the exchange
+                            }
+                        }
+                        KeyCode::Backspace => {
+                            buf.pop();
+                        }
+                        KeyCode::Char(c) => buf.push(c),
+                        _ => {}
+                    }
+                    continue;
+                }
+
                 // Text-capture mode takes over all input while open.
                 if let Some(gi) = input.as_mut() {
                     // Instant single-digit pick — only when it's unambiguous: a
@@ -320,6 +346,12 @@ pub fn run(
                         detail = None;
                     }
                     KeyCode::Char('s') => squash = !squash,
+                    // i: compose a free-form message into the session (#405).
+                    KeyCode::Char('i') => {
+                        detail = None;
+                        compose = Some(String::new());
+                        status = None;
+                    }
                     KeyCode::Down | KeyCode::Char('j') => {
                         follow = false;
                         detail = None;
@@ -453,6 +485,27 @@ fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>
     }
 }
 
+/// Send a free-form operator message into the session over the gateway API
+/// (#405) — the same `event.ingest` ingress `chat` uses. Async (`async_mode`)
+/// so the sync TUI loop never blocks on the agent turn; the operator's line
+/// (recorded gateway-side) and the agent's reply then stream in via polling.
+fn send_message(client: &RoomClient, root_session_id: &str, text: &str) -> String {
+    match rpc(
+        client,
+        "event.ingest",
+        serde_json::json!({
+            "event_type": "chat",
+            "message": text,
+            "session_id": root_session_id,
+            "async_mode": true,
+            "metadata": { "source": "session_room" },
+        }),
+    ) {
+        Ok(_) => "✓ sent".to_string(),
+        Err(e) => format!("✗ {e}"),
+    }
+}
+
 /// Drill-down detail for a selected row's source: a single event's full
 /// metadata/payload/refs, or what a collapsed run folds. (Deep ref-following —
 /// fetching the referenced approval/plan/workbench object — needs RPC read
@@ -503,6 +556,7 @@ fn draw(
     selected: usize,
     detail: Option<&[String]>,
     input: Option<&GateInput>,
+    compose: Option<&str>,
     status: Option<&str>,
     gate: Option<&GateRef>,
 ) {
@@ -560,7 +614,10 @@ fn draw(
         &mut state,
     );
 
-    let footer = if let Some(gi) = input {
+    let footer = if let Some(buf) = compose {
+        Paragraph::new(format!(" MESSAGE: {buf}▏   [Enter send · Esc cancel]"))
+            .style(Style::default().fg(Color::Green))
+    } else if let Some(gi) = input {
         let label = match gi.action {
             GateAction::Approve => "APPROVE — motivation (optional)",
             GateAction::Reject => "REJECT — motivation (optional)",
@@ -592,7 +649,7 @@ fn draw(
         // through the channel so a Discord/WhatsApp bridge can render its own.
         let gate_hint = gate.map(|g| TuiChannel.gate_prompt(g)).unwrap_or_default();
         Paragraph::new(format!(
-            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · ⏎ detail{gate_hint}"
+            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · i message · ⏎ detail{gate_hint}"
         ))
         .style(Style::default().fg(Color::DarkGray))
     };

--- a/docs/design/session-room-conversational-input.md
+++ b/docs/design/session-room-conversational-input.md
@@ -1,0 +1,106 @@
+# Session Room — Full Conversational Input (operator messages)
+
+Status: **proposed** (2026-06-04) · Part of the Session Room program (#363) ·
+Follows interaction polish (#404).
+
+## Problem
+
+The Session Room (`autonoetic/src/cli/room/`) is today a **read + gate-resolve**
+surface: it tails the canonical timeline and resolves approvals/clarifications,
+but the operator **cannot send a free-form message** into the session. To start
+or steer a conversation you still drop back to `chat.rs`. The goal is to make the
+room a true interaction surface so a session can be driven entirely from it — and,
+because the room is just one channel, so the same path works for Discord/WhatsApp
+later.
+
+## How operator input works today (findings)
+
+- **Ingress is `event.ingest`** (newline JSON-RPC over TCP, `AUTONOETIC_SHARED_SECRET`)
+  — the *same transport* the room's `RoomClient` already uses. `chat.rs` submits
+  every operator turn as `event.ingest { event_type: "chat", message, session_id,
+  target_agent_id?, metadata }` (`router.rs:583`). The handler already special-cases
+  `event_type == "chat"` (e.g. rerouting to an active workflow-child session,
+  `router.rs:632`).
+- **Session continuity**: the first message to a fresh `session_id` spawns; reusing
+  the same `session_id` continues (`is_message` flag → `can_message_agent` policy).
+- **Blocking vs async**: `event.ingest` blocks on the agent turn by default;
+  `async_mode: true` enqueues and returns immediately.
+- **The gap**: the operator's own message is pushed into the in-memory conversation
+  history (`execution.rs:3698`) and persisted to the content store, but **never
+  written to `live_digest_events`**. So a timeline reader (the room) sees the
+  agent's side but not the operator's. This is the foundational thing to fix.
+
+## Design
+
+Two slices. Slice A is gateway-side and benefits every channel; Slice B is the
+room UI.
+
+### Slice A — operator messages on the canonical timeline (gateway)
+
+In the `event.ingest` handler, for operator-originated chat, emit a
+`live_digest_events` row **before** dispatching to the agent (so the operator's
+line lands in the feed ahead of the agent's response, preserving conversational
+order):
+
+- `event_type`: `operator.message`
+- `principal` / `role`: derive — when there is **no `source_agent_id`** (a human
+  via room/chat), attribute to **`Human` + `Operator` seat**; when an agent
+  originated it, attribute to that agent. (v1 keys on `event_type == "chat"` with
+  no `source_agent_id` ⇒ operator. Foreign-channel attribution via `metadata`
+  sender is a follow-up.)
+- `altitude`: `Normal` (visible at the default floor; it's first-class conversation,
+  not plumbing).
+- `payload`: `{ "message": <redacted text> }` (reuse `redact_text_for_logs`, as the
+  `user.ask.pending` producer does).
+- `refs`: none required for v1.
+
+`render::summarize` gets an arm for `operator.message` (show the one-lined text;
+the actor label already renders 🧑/seat). This makes the operator visible in the
+room **and** in any future channel — no per-channel work.
+
+> Why gateway-side, not in the room: the timeline is the canonical, channel-neutral
+> spine (#390). Writing the operator event once in the gateway means the room,
+> Discord, and `chat.rs`-as-timeline all show the operator identically. A channel
+> writing its own "I sent this" row would fragment the source of truth.
+
+### Slice B — compose & send from the room (TUI)
+
+- A **compose** key (proposed `i` = "input", mirroring the gate-capture UX already
+  in `tui.rs`) opens a text buffer in the footer; `Enter` sends, `Esc` cancels.
+- Send via `RoomClient` → `event.ingest { event_type: "chat", message, session_id:
+  <root_session_id>, async_mode: true, metadata: { source: "session_room" } }`.
+  **Async** so the sync TUI loop never blocks on a full agent turn; the operator's
+  line (Slice A) and the agent's response then stream in through normal polling.
+- Status line reflects the outcome (`✓ sent` / `✗ <error>`); on a mid-turn/busy
+  rejection, surface it and keep the buffer so it can be resent.
+- Targeting v1: send to the room's `root_session_id` (omit `target_agent_id` →
+  gateway resolves the lead). The existing chat reroute logic handles workflow
+  children.
+
+### Non-goals (v1)
+
+- Starting a **brand-new** session from the room (attach-to-existing only; fresh
+  sessions stay with `chat`/CLI).
+- Rich/multi-line composer, history scrollback editing, attachments.
+- Per-occupant attribution for non-human channel senders (Slice A keys on the
+  operator case; richer attribution is a follow-up when the Discord bridge lands).
+
+## Open questions
+
+1. **Mid-turn sends** — does `async_mode: true` enqueue or reject while the agent
+   is mid-turn? Confirm and pick the UX (queue silently vs. "agent busy, resend").
+2. **Event-type name** — `operator.message` (Operator-seat framing) vs. a neutral
+   `chat.message`. Leaning `operator.message` to match the two-axis model (seat =
+   Operator, principal = Human *or* AI).
+3. **Echo timing** — emit the operator event synchronously in the handler before
+   enqueueing the turn (chosen), so order is deterministic even under async.
+
+## Test plan
+
+- Gateway: `event.ingest { event_type: "chat" }` writes one `operator.message`
+  timeline row attributed to Human/Operator; agent-originated ingest does not
+  mis-attribute. Integration test over the router (shared-env pattern).
+- Render: `operator.message` renders one-lined with the 🧑 operator label.
+- Room TUI: compose→send issues an async `event.ingest`; unit-test the param
+  shape and the busy/again handling (no live agent required).
+- Live smoke: drive a real session end-to-end from the room.


### PR DESCRIPTION
## Summary
**Stacked on #404.** Makes the Session Room a true interaction surface: the operator can **send free-form messages** into the session, and **both sides** of the conversation appear on the canonical timeline (not just agent replies). Because the room is one channel, the same path serves Discord/WhatsApp later.

> Base is `feat/session-room-interaction-polish` (#404) — merge that first; I'll retarget to `main` after. (Slice A's render arm reuses #404's `one_line`.)

Design: `docs/design/session-room-conversational-input.md`.

### Slice A — operator messages on the canonical timeline (gateway)
The gap: operator input went into conversation history but **never** to `live_digest_events`, so a timeline reader saw only the agent's side.
- `event.ingest` chat path now emits an `operator.message` row **before dispatch** (so it precedes the agent's reply even under `async_mode`).
- Attribution: human chat (no `source_agent_id`) → **Human + Operator seat**; agent-originated ingest → that agent's seat. Altitude `Normal`; payload `{ message: <redacted> }`.
- Written **once, gateway-side**, so every channel shows the operator identically (#390). Extracted as `runtime::session_timeline::operator_message_event` (unit-tested).
- `render::summarize` gains an `operator.message` arm (one-lined, 🧑 operator label).

### Slice B — compose & send from the room (TUI)
- `i` opens a footer compose buffer; `Enter` sends `event.ingest { event_type: chat, async_mode: true, session_id: <root> }`, `Esc` cancels.
- **Async** so the sync TUI loop never blocks on the agent turn; the operator line + reply stream in via normal polling. Status feedback; jumps to follow newest.

## Test plan
- [x] `cargo build` clean; `cargo test -p autonoetic` — 15 room tests; gateway `operator_message_event` unit test green
- [x] **Live end-to-end**: started a gateway, sent `event.ingest` chat (async) → `operator.message` on the timeline attributed `{id: operator, kind: human}`, Operator seat, Normal altitude; viewer rendered:
  `▸ [🧑 operator] Operator here: focus on US equities and crypto, daily cadence.` (note the multi-line input flattened to one line)
- Interactive TUI compose keypress flow can't be driven headless, but it issues exactly the `event.ingest` call the live test exercised.

## Non-goals (v1) / follow-ups
- Starting a **brand-new** session from the room (attach-to-existing only).
- Mid-turn/busy send UX refinement; per-occupant attribution for non-human channel senders (when Discord lands).

Tracks #405 · #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)