### PR TITLE
feat(session-room): surface sandbox escape attempts on the timeline (#413)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -92,8 +92,10 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         // Extended-thinking "why" is verbose; hidable by default, surfaced on dial-down.
         "turn.start" | "turn.end" | "llm.round" | "tool.requested" | "agent.reasoning"
         | "workbench.created" | "workbench.reconciled" | "workbench.discarded" => Altitude::Detail,
-        // Failures and the emergency-stop circuit breaker always surface.
-        "llm.request_failed" | "tool.failed" | "session.emergency_stop" => Altitude::Error,
+        // Failures, the emergency-stop circuit breaker, and security-critical
+        // events always surface.
+        "llm.request_failed" | "tool.failed" | "session.emergency_stop"
+        | "security.sandbox_escape" => Altitude::Error,
         // Gates awaiting the operator (conversational asks, RFC §3.5) and
         // integrity events. `runtime.lock_drift` stores an explicit altitude
         // (Error when rejected, Attention when overridden); this is just the

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -1196,12 +1196,19 @@ impl GatewayStore {
         // Surface the escape attempt on the canonical timeline (#413). It was
         // store-only (sandbox_escape_attempts table), so a security-critical,
         // session-scoped event was invisible in the room. Attributed to the agent
-        // whose sandbox tripped; always Error.
-        if !root_session_id.is_empty() {
+        // whose sandbox tripped; always Error. Fall back to session_id as the
+        // timeline root if the caller passed an empty root (upstream fallback
+        // bug) — never silently drop a recorded security event from the room.
+        let timeline_root = if root_session_id.is_empty() {
+            session_id
+        } else {
+            root_session_id
+        };
+        if !timeline_root.is_empty() {
             let principal = autonoetic_types::principal::Principal::agent(agent_id);
             let seat = crate::runtime::session_timeline::derive_role(agent_id);
             let event = crate::runtime::session_timeline::build_timeline_event(
-                root_session_id.to_string(),
+                timeline_root.to_string(),
                 session_id.to_string(),
                 None,
                 &principal,

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -1190,6 +1190,40 @@ impl GatewayStore {
                 chrono::Utc::now().to_rfc3339(),
             ],
         )?;
+        // Release the conn lock before emitting — create_live_digest_event re-locks.
+        drop(conn);
+
+        // Surface the escape attempt on the canonical timeline (#413). It was
+        // store-only (sandbox_escape_attempts table), so a security-critical,
+        // session-scoped event was invisible in the room. Attributed to the agent
+        // whose sandbox tripped; always Error.
+        if !root_session_id.is_empty() {
+            let principal = autonoetic_types::principal::Principal::agent(agent_id);
+            let seat = crate::runtime::session_timeline::derive_role(agent_id);
+            let event = crate::runtime::session_timeline::build_timeline_event(
+                root_session_id.to_string(),
+                session_id.to_string(),
+                None,
+                &principal,
+                &seat,
+                "security.sandbox_escape",
+                None, // base_altitude ⇒ Error
+                Some(serde_json::json!({
+                    "indicator": indicator,
+                    "detail": crate::log_redaction::redact_text_for_logs(detail),
+                    "exit_code": exit_code,
+                    "agent_id": agent_id,
+                })),
+                autonoetic_types::session_timeline::TimelineRefs::default(),
+            );
+            if let Err(e) = self.create_live_digest_event(&event) {
+                tracing::debug!(
+                    target: "session_timeline",
+                    error = %e,
+                    "sandbox_escape timeline emit failed"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -1361,5 +1395,42 @@ mod fts_fallback_tests {
     fn test_should_fallback_false_on_other_error() {
         let err = rusqlite::Error::InvalidParameterName("test".into());
         assert!(!should_fallback_to_like(&err, "runtime.lock"));
+    }
+}
+
+#[cfg(test)]
+mod sandbox_escape_timeline_tests {
+    use super::*;
+    use autonoetic_types::session_timeline::{Altitude, SessionRole};
+    use tempfile::tempdir;
+
+    #[test]
+    fn record_sandbox_escape_surfaces_on_timeline() {
+        let dir = tempdir().unwrap();
+        let store = GatewayStore::open(dir.path()).unwrap();
+        store
+            .record_sandbox_escape_attempt(
+                "root-1",
+                "root-1",
+                "coder.default",
+                "ptrace syscall",
+                "blocked by seccomp",
+                Some(159),
+            )
+            .unwrap();
+
+        let result = store
+            .list_session_timeline("root-1", None, 50, Some(Altitude::Detail), None)
+            .unwrap();
+        let ev = result
+            .entries
+            .iter()
+            .find(|e| e.event_type == "security.sandbox_escape")
+            .expect("sandbox escape must reach the timeline");
+        // Security-critical ⇒ Error; attributed to the agent whose sandbox tripped.
+        assert_eq!(ev.altitude, Altitude::Error);
+        assert!(matches!(ev.role, SessionRole::Specialist { .. }));
+        assert_eq!(ev.principal.id, "coder.default");
+        assert!(ev.payload.as_deref().unwrap().contains("ptrace syscall"));
     }
 }

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -161,6 +161,11 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
                 None => format!("escalation: {synthesis}"),
             }
         }
+        // A sandbox escape attempt during execution (#413) — security-critical.
+        "security.sandbox_escape" => format!(
+            "SANDBOX ESCAPE ATTEMPT — {}",
+            one_line(&field("indicator").unwrap_or_else(|| "blocked".into()), 120)
+        ),
         "llm.request_failed" => format!(
             "LLM error: {}{}",
             one_line(&field("error").unwrap_or_default(), 120),
@@ -662,6 +667,21 @@ mod tests {
         assert!(line.contains("[coder]"));
         // Revision id shown as-is (already prefixed), not doubled to "rev rev-9".
         assert!(line.contains("escalation: recommend promote (rev-9)"));
+    }
+
+    #[test]
+    fn sandbox_escape_renders_prominently() {
+        let e = entry(
+            SessionRole::Specialist { kind: "coder".into() },
+            Principal::agent("coder.default"),
+            "security.sandbox_escape",
+            Altitude::Error,
+            serde_json::json!({ "indicator": "ptrace syscall", "detail": "blocked" }),
+        );
+        let line = render_line(&e);
+        assert!(line.starts_with("✗"));
+        assert!(line.contains("[coder]"));
+        assert!(line.contains("SANDBOX ESCAPE ATTEMPT — ptrace syscall"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Last of the **#413** audit gaps. A **sandbox escape attempt** is security-critical and session-scoped (`session_id` + `root_session_id` + `agent_id`) but was store-only (`sandbox_escape_attempts` table) — invisible in the room.

`record_sandbox_escape_attempt` now also emits a **`security.sandbox_escape`** timeline event (after dropping the conn lock — `create_live_digest_event` re-locks), attributed to the agent whose sandbox tripped; always **Error**. Renders `✗ [coder] SANDBOX ESCAPE ATTEMPT — <indicator>` (detail redacted in payload).

### Scoping note: security findings are deliberately *not* added
`SecurityFinding` (sentinel sweeps) has **no session scope** — it's keyed to a `sentinel_revision_id`, not a root session. It's a cross-cutting findings queue surfaced via the promotion-gate / escalation path (escalations landed in #415), so it doesn't belong on a *session* timeline. The session-scoped gaps from the audit are now all covered.

## Test plan
- [x] `cargo build` clean
- [x] gateway: full `record_sandbox_escape_attempt` → timeline (Error + agent seat + indicator in payload) — `record_sandbox_escape_surfaces_on_timeline`
- [x] render: `sandbox_escape_renders_prominently`

## #413 — done
- ✅ Emergency stop (#414)
- ✅ Escalations (#415)
- ✅ Sandbox escape (this); security findings ruled out (not session-scoped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)