### PR TITLE
feat(session-room): P4 — link the preceding action chain to failures (#367)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -173,7 +173,13 @@ pub struct SessionTracer {
     live_report: Option<Arc<Mutex<SessionReportWriter>>>,
     /// Optional GatewayStore for dual-write to causal_events table.
     gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
+    /// Turn-scoped ring of recent action labels (most recent last), so a failure
+    /// can carry the chain that led to it instead of a context-free error (#367).
+    recent_actions: std::collections::VecDeque<String>,
 }
+
+/// How many recent actions to keep for the error→action-chain link.
+const RECENT_ACTIONS_CAP: usize = 6;
 
 impl SessionTracer {
     pub fn new(agent_dir: &Path, agent_id: &str, session_id: &str) -> anyhow::Result<Self> {
@@ -208,6 +214,7 @@ impl SessionTracer {
             live_digest: None,
             live_report: None,
             gateway_store: None,
+            recent_actions: std::collections::VecDeque::new(),
         })
     }
 
@@ -229,8 +236,20 @@ impl SessionTracer {
         if let Some(w) = &self.live_report {
             w.lock().unwrap().start_turn(self.turn_id.as_deref())?;
         }
+        // The action chain is turn-scoped — a failure links to what happened in
+        // this turn, not stale actions from earlier ones (#367).
+        self.recent_actions.clear();
         self.append_live_digest_event("turn.start", None);
         Ok(())
+    }
+
+    /// Record a short action label in the turn-scoped ring (capped), so a later
+    /// failure can carry the chain that led to it.
+    fn note_action(&mut self, label: impl Into<String>) {
+        self.recent_actions.push_back(label.into());
+        while self.recent_actions.len() > RECENT_ACTIONS_CAP {
+            self.recent_actions.pop_front();
+        }
     }
 
     pub fn record_digest_llm_round(
@@ -661,9 +680,14 @@ impl SessionTracer {
                 );
             }
         }
+        // Link the preceding action chain so a failure isn't a context-free ✗
+        // (#367) — the room can show "after: a → b → c".
         self.append_live_digest_event(
             "llm.request_failed",
-            Some(serde_json::json!({ "error": msg })),
+            Some(serde_json::json!({
+                "error": msg,
+                "preceding": Vec::from_iter(self.recent_actions.iter().cloned()),
+            })),
         );
         Ok(())
     }
@@ -712,6 +736,7 @@ impl SessionTracer {
                 }
             }
         }
+        self.note_action(tool_name);
         self.append_live_digest_event(
             "tool.requested",
             Some(serde_json::json!({
@@ -1093,6 +1118,7 @@ impl SessionTracer {
             live_digest: None,
             live_report: None,
             gateway_store: None,
+            recent_actions: std::collections::VecDeque::new(),
         }
     }
 
@@ -1118,6 +1144,7 @@ impl SessionTracer {
             live_digest: None,
             live_report: None,
             gateway_store: Some(store),
+            recent_actions: std::collections::VecDeque::new(),
         }
     }
 }
@@ -1127,6 +1154,24 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn recent_actions_ring_caps_and_clears_on_turn_start() {
+        let mut t = SessionTracer::test_tracer();
+        for i in 0..(RECENT_ACTIONS_CAP + 3) {
+            t.note_action(format!("a{i}"));
+        }
+        // Capped to the most recent N; oldest dropped, newest kept.
+        assert_eq!(t.recent_actions.len(), RECENT_ACTIONS_CAP);
+        assert_eq!(
+            t.recent_actions.back().unwrap(),
+            &format!("a{}", RECENT_ACTIONS_CAP + 2)
+        );
+        assert_eq!(t.recent_actions.front().unwrap(), "a3");
+        // A new turn starts a fresh chain.
+        t.start_digest_turn().unwrap();
+        assert!(t.recent_actions.is_empty());
+    }
 
     #[test]
     fn cap_chars_is_a_hard_cap_including_ellipsis() {

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -736,7 +736,12 @@ impl SessionTracer {
                 }
             }
         }
-        self.note_action(tool_name);
+        // `digest_annotate` is internal bookkeeping, excluded from the human-facing
+        // digest/report above; keep it out of the failure action-chain too so a
+        // failure doesn't render `after: digest_annotate → …`.
+        if tool_name != "digest_annotate" {
+            self.note_action(tool_name);
+        }
         self.append_live_digest_event(
             "tool.requested",
             Some(serde_json::json!({
@@ -1171,6 +1176,18 @@ mod tests {
         // A new turn starts a fresh chain.
         t.start_digest_turn().unwrap();
         assert!(t.recent_actions.is_empty());
+    }
+
+    #[test]
+    fn digest_annotate_is_excluded_from_action_chain() {
+        let mut t = SessionTracer::test_tracer();
+        // Internal bookkeeping must not leak into the operator-facing chain.
+        t.log_tool_requested("digest_annotate", "{}", None).unwrap();
+        t.log_tool_requested("read_file", "{}", None).unwrap();
+        assert_eq!(
+            Vec::from_iter(t.recent_actions.iter().cloned()),
+            vec!["read_file".to_string()]
+        );
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -82,6 +82,20 @@ fn choices_hint(payload: Option<&serde_json::Value>) -> String {
     }
 }
 
+/// Format the preceding action chain a failure carries (#367) as ` ⟵ after: a → b`.
+/// Reads the `preceding` array of action labels; empty/absent ⇒ "".
+fn preceding_chain(payload: Option<&serde_json::Value>) -> String {
+    let Some(arr) = payload.and_then(|v| v.get("preceding")).and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+    let parts: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("  ⟵ after: {}", parts.join(" → "))
+    }
+}
+
 /// Human summary of an event, from its type + payload. Keeps the most useful
 /// field per known event type; falls back to the bare event type.
 pub fn summarize(entry: &SessionTimelineEntry) -> String {
@@ -134,7 +148,11 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
                 .or_else(|| field("tool"))
                 .unwrap_or_else(|| "completed".into())
         ),
-        "llm.request_failed" => format!("LLM error: {}", field("error").unwrap_or_default()),
+        "llm.request_failed" => format!(
+            "LLM error: {}{}",
+            one_line(&field("error").unwrap_or_default(), 120),
+            preceding_chain(p.as_ref()),
+        ),
         other => other.to_string(),
     }
 }
@@ -537,6 +555,31 @@ mod tests {
             serde_json::json!({ "tool_name": "Edit", "result": "ok" }),
         );
         assert!(render_line(&e).contains("tool Edit"));
+    }
+
+    #[test]
+    fn llm_failure_links_preceding_action_chain() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "llm.request_failed",
+            Altitude::Error,
+            serde_json::json!({ "error": "rate limited", "preceding": ["read_file", "edit", "run"] }),
+        );
+        let line = render_line(&e);
+        assert!(line.starts_with("✗"));
+        assert!(line.contains("LLM error: rate limited"));
+        assert!(line.contains("after: read_file → edit → run"));
+
+        // No preceding ⇒ just the error, no dangling "after:".
+        let bare = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "llm.request_failed",
+            Altitude::Error,
+            serde_json::json!({ "error": "boom" }),
+        );
+        assert!(!render_line(&bare).contains("after:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Continues **P4 (#367)**: a failure on the timeline was a context-free `✗`. Now `llm.request_failed` carries the **turn-scoped chain of recent actions** that led to it, so you can see *what the agent was doing* when it failed.

- `SessionTracer` keeps a capped (6), **turn-scoped** ring of action labels, cleared at `start_digest_turn` (a failure links to *this* turn's actions, not stale ones).
- `log_tool_requested` records the tool name into the ring.
- `log_llm_request_failed` attaches `{ preceding: [...] }` to the timeline event.
- Render: `LLM error: <msg>  ⟵ after: read_file → edit → run`. The error is one-lined; no `after:` when the chain is empty.

## Test plan
- [x] `cargo build` clean
- [x] render: chain shown when present, absent when empty (`llm_failure_links_preceding_action_chain`)
- [x] tracer: ring caps at 6 (oldest dropped) and clears on turn start (`recent_actions_ring_caps_and_clears_on_turn_start`)

## Remaining P4 follow-ups
- Turn-intent one-liner at turn start (note: `agent.message` already surfaces much of the intent).
- Agent-side prompt-tuning so reasoning annotations are habitual.

Part of #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)