### PR TITLE
constitution: activate signed 2026.06.05 (P-2.25 promotion fail-closed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,14 +38,14 @@ When `docs/constitution/versions/<version>/constitution.md` changes, run the
 maintained script (requires PyNaCl: `python3 -m pip install pynacl`):
 
 ```bash
-python3 docs/constitution/recompute_lock.py --version 2026.06.04 \
+python3 docs/constitution/recompute_lock.py --version 2026.06.05 \
   --signing-sk-b64 "$AUTONOETIC_CONSTITUTION_SIGNING_SK_B64"
 ```
 
 To intentionally rotate signer material:
 
 ```bash
-python3 docs/constitution/recompute_lock.py --version 2026.06.04 --generate-key
+python3 docs/constitution/recompute_lock.py --version 2026.06.05 --generate-key
 ```
 
 If signer key rotated, update `trusted_signers` for

--- a/autonoetic-gateway/src/constitution_digest.rs
+++ b/autonoetic-gateway/src/constitution_digest.rs
@@ -657,7 +657,7 @@ mod tests {
         let agents_dir = tmp.path().join("agents");
         std::fs::create_dir_all(&agents_dir).unwrap();
 
-        let rel = Path::new("docs/constitution/versions/2026.06.04");
+        let rel = Path::new("docs/constitution/versions/2026.06.05");
         let parent_docs = tmp.path().join(rel);
         std::fs::create_dir_all(&parent_docs).unwrap();
         let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -714,7 +714,7 @@ mod tests {
         );
         assert_eq!(
             lock.constitution_source,
-            "docs/constitution/versions/2026.06.04/constitution.md"
+            "docs/constitution/versions/2026.06.05/constitution.md"
         );
     }
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -761,11 +761,11 @@ impl Default for ConstitutionConfig {
 }
 
 fn default_constitution_source_path() -> PathBuf {
-    PathBuf::from("docs/constitution/versions/2026.06.04/constitution.md")
+    PathBuf::from("docs/constitution/versions/2026.06.05/constitution.md")
 }
 
 fn default_constitution_lock_path() -> PathBuf {
-    PathBuf::from("docs/constitution/versions/2026.06.04/gateway-constitution.lock.json")
+    PathBuf::from("docs/constitution/versions/2026.06.05/gateway-constitution.lock.json")
 }
 
 fn default_require_constitution_signature() -> bool {

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -26,14 +26,14 @@ node_name: "gateway"
 #   <agents_dir>/.gateway/constitution/
 # You can point source_path/lock_path there for fully runtime-local enforcement.
 constitution:
-  source_path: "docs/constitution/versions/2026.06.04/constitution.md"
-  lock_path: "docs/constitution/versions/2026.06.04/gateway-constitution.lock.json"
+  source_path: "docs/constitution/versions/2026.06.05/constitution.md"
+  lock_path: "docs/constitution/versions/2026.06.05/gateway-constitution.lock.json"
   require_signature: true
   trusted_signers:
     autonoetic:constitution:v1: "lNxT1b/jWa6LqM2Thd7rW1IppvlH3rlEnAOPV81Igzk="
 # constitution:
-#   source_path: ".gateway/constitution/versions/2026.06.04/constitution.md"
-#   lock_path: ".gateway/constitution/versions/2026.06.04/gateway-constitution.lock.json"
+#   source_path: ".gateway/constitution/versions/2026.06.05/constitution.md"
+#   lock_path: ".gateway/constitution/versions/2026.06.05/gateway-constitution.lock.json"
 #   require_signature: true
 #   trusted_signers:
 #     autonoetic:constitution:v1: "lNxT1b/jWa6LqM2Thd7rW1IppvlH3rlEnAOPV81Igzk="

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -25,8 +25,8 @@ Fields marked **required** must be present or the gateway will fail to start.
 | ~~`default_lead_agent_id`~~ | — | — | **Removed.** `event.ingest` requires an explicit `target_agent_id`; the gateway no longer has a fallback lead. Omit this field. |
 | `node_id` | string | `"gateway"` | Node identity for OFP federation and causal chain authorship. Overridable by `AUTONOETIC_NODE_ID` env var. |
 | `node_name` | string | `"gateway"` | Human-readable node name for OFP federation. Overridable by `AUTONOETIC_NODE_NAME` env var. |
-| `constitution.source_path` | string (path) | `"docs/constitution/versions/2026.06.04/constitution.md"` | Active constitution markdown source used for digest/profile extraction. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
-| `constitution.lock_path` | string (path) | `"docs/constitution/versions/2026.06.04/gateway-constitution.lock.json"` | Active constitution lock manifest. Startup refuses to boot if lock integrity checks fail. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
+| `constitution.source_path` | string (path) | `"docs/constitution/versions/2026.06.05/constitution.md"` | Active constitution markdown source used for digest/profile extraction. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
+| `constitution.lock_path` | string (path) | `"docs/constitution/versions/2026.06.05/gateway-constitution.lock.json"` | Active constitution lock manifest. Startup refuses to boot if lock integrity checks fail. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
 | `constitution.require_signature` | bool | `true` | Require a valid constitution lock signature at startup (`fail-shut` on missing/invalid signature). |
 | `constitution.trusted_signers` | map<string,string> | `{ autonoetic:constitution:v1: ... }` | Trusted signer registry (`signer_id` -> base64 Ed25519 public key, 32 bytes). Used for non-`gateway:*` signer IDs. |
 | `max_concurrent_spawns` | usize | `8` | Maximum agent runtime executions allowed concurrently across all sessions. |
@@ -61,8 +61,8 @@ Controls which constitutional release the gateway enforces.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `constitution.source_path` | string (path) | `"docs/constitution/versions/2026.06.04/constitution.md"` | Canonical constitution markdown used by `constitution_read`, `gateway.info`, and federation digest/profile checks. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
-| `constitution.lock_path` | string (path) | `"docs/constitution/versions/2026.06.04/gateway-constitution.lock.json"` | Lock manifest containing pinned digest/version/metadata. Startup verifies this against computed values and fails shut on mismatch. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
+| `constitution.source_path` | string (path) | `"docs/constitution/versions/2026.06.05/constitution.md"` | Canonical constitution markdown used by `constitution_read`, `gateway.info`, and federation digest/profile checks. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
+| `constitution.lock_path` | string (path) | `"docs/constitution/versions/2026.06.05/gateway-constitution.lock.json"` | Lock manifest containing pinned digest/version/metadata. Startup verifies this against computed values and fails shut on mismatch. Relative paths resolve in this order: `agents_dir/<path>`, `agents_dir` parent, current working directory, workspace root fallback. |
 | `constitution.require_signature` | bool | `true` | If `true`, unsigned locks are rejected and signed locks must verify. |
 | `constitution.trusted_signers` | map<string,string> | `{ autonoetic:constitution:v1: ... }` | Trust store for constitution lock signatures. Keys are signer IDs, values are base64 Ed25519 public keys (32 bytes). |
 
@@ -101,8 +101,8 @@ Example:
 
 ```yaml
 constitution:
-  source_path: "docs/constitution/versions/2026.06.04/constitution.md"
-  lock_path: "docs/constitution/versions/2026.06.04/gateway-constitution.lock.json"
+  source_path: "docs/constitution/versions/2026.06.05/constitution.md"
+  lock_path: "docs/constitution/versions/2026.06.05/gateway-constitution.lock.json"
   require_signature: true
   trusted_signers:
     autonoetic:constitution:v1: "lNxT1b/jWa6LqM2Thd7rW1IppvlH3rlEnAOPV81Igzk="
@@ -112,8 +112,8 @@ To enforce the bootstrapped runtime snapshot instead of the repo docs copy:
 
 ```yaml
 constitution:
-  source_path: ".gateway/constitution/versions/2026.06.04/constitution.md"
-  lock_path: ".gateway/constitution/versions/2026.06.04/gateway-constitution.lock.json"
+  source_path: ".gateway/constitution/versions/2026.06.05/constitution.md"
+  lock_path: ".gateway/constitution/versions/2026.06.05/gateway-constitution.lock.json"
   require_signature: true
   trusted_signers:
     autonoetic:constitution:v1: "lNxT1b/jWa6LqM2Thd7rW1IppvlH3rlEnAOPV81Igzk="
@@ -1078,8 +1078,8 @@ tls: false
 node_id: "gateway"
 node_name: "gateway"
 constitution:
-  source_path: "docs/constitution/versions/2026.06.04/constitution.md"
-  lock_path: "docs/constitution/versions/2026.06.04/gateway-constitution.lock.json"
+  source_path: "docs/constitution/versions/2026.06.05/constitution.md"
+  lock_path: "docs/constitution/versions/2026.06.05/gateway-constitution.lock.json"
   require_signature: true
   trusted_signers:
     autonoetic:constitution:v1: "lNxT1b/jWa6LqM2Thd7rW1IppvlH3rlEnAOPV81Igzk="

--- a/docs/constitution/versions/2026.06.05/gateway-constitution.lock.json
+++ b/docs/constitution/versions/2026.06.05/gateway-constitution.lock.json
@@ -1,10 +1,10 @@
 {
   "format_version": 1,
   "constitution_id": "autonoetic-gateway-constitution",
-  "constitution_version": "2026.06.04",
-  "constitution_source": "docs/constitution/versions/2026.06.04/constitution.md",
-  "constitution_digest": "47252a1eadd3192afd8bb97c7cf97e65fae1adcedd45b6d5ae7a68d08313bd76",
-  "rule_enforcement_count": 172,
+  "constitution_version": "2026.06.05",
+  "constitution_source": "docs/constitution/versions/2026.06.05/constitution.md",
+  "constitution_digest": "e615a0a579819cce801f29729736e75ca006591ccba7d635fc574984b91c2c9a",
+  "rule_enforcement_count": 173,
   "right_enforcement_count": 14,
   "canonicalization": {
     "algorithm": "sha256",
@@ -15,6 +15,6 @@
   "signature": {
     "algorithm": "ed25519",
     "signer_id": "autonoetic:constitution:v1",
-    "signature_b64": "vqHBmuoleG38wMnMMCPnR4bygoYMi97R8EO90HXLG0hze9pDuNuy4Nu0QgqHhkYSZhb4/Zd2ZEKoFgbLP6vRBg=="
+    "signature_b64": "G7iiqPYfntU6pHrOHdbYSLwsYGjc9Ja6eacJ2DFzGcGE/PdfbwWsjvP0cg0pyZVi9ndAsA9Wp1C4kSoCfU9sCA=="
   }
 }


### PR DESCRIPTION
Activates the operator-signed constitution 2026.06.05 (P-2.25, from #421). Commits the signed lock (digest `e615a0a…`, 173 rules/14 rights) and flips the active version everywhere: config defaults, config-template, config-reference, the version-pinned `constitution_digest.rs` test paths, and CLAUDE.md examples.

`constitution_lock_matches_canonical_digest_and_counts` passes — verifies the digest, counts, and signature against the now-configured 2026.06.05. No `enforcement_register` row needed (the count comes from the constitution.md P- rows; P-2.25's refusal rides on the existing P-2.8/2.17/2.22 gate-event tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)