### PR TITLE
feat(session-room): surface runtime-lock drift on the timeline (#367)

### DIFF
--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1081,19 +1081,24 @@ impl AgentExecutor {
                     } else {
                         "build_sha256"
                     };
+                    let drift_payload = serde_json::json!({
+                        "drift_field": drift_field,
+                        "locked_build_sha256": drift.locked_build_sha256,
+                        "current_build_sha256": drift.current_build_sha256,
+                        "locked_binary_sha256": drift.locked_binary_sha256,
+                        "current_binary_sha256": drift.current_binary_sha256,
+                        "override": allow,
+                    });
                     let _ = tracer.log_event(
                         "runtime_lock_drift",
                         if allow { "override" } else { "rejected" },
                         status,
-                        Some(serde_json::json!({
-                            "drift_field": drift_field,
-                            "locked_build_sha256": drift.locked_build_sha256,
-                            "current_build_sha256": drift.current_build_sha256,
-                            "locked_binary_sha256": drift.locked_binary_sha256,
-                            "current_binary_sha256": drift.current_binary_sha256,
-                            "override": allow,
-                        })),
+                        Some(drift_payload.clone()),
                     );
+                    // Also surface it on the canonical timeline so the room shows
+                    // it (#367) — previously causal-only. Emitted before the
+                    // reject `bail!` below so a drift-killed session isn't silent.
+                    tracer.record_runtime_lock_drift(drift_payload, allow);
                     if !allow {
                         let mut msg = format!("runtime lock drift detected ({drift_field}): ");
                         if drift.locked_binary_sha256.is_some() {

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -94,10 +94,12 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         | "workbench.created" | "workbench.reconciled" | "workbench.discarded" => Altitude::Detail,
         // Failures always surface.
         "llm.request_failed" | "tool.failed" => Altitude::Error,
-        // Gates awaiting the operator (conversational asks, RFC §3.5).
-        "user.ask.pending" | "approval.pending" | "plan.pending" | "divergence.intervention" => {
-            Altitude::Attention
-        }
+        // Gates awaiting the operator (conversational asks, RFC §3.5) and
+        // integrity events. `runtime.lock_drift` stores an explicit altitude
+        // (Error when rejected, Attention when overridden); this is just the
+        // safe floor for any NULL-altitude fallback.
+        "user.ask.pending" | "approval.pending" | "plan.pending" | "divergence.intervention"
+        | "runtime.lock_drift" => Altitude::Attention,
         // Everything else is normal progress.
         _ => Altitude::Normal,
     }

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -311,6 +311,46 @@ impl SessionTracer {
         Ok(())
     }
 
+    /// Surface a runtime-lock drift on the canonical timeline (#367) — an
+    /// integrity event that was previously causal-only, so the room never showed
+    /// it. The runtime's own mechanical ruling, so it speaks from the `Runtime`
+    /// seat. A **rejected** drift (the session is about to fail) is `Error`; an
+    /// **override** (`allow_runtime_lock_drift`, running in a drifted environment
+    /// anyway) is `Attention` — a silently-weakened reproducibility guarantee
+    /// the operator should still see. `payload` mirrors the causal record.
+    pub fn record_runtime_lock_drift(&self, payload: serde_json::Value, allow: bool) {
+        let Some(store) = &self.gateway_store else {
+            return;
+        };
+        let principal = autonoetic_types::principal::Principal {
+            kind: autonoetic_types::principal::PrincipalKind::Script,
+            id: "gateway".to_string(),
+        };
+        let altitude = if allow {
+            autonoetic_types::session_timeline::Altitude::Attention
+        } else {
+            autonoetic_types::session_timeline::Altitude::Error
+        };
+        let event = crate::runtime::session_timeline::build_timeline_event(
+            base_session_id(&self.session_id).to_string(),
+            self.session_id.clone(),
+            self.turn_id.clone(),
+            &principal,
+            &autonoetic_types::session_timeline::SessionRole::Runtime,
+            "runtime.lock_drift",
+            Some(altitude),
+            Some(payload),
+            autonoetic_types::session_timeline::TimelineRefs::default(),
+        );
+        if let Err(e) = store.create_live_digest_event(&event) {
+            tracing::debug!(
+                target: "session_timeline",
+                error = %e,
+                "runtime.lock_drift timeline emit failed"
+            );
+        }
+    }
+
     pub fn with_turn_id(mut self, turn_id: impl Into<String>) -> Self {
         self.turn_id = Some(turn_id.into());
         self
@@ -1265,6 +1305,65 @@ mod tests {
             Some(value) => unsafe { std::env::set_var("AUTONOETIC_EVIDENCE_MODE", value) },
             None => unsafe { std::env::remove_var("AUTONOETIC_EVIDENCE_MODE") },
         }
+    }
+
+    #[test]
+    fn record_runtime_lock_drift_surfaces_on_timeline() {
+        use autonoetic_types::session_timeline::{Altitude, SessionRole};
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let agent_dir = agents_dir.join("test-agent");
+        let gateway_dir = agents_dir.join(".gateway");
+        fs::create_dir_all(agent_dir.join("history")).unwrap();
+        fs::create_dir_all(&gateway_dir).unwrap();
+        let store = std::sync::Arc::new(
+            crate::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+        );
+        let tracer = SessionTracer::test_tracer_with_store(&agent_dir, store.clone());
+
+        tracer.record_runtime_lock_drift(
+            serde_json::json!({ "drift_field": "binary_sha256", "override": false }),
+            false,
+        );
+        tracer.record_runtime_lock_drift(
+            serde_json::json!({ "drift_field": "build_sha256", "override": true }),
+            true,
+        );
+
+        let result = store
+            .list_session_timeline("test-session", None, 50, Some(Altitude::Detail), None)
+            .unwrap();
+        let drifts: Vec<_> = result
+            .entries
+            .iter()
+            .filter(|e| e.event_type == "runtime.lock_drift")
+            .collect();
+        assert_eq!(drifts.len(), 2, "both drifts must reach the timeline");
+        // Attributed to the Runtime seat (the executor's mechanical ruling).
+        assert!(drifts.iter().all(|e| matches!(e.role, SessionRole::Runtime)));
+        // Rejected ⇒ Error; override ⇒ Attention.
+        let rejected = drifts
+            .iter()
+            .find(|e| {
+                e.payload
+                    .as_deref()
+                    .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                    .and_then(|v| v.get("override").and_then(|o| o.as_bool()))
+                    == Some(false)
+            })
+            .unwrap();
+        assert_eq!(rejected.altitude, Altitude::Error);
+        let overridden = drifts
+            .iter()
+            .find(|e| {
+                e.payload
+                    .as_deref()
+                    .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                    .and_then(|v| v.get("override").and_then(|o| o.as_bool()))
+                    == Some(true)
+            })
+            .unwrap();
+        assert_eq!(overridden.altitude, Altitude::Attention);
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -153,6 +153,19 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
             one_line(&field("error").unwrap_or_default(), 120),
             preceding_chain(p.as_ref()),
         ),
+        "runtime.lock_drift" => {
+            let overridden = p
+                .as_ref()
+                .and_then(|v| v.get("override"))
+                .and_then(|x| x.as_bool())
+                .unwrap_or(false);
+            let what = field("drift_field").unwrap_or_else(|| "binary".into());
+            if overridden {
+                format!("runtime lock drift ({what}) — overridden, running anyway")
+            } else {
+                format!("runtime lock drift ({what}) — execution blocked")
+            }
+        }
         other => other.to_string(),
     }
 }
@@ -571,7 +584,6 @@ mod tests {
         assert!(line.contains("LLM error: rate limited"));
         assert!(line.contains("after: read_file → edit → run"));
 
-        // No preceding ⇒ just the error, no dangling "after:".
         let bare = entry(
             SessionRole::Planner,
             Principal::agent("planner.default"),
@@ -580,6 +592,26 @@ mod tests {
             serde_json::json!({ "error": "boom" }),
         );
         assert!(!render_line(&bare).contains("after:"));
+    }
+
+    #[test]
+    fn runtime_lock_drift_renders_blocked_and_overridden() {
+        let mk = |overridden: bool, alt: Altitude| {
+            entry(
+                SessionRole::Runtime,
+                Principal { kind: PrincipalKind::Script, id: "gateway".into() },
+                "runtime.lock_drift",
+                alt,
+                serde_json::json!({ "drift_field": "binary_sha256", "override": overridden }),
+            )
+        };
+        let blocked = render_line(&mk(false, Altitude::Error));
+        assert!(blocked.starts_with("✗"));
+        assert!(blocked.contains("runtime lock drift (binary_sha256) — execution blocked"));
+
+        let overridden = render_line(&mk(true, Altitude::Attention));
+        assert!(overridden.starts_with("⚠"));
+        assert!(overridden.contains("overridden, running anyway"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
A **runtime-lock drift** (the executable's SHA no longer matches the pinned closure) was logged only to the causal chain (`lifecycle.rs`), so it never appeared in the room — even when it **kills the session** (the rejected case `bail!`s). Now it also emits a `runtime.lock_drift` timeline event.

- `SessionTracer::record_runtime_lock_drift` emits from the **Runtime seat** (the executor's mechanical ruling). **Rejected ⇒ `Error`** (✗, the session is about to fail); **override** (`allow_runtime_lock_drift`) **⇒ `Attention`** (⚠, a silently-weakened reproducibility guarantee the operator should still see). Payload mirrors the causal record; emitted **before** the reject `bail!`.
- `base_altitude` floors `runtime.lock_drift` at Attention (NULL-fallback safety; the row stores an explicit altitude).
- Render: `runtime lock drift (binary_sha256) — execution blocked` / `— overridden, running anyway`.

## Test plan
- [x] `cargo build` clean
- [x] render: blocked (✗) vs overridden (⚠) (`runtime_lock_drift_renders_blocked_and_overridden`)
- [x] gateway: both drifts reach the timeline with the Runtime seat and Error/Attention altitudes (`record_runtime_lock_drift_surfaces_on_timeline`)

## Audit: other causal-only operator events
You asked me to check for other cases like this. The dual-emission rationale + guardrail are now documented in `docs/session-room-architecture.md` (#411). The audit found these **operator-meaningful events that are still causal/store-only** (not on the timeline), tracked in #413:
- **Emergency stop** (`scheduler.rs`) — the root-session circuit breaker.
- **Escalations** (`federation.rs`, `checkpoint.rs`).
- **Sandbox-escape / security findings** (`sandbox.rs`, `policy.rs`).

Not in this PR — each lives in a different subsystem and needs its own producer/altitude design. (`operator_alert` for critical divergence is **not** a gap — it's already on the timeline as `divergence.intervention`.)

Part of #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)