### PR TITLE
fix(session-room): operator.message emit ordering + role_floor (Copilot #406)

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -657,28 +657,6 @@ impl JsonRpcRouter {
                         }
                     }
                 }
-                // Operator's own message onto the canonical timeline (#405) — so
-                // any channel (room, Discord) shows both sides of the conversation,
-                // not just the agent's replies. Written here, gateway-side and once,
-                // before dispatch so the operator line precedes the agent's response
-                // even under async_mode.
-                if params.event_type.trim() == "chat" && !params.message.trim().is_empty() {
-                    if let Some(store) = self.execution.gateway_store() {
-                        let event = crate::runtime::session_timeline::operator_message_event(
-                            &session_id,
-                            params.source_agent_id.as_deref(),
-                            &crate::log_redaction::redact_text_for_logs(&params.message),
-                        );
-                        if let Err(e) = store.create_live_digest_event(&event) {
-                            tracing::debug!(
-                                target: "session_timeline",
-                                error = %e,
-                                "operator.message timeline emit failed"
-                            );
-                        }
-                    }
-                }
-
                 let explicit_target = if ingest_rerouted_from_child {
                     reroute_lead.as_deref()
                 } else {
@@ -695,6 +673,30 @@ impl JsonRpcRouter {
                             );
                         }
                     };
+
+                // Operator's own message onto the canonical timeline (#405) — so
+                // any channel (room, Discord) shows both sides of the conversation,
+                // not just the agent's replies. Written gateway-side and once,
+                // *after* routing is confirmed (so a routing failure leaves no
+                // "ghost" message that was never dispatched) but before dispatch,
+                // so the operator line precedes the agent's response even under
+                // async_mode.
+                if params.event_type.trim() == "chat" && !params.message.trim().is_empty() {
+                    if let Some(store) = self.execution.gateway_store() {
+                        let event = crate::runtime::session_timeline::operator_message_event(
+                            &session_id,
+                            params.source_agent_id.as_deref(),
+                            &crate::log_redaction::redact_text_for_logs(&params.message),
+                        );
+                        if let Err(e) = store.create_live_digest_event(&event) {
+                            tracing::debug!(
+                                target: "session_timeline",
+                                error = %e,
+                                "operator.message timeline emit failed"
+                            );
+                        }
+                    }
+                }
 
                 let ingress = IngressType::Ingest {
                     target_agent_id: target_agent_id.clone(),

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -55,8 +55,11 @@ pub fn build_timeline_event(
 /// conversation, not just agent replies. Attribution: a human chat (no
 /// `source_agent_id`) is the **Operator seat / Human** principal; an
 /// agent-originated ingest is attributed to that agent's seat. Altitude is
-/// `Normal` (first-class conversation, visible at the default floor). The
-/// caller redacts the message text before passing it in.
+/// derived via `altitude_for` (`None` below): `operator.message` has a `Normal`
+/// base (first-class conversation, visible at the default floor) but the seat's
+/// `role_floor` can only *raise* it — e.g. a Sentinel-seat message surfaces at
+/// `Attention`, honoring the module's raise-only invariant. The caller redacts
+/// the message text before passing it in.
 pub fn operator_message_event(
     session_id: &str,
     source_agent_id: Option<&str>,
@@ -74,7 +77,7 @@ pub fn operator_message_event(
         &principal,
         &role,
         "operator.message",
-        Some(Altitude::Normal),
+        None, // derive: max(base=Normal, role_floor(role))
         Some(serde_json::json!({ "message": redacted_message })),
         TimelineRefs::default(),
     )
@@ -156,7 +159,8 @@ mod tests {
 
     #[test]
     fn operator_message_event_attributes_human_and_agent() {
-        // A human chat (no source_agent_id) ⇒ Operator seat / Human principal.
+        // A human chat (no source_agent_id) ⇒ Operator seat / Human principal,
+        // Normal altitude (Operator's role_floor is Detail ⇒ max stays Normal).
         let human = operator_message_event("session-1", None, "hello there");
         assert_eq!(human.event_type, "operator.message");
         assert_eq!(human.altitude.as_deref(), Some("normal"));
@@ -177,6 +181,11 @@ mod tests {
             agent.principal_kind,
             Some(Principal::human("operator").kind_to_storage())
         );
+
+        // role_floor must still raise altitude: a Sentinel-seat message surfaces
+        // at Attention, not Normal (the raise-only invariant — not hard-coded).
+        let sentinel = operator_message_event("session-1", Some("sentinel.divergence"), "halt");
+        assert_eq!(sentinel.altitude.as_deref(), Some("attention"));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up addressing the two Copilot comments on #406 (which is already merged via #404).

### 1. No "ghost" messages on routing failure
`event.ingest` emitted the `operator.message` timeline row **before** `resolve_ingest_target_agent_id`. If routing failed, the caller got an error but the timeline already held an undispatched message. Now the row is emitted **after routing is confirmed** (still before dispatch, so it precedes the agent's reply even under `async_mode`).

### 2. Honor `role_floor` instead of hard-coding `Normal`
`operator_message_event` hard-coded `Some(Altitude::Normal)`, bypassing `altitude_for`/`role_floor` and contradicting the module's raise-only invariant. It now passes `None` → `altitude_for("operator.message", role) = max(Normal, role_floor(role))`. A Sentinel-seat message surfaces at `Attention`; the Operator seat stays `Normal`.

## Test plan
- [x] `cargo build -p autonoetic-gateway`
- [x] `operator_message_event_attributes_human_and_agent` extended to assert a Sentinel-seat message → `attention` (the raise-only behavior)

Tracks #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)