### PR TITLE
feat(room): standalone session resume + /session slash command

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1027,6 +1027,75 @@ impl JsonRpcRouter {
                 }
             }
 
+            "session.list" => {
+                // Discover existing root sessions so the operator can reload or
+                // attach to one. Backed by `causal_events` (every gateway
+                // action leaves a row) — `MAX(timestamp)` gives last activity.
+                let params: autonoetic_types::session_timeline::SessionListParams =
+                    match serde_json::from_value(req.params) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32602,
+                                format!("Invalid params for session.list: {}", e),
+                            );
+                        }
+                    };
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                let limit = params.limit.clamp(1, 500) as i64;
+                match store.list_recent_sessions(limit) {
+                    Ok(rows) => {
+                        let mut entries: Vec<autonoetic_types::session_timeline::SessionListEntry> =
+                            rows.into_iter()
+                                .filter_map(|(sid, agent_id, last_ts)| {
+                                    if let Some(filter) = params.agent_id.as_deref() {
+                                        if agent_id != filter {
+                                            return None;
+                                        }
+                                    }
+                                    Some(
+                                        autonoetic_types::session_timeline::SessionListEntry {
+                                            root_session_id: sid,
+                                            agent_id,
+                                            last_active_at: last_ts,
+                                        },
+                                    )
+                                })
+                                .collect();
+                        // Re-apply limit after the agent filter so callers get
+                        // at most `limit` matches of the requested agent, not
+                        // a 50-row global cap that drops to 0 after filtering.
+                        if entries.len() as i64 > limit {
+                            entries.truncate(limit as usize);
+                        }
+                        JsonRpcResponse::success(
+                            req.id,
+                            serde_json::to_value(
+                                autonoetic_types::session_timeline::SessionListResult {
+                                    sessions: entries,
+                                },
+                            )
+                            .unwrap_or_else(|_| serde_json::json!({"sessions": []})),
+                        )
+                    }
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("session.list failed: {}", e),
+                    ),
+                }
+            }
+
             "channel.bind" => {
                 // #393 (P3.c): bind an external conversation (Discord thread,
                 // WhatsApp chat) to a room so it survives reconnects and routes

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1053,31 +1053,20 @@ impl JsonRpcRouter {
                     }
                 };
                 let limit = params.limit.clamp(1, 500) as i64;
-                match store.list_recent_sessions(limit) {
+                match store.list_recent_sessions(limit, params.agent_id.as_deref()) {
                     Ok(rows) => {
-                        let mut entries: Vec<autonoetic_types::session_timeline::SessionListEntry> =
+                        let entries: Vec<autonoetic_types::session_timeline::SessionListEntry> =
                             rows.into_iter()
-                                .filter_map(|(sid, agent_id, last_ts)| {
-                                    if let Some(filter) = params.agent_id.as_deref() {
-                                        if agent_id != filter {
-                                            return None;
-                                        }
+                                .map(|(sid, agent_id, last_ts)| {
+                                    autonoetic_types::session_timeline::SessionListEntry {
+                                        root_session_id: sid,
+                                        agent_id,
+                                        last_active_at: last_ts,
                                     }
-                                    Some(
-                                        autonoetic_types::session_timeline::SessionListEntry {
-                                            root_session_id: sid,
-                                            agent_id,
-                                            last_active_at: last_ts,
-                                        },
-                                    )
                                 })
                                 .collect();
-                        // Re-apply limit after the agent filter so callers get
-                        // at most `limit` matches of the requested agent, not
-                        // a 50-row global cap that drops to 0 after filtering.
-                        if entries.len() as i64 > limit {
-                            entries.truncate(limit as usize);
-                        }
+                        // The agent filter is pushed into the store query, so the
+                        // returned rows are already filtered and bounded by `limit`.
                         JsonRpcResponse::success(
                             req.id,
                             serde_json::to_value(

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -1328,16 +1328,35 @@ impl GatewayStore {
     pub fn list_recent_sessions(
         &self,
         limit: i64,
+        agent_id: Option<&str>,
     ) -> Result<Vec<(String, String, String)>> {
+        // When `agent_id` is provided, push the filter into SQL so the LIMIT
+        // applies *after* filtering — otherwise `--resume --agent` could miss
+        // a session for that agent that just isn't in the global top-N.
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT session_id, agent_id, MAX(timestamp) as last_ts
-             FROM causal_events
-             GROUP BY session_id
-             ORDER BY last_ts DESC
-             LIMIT ?1",
-        )?;
-        let rows = stmt.query_map(params![limit], |row| {
+        let (sql, params_vec): (&str, Vec<Box<dyn rusqlite::ToSql>>) = match agent_id {
+            Some(_) => (
+                "SELECT session_id, agent_id, MAX(timestamp) as last_ts
+                 FROM causal_events
+                 WHERE agent_id = ?2
+                 GROUP BY session_id
+                 ORDER BY last_ts DESC
+                 LIMIT ?1",
+                vec![Box::new(limit), Box::new(agent_id.unwrap().to_string())],
+            ),
+            None => (
+                "SELECT session_id, agent_id, MAX(timestamp) as last_ts
+                 FROM causal_events
+                 GROUP BY session_id
+                 ORDER BY last_ts DESC
+                 LIMIT ?1",
+                vec![Box::new(limit)],
+            ),
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let params_refs: Vec<&dyn rusqlite::ToSql> =
+            params_vec.iter().map(|b| &**b as &dyn rusqlite::ToSql).collect();
+        let rows = stmt.query_map(params_refs.as_slice(), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
         })?;
         let mut results = Vec::new();

--- a/autonoetic-types/src/session_timeline.rs
+++ b/autonoetic-types/src/session_timeline.rs
@@ -180,3 +180,34 @@ pub struct SessionTimelineListResult {
     pub next_cursor: Option<String>,
     pub has_more: bool,
 }
+
+/// Parameters for `session.list` — discover existing root sessions so the
+/// operator can reload or attach to one. Optional `agent_id` filter narrows
+/// the list to a single agent's sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionListParams {
+    /// Optional agent filter (e.g. `planner.default`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// Max entries to return. Clamped to 1..=500 by the gateway.
+    #[serde(default = "default_list_limit")]
+    pub limit: u32,
+}
+
+fn default_list_limit() -> u32 {
+    50
+}
+
+/// One row of `session.list`. The room uses `last_active_at` to display
+/// "last activity 12m ago" hints; the SDKs use it for sorting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionListEntry {
+    pub root_session_id: String,
+    pub agent_id: String,
+    pub last_active_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionListResult {
+    pub sessions: Vec<SessionListEntry>,
+}

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -1265,7 +1265,7 @@ fn load_known_sessions(
     }
 
     if let Some(store) = gateway_store {
-        if let Ok(db_sessions) = store.list_recent_sessions(200) {
+        if let Ok(db_sessions) = store.list_recent_sessions(200, None) {
             for (session_id, agent_id, last_ts) in db_sessions {
                 let entry = by_session
                     .entry(session_id.clone())

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -948,8 +948,17 @@ pub struct TraceArgs {
 
 #[derive(Args)]
 pub struct RoomArgs {
-    /// Root session id whose timeline to render.
-    pub root_session_id: String,
+    /// Root session id whose timeline to render. Omit when `--resume` is set
+    /// to pick the most recent session from the gateway.
+    pub root_session_id: Option<String>,
+    /// Pick the most recent root session from the gateway. Combine with
+    /// `--agent <id>` to restrict the pick to one agent.
+    #[arg(long)]
+    pub resume: bool,
+    /// When combined with `--resume`, only consider sessions owned by this
+    /// agent (e.g. `planner.default`).
+    #[arg(long)]
+    pub agent: Option<String>,
     /// Altitude floor: detail | normal | attention | error. Default: normal.
     #[arg(long, default_value = "normal")]
     pub min_altitude: String,

--- a/autonoetic/src/cli/room/mod.rs
+++ b/autonoetic/src/cli/room/mod.rs
@@ -9,6 +9,7 @@
 mod channel;
 mod client;
 mod render;
+mod slash;
 mod tui;
 
 use crate::cli::common::RoomArgs;
@@ -19,6 +20,14 @@ use std::path::Path;
 use std::time::Duration;
 
 pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<()> {
+    handle_room_with_target(config_path, args, None).await
+}
+
+pub async fn handle_room_with_target(
+    config_path: &Path,
+    args: &RoomArgs,
+    mut target_agent_id: Option<String>,
+) -> anyhow::Result<()> {
     let config = autonoetic_gateway::config::load_config(config_path)?;
 
     // `parse_str` returns `Some` for every valid floor — `None` means invalid.
@@ -33,17 +42,28 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
     // The whole room is a gateway API client (#392) — no store access.
     let client = RoomClient::from_config(&config)?;
 
+    // Resolve the session id before any read. `--resume` asks the gateway for
+    // the most recent session (optionally filtered by --agent); otherwise the
+    // caller must supply a positional `root_session_id`.
+    let mut root_session_id = resolve_root_session_id(&client, args).await?;
+
     // Interactive shell — reads via session.timeline.list, resolves gates via
     // approvals.* / interaction.resolve_and_answer.
     if args.tui {
-        return tui::run(&client, &args.root_session_id, min_altitude, args.limit);
+        return tui::run(
+            &client,
+            &mut root_session_id,
+            min_altitude,
+            args.limit,
+            &mut target_agent_id,
+        );
     }
 
     // Read-only viewer.
     let mut cursor: Option<String> = None;
     let rendered_any = drain_new_rpc(
         &client,
-        &args.root_session_id,
+        &root_session_id,
         &mut cursor,
         args.limit,
         &args.min_altitude,
@@ -54,7 +74,7 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
         if !rendered_any {
             eprintln!(
                 "(no activity at or above '{}' for session '{}')",
-                args.min_altitude, args.root_session_id
+                args.min_altitude, root_session_id
             );
         }
         return Ok(());
@@ -62,7 +82,7 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
 
     eprintln!(
         "Following room '{}' (floor: {}) via the {} channel. Press Ctrl+C to stop.",
-        args.root_session_id,
+        root_session_id,
         args.min_altitude,
         CliChannel.kind(),
     );
@@ -71,13 +91,60 @@ pub async fn handle_room(config_path: &Path, args: &RoomArgs) -> anyhow::Result<
         interval.tick().await;
         drain_new_rpc(
             &client,
-            &args.root_session_id,
+            &root_session_id,
             &mut cursor,
             args.limit,
             &args.min_altitude,
         )
         .await?;
     }
+}
+
+/// Pick the `root_session_id` to render, based on the args. Explicit positional
+/// always wins; `--resume` is the fallback for the standalone `autonoetic room`
+/// launch (no chat loop, no fresh session_id).
+async fn resolve_root_session_id(
+    client: &RoomClient,
+    args: &RoomArgs,
+) -> anyhow::Result<String> {
+    if let Some(id) = args.root_session_id.as_deref() {
+        let id = id.trim();
+        if !id.is_empty() {
+            return Ok(id.to_string());
+        }
+    }
+    if !args.resume {
+        anyhow::bail!(
+            "no <SESSION_ID> given and --resume is not set. Pass a root session id \
+             (e.g. `autonoetic room session-abc123`) or add --resume to pick the \
+             most recent one (`autonoetic room --resume [--agent <id>]`)."
+        );
+    }
+    let params = serde_json::json!({
+        "agent_id": args.agent,
+        "limit": 1,
+    });
+    let value = client.call("session.list", params).await?;
+    let parsed: autonoetic_types::session_timeline::SessionListResult =
+        serde_json::from_value(value).map_err(|e| {
+            anyhow::anyhow!("malformed session.list response: {e}")
+        })?;
+    let entry = parsed.sessions.into_iter().next().ok_or_else(|| {
+        let agent_hint = args
+            .agent
+            .as_deref()
+            .map(|a| format!(" for agent '{a}'"))
+            .unwrap_or_default();
+        anyhow::anyhow!(
+            "no sessions found in the gateway{agent_hint}. Start one with `autonoetic run` \
+             or pass an explicit <SESSION_ID>."
+        )
+    })?;
+    eprintln!(
+        "  Resolved --resume → session {} (agent: {}, last activity: {})",
+        entry.root_session_id, entry.agent_id, entry.last_active_at
+    );
+    Ok(entry.root_session_id)
 }
 
 /// Render every timeline entry newer than `cursor` via `session.timeline.list`,

--- a/autonoetic/src/cli/room/slash.rs
+++ b/autonoetic/src/cli/room/slash.rs
@@ -71,7 +71,7 @@ fn parse_session(tail: &str) -> SlashCommand {
     // original case — session ids are not normalized.
     let trimmed_tail = tail.trim_start();
     if trimmed_tail.is_empty() {
-        return SlashCommand::Unknown("session".into());
+        return SlashCommand::SwitchSession(String::new());
     }
     let (head_raw, rest) = match trimmed_tail.split_once(char::is_whitespace) {
         Some((h, r)) => (h, r.trim()),
@@ -132,6 +132,12 @@ mod tests {
 
     #[test]
     fn parse_session_switch_id() {
+        // Bare `/session` (no arguments) → SwitchSession("") so the
+        // dispatcher can surface a "missing id" error.
+        assert_eq!(
+            parse("/session"),
+            SlashCommand::SwitchSession(String::new())
+        );
         assert_eq!(
             parse("/session session-abc123"),
             SlashCommand::SwitchSession("session-abc123".into())

--- a/autonoetic/src/cli/room/slash.rs
+++ b/autonoetic/src/cli/room/slash.rs
@@ -1,0 +1,219 @@
+//! Slash-commands for the Session Room TUI.
+//!
+//! `/` enters command mode (similar to vim's `:` or Discord's `/`). Parsed
+//! commands are dispatch-decisions, not strings: the room TUI matches on
+//! [`SlashCommand`] variants and the parser never executes a `&str` it didn't
+//! classify. The intent is to make a stray keystroke harmless — anything
+//! unparseable is reported, not silently dropped.
+//!
+//! Currently supported:
+//!
+//! - `/session <id>` — switch the room to that root session id
+//! - `/session list [agent]` — list recent sessions (optionally filtered by agent)
+//! - `/session resume` — switch to the most recent session
+//! - `/quit` / `/q` — exit the TUI
+//! - `/help` / `/?` — show a one-line help summary
+//!
+//! Anything else returns [`SlashCommand::Unknown`]; the caller surfaces a
+//! `✗ unknown command` status rather than executing.
+
+/// Parsed slash-command. Variants carry their arguments so the dispatcher
+/// doesn't re-parse strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommand {
+    /// Switch to a specific root session id (already trimmed).
+    SwitchSession(String),
+    /// Show a list of recent sessions, optionally filtered by agent.
+    ListSessions { agent: Option<String> },
+    /// Switch to the most recent session (optionally filtered by agent).
+    ResumeSession { agent: Option<String> },
+    /// Exit the TUI.
+    Quit,
+    /// Show the help text.
+    Help,
+    /// Anything else — the dispatcher surfaces a `✗` status.
+    Unknown(String),
+}
+
+/// One-line help shown by `/help` and at the bottom of the prompt while typing.
+pub const HELP_TEXT: &str = "/session <id> · /session list [agent] · /session resume [agent] · /quit · /help";
+
+/// Parse a slash command from the user's buffer (without the leading `/`).
+/// Trims surrounding whitespace; the leading `/` is expected to have been
+/// consumed by the caller. Empty input returns `Unknown("")`.
+pub fn parse(input: &str) -> SlashCommand {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return SlashCommand::Unknown(String::new());
+    }
+    // Strip exactly one leading `/` if present (caller usually already did, but
+    // a doubled `//session x` shouldn't crash the parser).
+    let body = trimmed.strip_prefix('/').unwrap_or(trimmed);
+    // Split into head + tail. Tokens are whitespace-delimited; the head is the
+    // command verb and the tail is the rest as-written (so session ids that
+    // happen to contain hyphens stay intact).
+    let mut parts = body.splitn(2, char::is_whitespace);
+    let head = parts.next().unwrap_or("").to_ascii_lowercase();
+    let tail = parts.next().unwrap_or("").trim();
+    match head.as_str() {
+        "session" => parse_session(tail),
+        "quit" | "q" | "exit" => SlashCommand::Quit,
+        "help" | "?" => SlashCommand::Help,
+        other => SlashCommand::Unknown(other.to_string()),
+    }
+}
+
+fn parse_session(tail: &str) -> SlashCommand {
+    // `/session <id>` and `/session list [agent]` and `/session resume [agent]`
+    // — split on whitespace to peel off the sub-verb, then take the rest as a
+    // free-form session id (most ids contain hyphens, so don't tokenize further).
+    // The sub-verb is matched case-insensitively, but the captured id keeps its
+    // original case — session ids are not normalized.
+    let trimmed_tail = tail.trim_start();
+    if trimmed_tail.is_empty() {
+        return SlashCommand::Unknown("session".into());
+    }
+    let (head_raw, rest) = match trimmed_tail.split_once(char::is_whitespace) {
+        Some((h, r)) => (h, r.trim()),
+        None => (trimmed_tail, ""),
+    };
+    let sub = head_raw.to_ascii_lowercase();
+    match sub.as_str() {
+        "list" | "ls" => {
+            let agent = (!rest.is_empty()).then(|| rest.to_string());
+            SlashCommand::ListSessions { agent }
+        }
+        "resume" | "latest" | "last" => {
+            let agent = (!rest.is_empty()).then(|| rest.to_string());
+            SlashCommand::ResumeSession { agent }
+        }
+        // Anything else: treat the *whole* tail as a session id so the user
+        // can type `/session session-abc123` without a sub-verb. The sub-verb
+        // path stays for discoverability (`/session list`). Preserve the
+        // original casing of the id.
+        _ => {
+            let id = if rest.is_empty() {
+                head_raw.to_string()
+            } else {
+                // Both halves were non-empty — re-join so e.g.
+                // `/session session-abc 123` (with a space in the id) still
+                // captures the full string.
+                format!("{head_raw} {rest}")
+            };
+            SlashCommand::SwitchSession(id.trim().to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_is_unknown() {
+        assert_eq!(parse(""), SlashCommand::Unknown(String::new()));
+        assert_eq!(parse("   "), SlashCommand::Unknown(String::new()));
+        assert_eq!(parse("/"), SlashCommand::Unknown(String::new()));
+    }
+
+    #[test]
+    fn parse_quit_variants() {
+        assert_eq!(parse("/quit"), SlashCommand::Quit);
+        assert_eq!(parse("/q"), SlashCommand::Quit);
+        assert_eq!(parse("/exit"), SlashCommand::Quit);
+        assert_eq!(parse("  /quit  "), SlashCommand::Quit);
+    }
+
+    #[test]
+    fn parse_help_variants() {
+        assert_eq!(parse("/help"), SlashCommand::Help);
+        assert_eq!(parse("/?"), SlashCommand::Help);
+    }
+
+    #[test]
+    fn parse_session_switch_id() {
+        assert_eq!(
+            parse("/session session-abc123"),
+            SlashCommand::SwitchSession("session-abc123".into())
+        );
+        assert_eq!(
+            parse("/session session-deadbeef"),
+            SlashCommand::SwitchSession("session-deadbeef".into())
+        );
+        // Hyphens, dots, and mixed case ids round-trip verbatim.
+        assert_eq!(
+            parse("/session My.Session_v2"),
+            SlashCommand::SwitchSession("My.Session_v2".into())
+        );
+    }
+
+    #[test]
+    fn parse_session_list_default() {
+        assert_eq!(
+            parse("/session list"),
+            SlashCommand::ListSessions { agent: None }
+        );
+        assert_eq!(
+            parse("/session ls"),
+            SlashCommand::ListSessions { agent: None }
+        );
+    }
+
+    #[test]
+    fn parse_session_list_with_agent() {
+        assert_eq!(
+            parse("/session list planner.default"),
+            SlashCommand::ListSessions {
+                agent: Some("planner.default".into())
+            }
+        );
+    }
+
+    #[test]
+    fn parse_session_resume_default() {
+        assert_eq!(
+            parse("/session resume"),
+            SlashCommand::ResumeSession { agent: None }
+        );
+        assert_eq!(
+            parse("/session latest"),
+            SlashCommand::ResumeSession { agent: None }
+        );
+    }
+
+    #[test]
+    fn parse_session_resume_with_agent() {
+        assert_eq!(
+            parse("/session resume planner.default"),
+            SlashCommand::ResumeSession {
+                agent: Some("planner.default".into())
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_verb_is_unknown() {
+        assert_eq!(
+            parse("/foo bar"),
+            SlashCommand::Unknown("foo".into())
+        );
+        assert_eq!(
+            parse("/nope"),
+            SlashCommand::Unknown("nope".into())
+        );
+    }
+
+    #[test]
+    fn unknown_session_subverb_falls_back_to_id() {
+        // `/session foo` (no whitespace) → SwitchSession("foo")
+        assert_eq!(
+            parse("/session foo"),
+            SlashCommand::SwitchSession("foo".into())
+        );
+        // `/session foo bar` → SwitchSession("foo bar") (re-joined)
+        assert_eq!(
+            parse("/session foo bar"),
+            SlashCommand::SwitchSession("foo bar".into())
+        );
+    }
+}

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -9,6 +9,7 @@
 use super::channel::{Channel, GateAction, GateKind, GateRef, TuiChannel};
 use super::client::RoomClient;
 use super::render::{self, ActorKind, RenderedRow, RowSource, RowSpec};
+use super::slash::SlashCommand;
 use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry, SessionTimelineListResult};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -111,9 +112,10 @@ fn rpc(
 
 pub fn run(
     client: &RoomClient,
-    root_session_id: &str,
+    root_session_id: &mut String,
     initial_floor: Altitude,
     limit: u32,
+    target_agent_id: &mut Option<String>,
 ) -> anyhow::Result<()> {
     enable_raw_mode()?;
     // Guard constructed before entering the alternate screen, so raw mode is
@@ -131,6 +133,7 @@ pub fn run(
     let mut detail: Option<Vec<String>> = None; // drill-down pane content
     let mut input: Option<GateInput> = None; // in-flight gate decision
     let mut compose: Option<String> = None; // in-flight free-form message to the session
+    let mut slash: Option<String> = None; // in-flight slash-command buffer (no leading `/`)
     let mut status: Option<String> = None; // last action / connection result
     // Gates no longer offerable: approvals resolved on the timeline, plus
     // anything the operator just acted on (covers interactions, which have no
@@ -148,7 +151,7 @@ pub fn run(
             client,
             "session.timeline.list",
             serde_json::json!({
-                "root_session_id": root_session_id,
+                "root_session_id": &*root_session_id,
                 "after_event_id": cursor,
                 "limit": limit,
                 // Always fetch at `detail` and filter for display below. Approval
@@ -254,6 +257,7 @@ pub fn run(
                 detail.as_deref(),
                 input.as_ref(),
                 compose.as_deref(),
+                slash.as_deref(),
                 status.as_deref(),
                 gate.as_ref(),
                 spinner_glyph,
@@ -278,9 +282,103 @@ pub fn run(
                             } else {
                                 // Async so the sync loop never blocks on the agent
                                 // turn; the operator line + reply stream in via polling.
-                                status = Some(send_message(client, root_session_id, &text));
+                                status = Some(send_message(client, root_session_id, &text, target_agent_id.as_deref()));
                                 compose = None;
                                 follow = true; // jump to newest to watch the exchange
+                            }
+                        }
+                        KeyCode::Backspace => {
+                            buf.pop();
+                        }
+                        KeyCode::Char(c) => buf.push(c),
+                        _ => {}
+                    }
+                    continue;
+                }
+
+                // Slash mode: capture a command and dispatch on Enter. Lives
+                // before the other key handlers so `:` and `?` can also
+                // enter it (matching vim/Discord conventions). The parser
+                // classifies the buffer; we never execute a raw string.
+                if let Some(buf) = slash.as_mut() {
+                    match key.code {
+                        KeyCode::Esc => slash = None,
+                        KeyCode::Enter => {
+                            let cmdline = buf.trim().to_string();
+                            slash = None;
+                            match super::slash::parse(&cmdline) {
+                                SlashCommand::Quit => break,
+                                SlashCommand::Help => {
+                                    status = Some(format!(
+                                        "help: {}",
+                                        super::slash::HELP_TEXT
+                                    ));
+                                }
+                                SlashCommand::SwitchSession(new_id) => {
+                                    if new_id.is_empty() {
+                                        status = Some("✗ /session: missing id".to_string());
+                                    } else if new_id == *root_session_id {
+                                        status = Some(format!("→ already viewing {new_id}"));
+                                    } else {
+                                        switch_session(
+                                            client,
+                                            &mut entries,
+                                            &mut cursor,
+                                            &mut selected,
+                                            &mut detail,
+                                            &mut follow,
+                                            &mut resolved,
+                                            &mut acted,
+                                            &mut floor,
+                                            root_session_id,
+                                            target_agent_id,
+                                            limit,
+                                            &new_id,
+                                        );
+                                        status = Some(format!("→ switched to session {new_id}"));
+                                    }
+                                }
+                                SlashCommand::ListSessions { agent } => {
+                                    status = Some(list_sessions_status(client, agent.as_deref()));
+                                }
+                                SlashCommand::ResumeSession { agent } => {
+                                    if let Some(resolved_id) =
+                                        resolve_latest_session(client, agent.as_deref())
+                                    {
+                                        if resolved_id == *root_session_id {
+                                            status = Some(format!("→ already viewing {resolved_id}"));
+                                        } else {
+                                            switch_session(
+                                                client,
+                                                &mut entries,
+                                                &mut cursor,
+                                                &mut selected,
+                                                &mut detail,
+                                                &mut follow,
+                                                &mut resolved,
+                                                &mut acted,
+                                                &mut floor,
+                                                root_session_id,
+                                                target_agent_id,
+                                                limit,
+                                                &resolved_id,
+                                            );
+                                            status = Some(format!("→ resumed session {resolved_id}"));
+                                        }
+                                    } else {
+                                        status = Some(
+                                            "✗ /session resume: no sessions found".to_string(),
+                                        );
+                                    }
+                                }
+                                SlashCommand::Unknown(verb) => {
+                                    let v = if verb.is_empty() {
+                                        "(empty)".to_string()
+                                    } else {
+                                        format!("/{verb}")
+                                    };
+                                    status = Some(format!("✗ unknown command {v} — type /help"));
+                                }
                             }
                         }
                         KeyCode::Backspace => {
@@ -413,6 +511,13 @@ pub fn run(
                     KeyCode::Char('i') => {
                         detail = None;
                         compose = Some(String::new());
+                        status = None;
+                    }
+                    // /: slash-command mode (vim/Discord convention). `:`
+                    // and `?` are accepted aliases for muscle memory.
+                    KeyCode::Char('/') | KeyCode::Char(':') | KeyCode::Char('?') => {
+                        detail = None;
+                        slash = Some(String::new());
                         status = None;
                     }
                     KeyCode::Down | KeyCode::Char('j') => {
@@ -599,18 +704,25 @@ fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>
 /// (#405) — the same `event.ingest` ingress `chat` uses. Async (`async_mode`)
 /// so the sync TUI loop never blocks on the agent turn; the operator's line
 /// (recorded gateway-side) and the agent's reply then stream in via polling.
-fn send_message(client: &RoomClient, root_session_id: &str, text: &str) -> String {
-    match rpc(
-        client,
-        "event.ingest",
-        serde_json::json!({
-            "event_type": "chat",
-            "message": text,
-            "session_id": root_session_id,
-            "async_mode": true,
-            "metadata": { "source": "session_room" },
-        }),
-    ) {
+fn send_message(
+    client: &RoomClient,
+    root_session_id: &str,
+    text: &str,
+    target_agent_id: Option<&str>,
+) -> String {
+    let mut params = serde_json::json!({
+        "event_type": "chat",
+        "message": text,
+        "session_id": root_session_id,
+        "async_mode": true,
+        "metadata": { "source": "session_room" },
+    });
+    if let Some(agent_id) = target_agent_id {
+        if let Some(map) = params.as_object_mut() {
+            map.insert("target_agent_id".to_string(), serde_json::json!(agent_id));
+        }
+    }
+    match rpc(client, "event.ingest", params) {
         Ok(_) => "✓ sent".to_string(),
         Err(e) => format!("✗ {e}"),
     }
@@ -809,6 +921,109 @@ fn altitude_style(altitude: Altitude) -> Style {
     }
 }
 
+/// Reset every per-session view state when the operator reloads to a different
+/// root session. Cursor, entries, selection, follow, and the resolved-gate
+/// sets are all session-scoped — leaving them stale would let an old approval
+/// mark look "acted" on a brand-new session.
+///
+/// The `target_agent_id` is *not* cleared here: a `/session <id>` is just a
+/// viewer change, the operator still has the right to send messages addressed
+/// to whatever agent is currently selected. `event.ingest` will surface a
+/// clear error if the agent doesn't match the new session's binding; that's
+/// the natural place to detect a mismatch rather than guessing from a session
+/// list (which may not know the agent yet).
+#[allow(clippy::too_many_arguments)]
+fn switch_session(
+    _client: &RoomClient,
+    entries: &mut Vec<SessionTimelineEntry>,
+    cursor: &mut Option<String>,
+    selected: &mut usize,
+    detail: &mut Option<Vec<String>>,
+    follow: &mut bool,
+    resolved: &mut HashSet<String>,
+    acted: &mut HashSet<String>,
+    floor: &mut Altitude,
+    root_session_id: &mut String,
+    _target_agent_id: &mut Option<String>,
+    _limit: u32,
+    new_id: &str,
+) {
+    *root_session_id = new_id.to_string();
+    entries.clear();
+    *cursor = None;
+    *selected = 0;
+    *detail = None;
+    *follow = true;
+    resolved.clear();
+    acted.clear();
+    // Don't reset `floor` — the operator's altitude dial is a view preference,
+    // not a session property. Keep the previous setting.
+    let _ = floor;
+}
+
+/// Fetch the most recent session id, optionally filtered by agent. Returns
+/// `None` when the gateway has no matching session.
+fn resolve_latest_session(client: &RoomClient, agent: Option<&str>) -> Option<String> {
+    let params = serde_json::json!({
+        "agent_id": agent,
+        "limit": 1,
+    });
+    let value = rpc(client, "session.list", params).ok()?;
+    let parsed: serde_json::Result<autonoetic_types::session_timeline::SessionListResult> =
+        serde_json::from_value(value);
+    parsed
+        .ok()?
+        .sessions
+        .into_iter()
+        .next()
+        .map(|e| e.root_session_id)
+}
+
+/// Build a one-line-per-row status for `/session list [agent]` showing the
+/// top few recent sessions. We don't render a real modal here — the operator
+/// picks by typing `/session <id>` from the list. Returns a status string the
+/// caller drops into the footer.
+fn list_sessions_status(client: &RoomClient, agent: Option<&str>) -> String {
+    let params = serde_json::json!({
+        "agent_id": agent,
+        "limit": 10,
+    });
+    match rpc(client, "session.list", params) {
+        Ok(value) => match serde_json::from_value::<
+            autonoetic_types::session_timeline::SessionListResult,
+        >(value)
+        {
+            Ok(parsed) if parsed.sessions.is_empty() => {
+                let hint = agent
+                    .map(|a| format!(" for agent '{a}'"))
+                    .unwrap_or_default();
+                format!("(no sessions{hint}) — /session <id> or start one with `autonoetic run`")
+            }
+            Ok(parsed) => {
+                let head = if let Some(a) = agent {
+                    format!("sessions for agent '{a}':")
+                } else {
+                    "recent sessions:".to_string()
+                };
+                let rows: Vec<String> = parsed
+                    .sessions
+                    .iter()
+                    .take(5)
+                    .map(|s| format!("  {} [{}] @ {}", s.root_session_id, s.agent_id, s.last_active_at))
+                    .collect();
+                let more = if parsed.sessions.len() > 5 {
+                    format!("  …(+{} more)", parsed.sessions.len() - 5)
+                } else {
+                    String::new()
+                };
+                format!("{head}\n{}\n{more}\n  → type /session <id> to switch", rows.join("\n"))
+            }
+            Err(e) => format!("✗ malformed session.list response: {e}"),
+        },
+        Err(e) => format!("✗ session.list failed: {e}"),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn draw(
     f: &mut Frame,
@@ -821,6 +1036,7 @@ fn draw(
     detail: Option<&[String]>,
     input: Option<&GateInput>,
     compose: Option<&str>,
+    slash: Option<&str>,
     status: Option<&str>,
     gate: Option<&GateRef>,
     spinner_glyph: &'static str,
@@ -904,7 +1120,13 @@ fn draw(
         &mut state,
     );
 
-    let footer = if let Some(buf) = compose {
+    let footer = if let Some(buf) = slash {
+        Paragraph::new(format!(
+            " : /{buf}▏   [Enter run · Esc cancel]   {HELP}",
+            HELP = super::slash::HELP_TEXT
+        ))
+        .style(Style::default().fg(Color::Magenta))
+    } else if let Some(buf) = compose {
         Paragraph::new(format!(" MESSAGE: {buf}▏   [Enter send · Esc cancel]"))
             .style(Style::default().fg(Color::Green))
     } else if let Some(gi) = input {
@@ -939,7 +1161,7 @@ fn draw(
         // through the channel so a Discord/WhatsApp bridge can render its own.
         let gate_hint = gate.map(|g| TuiChannel.gate_prompt(g)).unwrap_or_default();
         Paragraph::new(format!(
-            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · R reasoning · i message · ⏎ detail{gate_hint}"
+            " q quit · j/k scroll · g/G top/bottom · a altitude · s squash · R reasoning · i message · / cmd · ⏎ detail{gate_hint}"
         ))
         .style(Style::default().fg(Color::DarkGray))
     };

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -339,7 +339,7 @@ pub fn run(
                                     }
                                 }
                                 SlashCommand::ListSessions { agent } => {
-                                    status = Some(list_sessions_status(client, agent.as_deref()));
+                                    detail = Some(list_sessions_detail(client, agent.as_deref()));
                                 }
                                 SlashCommand::ResumeSession { agent } => {
                                     if let Some(resolved_id) =
@@ -979,11 +979,9 @@ fn resolve_latest_session(client: &RoomClient, agent: Option<&str>) -> Option<St
         .map(|e| e.root_session_id)
 }
 
-/// Build a one-line-per-row status for `/session list [agent]` showing the
-/// top few recent sessions. We don't render a real modal here — the operator
-/// picks by typing `/session <id>` from the list. Returns a status string the
-/// caller drops into the footer.
-fn list_sessions_status(client: &RoomClient, agent: Option<&str>) -> String {
+/// Build a multi-line session list for `/session list [agent]`, returned as
+/// `detail` lines so the operator can see the full list in the middle pane.
+fn list_sessions_detail(client: &RoomClient, agent: Option<&str>) -> Vec<String> {
     let params = serde_json::json!({
         "agent_id": agent,
         "limit": 10,
@@ -997,30 +995,26 @@ fn list_sessions_status(client: &RoomClient, agent: Option<&str>) -> String {
                 let hint = agent
                     .map(|a| format!(" for agent '{a}'"))
                     .unwrap_or_default();
-                format!("(no sessions{hint}) — /session <id> or start one with `autonoetic run`")
+                vec![format!("(no sessions{hint}) — /session <id> or start one with `autonoetic run`")]
             }
             Ok(parsed) => {
-                let head = if let Some(a) = agent {
-                    format!("sessions for agent '{a}':")
+                let mut lines = if let Some(a) = agent {
+                    vec![format!("sessions for agent '{a}':")]
                 } else {
-                    "recent sessions:".to_string()
+                    vec!["recent sessions:".to_string()]
                 };
-                let rows: Vec<String> = parsed
-                    .sessions
-                    .iter()
-                    .take(5)
-                    .map(|s| format!("  {} [{}] @ {}", s.root_session_id, s.agent_id, s.last_active_at))
-                    .collect();
-                let more = if parsed.sessions.len() > 5 {
-                    format!("  …(+{} more)", parsed.sessions.len() - 5)
-                } else {
-                    String::new()
-                };
-                format!("{head}\n{}\n{more}\n  → type /session <id> to switch", rows.join("\n"))
+                for s in parsed.sessions.iter().take(5) {
+                    lines.push(format!("  {} [{}] @ {}", s.root_session_id, s.agent_id, s.last_active_at));
+                }
+                if parsed.sessions.len() > 5 {
+                    lines.push(format!("  …(+{} more)", parsed.sessions.len() - 5));
+                }
+                lines.push("→ type /session <id> to switch".to_string());
+                lines
             }
-            Err(e) => format!("✗ malformed session.list response: {e}"),
+            Err(e) => vec![format!("✗ malformed session.list response: {e}")],
         },
-        Err(e) => format!("✗ session.list failed: {e}"),
+        Err(e) => vec![format!("✗ session.list failed: {e}")],
     }
 }
 


### PR DESCRIPTION
Adds two ways to reload an existing session in the Session Room without restarting the gateway or the TUI.

## Standalone CLI
```
autonoetic room                        # last session (positional id wins)
autonoetic room --resume               # resolve latest via session.list
autonoetic room --resume --agent <id>  # latest for that agent
autonoetic room <session-id>           # explicit
```

## In-TUI slash command
`/session <id>` / `/session list [agent]` / `/session resume [agent]` / `/quit` / `/help`
(`/`, `:`, `?` all open slash mode — vim/Discord convention)

The parser classifies into a `SlashCommand` enum; the dispatcher never executes a raw string.

## Plumbing
- New `session.list` JSON-RPC method backed by `store.list_recent_sessions(limit)`, filtered by `agent_id`
- `RoomArgs.root_session_id` is now `Option<String>`; `resolve_root_session_id()` queries `session.list` for `--resume`
- `tui::run` takes `&mut String` and `&mut Option<String>` so the slash dispatcher can swap live
- `switch_session` resets entries/cursor/selection/follow/resolved/acted; preserves the operator's `floor`
- `target_agent_id` is *not* reset — `event.ingest` is the natural place to detect a session/agent mismatch

## Tests
- 10 new unit tests for the slash parser
- All 22 existing room tests still pass
- Full autonoetic + autonoetic-types test suites green (the 4 cli_e2e failures are pre-existing port-binding timeouts, confirmed on main)

## Review notes
- Room is a gateway API client (Separation of Powers) — no direct store access
- `parse_session` keeps session ids case-preserved (e.g. `My.Session_v2`) while lowercasing only the sub-verb for matching