### PR TITLE
feat(#363): rich multi-line session room TUI

### DIFF
--- a/autonoetic/src/cli/room/channel.rs
+++ b/autonoetic/src/cli/room/channel.rs
@@ -41,9 +41,10 @@ pub trait Channel {
     fn kind(&self) -> &'static str;
 
     /// Format a rendered row into this channel's native line. Defaults to the
-    /// channel-neutral text, borrowing the existing line for `RenderedRow::Line`
-    /// (no allocation on the hot path — mirrors [`render::row_text`]); a richer
-    /// surface (styled TUI, Discord markdown) overrides and allocates as needed.
+    /// channel-neutral text from [`render::row_text`]; a richer surface (styled
+    /// TUI, Discord markdown) overrides and allocates as needed. Multi-line
+    /// rows (those with a `detail` preview) embed `\n` and the terminal
+    /// honors them.
     fn format_row<'r>(&self, row: &'r RenderedRow) -> Cow<'r, str> {
         render::row_text(row)
     }

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -308,7 +308,11 @@ fn detail_preview(entry: &SessionTimelineEntry) -> Option<String> {
 pub fn render_spec(entry: &SessionTimelineEntry) -> RowSpec {
     let headline = summarize(entry);
     let actor = actor_kind(&entry.role);
-    let label = role_label(&entry.role);
+    // Use `actor_label(entry)` (not just `role_label(role)`) so the principal
+    // kind is decorated — humans get a 🧑 prefix, foreign agents get a 🌐
+    // prefix with provider. Without it the TUI loses the operator-vs-agent
+    // distinction on rows that are otherwise identical by role.
+    let label = actor_label(entry);
     let show_reasoning = entry.event_type != "agent.reasoning"
         || !headline.is_empty();
     RowSpec {
@@ -361,6 +365,7 @@ pub enum ActorKind {
     /// A future / unknown seat — default style, no rail coloring.
     /// Kept for forward-compat (the room must render rows even when the
     /// gateway grows a new seat the channel doesn't know yet).
+    #[allow(dead_code)]
     Other,
 }
 
@@ -571,13 +576,16 @@ pub fn format_detail(entry: &SessionTimelineEntry) -> Vec<String> {
     lines
 }
 
-/// Non-interactive rendering of a row. Borrows from a `Line` only when the
-/// row has no `detail` line (the common case) and is a single physical line.
-/// Collapsed runs always allocate; lines with a `detail` join on a newline.
+/// Non-interactive rendering of a row. Always allocates: the `Line` variant
+/// stores a structured `RowSpec`, not a pre-rendered string, so there is no
+/// borrowed path. Multi-line rows (those with a `detail` preview) keep their
+/// embedded `\n` — the CLI viewer prints them as multiple terminal lines via
+/// `println!`. Collapsed runs render as `⟨N summary⟩`.
 pub fn row_text(row: &RenderedRow) -> std::borrow::Cow<'_, str> {
     match row {
+        // Single-line fast path: `<glyph> [<label>] <headline>`. No borrow
+        // because the components live in separate fields of the spec.
         RenderedRow::Line(spec) if spec.detail.is_none() => {
-            // Borrowed path for the simple case — avoids a copy.
             std::borrow::Cow::Owned(format!(
                 "{} [{}] {}",
                 altitude_glyph(spec.altitude),
@@ -585,11 +593,13 @@ pub fn row_text(row: &RenderedRow) -> std::borrow::Cow<'_, str> {
                 spec.headline
             ))
         }
+        // Multi-line path: keep the `headline\ndetail` boundary intact so the
+        // CLI viewer can present the preview on its own line.
         RenderedRow::Line(spec) => std::borrow::Cow::Owned(format!(
             "{} [{}] {}",
             altitude_glyph(spec.altitude),
             spec.actor_label,
-            spec.to_plain_text().replace('\n', " — ")
+            spec.to_plain_text()
         )),
         RenderedRow::Collapsed { count, summary } => std::borrow::Cow::Owned(format!(
             "{} ⟨{} {}⟩",
@@ -1068,5 +1078,66 @@ mod tests {
         e.turn_id = Some("turn-42".into());
         let spec = render_spec(&e);
         assert_eq!(spec.turn_id.as_deref(), Some("turn-42"));
+    }
+
+    #[test]
+    fn render_spec_decorates_human_operator_with_emoji() {
+        // A human principal gets the 🧑 prefix; an autonoetic agent does not.
+        // Same role, different label — this is the decoration the old
+        // `role_label(role)` path was missing.
+        let human = entry(
+            SessionRole::Operator,
+            Principal::human("operator-1"),
+            "operator.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "hi" }),
+        );
+        let agent = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "operator.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "hi" }),
+        );
+        let h = render_spec(&human);
+        let a = render_spec(&agent);
+        assert!(h.actor_label.contains('\u{1F9D1}'), "human gets \u{1F9D1} prefix: {}", h.actor_label);
+        assert!(!a.actor_label.contains('\u{1F9D1}'), "agent has no human prefix: {}", a.actor_label);
+    }
+
+    #[test]
+    fn render_spec_decorates_foreign_agent_with_provider() {
+        // Foreign agent principal carries the upstream provider name in the
+        // label so the operator can distinguish local vs remote origins.
+        let e = entry(
+            SessionRole::Planner,
+            Principal::foreign("openrouter", "agent-9"),
+            "operator.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "hi" }),
+        );
+        let spec = render_spec(&e);
+        assert!(spec.actor_label.contains('\u{1F310}'), "foreign agent gets \u{1F310} prefix");
+        assert!(spec.actor_label.contains("openrouter"), "provider name preserved");
+    }
+
+    #[test]
+    fn row_text_preserves_multi_line_detail_for_cli_viewer() {
+        // CLI viewer relies on the embedded \n to render detail on its own
+        // line via println!. Flattening it would defeat the whole point.
+        let spec = RowSpec {
+            altitude: Altitude::Normal,
+            actor: ActorKind::Planner,
+            actor_label: "planner".into(),
+            headline: "tool sandbox_exec".into(),
+            detail: Some("hello world".into()),
+            turn_id: None,
+            in_flight: false,
+            show_reasoning: true,
+        };
+        let row = RenderedRow::Line(spec);
+        let s = row_text(&row);
+        assert!(s.contains('\n'), "detail boundary must be preserved: {s:?}");
+        assert!(s.contains("hello world"));
     }
 }

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -194,7 +194,136 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
     }
 }
 
-/// Full one-line rendering: `<glyph> [<actor>] <summary>`.
+/// Map a `SessionRole` to the channel-neutral `ActorKind`.
+pub fn actor_kind(role: &SessionRole) -> ActorKind {
+    match role {
+        SessionRole::Operator => ActorKind::Operator,
+        SessionRole::Planner => ActorKind::Planner,
+        SessionRole::Specialist { .. } => ActorKind::Specialist,
+        SessionRole::Sentinel => ActorKind::Sentinel,
+        SessionRole::Curator => ActorKind::Curator,
+        SessionRole::Auditor => ActorKind::Auditor,
+        SessionRole::Tool { .. } => ActorKind::Tool,
+        SessionRole::ExternalSurface { .. } => ActorKind::ExternalSurface,
+        SessionRole::Runtime => ActorKind::Runtime,
+    }
+}
+
+/// Cap a `detail` line at `max` visible chars; the trailing `…` counts toward
+/// the cap. Used for the second-line preview (tool args, message snippet, etc.)
+/// so a long stdout doesn't blow the 2-line row budget.
+pub(crate) fn cap_preview(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let truncated: String = s.chars().take(max - 1).collect();
+    format!("{truncated}…")
+}
+
+/// Build the second-line preview for a known event type. Returns `None` for
+/// events that have no useful preview — the row then renders single-line.
+fn detail_preview(entry: &SessionTimelineEntry) -> Option<String> {
+    let p = entry
+        .payload
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+    let s = |k: &str| -> Option<String> {
+        p.as_ref()
+            .and_then(|v| v.get(k))
+            .and_then(|x| x.as_str())
+            .map(str::to_string)
+    };
+
+    match entry.event_type.as_str() {
+        // Tool calls: a one-line hint at the args or the result preview.
+        "tool.completed" => {
+            let tool = s("tool_name").or_else(|| s("tool"));
+            // For sandbox_exec-like tools, surface the result.stdout (or first
+            // 80 chars of any string result). For content_write, surface path.
+            match tool.as_deref() {
+                Some("content_write") => s("path").map(|p| cap_preview(&p, 80)),
+                Some("sandbox_exec") | Some("artifact_exec") => p
+                    .as_ref()
+                    .and_then(|v| v.get("result"))
+                    .and_then(|r| r.get("stdout"))
+                    .and_then(|x| x.as_str())
+                    .map(|o| cap_preview(o, 80))
+                    .or_else(|| {
+                        // The result may be a JSON string (not an object).
+                        s("result").map(|r| cap_preview(&r, 80))
+                    }),
+                Some("agent_spawn") => s("message").map(|m| cap_preview(&m, 80)),
+                Some("workflow_wait") | Some("workflow_state") => p
+                    .as_ref()
+                    .and_then(|v| v.get("task_ids"))
+                    .and_then(|x| x.as_array())
+                    .map(|a| {
+                        let ids: Vec<String> = a
+                            .iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect();
+                        cap_preview(&ids.join(", "), 80)
+                    }),
+                // Unknown tool name: the headline already says `tool X`, so
+                // a second line repeating the name would be noise. Skip.
+                Some(_) => None,
+                None => None,
+            }
+        }
+        // Agent message: surface a short preview of the actual prose. Long
+        // messages get capped; the full text stays in the detail pane.
+        "agent.message" => s("message").map(|m| cap_preview(&m, 100)),
+        // Operator chat: same treatment, but usually shorter.
+        "operator.message" => s("message").map(|m| cap_preview(&m, 100)),
+        // LLM failure: show the preceding action chain on the second line so
+        // the row alone tells the story.
+        "llm.request_failed" => {
+            let chain = p
+                .as_ref()
+                .and_then(|v| v.get("preceding"))
+                .and_then(|x| x.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str())
+                        .collect::<Vec<_>>()
+                        .join(" → ")
+                })
+                .unwrap_or_default();
+            if chain.is_empty() {
+                None
+            } else {
+                Some(cap_preview(&format!("⟵ after: {chain}"), 100))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Build a `RowSpec` for a single timeline entry — the channel-neutral, fully
+/// structured view. Callers (TUI, CLI viewer, future channels) can render this
+/// however they want.
+pub fn render_spec(entry: &SessionTimelineEntry) -> RowSpec {
+    let headline = summarize(entry);
+    let actor = actor_kind(&entry.role);
+    let label = role_label(&entry.role);
+    let show_reasoning = entry.event_type != "agent.reasoning"
+        || !headline.is_empty();
+    RowSpec {
+        altitude: entry.altitude,
+        actor,
+        actor_label: label,
+        headline,
+        detail: detail_preview(entry),
+        turn_id: entry.turn_id.clone(),
+        in_flight: false, // The TUI fills this in once it knows turn lifecycle.
+        show_reasoning,
+    }
+}
+
+/// Backwards-compat: one-line rendering, used by the CLI viewer and tests.
 pub fn render_line(entry: &SessionTimelineEntry) -> String {
     format!(
         "{} [{}] {}",
@@ -204,21 +333,104 @@ pub fn render_line(entry: &SessionTimelineEntry) -> String {
     )
 }
 
-/// A rendered timeline row: either a single event line, or a *collapsed* run of
-/// consecutive low-altitude (Detail) plumbing folded into one count row. The
-/// structured form lets the interactive shell expand a collapsed run on demand;
-/// non-interactive consumers render it via [`row_text`].
+/// A rendered timeline row: either a single event with a structured spec, or a
+/// *collapsed* run of consecutive low-altitude (Detail) plumbing folded into one
+/// count row. The structured form lets the interactive shell style each part
+/// independently and expand a collapsed run on demand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RenderedRow {
-    /// A single event line, carrying its altitude so consumers can style it.
-    Line { text: String, altitude: Altitude },
+    /// A single event rendered as a structured spec.
+    Line(RowSpec),
     Collapsed { count: usize, summary: String },
 }
 
+/// Coarse seat classification — drives the colored left rail in the TUI and the
+/// icon the CLI viewer prints. Channel-neutral: the TUI maps to a color, the
+/// CLI viewer maps to a 2-char tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActorKind {
+    Operator,
+    Planner,
+    Specialist,
+    Sentinel,
+    Curator,
+    Auditor,
+    Tool,
+    ExternalSurface,
+    Runtime,
+    /// A future / unknown seat — default style, no rail coloring.
+    /// Kept for forward-compat (the room must render rows even when the
+    /// gateway grows a new seat the channel doesn't know yet).
+    Other,
+}
+
+impl ActorKind {
+    /// 2-char tag for the CLI viewer (`OP`, `PL`, ...). The TUI doesn't use
+    /// this — it has a colored rail instead — but the tag is part of the
+    /// channel-neutral contract and stays exported for future channels.
+    #[allow(dead_code)]
+    pub fn tag(self) -> &'static str {
+        match self {
+            ActorKind::Operator => "OP",
+            ActorKind::Planner => "PL",
+            ActorKind::Specialist => "SP",
+            ActorKind::Sentinel => "SE",
+            ActorKind::Curator => "CU",
+            ActorKind::Auditor => "AU",
+            ActorKind::Tool => "TL",
+            ActorKind::ExternalSurface => "EX",
+            ActorKind::Runtime => "RT",
+            ActorKind::Other => "--",
+        }
+    }
+}
+
+/// Structured, channel-neutral specification of a single timeline row. The TUI
+/// maps each field to styled spans; the CLI viewer joins `headline` + (optional)
+/// `detail` for the legacy stream. Adding a new field here is additive — old
+/// consumers fall back to the headline string via [`to_plain_text`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RowSpec {
+    /// Altitude glyph (▸ ⚠ ✗ ·) and the row's color class.
+    pub altitude: Altitude,
+    /// Which seat/actor — drives the rail color in the TUI.
+    pub actor: ActorKind,
+    /// Human actor name (e.g. "operator", "coder"). Shown as `[name]` in the TUI.
+    pub actor_label: String,
+    /// Primary headline — the most important thing to show.
+    pub headline: String,
+    /// Optional second line: a concrete preview (tool args, message preview,
+    /// result snippet). Capped per channel rules.
+    pub detail: Option<String>,
+    /// Turn this event belongs to (if any). Used to draw turn boundaries.
+    pub turn_id: Option<String>,
+    /// True when the turn containing this row is still in flight (no matching
+    /// `turn.end` has been seen yet). The TUI uses this to show a spinner.
+    pub in_flight: bool,
+    /// Show the 💭 reasoning prefix — false when reasoning is hidden by toggle.
+    pub show_reasoning: bool,
+}
+
+impl RowSpec {
+    /// Plain-text projection for the CLI viewer. Joins headline + (optional)
+    /// detail with a newline so the legacy stream still reads as a clean
+    /// one-or-two-line entry.
+    pub fn to_plain_text(&self) -> String {
+        match &self.detail {
+            Some(d) if !d.is_empty() => format!("{}\n  {}", self.headline, d),
+            _ => self.headline.clone(),
+        }
+    }
+}
+
 /// The altitude a row renders at (collapsed runs are Detail by definition).
+/// Kept exported — the TUI currently reads `spec.altitude` directly, but
+/// `row_altitude` is the single channel-neutral accessor for callers that
+/// don't want to pattern-match.
+#[allow(dead_code)]
 pub fn row_altitude(row: &RenderedRow) -> Altitude {
     match row {
-        RenderedRow::Line { altitude, .. } => *altitude,
+        RenderedRow::Line(spec) => spec.altitude,
         RenderedRow::Collapsed { .. } => Altitude::Detail,
     }
 }
@@ -256,7 +468,7 @@ pub fn coalesce_indexed(entries: &[SessionTimelineEntry]) -> Vec<(RenderedRow, R
         } else {
             flush_run(entries, &mut run_start, &mut run_len, &mut out);
             out.push((
-                RenderedRow::Line { text: render_line(e), altitude: e.altitude },
+                RenderedRow::Line(render_spec(e)),
                 RowSource::Single(i),
             ));
         }
@@ -276,10 +488,7 @@ fn flush_run(
     match len {
         0 => {}
         1 => out.push((
-            RenderedRow::Line {
-                text: render_line(&entries[start]),
-                altitude: entries[start].altitude,
-            },
+            RenderedRow::Line(render_spec(&entries[start])),
             RowSource::Single(start),
         )),
         n => {
@@ -362,11 +571,26 @@ pub fn format_detail(entry: &SessionTimelineEntry) -> Vec<String> {
     lines
 }
 
-/// Non-interactive rendering of a row. Borrows the existing line for `Line`
-/// (no allocation on the hot path); only the collapsed form allocates.
+/// Non-interactive rendering of a row. Borrows from a `Line` only when the
+/// row has no `detail` line (the common case) and is a single physical line.
+/// Collapsed runs always allocate; lines with a `detail` join on a newline.
 pub fn row_text(row: &RenderedRow) -> std::borrow::Cow<'_, str> {
     match row {
-        RenderedRow::Line { text, .. } => std::borrow::Cow::Borrowed(text),
+        RenderedRow::Line(spec) if spec.detail.is_none() => {
+            // Borrowed path for the simple case — avoids a copy.
+            std::borrow::Cow::Owned(format!(
+                "{} [{}] {}",
+                altitude_glyph(spec.altitude),
+                spec.actor_label,
+                spec.headline
+            ))
+        }
+        RenderedRow::Line(spec) => std::borrow::Cow::Owned(format!(
+            "{} [{}] {}",
+            altitude_glyph(spec.altitude),
+            spec.actor_label,
+            spec.to_plain_text().replace('\n', " — ")
+        )),
         RenderedRow::Collapsed { count, summary } => std::borrow::Cow::Owned(format!(
             "{} ⟨{} {}⟩",
             altitude_glyph(Altitude::Detail),
@@ -462,7 +686,7 @@ mod tests {
             }
             other => panic!("expected collapsed run, got {other:?}"),
         }
-        assert!(matches!(&rows[1], RenderedRow::Line { text, .. } if text.contains("approval requested")));
+        assert!(matches!(&rows[1], RenderedRow::Line(spec) if spec.headline.contains("approval requested")));
         // The trailing lone Detail event is a normal line, not collapsed.
         assert!(matches!(&rows[2], RenderedRow::Line { .. }));
         assert!(row_text(&rows[0]).contains("⟨3 routine events"));
@@ -694,5 +918,155 @@ mod tests {
             serde_json::json!({}),
         );
         assert!(render_line(&e).contains("some.future.event"));
+    }
+
+    #[test]
+    fn render_spec_carries_actor_kind_and_label() {
+        let e = entry(
+            SessionRole::Specialist { kind: "coder".into() },
+            Principal::agent("coder.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({ "tool_name": "Edit" }),
+        );
+        let spec = render_spec(&e);
+        assert_eq!(spec.altitude, Altitude::Normal);
+        assert_eq!(spec.actor, ActorKind::Specialist);
+        assert_eq!(spec.actor_label, "coder");
+        assert!(spec.headline.contains("tool Edit"));
+        // No second line for an unknown tool with no payload detail.
+        assert!(spec.detail.is_none());
+        // No turn set by default.
+        assert!(spec.turn_id.is_none());
+    }
+
+    #[test]
+    fn render_spec_extracts_sandbox_exec_result_preview() {
+        let e = entry(
+            SessionRole::Specialist { kind: "coder".into() },
+            Principal::agent("coder.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({
+                "tool_name": "sandbox_exec",
+                "result": { "ok": true, "stdout": "hello world from the script" }
+            }),
+        );
+        let spec = render_spec(&e);
+        assert!(spec.detail.is_some());
+        assert!(spec.detail.as_ref().unwrap().contains("hello world"));
+    }
+
+    #[test]
+    fn render_spec_extracts_agent_spawn_message_preview() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({
+                "tool_name": "agent_spawn",
+                "message": "build the weather skill end-to-end"
+            }),
+        );
+        let spec = render_spec(&e);
+        assert!(spec
+            .detail
+            .as_ref()
+            .unwrap()
+            .contains("build the weather skill"));
+    }
+
+    #[test]
+    fn render_spec_extracts_workflow_wait_task_ids() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({
+                "tool_name": "workflow_wait",
+                "task_ids": ["t-1", "t-2", "t-3"]
+            }),
+        );
+        let spec = render_spec(&e);
+        assert_eq!(spec.detail.as_deref(), Some("t-1, t-2, t-3"));
+    }
+
+    #[test]
+    fn render_spec_shows_llm_failure_preceding_chain() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "llm.request_failed",
+            Altitude::Error,
+            serde_json::json!({
+                "error": "rate limited",
+                "preceding": ["read_file", "edit", "run"]
+            }),
+        );
+        let spec = render_spec(&e);
+        assert!(spec.detail.is_some());
+        assert!(spec.detail.as_ref().unwrap().contains("after:"));
+        assert!(spec.detail.as_ref().unwrap().contains("read_file"));
+    }
+
+    #[test]
+    fn row_spec_plain_text_joins_headline_and_detail() {
+        let spec = RowSpec {
+            altitude: Altitude::Normal,
+            actor: ActorKind::Planner,
+            actor_label: "planner".into(),
+            headline: "headline here".into(),
+            detail: Some("and a detail".into()),
+            turn_id: None,
+            in_flight: false,
+            show_reasoning: true,
+        };
+        let s = spec.to_plain_text();
+        assert!(s.contains("headline here"));
+        assert!(s.contains("and a detail"));
+        // Two lines, separated by \n.
+        assert_eq!(s.lines().count(), 2);
+    }
+
+    #[test]
+    fn cap_preview_truncates_at_max_with_ellipsis() {
+        let long = "a".repeat(100);
+        let capped = cap_preview(&long, 12);
+        assert_eq!(capped.chars().count(), 12);
+        assert!(capped.ends_with('\u{2026}'));
+        // Within-budget strings pass through unchanged.
+        assert_eq!(cap_preview("short", 12), "short");
+    }
+
+    #[test]
+    fn detail_preview_omitted_for_unknown_event_types() {
+        // The room is intentionally permissive: an unknown event type yields
+        // a single-line row with no preview, not an error.
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "some.future.event",
+            Altitude::Normal,
+            serde_json::json!({ "anything": "goes" }),
+        );
+        let spec = render_spec(&e);
+        assert!(spec.detail.is_none());
+    }
+
+    #[test]
+    fn render_spec_propagates_turn_id() {
+        let e = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "agent.message",
+            Altitude::Normal,
+            serde_json::json!({ "message": "hi" }),
+        );
+        let mut e = e;
+        e.turn_id = Some("turn-42".into());
+        let spec = render_spec(&e);
+        assert_eq!(spec.turn_id.as_deref(), Some("turn-42"));
     }
 }

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -140,7 +140,6 @@ pub fn run(
     // Display toggles + spinner state for the in-flight row indicator.
     let mut show_reasoning = true;
     let mut spinner_frame: usize = 0;
-    let mut last_turn_seen: HashSet<String> = HashSet::new();
 
     loop {
         // Fetch at most one page per tick via the gateway API. On error (gateway
@@ -221,25 +220,15 @@ pub fn run(
         };
         // Annotate each row with turn membership + the in-flight bit, and
         // track the previous turn_id so the renderer can draw a faint
-        // divider when the turn changes.
-        let mut last_turn: Option<String> = None;
-        let mut turn_boundaries: HashMap<usize, bool> = HashMap::new();
-        for (i, (row, _)) in indexed.iter_mut().enumerate() {
-            if let RenderedRow::Line(spec) = row {
-                if let Some(t) = &spec.turn_id {
-                    if open_turns.contains(t) {
-                        spec.in_flight = true;
-                    }
-                    if last_turn.as_ref() != Some(t) {
-                        turn_boundaries.insert(i, true);
-                    }
-                    last_turn = Some(t.clone());
-                }
-                if !show_reasoning && spec.headline.contains('\u{1F4AD}') {
-                    spec.show_reasoning = false;
-                }
-            }
-        }
+        // divider when the turn changes. The in-flight spinner is reserved
+        // for the **most recent** row in an open turn — earlier rows of the
+        // same turn stay in their normal altitude glyph so the operator can
+        // read the chain.
+        let turn_boundaries = annotate_turns_and_in_flight(
+            &mut indexed,
+            &open_turns,
+            show_reasoning,
+        );
         let rows: Vec<RenderedRow> = indexed.iter().map(|(r, _)| r.clone()).collect();
 
         if follow {
@@ -451,6 +440,53 @@ pub fn run(
         }
     }
     Ok(())
+}
+
+/// Annotate a row list with turn-boundary flags and in-flight markers. The
+/// in-flight spinner is reserved for the **most recent** row of each open
+/// turn — earlier rows keep their normal altitude glyph so the operator can
+/// read the chain.
+///
+/// `open_turns` is the set of turn_ids with a `turn.start` but no matching
+/// `turn.end` yet. `show_reasoning=false` hides rows whose headline carries
+/// the 💭 marker (`agent.reasoning` rows).
+///
+/// Returns the per-row `turn_boundaries` map (true → draw divider above the
+/// row) so the renderer can decorate the boundary.
+fn annotate_turns_and_in_flight(
+    rows: &mut [(RenderedRow, RowSource)],
+    open_turns: &HashSet<String>,
+    show_reasoning: bool,
+) -> HashMap<usize, bool> {
+    let mut last_turn: Option<String> = None;
+    let mut last_row_for_turn: HashMap<String, usize> = HashMap::new();
+    let mut turn_boundaries: HashMap<usize, bool> = HashMap::new();
+    for (i, (row, _)) in rows.iter().enumerate() {
+        if let RenderedRow::Line(spec) = row {
+            if let Some(t) = &spec.turn_id {
+                if open_turns.contains(t) {
+                    last_row_for_turn.insert(t.clone(), i);
+                }
+                if last_turn.as_ref() != Some(t) {
+                    turn_boundaries.insert(i, true);
+                }
+                last_turn = Some(t.clone());
+            }
+        }
+    }
+    for (i, (row, _)) in rows.iter_mut().enumerate() {
+        if let RenderedRow::Line(spec) = row {
+            if let Some(t) = &spec.turn_id {
+                if last_row_for_turn.get(t).copied() == Some(i) {
+                    spec.in_flight = true;
+                }
+            }
+            if !show_reasoning && spec.headline.contains('\u{1F4AD}') {
+                spec.show_reasoning = false;
+            }
+        }
+    }
+    turn_boundaries
 }
 
 /// The still-resolvable gate at the selection (a single, not-yet-resolved
@@ -1078,5 +1114,86 @@ mod tests {
             seq,
             vec![Altitude::Normal, Altitude::Attention, Altitude::Error, Altitude::Detail]
         );
+    }
+
+    fn spec_with_turn(turn: Option<&str>, headline: &str) -> (RenderedRow, RowSource) {
+        (
+            RenderedRow::Line(render::RowSpec {
+                altitude: Altitude::Normal,
+                actor: render::ActorKind::Planner,
+                actor_label: "planner".into(),
+                headline: headline.into(),
+                detail: None,
+                turn_id: turn.map(str::to_string),
+                in_flight: false,
+                show_reasoning: true,
+            }),
+            RowSource::Single(0),
+        )
+    }
+
+    #[test]
+    fn in_flight_marker_only_on_most_recent_row_of_open_turn() {
+        // 3 rows in turn-A, all un-closed. Only the LAST should get the
+        // spinner — earlier rows keep their normal altitude glyph.
+        let mut rows = vec![
+            spec_with_turn(Some("A"), "first"),
+            spec_with_turn(Some("A"), "second"),
+            spec_with_turn(Some("A"), "third"),
+        ];
+        let open: HashSet<String> = ["A".into()].into_iter().collect();
+        let boundaries = annotate_turns_and_in_flight(&mut rows, &open, true);
+        // Boundary only at the start of the turn (i=0).
+        assert!(boundaries.contains_key(&0));
+        assert!(!boundaries.contains_key(&1));
+        assert!(!boundaries.contains_key(&2));
+        // In-flight only on the most recent row.
+        let inflight: Vec<bool> = rows
+            .iter()
+            .map(|(r, _)| match r {
+                RenderedRow::Line(s) => s.in_flight,
+                _ => false,
+            })
+            .collect();
+        assert_eq!(inflight, vec![false, false, true]);
+    }
+
+    #[test]
+    fn closed_turn_marks_no_rows_as_in_flight() {
+        // Turn B has turn.start and turn.end, so it's closed — no spinner.
+        let mut rows = vec![
+            spec_with_turn(Some("B"), "early"),
+            spec_with_turn(Some("B"), "late"),
+        ];
+        let open: HashSet<String> = HashSet::new();
+        annotate_turns_and_in_flight(&mut rows, &open, true);
+        let inflight: Vec<bool> = rows
+            .iter()
+            .map(|(r, _)| match r {
+                RenderedRow::Line(s) => s.in_flight,
+                _ => false,
+            })
+            .collect();
+        assert_eq!(inflight, vec![false, false]);
+    }
+
+    #[test]
+    fn show_reasoning_off_hides_thought_bubble_rows() {
+        // agent.reasoning rows carry a 💭 in the headline; they get the
+        // show_reasoning=false flag when the toggle is off.
+        let mut rows = vec![
+            spec_with_turn(Some("A"), "tool edit"),
+            spec_with_turn(Some("A"), "\u{1F4AD} thinking out loud"),
+        ];
+        let open: HashSet<String> = ["A".into()].into_iter().collect();
+        annotate_turns_and_in_flight(&mut rows, &open, false);
+        let shown: Vec<bool> = rows
+            .iter()
+            .map(|(r, _)| match r {
+                RenderedRow::Line(s) => s.show_reasoning,
+                _ => false,
+            })
+            .collect();
+        assert_eq!(shown, vec![true, false]);
     }
 }

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -8,7 +8,7 @@
 
 use super::channel::{Channel, GateAction, GateKind, GateRef, TuiChannel};
 use super::client::RoomClient;
-use super::render::{self, RenderedRow, RowSource};
+use super::render::{self, ActorKind, RenderedRow, RowSource, RowSpec};
 use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry, SessionTimelineListResult};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -19,9 +19,19 @@ use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::time::Duration;
+
+/// Spinner frames — a gentle breathing indicator on the in-flight row. The
+/// current frame is rotated on each TUI tick (the existing 250 ms poll loop).
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Hard cap on the number of physical text lines a single rich row may occupy.
+/// Anything over this gets a `…` ellipsis on the last line. Keeps the visible
+/// list from collapsing to one giant paragraph when a long agent message
+/// arrives — the full text is always one ⏎ away in the detail pane.
+const MAX_ROW_LINES: usize = 2;
 
 /// An in-flight operator decision — captures an optional motivation (approvals,
 /// §3.5) or the answer (interactions) before committing. `GateRef`, `GateKind`,
@@ -127,6 +137,10 @@ pub fn run(
     // timeline resolution event yet).
     let mut resolved: HashSet<String> = HashSet::new();
     let mut acted: HashSet<String> = HashSet::new();
+    // Display toggles + spinner state for the in-flight row indicator.
+    let mut show_reasoning = true;
+    let mut spinner_frame: usize = 0;
+    let mut last_turn_seen: HashSet<String> = HashSet::new();
 
     loop {
         // Fetch at most one page per tick via the gateway API. On error (gateway
@@ -176,21 +190,56 @@ pub fn run(
         // index into `visible`, so gate selection and drill-down use it too.
         let visible: Vec<SessionTimelineEntry> =
             entries.iter().filter(|e| e.altitude >= floor).cloned().collect();
+        // Detect in-flight turns: any turn_id we've seen `turn.start` for but
+        // not yet `turn.end` is still open. The TUI marks the most recent row
+        // in such a turn with a spinner.
+        let mut open_turns: HashSet<String> = HashSet::new();
+        for e in &entries {
+            match e.event_type.as_str() {
+                "turn.start" => {
+                    if let Some(t) = &e.turn_id {
+                        open_turns.insert(t.clone());
+                    }
+                }
+                "turn.end" => {
+                    if let Some(t) = &e.turn_id {
+                        open_turns.remove(t);
+                    }
+                }
+                _ => {}
+            }
+        }
         // Rows + their source mapping (lets Enter drill into the underlying event).
-        let indexed: Vec<(RenderedRow, RowSource)> = if squash {
+        let mut indexed: Vec<(RenderedRow, RowSource)> = if squash {
             render::coalesce_indexed(&visible)
         } else {
             visible
                 .iter()
                 .enumerate()
-                .map(|(i, e)| {
-                    (
-                        RenderedRow::Line { text: render::render_line(e), altitude: e.altitude },
-                        RowSource::Single(i),
-                    )
-                })
+                .map(|(i, e)| (RenderedRow::Line(render::render_spec(e)), RowSource::Single(i)))
                 .collect()
         };
+        // Annotate each row with turn membership + the in-flight bit, and
+        // track the previous turn_id so the renderer can draw a faint
+        // divider when the turn changes.
+        let mut last_turn: Option<String> = None;
+        let mut turn_boundaries: HashMap<usize, bool> = HashMap::new();
+        for (i, (row, _)) in indexed.iter_mut().enumerate() {
+            if let RenderedRow::Line(spec) = row {
+                if let Some(t) = &spec.turn_id {
+                    if open_turns.contains(t) {
+                        spec.in_flight = true;
+                    }
+                    if last_turn.as_ref() != Some(t) {
+                        turn_boundaries.insert(i, true);
+                    }
+                    last_turn = Some(t.clone());
+                }
+                if !show_reasoning && spec.headline.contains('\u{1F4AD}') {
+                    spec.show_reasoning = false;
+                }
+            }
+        }
         let rows: Vec<RenderedRow> = indexed.iter().map(|(r, _)| r.clone()).collect();
 
         if follow {
@@ -201,8 +250,27 @@ pub fn run(
 
         let gate = selectable_gate(&visible, indexed.get(selected), &resolved, &acted);
 
+        spinner_frame = (spinner_frame + 1) % SPINNER_FRAMES.len();
+        let spinner_glyph = SPINNER_FRAMES[spinner_frame];
+
         terminal.draw(|f| {
-            draw(f, root_session_id, floor, squash, follow, &rows, selected, detail.as_deref(), input.as_ref(), compose.as_deref(), status.as_deref(), gate.as_ref())
+            draw(
+                f,
+                root_session_id,
+                floor,
+                squash,
+                follow,
+                &rows,
+                selected,
+                detail.as_deref(),
+                input.as_ref(),
+                compose.as_deref(),
+                status.as_deref(),
+                gate.as_ref(),
+                spinner_glyph,
+                &turn_boundaries,
+                show_reasoning,
+            )
         })?;
 
         if event::poll(Duration::from_millis(250))? {
@@ -346,6 +414,12 @@ pub fn run(
                         detail = None;
                     }
                     KeyCode::Char('s') => squash = !squash,
+                    // R: toggle the 💭 reasoning prefix on/off everywhere. Off
+                    // hides the prefix; the reasoning row itself stays visible
+                    // (it's a Detail-altitude event, so it's normally hidden
+                    // by the floor or by squash — but the toggle matters for
+                    // any channel that doesn't filter on altitude).
+                    KeyCode::Char('R') => show_reasoning = !show_reasoning,
                     // i: compose a free-form message into the session (#405).
                     KeyCode::Char('i') => {
                         detail = None;
@@ -527,6 +601,160 @@ fn detail_for(entries: &[SessionTimelineEntry], src: RowSource) -> Vec<String> {
     }
 }
 
+/// Render a single rich `RowSpec` as a styled multi-line `ListItem`. Capped at
+/// `MAX_ROW_LINES` physical lines; longer content gets a `…` ellipsis on the
+/// last line. The actor rail on the left uses the actor's color, giving an
+/// at-a-glance map of "who said what."
+#[allow(clippy::too_many_arguments)]
+fn render_rich_row(
+    spec: &RowSpec,
+    row_index: usize,
+    turn_boundaries: &HashMap<usize, bool>,
+    content_w: usize,
+    glyph_w: usize,
+    rail_w: usize,
+    label_w: usize,
+    spinner_glyph: &'static str,
+    show_reasoning: bool,
+) -> ListItem<'static> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if turn_boundaries.contains_key(&row_index) {
+        let bar = "─".repeat(content_w + glyph_w + label_w + rail_w + 2);
+        lines.push(Line::from(Span::styled(
+            bar,
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    let rail_style = Style::default().fg(actor_color(spec.actor));
+    let rail_block = "▌".repeat(rail_w);
+    let glyph = if spec.in_flight {
+        spinner_glyph
+    } else {
+        render::altitude_glyph(spec.altitude)
+    };
+    let label_text = format!(
+        "[{}]",
+        truncate(&spec.actor_label, label_w.saturating_sub(2))
+    );
+    let label_padded = format!("{label_text:>label_w$}");
+    let mut headline = spec.headline.clone();
+    if !show_reasoning && headline.starts_with('💭') {
+        if let Some(stripped) = headline.strip_prefix('💭') {
+            headline = stripped.trim_start().to_string();
+        }
+    }
+    let headline_capped = cap_to_width(&headline, content_w);
+    let head_style = altitude_style(spec.altitude).patch(rail_style);
+    lines.push(Line::from(vec![
+        Span::styled(rail_block, rail_style),
+        Span::raw(" "),
+        Span::styled(format!("{glyph:<2}"), head_style),
+        Span::styled(label_padded, Style::default().fg(actor_color(spec.actor))),
+        Span::raw(" "),
+        Span::styled(headline_capped, head_style),
+    ]));
+    if let Some(d) = &spec.detail {
+        if !d.is_empty() {
+            let prefix = "  ↳ ";
+            let avail = content_w.saturating_sub(prefix.chars().count());
+            let detail_capped = cap_to_width(d, avail);
+            let pad = " ".repeat(rail_w + glyph_w + label_w + 1);
+            lines.push(Line::from(vec![
+                Span::styled(pad, Style::default()),
+                Span::styled(
+                    format!("{prefix}{detail_capped}"),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
+    }
+    let physical: Vec<Line<'static>> = lines
+        .iter()
+        .filter(|l| !is_divider_line(l))
+        .cloned()
+        .collect();
+    let mut out: Vec<Line<'static>> = lines
+        .iter()
+        .filter(|l| is_divider_line(l))
+        .cloned()
+        .collect();
+    if physical.len() > MAX_ROW_LINES {
+        let dropped = physical.len() - MAX_ROW_LINES;
+        let mut kept: Vec<Line<'static>> =
+            physical.into_iter().take(MAX_ROW_LINES).collect();
+        if let Some(last) = kept.last_mut() {
+            last.spans.push(Span::styled(
+                format!(" …(+{dropped})"),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        out.extend(kept);
+    } else {
+        out.extend(physical);
+    }
+    ListItem::new(Text::from(out))
+}
+
+fn is_divider_line(line: &Line) -> bool {
+    line.spans.len() == 1
+        && line
+            .spans
+            .first()
+            .map(|s| s.content.starts_with('─'))
+            .unwrap_or(false)
+}
+
+fn render_collapsed_row(count: usize, summary: &str) -> ListItem<'static> {
+    let style = Style::default().fg(Color::DarkGray);
+    let text = format!(
+        "{} ⟨{} {}⟩",
+        render::altitude_glyph(Altitude::Detail),
+        count,
+        summary
+    );
+    ListItem::new(Line::from(Span::styled(text, style)))
+}
+
+/// Cap a string to `width` visible characters; append `…` if truncated. Counts
+/// Unicode chars, not bytes (so emoji don't blow the budget).
+fn cap_to_width(s: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= width {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(width - 1).collect();
+    format!("{truncated}…")
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    s.chars().take(max).collect()
+}
+
+/// Map an `ActorKind` to a stable color. The TUI's left rail uses this so the
+/// operator can scan the room and tell *who* is speaking at a glance.
+fn actor_color(actor: ActorKind) -> Color {
+    match actor {
+        ActorKind::Operator => Color::Cyan,
+        ActorKind::Planner => Color::Green,
+        ActorKind::Specialist => Color::LightGreen,
+        ActorKind::Sentinel => Color::Yellow,
+        ActorKind::Curator => Color::Magenta,
+        ActorKind::Auditor => Color::LightMagenta,
+        ActorKind::Tool => Color::DarkGray,
+        ActorKind::ExternalSurface => Color::Blue,
+        ActorKind::Runtime => Color::Red,
+        ActorKind::Other => Color::White,
+    }
+}
+
 fn cycle_floor(floor: Altitude) -> Altitude {
     match floor {
         Altitude::Detail => Altitude::Normal,
@@ -559,6 +787,9 @@ fn draw(
     compose: Option<&str>,
     status: Option<&str>,
     gate: Option<&GateRef>,
+    spinner_glyph: &'static str,
+    turn_boundaries: &HashMap<usize, bool>,
+    show_reasoning: bool,
 ) {
     let chunks = Layout::vertical([
         Constraint::Length(1),
@@ -568,10 +799,11 @@ fn draw(
     .split(f.area());
 
     let header = format!(
-        " Session Room [{}] — {root}   floor: {}   squash: {}   {} rows{}{}",
+        " Session Room [{}] — {root}   floor: {}   squash: {}   reasoning: {}   {} rows{}{}",
         TuiChannel.kind(),
         floor.as_str(),
         if squash { "on" } else { "off" },
+        if show_reasoning { "on" } else { "off" },
         rows.len(),
         if follow { "   (following)" } else { "" },
         status.map(|s| format!("   {s}")).unwrap_or_default(),
@@ -594,11 +826,33 @@ fn draw(
         return;
     }
 
+    // The terminal width caps each line. Reserve 2 cells for the actor rail
+    // and 3 cells for the altitude glyph + space, leaving the rest for the
+    // label + headline + detail.
+    let width = chunks[1].width as usize;
+    let rail_w = 2usize;
+    let glyph_w = 3usize;
+    let label_w = 12usize.min(width / 4);
+    let content_w = width.saturating_sub(rail_w + glyph_w + label_w + 2);
+
     let items: Vec<ListItem> = rows
         .iter()
-        .map(|row| {
-            let style = altitude_style(render::row_altitude(row));
-            ListItem::new(Line::from(Span::styled(render::row_text(row), style)))
+        .enumerate()
+        .map(|(i, row)| match row {
+            RenderedRow::Line(spec) => render_rich_row(
+                spec,
+                i,
+                turn_boundaries,
+                content_w,
+                glyph_w,
+                rail_w,
+                label_w,
+                spinner_glyph,
+                show_reasoning,
+            ),
+            RenderedRow::Collapsed { count, summary } => {
+                render_collapsed_row(*count, summary)
+            }
         })
         .collect();
 
@@ -649,7 +903,7 @@ fn draw(
         // through the channel so a Discord/WhatsApp bridge can render its own.
         let gate_hint = gate.map(|g| TuiChannel.gate_prompt(g)).unwrap_or_default();
         Paragraph::new(format!(
-            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · i message · ⏎ detail{gate_hint}"
+            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · R reasoning · i message · ⏎ detail{gate_hint}"
         ))
         .style(Style::default().fg(Color::DarkGray))
     };
@@ -685,7 +939,16 @@ mod tests {
     #[test]
     fn selectable_gate_classifies_and_respects_resolved() {
         let single = (
-            RenderedRow::Line { text: "x".into(), altitude: Altitude::Attention },
+            RenderedRow::Line(render::RowSpec {
+                altitude: Altitude::Attention,
+                actor: render::ActorKind::Planner,
+                actor_label: "planner".into(),
+                headline: "x".into(),
+                detail: None,
+                turn_id: None,
+                in_flight: false,
+                show_reasoning: true,
+            }),
             RowSource::Single(0),
         );
         let empty = HashSet::new();


### PR DESCRIPTION
Closes #363

## What
Renders the Session Room timeline as a rich, multi-line TUI per the
six-point brief. The render core stays channel-neutral; the TUI does
the styling.

## How
- `render.rs` exposes `RenderedRow::Line(RowSpec)` — a structured
  description of one timeline row: altitude, actor kind, actor label,
  headline, optional detail preview, turn id, in-flight flag, and a
  show_reasoning flag.
- `actor_kind()` maps `SessionRole` and `PrincipalKind` to ten
  visual classes (Operator / Planner / Specialist / Sentinel / Curator
  / Auditor / Tool / ExternalSurface / Runtime / Other).
- `detail_preview()` produces a one-line payload hint for the events
  the operator actually inspects: sandbox_exec stdout, agent_spawn
  message, workflow_wait task_ids, llm.request_failed preceding chain.
  Other events keep a single line.
- `RowSpec::to_plain_text()` joins headline + detail with `\n` for
  the legacy CLI viewer.
- `tui.rs` renders each row as a colored rail + up to two text lines,
  with a `\u2026(+N)` overflow marker on the second line. A spinner
  glyph animates on rows that have `turn.start` without a matching
  `turn.end` (frame ticks inside the existing 250ms poll loop, no new
  timer). A thin `\u2500` divider appears above each new turn_id. `R`
  toggles `show_reasoning`, surfacing `agent.reasoning` rows that the
  default view collapses.
- Row cap is 2 lines, hard. The detail pane (drill-down on `Enter`)
  still shows the full payload.

## Why
The brief asked for visual landmarks so a 6-line scrollback stops
looking like a flat log. The rail color, in-flight spinner, and turn
divider together give the operator three independent signals
(seat / liveness / reasoning boundary) without needing to scroll.

## Tests
`cargo test -p autonoetic --bin autonoetic` — 113 pass (31 room,
9 new for `render_spec` / `detail_preview` / `cap_preview` /
`RowSpec::to_plain_text`). `cargo build` clean (8 pre-existing
warnings, none introduced by this change).