### PR TITLE
feat(session-room): surface emergency stop on the timeline (#413)

### DIFF
--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -1084,7 +1084,7 @@ impl GatewayExecutionService {
                 "session.emergency_stop",
                 None, // base_altitude ⇒ Error
                 Some(serde_json::json!({
-                    "stop_id": stop_id,
+                    "stop_id": stop_id.clone(),
                     "reason": reason,
                     "trigger_kind": trigger_kind,
                     "requested_by_type": requested_by_type,

--- a/autonoetic-gateway/src/execution.rs
+++ b/autonoetic-gateway/src/execution.rs
@@ -1067,6 +1067,40 @@ impl GatewayExecutionService {
             details_json: None,
         })?;
 
+        // Surface the circuit breaker on the canonical timeline (#413) — the most
+        // important operator event; it was causal/record-only, so the room never
+        // showed it. Attributed to whoever requested it; always Error altitude.
+        {
+            let (principal, seat) = crate::runtime::session_timeline::actor_from_kind_id(
+                requested_by_type,
+                requested_by_id,
+            );
+            let event = crate::runtime::session_timeline::build_timeline_event(
+                root_session_id.to_string(),
+                root_session_id.to_string(),
+                None,
+                &principal,
+                &seat,
+                "session.emergency_stop",
+                None, // base_altitude ⇒ Error
+                Some(serde_json::json!({
+                    "stop_id": stop_id,
+                    "reason": reason,
+                    "trigger_kind": trigger_kind,
+                    "requested_by_type": requested_by_type,
+                    "requested_by_id": requested_by_id,
+                })),
+                autonoetic_types::session_timeline::TimelineRefs::default(),
+            );
+            if let Err(e) = store.create_live_digest_event(&event) {
+                tracing::debug!(
+                    target: "session_timeline",
+                    error = %e,
+                    "emergency_stop timeline emit failed"
+                );
+            }
+        }
+
         let mut details = serde_json::json!({
             "aborted_handles": 0u32,
             "workflow_tasks_aborted": 0u32,

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -92,8 +92,8 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         // Extended-thinking "why" is verbose; hidable by default, surfaced on dial-down.
         "turn.start" | "turn.end" | "llm.round" | "tool.requested" | "agent.reasoning"
         | "workbench.created" | "workbench.reconciled" | "workbench.discarded" => Altitude::Detail,
-        // Failures always surface.
-        "llm.request_failed" | "tool.failed" => Altitude::Error,
+        // Failures and the emergency-stop circuit breaker always surface.
+        "llm.request_failed" | "tool.failed" | "session.emergency_stop" => Altitude::Error,
         // Gates awaiting the operator (conversational asks, RFC §3.5) and
         // integrity events. `runtime.lock_drift` stores an explicit altitude
         // (Error when rejected, Attention when overridden); this is just the
@@ -133,6 +133,22 @@ pub fn derive_role(agent_id: &str) -> SessionRole {
         "auditor" => SessionRole::Auditor,
         "runtime" | "gateway" => SessionRole::Runtime,
         other => SessionRole::Specialist { kind: other.to_string() },
+    }
+}
+
+/// Map an explicit `(kind, id)` pair to a `(principal, seat)` — for producers
+/// that already know who acted (emergency stop, escalations) rather than parsing
+/// a `decided_by` string. `operator`/`human` ⇒ Operator seat; `agent` ⇒ that
+/// agent's seat; anything else (`system`, `security_policy`, …) ⇒ Runtime.
+pub fn actor_from_kind_id(kind: &str, id: &str) -> (autonoetic_types::principal::Principal, SessionRole) {
+    use autonoetic_types::principal::{Principal, PrincipalKind};
+    match kind {
+        "operator" | "human" => (Principal::human(id), SessionRole::Operator),
+        "agent" | "autonoetic_agent" => (Principal::agent(id), derive_role(id)),
+        _ => (
+            Principal { kind: PrincipalKind::Script, id: id.to_string() },
+            SessionRole::Runtime,
+        ),
     }
 }
 
@@ -244,6 +260,22 @@ mod tests {
             altitude_for("agent.reasoning", &SessionRole::Sentinel),
             Altitude::Attention
         );
+    }
+
+    #[test]
+    fn emergency_stop_is_error_and_attributed() {
+        use autonoetic_types::principal::PrincipalKind;
+        // Always Error — the circuit breaker must surface at the top floor.
+        assert_eq!(base_altitude("session.emergency_stop"), Altitude::Error);
+
+        // Attribution by explicit kind.
+        let (op, seat) = actor_from_kind_id("operator", "operator");
+        assert!(matches!(op.kind, PrincipalKind::Human) && matches!(seat, SessionRole::Operator));
+        let (agent, seat) = actor_from_kind_id("agent", "auditor.default");
+        assert!(matches!(agent.kind, PrincipalKind::AutonoeticAgent));
+        assert!(matches!(seat, SessionRole::Auditor));
+        let (sys, seat) = actor_from_kind_id("security_policy", "gateway");
+        assert!(matches!(sys.kind, PrincipalKind::Script) && matches!(seat, SessionRole::Runtime));
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -138,12 +138,13 @@ pub fn derive_role(agent_id: &str) -> SessionRole {
 
 /// Map an explicit `(kind, id)` pair to a `(principal, seat)` — for producers
 /// that already know who acted (emergency stop, escalations) rather than parsing
-/// a `decided_by` string. `operator`/`human` ⇒ Operator seat; `agent` ⇒ that
-/// agent's seat; anything else (`system`, `security_policy`, …) ⇒ Runtime.
+/// a `decided_by` string. `user`/`operator`/`human` ⇒ Operator seat (the
+/// emergency-stop API/CLI uses `"user"`); `agent` ⇒ that agent's seat; anything
+/// else (`system`, `security_policy`, …) ⇒ Runtime.
 pub fn actor_from_kind_id(kind: &str, id: &str) -> (autonoetic_types::principal::Principal, SessionRole) {
     use autonoetic_types::principal::{Principal, PrincipalKind};
     match kind {
-        "operator" | "human" => (Principal::human(id), SessionRole::Operator),
+        "user" | "operator" | "human" => (Principal::human(id), SessionRole::Operator),
         "agent" | "autonoetic_agent" => (Principal::agent(id), derive_role(id)),
         _ => (
             Principal { kind: PrincipalKind::Script, id: id.to_string() },
@@ -268,9 +269,15 @@ mod tests {
         // Always Error — the circuit breaker must surface at the top floor.
         assert_eq!(base_altitude("session.emergency_stop"), Altitude::Error);
 
-        // Attribution by explicit kind.
-        let (op, seat) = actor_from_kind_id("operator", "operator");
-        assert!(matches!(op.kind, PrincipalKind::Human) && matches!(seat, SessionRole::Operator));
+        // Attribution by explicit kind. The emergency-stop API/CLI uses "user";
+        // it (and "operator"/"human") must read as a human in the Operator seat.
+        for human_kind in ["user", "operator", "human"] {
+            let (op, seat) = actor_from_kind_id(human_kind, "operator");
+            assert!(
+                matches!(op.kind, PrincipalKind::Human) && matches!(seat, SessionRole::Operator),
+                "kind {human_kind:?} should map to Human/Operator"
+            );
+        }
         let (agent, seat) = actor_from_kind_id("agent", "auditor.default");
         assert!(matches!(agent.kind, PrincipalKind::AutonoeticAgent));
         assert!(matches!(seat, SessionRole::Auditor));

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -166,6 +166,12 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
                 format!("runtime lock drift ({what}) — execution blocked")
             }
         }
+        // The root-session circuit breaker (#413) — kills processes, aborts tasks,
+        // cancels gates. The most important thing to surface.
+        "session.emergency_stop" => format!(
+            "EMERGENCY STOP — {}",
+            one_line(&field("reason").unwrap_or_else(|| "session halted".into()), 120)
+        ),
         other => other.to_string(),
     }
 }
@@ -592,6 +598,21 @@ mod tests {
             serde_json::json!({ "error": "boom" }),
         );
         assert!(!render_line(&bare).contains("after:"));
+    }
+
+    #[test]
+    fn emergency_stop_renders_prominently_with_operator_label() {
+        let e = entry(
+            SessionRole::Operator,
+            Principal::human("operator"),
+            "session.emergency_stop",
+            Altitude::Error,
+            serde_json::json!({ "reason": "runaway tool loop", "stop_id": "estop-1234" }),
+        );
+        let line = render_line(&e);
+        assert!(line.starts_with("✗"));
+        assert!(line.contains("🧑 operator"));
+        assert!(line.contains("EMERGENCY STOP — runaway tool loop"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
First of the #413 audit gaps. The **root-session circuit breaker** (emergency stop — kills processes, aborts tasks, cancels gates, deletes grants) wrote a causal event + an `EmergencyStopRecord` but **no timeline event** — so the single most important operator action was invisible in the room. Now it also emits `session.emergency_stop`.

- `emergency_stop_root_session_with_options` emits via `build_timeline_event` right after the stop is recorded, attributed to the requester through a new reusable helper `session_timeline::actor_from_kind_id(kind, id)` (`operator`→Operator/Human, `agent`→that seat, `system`/`security_policy`→Runtime).
- `base_altitude`: `session.emergency_stop` ⇒ **Error** (always top floor).
- Render: `✗ [🧑 operator] EMERGENCY STOP — runaway tool loop`.

## Test plan
- [x] `cargo build` clean
- [x] render: Error glyph + operator label + reason (`emergency_stop_renders_prominently_with_operator_label`)
- [x] gateway: `session.emergency_stop` ⇒ Error + `actor_from_kind_id` attribution (`emergency_stop_is_error_and_attributed`)
- Emit site is deep in `execution.rs` (needs a full execution harness); covered by the unit-tested building blocks (`actor_from_kind_id`, `base_altitude`, render) — same approach as the divergence/drift producers.

## Remaining #413
- **Escalations** (`federation.rs`, `checkpoint.rs`).
- **Sandbox-escape / security findings** (`sandbox.rs`, `policy.rs`).

Reuses `actor_from_kind_id`, which those will want too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)