### PR TITLE
feat(session-room): P4 — agent narrative on the timeline (message + reasoning) (#367)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -89,7 +89,8 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         // Mechanics / poll-ish / infra — hidden at the normal floor. Workbench
         // lifecycle is plumbing around the real work (edits/artifacts), so it
         // stays Detail and surfaces only when the operator dials down.
-        "turn.start" | "turn.end" | "llm.round" | "tool.requested"
+        // Extended-thinking "why" is verbose; hidable by default, surfaced on dial-down.
+        "turn.start" | "turn.end" | "llm.round" | "tool.requested" | "agent.reasoning"
         | "workbench.created" | "workbench.reconciled" | "workbench.discarded" => Altitude::Detail,
         // Failures always surface.
         "llm.request_failed" | "tool.failed" => Altitude::Error,
@@ -228,6 +229,19 @@ mod tests {
         assert_eq!(ev.principal_kind.as_deref(), Some("autonoetic_agent"));
         assert_eq!(ev.principal_id.as_deref(), Some("planner.default"));
         assert!(ev.refs_json.as_deref().unwrap().contains("apr-abc"));
+    }
+
+    #[test]
+    fn agent_narrative_altitudes() {
+        // The agent speaking is first-class (Normal, default floor); its reasoning
+        // is hidable (Detail) until the operator dials down. (#367 P4)
+        assert_eq!(base_altitude("agent.message"), Altitude::Normal);
+        assert_eq!(base_altitude("agent.reasoning"), Altitude::Detail);
+        // A Sentinel still raises both to its floor.
+        assert_eq!(
+            altitude_for("agent.reasoning", &SessionRole::Sentinel),
+            Altitude::Attention
+        );
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -602,6 +602,35 @@ impl SessionTracer {
             }
         }
         self.log_event("llm", "completion", EntryStatus::Success, Some(llm_payload))?;
+
+        // P4 (#367) — the agent's *narrative* onto the canonical timeline so the
+        // room reads as a conversation (intent → actions → result), not just
+        // mechanical `llm.round` markers + tool calls. The full text/reasoning
+        // already live in the evidence store; here we surface a readable, capped,
+        // redacted copy. `agent.message` is the agent speaking (Normal, shown at
+        // the default floor, symmetric to `operator.message`); `agent.reasoning`
+        // is the hidable "why" (Detail). Empty text (a pure tool-call round) is
+        // skipped so we don't emit blank lines.
+        let message = text.trim();
+        if !message.is_empty() {
+            self.append_live_digest_event(
+                "agent.message",
+                Some(serde_json::json!({
+                    "message": redact_text_for_logs(&truncate_for_log(message, 2000)),
+                })),
+            );
+        }
+        if let Some(rc) = reasoning_content {
+            let rc = rc.trim();
+            if !rc.is_empty() {
+                self.append_live_digest_event(
+                    "agent.reasoning",
+                    Some(serde_json::json!({
+                        "reasoning": redact_text_for_logs(&truncate_for_log(rc, 2000)),
+                    })),
+                );
+            }
+        }
         Ok(())
     }
 

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -611,12 +611,14 @@ impl SessionTracer {
         // the default floor, symmetric to `operator.message`); `agent.reasoning`
         // is the hidable "why" (Detail). Empty text (a pure tool-call round) is
         // skipped so we don't emit blank lines.
+        // Redact the *full* text first (so JSON-aware key redaction sees valid
+        // JSON), then hard-cap for the timeline row.
         let message = text.trim();
         if !message.is_empty() {
             self.append_live_digest_event(
                 "agent.message",
                 Some(serde_json::json!({
-                    "message": redact_text_for_logs(&truncate_for_log(message, 2000)),
+                    "message": cap_chars(&redact_text_for_logs(message), 2000),
                 })),
             );
         }
@@ -626,7 +628,7 @@ impl SessionTracer {
                 self.append_live_digest_event(
                     "agent.reasoning",
                     Some(serde_json::json!({
-                        "reasoning": redact_text_for_logs(&truncate_for_log(rc, 2000)),
+                        "reasoning": cap_chars(&redact_text_for_logs(rc), 2000),
                     })),
                 );
             }
@@ -999,6 +1001,20 @@ fn truncate_for_log(value: &str, max_len: usize) -> String {
     format!("{}...", truncated)
 }
 
+/// Hard cap to `max` chars, ellipsis included (so the result never exceeds
+/// `max` — unlike `truncate_for_log`, which appends `...` after the limit).
+/// Used for timeline rows after redaction.
+fn cap_chars(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let truncated: String = value.chars().take(max - 1).collect();
+    format!("{truncated}…")
+}
+
 fn sanitize_token(value: &str) -> String {
     value
         .chars()
@@ -1111,6 +1127,16 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn cap_chars_is_a_hard_cap_including_ellipsis() {
+        let s = "abcdefghij"; // 10 chars
+        assert_eq!(cap_chars(s, 10), "abcdefghij"); // exactly fits, untouched
+        let out = cap_chars(s, 5);
+        assert_eq!(out.chars().count(), 5, "must not exceed max incl. ellipsis");
+        assert!(out.ends_with('…'));
+        assert_eq!(cap_chars(s, 0), "");
+    }
 
     #[test]
     fn test_force_tool_result_evidence_for_failures_and_approvals() {

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -117,6 +117,11 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
         // The operator's (or any actor's) own message into the session (#405).
         // The actor label already shows who; here we just show the text.
         "operator.message" => one_line(&field("message").unwrap_or_default(), 120),
+        // The agent's own narrative (#367 P4): what it says, and (hidable) its
+        // reasoning — so a turn reads intent → actions → result. Actor label
+        // shows which agent; the 💭 marks reasoning as the "why".
+        "agent.message" => one_line(&field("message").unwrap_or_default(), 160),
+        "agent.reasoning" => format!("💭 {}", one_line(&field("reasoning").unwrap_or_default(), 160)),
         "user.ask.pending" => format!(
             "asks: {}{}",
             one_line(&field("question").unwrap_or_default(), 100),
@@ -477,6 +482,33 @@ mod tests {
         // Whitespace (incl. newlines) collapses to single spaces.
         assert_eq!(one_line("a\n\n  b\tc", 50), "a b c");
         assert_eq!(one_line("anything", 0), "");
+    }
+
+    #[test]
+    fn agent_narrative_renders_message_and_reasoning() {
+        let msg = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "agent.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "I'll scan the repo,\nthen propose a plan." }),
+        );
+        let line = render_line(&msg);
+        assert!(line.starts_with("▸"));
+        assert!(line.contains("[planner]"));
+        // Flattened to one line.
+        assert!(line.contains("I'll scan the repo, then propose a plan."));
+
+        let reasoning = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "agent.reasoning",
+            Altitude::Detail,
+            serde_json::json!({ "reasoning": "the user wants periodic analysis" }),
+        );
+        let rline = render_line(&reasoning);
+        assert!(rline.starts_with("·")); // Detail glyph — hidable
+        assert!(rline.contains("💭 the user wants periodic analysis"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
First slice of **P4 (#367)** — make the room read as a *conversation* (intent → actions → result), not mechanical bullets.

The agent's text and reasoning were captured only to the evidence store; the timeline showed just `llm.round` markers + tool calls — so the room never showed **what the agent actually says**. Now `log_llm_completion` (the turn hot path, `lifecycle.rs:2152`) also emits, gateway-side:

- **`agent.message`** (Normal, default floor) — the agent's prose. Symmetric to `operator.message` (#405): both sides of the conversation now appear. Empty (pure tool-call) rounds are skipped.
- **`agent.reasoning`** (Detail, hidable) — the "why" from extended thinking, surfaced when the operator dials the floor down. Rendered with a 💭 marker.

Text is redacted + capped (2000 chars) for the timeline row; the full content stays in the evidence store (`text_sha256` / `evidence_ref` unchanged). `render::summarize` one-lines both.

## Test plan
- [x] `cargo build` clean; 17 room render/tui tests + gateway `session_timeline` tests pass
- [x] render: `agent.message` (▸, one-lined) and `agent.reasoning` (·, 💭) 
- [x] gateway: `base_altitude` → message Normal, reasoning Detail; Sentinel seat raises both
- [x] Confirmed `log_llm_completion` is on the turn loop with `response.text` + `response.reasoning_content` — full visual confirmation needs a live LLM session (no API key here)

## Follow-ups (rest of P4)
- Turn-intent one-liner at turn start.
- Prompt-tuning so planner/specialist reasoning annotations are habitual (agent-side).
- On error, link the preceding action chain.

Part of #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)