### PR TITLE
feat(session-room): surface promotion escalations on the timeline (#413)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -99,7 +99,7 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         // (Error when rejected, Attention when overridden); this is just the
         // safe floor for any NULL-altitude fallback.
         "user.ask.pending" | "approval.pending" | "plan.pending" | "divergence.intervention"
-        | "runtime.lock_drift" => Altitude::Attention,
+        | "runtime.lock_drift" | "escalation.pending" => Altitude::Attention,
         // Everything else is normal progress.
         _ => Altitude::Normal,
     }

--- a/autonoetic-gateway/src/scheduler/gateway_store/escalations.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/escalations.rs
@@ -107,6 +107,43 @@ impl GatewayStore {
                 escalation.escalation_type.as_str(),
             ],
         )?;
+        // Release the conn lock before emitting — create_live_digest_event re-locks
+        // the same Mutex, which would deadlock.
+        drop(conn);
+
+        // Surface the operator-facing escalation on the canonical timeline (#413).
+        // It was store-only: the `apr-esc-*` approval it spawns is inserted
+        // directly (not via the gate service), so no `approval.pending` fires —
+        // the escalation was invisible in the room. Attributed to the agent under
+        // review; Attention altitude (an operator decision is pending).
+        if !escalation.root_session_id.is_empty() {
+            let principal = autonoetic_types::principal::Principal::agent(&escalation.agent_id);
+            let seat = crate::runtime::session_timeline::derive_role(&escalation.agent_id);
+            let event = crate::runtime::session_timeline::build_timeline_event(
+                escalation.root_session_id.clone(),
+                escalation.root_session_id.clone(),
+                None,
+                &principal,
+                &seat,
+                "escalation.pending",
+                None, // base_altitude ⇒ Attention
+                Some(serde_json::json!({
+                    "escalation_id": escalation.escalation_id,
+                    "agent_id": escalation.agent_id,
+                    "revision_id": escalation.revision_id,
+                    "synthesis": escalation.planner_synthesis,
+                    "escalation_type": escalation.escalation_type.as_str(),
+                })),
+                autonoetic_types::session_timeline::TimelineRefs::default(),
+            );
+            if let Err(e) = self.create_live_digest_event(&event) {
+                tracing::debug!(
+                    target: "session_timeline",
+                    error = %e,
+                    "escalation.pending timeline emit failed"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -230,5 +267,42 @@ impl GatewayStore {
             ],
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autonoetic_types::session_timeline::{Altitude, SessionRole};
+    use tempfile::tempdir;
+
+    #[test]
+    fn create_escalation_surfaces_pending_on_timeline() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        let esc = EscalationMessage::new(
+            "esc-abc12345".to_string(),
+            "art-1".to_string(),
+            "coder.default".to_string(),
+            "rev-9".to_string(),
+            vec![],
+            "looks good, recommend promote".to_string(),
+            "root-xyz".to_string(),
+        );
+        store.create_escalation(&esc).unwrap();
+
+        let result = store
+            .list_session_timeline("root-xyz", None, 50, Some(Altitude::Detail), None)
+            .unwrap();
+        let ev = result
+            .entries
+            .iter()
+            .find(|e| e.event_type == "escalation.pending")
+            .expect("escalation.pending must reach the timeline");
+        // Operator-decision-pending ⇒ Attention; attributed to the agent under review.
+        assert_eq!(ev.altitude, Altitude::Attention);
+        assert!(matches!(ev.role, SessionRole::Specialist { .. }));
+        assert_eq!(ev.principal.id, "coder.default");
+        assert!(ev.payload.as_deref().unwrap().contains("recommend promote"));
     }
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/escalations.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/escalations.rs
@@ -134,7 +134,14 @@ impl GatewayStore {
                     "synthesis": escalation.planner_synthesis,
                     "escalation_type": escalation.escalation_type.as_str(),
                 })),
-                autonoetic_types::session_timeline::TimelineRefs::default(),
+                // Attach the artifact under review so detail views can show
+                // `refs: artifact=…` and consumers can drill down without parsing
+                // the payload.
+                autonoetic_types::session_timeline::TimelineRefs {
+                    artifact_id: (!escalation.artifact_id.is_empty())
+                        .then(|| escalation.artifact_id.clone()),
+                    ..Default::default()
+                },
             );
             if let Err(e) = self.create_live_digest_event(&event) {
                 tracing::debug!(
@@ -304,5 +311,7 @@ mod tests {
         assert!(matches!(ev.role, SessionRole::Specialist { .. }));
         assert_eq!(ev.principal.id, "coder.default");
         assert!(ev.payload.as_deref().unwrap().contains("recommend promote"));
+        // The artifact under review is attached as a ref for drill-down.
+        assert_eq!(ev.refs.artifact_id.as_deref(), Some("art-1"));
     }
 }

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -149,11 +149,18 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
                 .unwrap_or_else(|| "completed".into())
         ),
         // A promotion/governance escalation awaiting the operator's decision (#413).
-        "escalation.pending" => format!(
-            "escalation: {} (rev {})",
-            one_line(&field("synthesis").unwrap_or_else(|| "operator decision requested".into()), 120),
-            field("revision_id").unwrap_or_default()
-        ),
+        // Revision ids are already prefixed (`rev-9`, `rev_sha256:…`), so show the
+        // id as-is and omit the suffix entirely when absent.
+        "escalation.pending" => {
+            let synthesis = one_line(
+                &field("synthesis").unwrap_or_else(|| "operator decision requested".into()),
+                120,
+            );
+            match field("revision_id").filter(|r| !r.is_empty()) {
+                Some(rev) => format!("escalation: {synthesis} ({rev})"),
+                None => format!("escalation: {synthesis}"),
+            }
+        }
         "llm.request_failed" => format!(
             "LLM error: {}{}",
             one_line(&field("error").unwrap_or_default(), 120),
@@ -632,7 +639,8 @@ mod tests {
         let line = render_line(&e);
         assert!(line.starts_with("⚠"));
         assert!(line.contains("[coder]"));
-        assert!(line.contains("escalation: recommend promote (rev rev-9)"));
+        // Revision id shown as-is (already prefixed), not doubled to "rev rev-9".
+        assert!(line.contains("escalation: recommend promote (rev-9)"));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -148,6 +148,12 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
                 .or_else(|| field("tool"))
                 .unwrap_or_else(|| "completed".into())
         ),
+        // A promotion/governance escalation awaiting the operator's decision (#413).
+        "escalation.pending" => format!(
+            "escalation: {} (rev {})",
+            one_line(&field("synthesis").unwrap_or_else(|| "operator decision requested".into()), 120),
+            field("revision_id").unwrap_or_default()
+        ),
         "llm.request_failed" => format!(
             "LLM error: {}{}",
             one_line(&field("error").unwrap_or_default(), 120),
@@ -612,6 +618,21 @@ mod tests {
         let overridden = render_line(&mk(true, Altitude::Attention));
         assert!(overridden.starts_with("⚠"));
         assert!(overridden.contains("overridden, running anyway"));
+    }
+
+    #[test]
+    fn escalation_pending_renders_synthesis_and_revision() {
+        let e = entry(
+            SessionRole::Specialist { kind: "coder".into() },
+            Principal::agent("coder.default"),
+            "escalation.pending",
+            Altitude::Attention,
+            serde_json::json!({ "synthesis": "recommend promote", "revision_id": "rev-9" }),
+        );
+        let line = render_line(&e);
+        assert!(line.starts_with("⚠"));
+        assert!(line.contains("[coder]"));
+        assert!(line.contains("escalation: recommend promote (rev rev-9)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Second of the #413 audit gaps. A federation/promotion **escalation** is an operator-facing decision — it carries a `root_session_id` and spawns an `apr-esc-*` approval — but it was **store-only**: that approval is inserted directly (not via the gate service), so no `approval.pending` fires and the escalation was invisible in the room.

`GatewayStore::create_escalation` now also emits an **`escalation.pending`** timeline event — one chokepoint, so all three call sites (`federation.rs`, `post_promotion_review.rs`, `mod.rs`) are covered. Emitted **after dropping the conn lock** (`create_live_digest_event` re-locks the same Mutex — would deadlock otherwise). Attributed to the agent under review (`agent_id` → `derive_role`); **Attention** altitude. Renders `⚠ [coder] escalation: <synthesis> (rev <id>)`.

## Test plan
- [x] `cargo build` clean
- [x] gateway: full `create_escalation` → timeline (Attention + specialist seat + synthesis in payload) — `create_escalation_surfaces_pending_on_timeline`
- [x] render: synthesis + revision (`escalation_pending_renders_synthesis_and_revision`)
- Verified no double-emit: `approval.pending` fires only in `human_gate.rs`, and the `apr-esc` approval bypasses it.

## #413 progress
- ✅ Emergency stop (#414)
- ✅ Escalations (this)
- ⬜ Sandbox-escape / security findings (`sandbox.rs`, `policy.rs`) — last one

Follow-up: an `escalation.resolved` event (symmetry with the approval-resolution events) if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)