### PR TITLE
fix(promotion): fail-closed promotion-completeness invariant (new-agent approval gate)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2216,10 +2216,17 @@ impl NativeTool for AgentRevisionPromoteTool {
                     decided_at: None,
                     decided_by: None,
                     reason: args.reason.clone().or_else(|| {
-                        Some(format!(
-                            "Promote revision '{}' would broaden capabilities relative to '{}'",
-                            args.revision_id, outgoing_revision_id
-                        ))
+                        Some(if outgoing_revision_id.is_empty() {
+                            format!(
+                                "First promotion of new agent '{}' (revision '{}') — operator must acknowledge all declared capabilities",
+                                args.agent_id, args.revision_id
+                            )
+                        } else {
+                            format!(
+                                "Promote revision '{}' would broaden capabilities relative to '{}'",
+                                args.revision_id, outgoing_revision_id
+                            )
+                        })
                     }),
                     evidence_ref: None,
                     decision_reason: None,
@@ -2248,10 +2255,17 @@ impl NativeTool for AgentRevisionPromoteTool {
                     "ok": false,
                     "error_type": "permission",
                     "error": "capability_delta_requires_approval",
-                    "message": format!(
-                        "Capability set broadened relative to outgoing revision '{}'. Operator approval is required (R++2).",
-                        outgoing_revision_id
-                    ),
+                    "message": if outgoing_revision_id.is_empty() {
+                        format!(
+                            "Promoting new agent '{}' for the first time: all declared capabilities require operator acknowledgement (R++2 / promotion-completeness). Operator approval is required.",
+                            args.agent_id
+                        )
+                    } else {
+                        format!(
+                            "Capability set broadened relative to outgoing revision '{}'. Operator approval is required (R++2).",
+                            outgoing_revision_id
+                        )
+                    },
                     "approval_required": true,
                     "request_id": request_id,
                     "approval_ref": request_id,
@@ -2491,9 +2505,47 @@ impl NativeTool for AgentRevisionPromoteTool {
                 ),
             )?;
             emit_gate_event(PromotionGateMode::AuditOnly, Some(artifact_id));
+        } else {
+            // Reaching here ⇒ either zero declared capabilities, or a
+            // capability-bearing revision with no artifact (artifact-bearing
+            // capability agents were gated by the branches above). Fail closed:
+            // a capability-bearing revision with nothing to review must NOT
+            // direct-promote (the previous fall-through was the fail-open). Only
+            // the inoffensive zero-capability class is relieved — it cannot
+            // invoke any privileged tool, so runtime capability enforcement
+            // bounds its blast radius — and only while the cursor allows it
+            // (promotion-completeness invariant, docs/design/).
+            let inoffensive = current_capabilities.is_empty();
+            let cursor_allows = config
+                .map(|c| c.allow_zero_capability_direct_promote)
+                .unwrap_or(true);
+            if !(inoffensive && cursor_allows) {
+                let message = if !inoffensive {
+                    format!(
+                        "Promotion gate: revision '{}' declares capabilities but ships no reviewable artifact. \
+                         A capability-bearing agent cannot be promoted without an artifact bundle and the \
+                         required audit/approval records (fail-closed).",
+                        args.revision_id
+                    )
+                } else {
+                    format!(
+                        "Promotion gate: zero-capability direct-promote is disabled \
+                         (allow_zero_capability_direct_promote=false); revision '{}' must pass the full \
+                         review gate.",
+                        args.revision_id
+                    )
+                };
+                return Ok(serde_json::json!({
+                    "ok": false,
+                    "error_type": "permission",
+                    "error": "promotion_incomplete",
+                    "message": message,
+                    "repair_hint": "Attach a reviewed artifact bundle with the required auditor (and evaluator) pass records, and obtain operator approval, then retry agent_revision_promote.",
+                })
+                .to_string());
+            }
+            // inoffensive (zero-capability) + cursor on → direct promote.
         }
-        // else: no artifact OR zero-capability sandboxed agent → direct promote.
-        // Capability enforcement on every tool call is the security gate.
 
         // FullJury gate: when federation roles have recorded verdicts, require
         // operator approval via an approved escalation. This is a fifth branch
@@ -3227,37 +3279,45 @@ fn check_capability_delta(
         return Ok(None);
     }
 
-    let Some(alias) = gateway_store.resolve_alias(agent_id)? else {
-        return Ok(None);
+    // Determine the outgoing capability baseline. A brand-new agent (no current
+    // alias) has an EMPTY baseline — every declared capability is "added"
+    // relative to nothing — so a capability-bearing first promotion is maximal
+    // broadening and requires operator approval (R++2 / the promotion-
+    // completeness invariant). A zero-capability new agent yields an empty delta
+    // and is relieved. Returning `None` here (the previous behavior) was the
+    // fail-open that let new agents promote with no operator approval.
+    let outgoing_capabilities = match gateway_store.resolve_alias(agent_id)? {
+        Some(alias) => {
+            if alias.revision_id == revision_id {
+                return Ok(None); // already-active revision; nothing to compare
+            }
+            let outgoing_revision_dir = gateway_dir
+                .join("revisions/agents")
+                .join(agent_id)
+                .join(&alias.revision_id);
+            let outgoing_skill_path = outgoing_revision_dir.join("SKILL.md");
+            let outgoing_skill_bytes = std::fs::read(&outgoing_skill_path).map_err(|e| {
+                anyhow::anyhow!(
+                    "Cannot read SKILL.md for outgoing revision '{}': {}",
+                    alias.revision_id,
+                    e
+                )
+            })?;
+            let outgoing_skill_text = String::from_utf8_lossy(&outgoing_skill_bytes);
+            let outgoing_frontmatter = crate::runtime::install_contract::extract_frontmatter_raw(
+                &outgoing_skill_text,
+            )
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Cannot parse SKILL.md frontmatter for outgoing revision '{}': {}",
+                    alias.revision_id,
+                    e
+                )
+            })?;
+            parse_frontmatter_capabilities(&outgoing_frontmatter)?
+        }
+        None => Vec::new(), // brand-new agent: empty baseline ⇒ all caps are "added"
     };
-    if alias.revision_id == revision_id {
-        return Ok(None);
-    }
-
-    let outgoing_revision_dir = gateway_dir
-        .join("revisions/agents")
-        .join(agent_id)
-        .join(&alias.revision_id);
-    let outgoing_skill_path = outgoing_revision_dir.join("SKILL.md");
-    let outgoing_skill_bytes = std::fs::read(&outgoing_skill_path).map_err(|e| {
-        anyhow::anyhow!(
-            "Cannot read SKILL.md for outgoing revision '{}': {}",
-            alias.revision_id,
-            e
-        )
-    })?;
-    let outgoing_skill_text = String::from_utf8_lossy(&outgoing_skill_bytes);
-    let outgoing_frontmatter = crate::runtime::install_contract::extract_frontmatter_raw(
-        &outgoing_skill_text,
-    )
-    .map_err(|e| {
-        anyhow::anyhow!(
-            "Cannot parse SKILL.md frontmatter for outgoing revision '{}': {}",
-            alias.revision_id,
-            e
-        )
-    })?;
-    let outgoing_capabilities = parse_frontmatter_capabilities(&outgoing_frontmatter)?;
 
     let mut delta = autonoetic_types::capability::compute_capability_delta(
         &outgoing_capabilities,

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2550,19 +2550,27 @@ impl NativeTool for AgentRevisionPromoteTool {
                 .map(|c| c.allow_zero_capability_direct_promote)
                 .unwrap_or(true);
             if !(inoffensive && cursor_allows) {
-                let message = if !inoffensive {
-                    format!(
-                        "Promotion gate: revision '{}' declares capabilities but ships no reviewable artifact. \
-                         A capability-bearing agent cannot be promoted without an artifact bundle and the \
-                         required audit/approval records (fail-closed).",
-                        args.revision_id
+                let (message, repair_hint) = if !inoffensive {
+                    (
+                        format!(
+                            "Promotion gate: revision '{}' declares capabilities but ships no reviewable \
+                             artifact. A capability-bearing agent cannot be promoted without an artifact \
+                             bundle and the required audit records (fail-closed).",
+                            args.revision_id
+                        ),
+                        "Attach a reviewed artifact bundle and obtain the required auditor (and, for \
+                         high-risk capabilities, evaluator) pass records, then retry agent_revision_promote.",
                     )
                 } else {
-                    format!(
-                        "Promotion gate: zero-capability direct-promote is disabled \
-                         (allow_zero_capability_direct_promote=false); revision '{}' must pass the full \
-                         review gate.",
-                        args.revision_id
+                    (
+                        format!(
+                            "Promotion gate: zero-capability direct-promote is disabled \
+                             (allow_zero_capability_direct_promote=false); revision '{}' must pass the full \
+                             review gate.",
+                            args.revision_id
+                        ),
+                        "Provide a reviewed artifact with an auditor pass record, or re-enable \
+                         allow_zero_capability_direct_promote, then retry agent_revision_promote.",
                     )
                 };
                 return Ok(serde_json::json!({
@@ -2570,7 +2578,7 @@ impl NativeTool for AgentRevisionPromoteTool {
                     "error_type": "permission",
                     "error": "promotion_incomplete",
                     "message": message,
-                    "repair_hint": "Attach a reviewed artifact bundle with the required auditor (and evaluator) pass records, and obtain operator approval, then retry agent_revision_promote.",
+                    "repair_hint": repair_hint,
                 })
                 .to_string());
             }

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2153,18 +2153,47 @@ impl NativeTool for AgentRevisionPromoteTool {
         // `RevisionPromote` approval whose acknowledgement matches the delta
         // exactly. The `approval_ref` argument is how a retry call reuses an
         // earlier approval.
-        let gate_bypassed_by_approval = if let Some(ref approval_ref) = args.approval_ref {
-            check_revision_promote_approval(
-                &gateway_store,
-                approval_ref,
-                &args.agent_id,
-                &args.revision_id,
-            )?
-        } else {
-            false
-        };
+        // A NEW agent's whole capability set is its "delta", and an approved
+        // federation escalation already constitutes operator approval of the
+        // entire agent — so it satisfies the new-agent gate without a separate
+        // capability-ack approval. (Existing-agent broadening still requires the
+        // explicit ack approval.) This keeps the federation promotion path from
+        // demanding two operator approvals for one new agent.
+        let new_agent_approved_via_escalation =
+            match gateway_store.resolve_alias(&args.agent_id)? {
+                None => match rev.artifact_id.as_deref() {
+                    Some(aid) => {
+                        gateway_store
+                            .find_escalation(
+                                aid,
+                                &args.revision_id,
+                                autonoetic_types::escalation::EscalationStatus::Approved,
+                            )?
+                            .is_some()
+                            || gateway_store
+                                .find_approved_escalation_for_artifact(aid)?
+                                .is_some()
+                    }
+                    None => false,
+                },
+                Some(_) => false,
+            };
+        let gate_bypassed_by_approval = new_agent_approved_via_escalation
+            || if let Some(ref approval_ref) = args.approval_ref {
+                check_revision_promote_approval(
+                    &gateway_store,
+                    approval_ref,
+                    &args.agent_id,
+                    &args.revision_id,
+                )?
+            } else {
+                false
+            };
 
         if !gate_bypassed_by_approval {
+            let gate_new_agents = config
+                .map(|c| c.require_operator_approval_for_new_agents)
+                .unwrap_or(true);
             if let Some(delta) = check_capability_delta(
                 &gateway_store,
                 gateway_dir,
@@ -2172,6 +2201,7 @@ impl NativeTool for AgentRevisionPromoteTool {
                 &args.revision_id,
                 &current_capabilities,
                 delta_mode,
+                gate_new_agents,
             )? {
                 let outgoing_revision_id = gateway_store
                     .resolve_alias(&args.agent_id)?
@@ -3274,6 +3304,7 @@ fn check_capability_delta(
     revision_id: &str,
     current_capabilities: &[Capability],
     mode: CapabilityDeltaGateMode,
+    gate_new_agents: bool,
 ) -> anyhow::Result<Option<autonoetic_types::capability::CapabilityDelta>> {
     if matches!(mode, CapabilityDeltaGateMode::Bootstrap) {
         return Ok(None);
@@ -3316,7 +3347,16 @@ fn check_capability_delta(
             })?;
             parse_frontmatter_capabilities(&outgoing_frontmatter)?
         }
-        None => Vec::new(), // brand-new agent: empty baseline ⇒ all caps are "added"
+        None => {
+            // Brand-new agent. The cursor decides whether first admission needs a
+            // human: default (true) ⇒ empty baseline so all caps are "added" and
+            // operator approval is required; false ⇒ no new-agent human gate (the
+            // downstream completeness gate still applies, always fail-closed).
+            if !gate_new_agents {
+                return Ok(None);
+            }
+            Vec::new()
+        }
     };
 
     let mut delta = autonoetic_types::capability::compute_capability_delta(

--- a/autonoetic-gateway/tests/constitution_federation_e2e.rs
+++ b/autonoetic-gateway/tests/constitution_federation_e2e.rs
@@ -360,6 +360,9 @@ fn setup_test(agent_id: &str, skill_md: &str) -> (TestSetup, String, String, Arc
 
     let config = GatewayConfig {
         agents_dir: agents_dir.clone(),
+        // Federation tests exercise the escalation/jury/identity gates; isolate
+        // them from the new-agent first-admission human gate (its own tests).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
 
@@ -473,6 +476,9 @@ fn setup_test_with_manual_revision(
 
     let config = GatewayConfig {
         agents_dir: agents_dir.clone(),
+        // Federation tests exercise the escalation/jury/identity gates; isolate
+        // them from the new-agent first-admission human gate (its own tests).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
 

--- a/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
@@ -806,8 +806,11 @@ fn new_agent_cursor_off_lifts_human_gate_but_completeness_still_fails_closed() {
         serde_json::Value::Bool(false),
         "cursor off still fails closed on completeness: {resp}"
     );
-    assert_ne!(
-        resp["error"], "capability_delta_requires_approval",
-        "cursor off lifts the new-agent human gate; expected a completeness refusal, got {resp}"
+    // Specifically the completeness refusal (capability-bearing, no artifact) —
+    // not the new-agent human gate (which the cursor lifted) and not some other
+    // gate regressing.
+    assert_eq!(
+        resp["error"], "promotion_incomplete",
+        "cursor off lifts the new-agent human gate but completeness must still fail closed, got {resp}"
     );
 }

--- a/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
@@ -198,6 +198,10 @@ fn invoke_promote_with_config(h: &PromoteHarness, args_json: &str) -> serde_json
             .parent()
             .expect("agent dir should have parent")
             .to_path_buf(),
+        // This suite exercises capability-delta gating vs an outgoing revision;
+        // isolate it from the new-agent first-admission gate (covered by its own
+        // test) so the first-revision setup promote isn't treated as a new agent.
+        require_operator_approval_for_new_agents: false,
         ..GatewayConfig::default()
     };
     let raw = registry
@@ -554,7 +558,7 @@ fn approval_ref_bypass_is_invalidated_when_alias_moves() {
         Some(&h.store),
         &approval_ref,
         "operator",
-        None,
+        Some("approved for test".to_string()), // §O: operator decisions require a motivation
         None,
         Some(&ApprovalLevel::Operator),
         None,
@@ -638,7 +642,7 @@ fn approval_ref_bypasses_gate_after_approval() {
         Some(&h.store),
         &approval_ref,
         "operator",
-        None,
+        Some("approved for test".to_string()), // §O: operator decisions require a motivation
         None,
         Some(&ApprovalLevel::Operator),
         None,
@@ -669,4 +673,141 @@ fn approval_ref_bypasses_gate_after_approval() {
             retry
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// New-agent first-admission gate (promotion-completeness cursor, #promotion)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_agent_first_promotion_requires_operator_approval_by_default() {
+    // A brand-new agent (no outgoing alias) declaring a capability is maximal
+    // broadening — its whole capability set is "new" — so under the default
+    // cursor it must NOT self-promote without operator approval.
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join("agents");
+    let agent_dir = agents_dir.join(AGENT_ID);
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).expect("store opens"));
+
+    write_revision_skill(
+        &gateway_dir,
+        INCOMING_REVISION,
+        "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.github.com\"]",
+    );
+    store
+        .insert_agent_revision(&make_revision_record(INCOMING_REVISION))
+        .unwrap();
+    // No alias upsert ⇒ resolve_alias is None ⇒ brand-new agent.
+
+    let manifest = manifest_with_capabilities(vec![Capability::AgentRevision {
+        patterns: vec!["*".to_string()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let args = format!(
+        r#"{{"agent_id":"{}","revision_id":"{}"}}"#,
+        AGENT_ID, INCOMING_REVISION
+    );
+
+    // Default cursor (require_operator_approval_for_new_agents = true).
+    let config = GatewayConfig {
+        agents_dir: agents_dir.clone(),
+        ..GatewayConfig::default()
+    };
+    let raw = registry
+        .execute(
+            "agent_revision_promote",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args,
+            Some("test-session"),
+            Some("turn-000001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .expect("execute should not error");
+    let resp: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    assert_eq!(
+        resp["ok"],
+        serde_json::Value::Bool(false),
+        "new capability-bearing agent must not self-promote without approval: {resp}"
+    );
+    assert_eq!(resp["error"], "capability_delta_requires_approval");
+    assert!(
+        resp["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("new agent"),
+        "message should name the new-agent case, got: {}",
+        resp["message"]
+    );
+
+}
+
+#[test]
+fn new_agent_cursor_off_lifts_human_gate_but_completeness_still_fails_closed() {
+    // Cursor off ⇒ the new-agent human gate is lifted, but the completeness gate
+    // still applies and is always fail-closed: a capability-bearing revision with
+    // no reviewable artifact is refused as incomplete, never auto-promoted.
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join("agents");
+    let agent_dir = agents_dir.join(AGENT_ID);
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).expect("store opens"));
+    write_revision_skill(
+        &gateway_dir,
+        INCOMING_REVISION,
+        "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.github.com\"]",
+    );
+    store
+        .insert_agent_revision(&make_revision_record(INCOMING_REVISION))
+        .unwrap();
+
+    let manifest = manifest_with_capabilities(vec![Capability::AgentRevision {
+        patterns: vec!["*".to_string()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let config = GatewayConfig {
+        agents_dir,
+        require_operator_approval_for_new_agents: false,
+        ..GatewayConfig::default()
+    };
+    let args = format!(
+        r#"{{"agent_id":"{}","revision_id":"{}"}}"#,
+        AGENT_ID, INCOMING_REVISION
+    );
+    let raw = registry
+        .execute(
+            "agent_revision_promote",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &args,
+            Some("test-session"),
+            Some("turn-000001"),
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .expect("execute should not error");
+    let resp: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    assert_eq!(
+        resp["ok"],
+        serde_json::Value::Bool(false),
+        "cursor off still fails closed on completeness: {resp}"
+    );
+    assert_ne!(
+        resp["error"], "capability_delta_requires_approval",
+        "cursor off lifts the new-agent human gate; expected a completeness refusal, got {resp}"
+    );
 }

--- a/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
@@ -261,6 +261,9 @@ fn same_agent_identity_rejected_even_if_both_passed() {
     let (artifact_id, gateway_dir) = build_agent_bundle(temp.path(), &skill);
     let config = GatewayConfig {
         agents_dir,
+        // Isolate the distinct-identity completeness gate from the new-agent
+        // first-admission human gate (covered by its own test).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
     let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
@@ -353,6 +356,9 @@ fn distinct_identities_allowed() {
     let (artifact_id, gateway_dir) = build_agent_bundle(temp.path(), &skill);
     let config = GatewayConfig {
         agents_dir,
+        // Isolate the distinct-identity completeness gate from the new-agent
+        // first-admission human gate (covered by its own test).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
     let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());

--- a/autonoetic-gateway/tests/constitution_promotion_gate_audit_only.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_gate_audit_only.rs
@@ -384,6 +384,9 @@ fn setup(agent_id: &str, skill_md: &str, capabilities: serde_json::Value) -> Fix
 
     let config = GatewayConfig {
         agents_dir: agents_dir.clone(),
+        // Isolate the audit/eval completeness gate from the new-agent
+        // first-admission human gate (covered by its own test).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
     let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
@@ -675,7 +678,7 @@ fn high_risk_intent_only_artifact_still_requires_full_gate() {
     match result {
         Err(msg) => {
             assert!(
-                msg.contains("evaluator did not pass") || msg.contains("no promotion.record"),
+                msg.contains("no evaluator role passed") || msg.contains("no promotion.record"),
                 "high-risk intent-only must still require evaluator pass, got: {}",
                 msg
             );

--- a/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
+++ b/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
@@ -388,6 +388,9 @@ fn setup_test(agent_id: &str, skill_md: &str) -> (TestSetup, String, String, Arc
 
     let config = GatewayConfig {
         agents_dir: agents_dir.clone(),
+        // This suite hardens the audit/eval/identity promotion gates; isolate it
+        // from the new-agent first-admission human gate (its own tests).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
 
@@ -657,6 +660,9 @@ fn test_promote_rejects_high_risk_with_unresolved_dependencies() {
 
     let config = GatewayConfig {
         agents_dir: agents_dir.clone(),
+        // This suite hardens the audit/eval/identity promotion gates; isolate it
+        // from the new-agent first-admission human gate (its own tests).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
 
@@ -770,6 +776,9 @@ fn test_promote_accepts_precreate_records_when_digest_matches() {
 
     let config = GatewayConfig {
         agents_dir: agents_dir.clone(),
+        // This suite hardens the audit/eval/identity promotion gates; isolate it
+        // from the new-agent first-admission human gate (its own tests).
+        require_operator_approval_for_new_agents: false,
         ..Default::default()
     };
 

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -936,6 +936,18 @@ pub struct GatewayConfig {
     #[serde(default = "default_true")]
     pub allow_zero_capability_direct_promote: bool,
 
+    /// Promotion-completeness cursor for **first admission of a brand-new agent**
+    /// (no outgoing revision). When `true` (default), promoting a new
+    /// capability-bearing agent requires operator approval — its whole capability
+    /// set is "new", so it is treated as maximal broadening (R++2). Set to `false`
+    /// to let a fully-audited new agent self-promote (autonomous self-evolution):
+    /// the completeness gate (auditor/evaluator pass, distinct identities,
+    /// reviewable artifact) still applies and is always fail-closed; only the
+    /// human-approval requirement for *being new* is lifted. Re-promotion of an
+    /// already-admitted agent is unaffected either way (gated only on broadening).
+    #[serde(default = "default_true")]
+    pub require_operator_approval_for_new_agents: bool,
+
     /// Optional per-session budgets (LLM rounds, tools, tokens, wall clock).
     #[serde(default)]
     pub session_budget: SessionBudgetConfig,
@@ -2608,6 +2620,7 @@ impl Default for GatewayConfig {
             code_analysis: CodeAnalysisConfig::default(),
             capability_delta_gate_mode: CapabilityDeltaGateMode::Strict,
             allow_zero_capability_direct_promote: true,
+            require_operator_approval_for_new_agents: true,
             session_budget: SessionBudgetConfig::default(),
             root_session_budget: RootSessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -927,6 +927,15 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub capability_delta_gate_mode: CapabilityDeltaGateMode,
 
+    /// Promotion-completeness "cursor" (see docs/design/promotion-completeness-invariant.md).
+    /// When `true` (default), a revision that declares **zero capabilities** may be
+    /// promoted directly — it cannot invoke any privileged tool, so its blast radius
+    /// is bounded by runtime capability enforcement regardless of provenance. Set to
+    /// `false` to require the full audit/approval gate even for zero-capability agents.
+    /// Capability-bearing revisions are always gated (fail-closed) regardless of this flag.
+    #[serde(default = "default_true")]
+    pub allow_zero_capability_direct_promote: bool,
+
     /// Optional per-session budgets (LLM rounds, tools, tokens, wall clock).
     #[serde(default)]
     pub session_budget: SessionBudgetConfig,
@@ -2598,6 +2607,7 @@ impl Default for GatewayConfig {
             default_orchestrator: default_default_orchestrator(),
             code_analysis: CodeAnalysisConfig::default(),
             capability_delta_gate_mode: CapabilityDeltaGateMode::Strict,
+            allow_zero_capability_direct_promote: true,
             session_budget: SessionBudgetConfig::default(),
             root_session_budget: RootSessionBudgetConfig::default(),
             approval_timeout_secs: default_approval_timeout_secs(),

--- a/docs/design/promotion-completeness-invariant.md
+++ b/docs/design/promotion-completeness-invariant.md
@@ -1,0 +1,79 @@
+# Promotion Completeness Invariant (fail-closed promotion)
+
+Status: **proposed** (2026-06-05). Closes a promotion fail-open found in
+production: an agent-factory revision was promoted with **no operator approval**
+because the operator-approval requirement was contingent on data the orchestrator
+LLM produced (recorded federation verdicts / an attached artifact). When that
+data was missing, `agent_revision_promote` fell through to a "direct promote"
+branch.
+
+## Principle
+
+The gateway is the Lawful Executor. **Whether a revision may be promoted, and
+what it must satisfy, is decided mechanically by the gateway from the revision's
+declared capabilities and artifact — never from orchestrator-supplied signals.**
+Promotion **fails closed**: if any required aspect for the revision's risk class
+is absent, promotion is **refused**, not allowed.
+
+A single, explicit relief exists — the **cursor**: a revision that is provably
+*inoffensive* may be promoted directly. "Inoffensive" is defined mechanically as
+**zero declared capabilities** — such an agent cannot invoke any privileged tool
+(runtime capability enforcement blocks every capability-gated call), so its blast
+radius is bounded regardless of provenance. The cursor is config-tunable
+(`promotion.allow_zero_capability_direct_promote`, default `true`) so strictness
+can be dialed up (require review even for zero-cap agents) but not silently down.
+
+## The invariant
+
+For a revision R of agent A being promoted:
+
+1. **Inoffensive relief (the cursor).** If R declares **zero capabilities** and
+   the cursor is enabled → direct promote. Otherwise R is *capability-bearing*
+   and the rest applies.
+2. **Artifact required.** A capability-bearing R must ship a reviewable artifact
+   bundle. No `artifact_id` ⇒ **refuse** (incomplete — there is nothing to review).
+3. **Audit / evaluation records** (existing `enforce_promotion_gate`, by class):
+   - CodeExecution / AgentSpawn, or NetworkAccess + artifact ⇒ auditor PASS **and**
+     an evaluator PASS, from identities distinct from each other and the proposer (P-2.17).
+   - Capability-bearing intent-only bundle ⇒ auditor PASS from an identity distinct
+     from the proposer.
+   Missing the required promotion record ⇒ **refuse** (already fail-closed today).
+4. **Operator approval is gateway-determined, not LLM-determined.** An approved
+   operator escalation is required to promote when **either**:
+   - federation role verdicts exist for the artifact (existing FullJury), **or**
+   - R is the **first promotion of a new agent** (no outgoing revision/alias) and
+     R is capability-bearing.
+   Missing ⇒ **refuse** with guidance to run `federation.escalate` and obtain
+   operator approval. This removes the previous dependence on the LLM having
+   recorded federation verdicts before operator approval was demanded.
+
+If all applicable aspects are satisfied → promote. If any is missing → refuse.
+There is no fall-through that promotes a capability-bearing revision without these.
+
+## What changes vs. today
+
+- The "no artifact OR zero-capability → direct promote" `else` is split: only the
+  **zero-capability** case direct-promotes (the cursor); a capability-bearing
+  revision with no artifact is **refused**.
+- Operator approval (escalation) is required for the **first promotion of a new
+  capability-bearing agent**, independent of whether the LLM recorded federation
+  verdicts. (Re-promotion of an existing agent keeps its current gating:
+  capability-delta approval on broadening + audit/eval records; this preserves
+  the autonomous improvement loop for already-admitted agents.)
+
+## Blast radius
+
+- A brand-new capability-bearing agent (e.g. from agent-factory) can no longer be
+  promoted without an approved operator escalation. The autonomous evolution loop
+  must call `federation.escalate` and obtain operator approval before promoting a
+  new agent — which was always the intended process.
+- Zero-capability agents are unaffected (direct promote, gated by the cursor).
+- Existing-agent re-promotion is unaffected.
+
+## Constitutional note
+
+This tightens promotion enforcement (P-2.x family). The numbered rule mapping and
+any constitution wording are prepared **unsigned** for operator ratification — the
+agent never signs the lock. The `enforcement_register` gains a row mapping the new
+refusal (`promotion_incomplete` / new-agent operator-approval) to its rule and the
+test that enforces it.

--- a/docs/design/promotion-completeness-invariant.md
+++ b/docs/design/promotion-completeness-invariant.md
@@ -50,6 +50,27 @@ For a revision R of agent A being promoted:
 If all applicable aspects are satisfied → promote. If any is missing → refuse.
 There is no fall-through that promotes a capability-bearing revision without these.
 
+## First admission vs. iteration (preserving self-evolution)
+
+The human-approval requirement is scoped to **first admission of a new agent**, not
+to every promotion:
+
+- **New agent** (no outgoing revision): capability-bearing first admission requires
+  operator approval — its whole capability set is "new", i.e. maximal broadening.
+  The approval can come from **either** path: the capability-acknowledgement
+  approval (auto-created by the gate) **or** an **approved federation escalation**
+  (the richer jury review). An approved escalation therefore satisfies the gate —
+  a federation-promoted new agent is never asked to approve twice.
+- **Iteration** (re-promotion of an already-admitted agent): unaffected. It is
+  gated only on capability **broadening** (existing behavior) plus the always-on
+  completeness gate. A non-broadening revision whose audits pass self-promotes —
+  autonomous self-evolution keeps working.
+
+The new-agent requirement is a **cursor**
+(`promotion.require_operator_approval_for_new_agents`, default `true`): keep it on
+for human-in-the-loop admission, or turn it off to let fully-audited new agents
+self-promote. Completeness stays fail-closed regardless.
+
 ## What changes vs. today
 
 - The "no artifact OR zero-capability → direct promote" `else` is split: only the

--- a/docs/design/promotion-completeness-invariant.md
+++ b/docs/design/promotion-completeness-invariant.md
@@ -20,7 +20,7 @@ A single, explicit relief exists — the **cursor**: a revision that is provably
 **zero declared capabilities** — such an agent cannot invoke any privileged tool
 (runtime capability enforcement blocks every capability-gated call), so its blast
 radius is bounded regardless of provenance. The cursor is config-tunable
-(`promotion.allow_zero_capability_direct_promote`, default `true`) so strictness
+(`allow_zero_capability_direct_promote`, a top-level `GatewayConfig` key, default `true`) so strictness
 can be dialed up (require review even for zero-cap agents) but not silently down.
 
 ## The invariant
@@ -67,7 +67,7 @@ to every promotion:
   autonomous self-evolution keeps working.
 
 The new-agent requirement is a **cursor**
-(`promotion.require_operator_approval_for_new_agents`, default `true`): keep it on
+(`require_operator_approval_for_new_agents`, a top-level `GatewayConfig` key, default `true`): keep it on
 for human-in-the-loop admission, or turn it off to let fully-audited new agents
 self-promote. Completeness stays fail-closed regardless.
 


### PR DESCRIPTION
## The bug (reported in production)
An agent-factory revision was **promoted with no operator approval** because the operator-approval requirement was *contingent on data the orchestrator LLM produced* (recorded federation verdicts / an attached artifact). When that data was missing (the LLM "returned no promotion information"), `agent_revision_promote` fell through to a **"direct promote"** branch. Fail-**open**.

## Principle (operator-decided)
The gateway decides completeness mechanically and **fails closed**; whether a revision may promote is never inferred from orchestrator-supplied signals. Design: `docs/design/promotion-completeness-invariant.md`.

- **Completeness — always fail-closed (no relief):** required review for the risk class (auditor/evaluator pass, distinct identities, reviewable artifact, no unresolved deps) must be present and passing. Missing/skipped/failed ⇒ **refuse**. The `else` that direct-promoted a capability-bearing revision with no artifact is gone — only the **inoffensive zero-capability** class direct-promotes (config cursor `allow_zero_capability_direct_promote`).
- **First admission of a new agent ⇒ operator approval** (the gap): a brand-new agent's whole capability set is "new" (maximal broadening), so `check_capability_delta` now uses an empty baseline → requires operator approval through the existing **room-visible** flow. Behind a cursor `require_operator_approval_for_new_agents` (default `true`).
- **Iteration stays autonomous:** re-promotion of an already-admitted agent is gated only on capability *broadening* (unchanged) + completeness. Self-evolution keeps working.
- **No double approval:** an **approved federation escalation** satisfies the new-agent gate (the escalation *is* the operator approval), so the federation promotion path isn't gated twice.

## Test plan
- [x] `cargo build` clean
- [x] New dedicated tests: new agent default ⇒ `capability_delta_requires_approval` ("Promoting new agent … for the first time"); cursor off ⇒ new-agent human gate lifted but completeness still fail-closed (`promotion_incomplete`).
- [x] All promotion-touching suites green: federation_e2e 7, promotion_gate_hardening 8, capability_delta 11, audit_only 5, distinct_identity 2, agent_revision lib 25, + agent_inspect/native_tool_registry/approval_hardening/protected_agents/etc. Gate suites that exercise *other* gates set the cursor off to isolate; also fixed two pre-existing stale assertions in `capability_delta` (evaluator message; §O approve-without-reason).

## Follow-ups (operator-ratified, unsigned per policy)
- `enforcement_register` row + constitution note mapping the new refusals to the P-2.x family.
- `config-template.yaml` / `config-reference.md` entries for the two new cursors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)