### PR TITLE
feat(events): report constitutional rule IDs on gateway refusals

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -106,6 +106,33 @@ impl JsonRpcResponse {
             }),
         }
     }
+
+    /// Like [`error`](Self::error) but attaches the constitutional rule/right IDs
+    /// the refusal enforced to `error.data` (`{ "enforced_rules": [...] }`), so a
+    /// client is told *which* clause blocked it — not just a prose message. Empty
+    /// `enforced_rules` ⇒ identical to `error`.
+    pub fn error_with_rules(
+        id: String,
+        code: i32,
+        message: impl Into<String>,
+        enforced_rules: Vec<String>,
+    ) -> Self {
+        let data = if enforced_rules.is_empty() {
+            None
+        } else {
+            Some(serde_json::json!({ "enforced_rules": enforced_rules }))
+        };
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data,
+            }),
+        }
+    }
 }
 
 type ProcessedSignalSet = Arc<std::sync::Mutex<std::collections::HashSet<String>>>;
@@ -161,7 +188,7 @@ impl JsonRpcRouter {
         &self,
         ingress: IngressType,
         session_id: String,
-    ) -> Result<(SpawnResult, Option<TraceSession>), (String, Option<TraceSession>)> {
+    ) -> Result<(SpawnResult, Option<TraceSession>), (String, Vec<String>, Option<TraceSession>)> {
         let (
             action_name,
             agent_id,
@@ -240,6 +267,7 @@ impl JsonRpcRouter {
                         "{} failed: unable to initialize gateway causal logger: {}",
                         action_name, e
                     ),
+                    Vec::new(),
                     None,
                 ));
             }
@@ -305,7 +333,13 @@ impl JsonRpcRouter {
         {
             Ok(r) => r,
             Err(e) => {
-                return Err((e.to_string(), Some(trace_session)));
+                // Preserve any constitutional rule IDs the refusal carried so the
+                // RPC error can surface them to the client (instead of prose only).
+                let enforced_rules = e
+                    .downcast_ref::<autonoetic_types::tool_error::tagged::Tagged>()
+                    .map(|t| t.enforced_rules().to_vec())
+                    .unwrap_or_default();
+                return Err((e.to_string(), enforced_rules, Some(trace_session)));
             }
         };
 
@@ -553,7 +587,7 @@ impl JsonRpcRouter {
                             }),
                         )
                     }
-                    Err((e, maybe_trace_session)) => {
+                    Err((e, enforced_rules, maybe_trace_session)) => {
                         if let Some(source_agent_id) = params.source_agent_id.as_deref() {
                             let _ = append_delegation_task_entry(
                                 self.config.as_ref(),
@@ -576,7 +610,12 @@ impl JsonRpcRouter {
                                 })),
                             );
                         }
-                        JsonRpcResponse::error(req.id, -32000, format!("agent.spawn failed: {}", e))
+                        JsonRpcResponse::error_with_rules(
+                            req.id,
+                            -32000,
+                            format!("agent.spawn failed: {}", e),
+                            enforced_rules,
+                        )
                     }
                 }
             }
@@ -760,7 +799,7 @@ impl JsonRpcRouter {
                                     }
                                     JsonRpcRouter::apply_spawn_result_to_async_entry(entry, &spawn_result);
                                 }
-                                Err((e, _)) => {
+                                Err((e, _enforced_rules, _)) => {
                                     if let Some(source) = source_agent_id {
                                         let _ = append_delegation_task_entry(
                                             config.as_ref(),
@@ -838,7 +877,7 @@ impl JsonRpcRouter {
                                 }),
                             )
                         }
-                        Err((e, maybe_trace_session)) => {
+                        Err((e, enforced_rules, maybe_trace_session)) => {
                             if let Some(source_agent_id) = params.source_agent_id.as_deref() {
                                 let _ = append_delegation_task_entry(
                                     self.config.as_ref(),
@@ -863,10 +902,11 @@ impl JsonRpcRouter {
                                     })),
                                 );
                             }
-                            JsonRpcResponse::error(
+                            JsonRpcResponse::error_with_rules(
                                 req.id,
                                 -32000,
                                 format!("event.ingest failed: {}", e),
+                                enforced_rules,
                             )
                         }
                     }
@@ -2604,5 +2644,34 @@ mod tests {
             .and_then(|s| s.as_str())
             == Some("already_processed");
         assert!(!is_dedup, "normal ingest must never hit the idempotency guard");
+    }
+
+    #[test]
+    fn error_with_rules_populates_data_for_clients() {
+        let resp = JsonRpcResponse::error_with_rules(
+            "1".into(),
+            -32000,
+            "agent.spawn failed: promotion incomplete",
+            vec!["P-2.25".into(), "P-2.8".into()],
+        );
+        let err = resp.error.expect("error should be set");
+        let rules = err
+            .data
+            .as_ref()
+            .and_then(|d| d.get("enforced_rules"))
+            .and_then(|r| r.as_array())
+            .expect("data.enforced_rules must be present");
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0], "P-2.25");
+        assert_eq!(rules[1], "P-2.8");
+    }
+
+    #[test]
+    fn error_with_rules_omits_data_when_no_rules() {
+        // No constitutional clause attributed ⇒ data stays None (back-compat
+        // with plain `error()`), so clients don't see an empty `enforced_rules`.
+        let resp = JsonRpcResponse::error_with_rules("1".into(), -32000, "boom", vec![]);
+        let err = resp.error.expect("error should be set");
+        assert!(err.data.is_none(), "no rules ⇒ no data envelope");
     }
 }

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -22,6 +22,12 @@ pub struct AsyncIngestResult {
     pub artifacts: Vec<serde_json::Value>,
     pub shared_knowledge: Vec<serde_json::Value>,
     pub error: Option<String>,
+    /// Constitutional rule/right IDs the refusal/termination enforced (e.g.
+    /// `P-2.25`). Empty unless `status == Failed` with an attributed cause —
+    /// lets an async client polling `session.status` learn *which* clause
+    /// refused, matching the `error.data.enforced_rules` of the sync path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub enforced_rules: Vec<String>,
     pub started_at: String,
     pub completed_at: Option<String>,
 }
@@ -766,6 +772,7 @@ impl JsonRpcRouter {
                                 artifacts: Vec::new(),
                                 shared_knowledge: Vec::new(),
                                 error: None,
+                                enforced_rules: Vec::new(),
                                 started_at: chrono::Utc::now().to_rfc3339(),
                                 completed_at: None,
                             },
@@ -799,7 +806,7 @@ impl JsonRpcRouter {
                                     }
                                     JsonRpcRouter::apply_spawn_result_to_async_entry(entry, &spawn_result);
                                 }
-                                Err((e, _enforced_rules, _)) => {
+                                Err((e, enforced_rules, _)) => {
                                     if let Some(source) = source_agent_id {
                                         let _ = append_delegation_task_entry(
                                             config.as_ref(),
@@ -810,11 +817,13 @@ impl JsonRpcRouter {
                                             Some(serde_json::json!({
                                                 "error": e.clone(),
                                                 "event_type": event_type_clone,
+                                                "enforced_rules": enforced_rules.clone(),
                                             })),
                                         );
                                     }
                                     entry.status = AsyncIngestStatus::Failed;
                                     entry.error = Some(e);
+                                    entry.enforced_rules = enforced_rules;
                                     entry.completed_at = Some(chrono::Utc::now().to_rfc3339());
                                 }
                             }
@@ -2673,5 +2682,30 @@ mod tests {
         let resp = JsonRpcResponse::error_with_rules("1".into(), -32000, "boom", vec![]);
         let err = resp.error.expect("error should be set");
         assert!(err.data.is_none(), "no rules ⇒ no data envelope");
+    }
+
+    #[test]
+    fn async_ingest_result_surfaces_enforced_rules_when_failed() {
+        // A failed async ingest carries the attributed clause so a client
+        // polling `session.status` learns the cause — parity with the sync
+        // path's `error.data.enforced_rules`. Empty ⇒ field omitted.
+        let mut r = AsyncIngestResult {
+            session_id: "s1".into(),
+            status: AsyncIngestStatus::Failed,
+            assistant_reply: None,
+            workflow_note: None,
+            artifacts: Vec::new(),
+            shared_knowledge: Vec::new(),
+            error: Some("promotion incomplete".into()),
+            enforced_rules: vec!["P-2.25".into()],
+            started_at: "t0".into(),
+            completed_at: Some("t1".into()),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["enforced_rules"][0], "P-2.25");
+
+        r.enforced_rules.clear();
+        let v = serde_json::to_value(&r).unwrap();
+        assert!(v.get("enforced_rules").is_none(), "empty ⇒ omitted");
     }
 }

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1286,6 +1286,35 @@ impl AgentExecutor {
                             "failed to emit loop_guard.tripped causal event"
                         );
                     }
+
+                    // Also surface it on the canonical timeline so the room shows
+                    // *why* the session was terminated, carrying the rule ID as a
+                    // first-class ref (was causal-only — invisible in the room).
+                    let sid = self.session_id.clone().unwrap_or_default();
+                    let root = crate::runtime::content_store::root_session_id(&sid).to_string();
+                    let principal =
+                        autonoetic_types::principal::Principal::agent(self.manifest.agent.id.clone());
+                    let role = crate::runtime::session_timeline::derive_role(&self.manifest.agent.id);
+                    let tl = crate::runtime::session_timeline::build_timeline_event(
+                        root,
+                        sid,
+                        Some(turn_id.clone()),
+                        &principal,
+                        &role,
+                        "guard.tripped",
+                        None, // base_altitude ⇒ Error
+                        Some(serde_json::json!({
+                            "reason": reason.code(),
+                            "rule_id": reason.rule_id(),
+                        })),
+                        autonoetic_types::session_timeline::TimelineRefs {
+                            enforced_rules: vec![reason.rule_id().to_string()],
+                            ..Default::default()
+                        },
+                    );
+                    if let Err(err) = store.create_live_digest_event(&tl) {
+                        tracing::debug!(target: "session_timeline", error = %err, "guard.tripped timeline emit failed");
+                    }
                 }
                 let _ =
                     self.save_yield_checkpoint(history, &turn_id, YieldReason::MaxTurnsReached, None);

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -92,10 +92,10 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         // Extended-thinking "why" is verbose; hidable by default, surfaced on dial-down.
         "turn.start" | "turn.end" | "llm.round" | "tool.requested" | "agent.reasoning"
         | "workbench.created" | "workbench.reconciled" | "workbench.discarded" => Altitude::Detail,
-        // Failures, the emergency-stop circuit breaker, and security-critical
-        // events always surface.
+        // Failures, the emergency-stop circuit breaker, security-critical events,
+        // and bounded-progress (loop-guard) trips always surface.
         "llm.request_failed" | "tool.failed" | "session.emergency_stop"
-        | "security.sandbox_escape" => Altitude::Error,
+        | "security.sandbox_escape" | "guard.tripped" => Altitude::Error,
         // Gates awaiting the operator (conversational asks, RFC §3.5) and
         // integrity events. `runtime.lock_drift` stores an explicit altitude
         // (Error when rejected, Attention when overridden); this is just the
@@ -263,6 +263,13 @@ mod tests {
             altitude_for("agent.reasoning", &SessionRole::Sentinel),
             Altitude::Attention
         );
+    }
+
+    #[test]
+    fn guard_tripped_is_error() {
+        // A loop-guard trip terminates the session — it must surface at the
+        // Error floor so the room shows *why*, not slip by as routine.
+        assert_eq!(base_altitude("guard.tripped"), Altitude::Error);
     }
 
     #[test]

--- a/autonoetic-types/src/session_timeline.rs
+++ b/autonoetic-types/src/session_timeline.rs
@@ -124,6 +124,11 @@ pub struct TimelineRefs {
     pub plan_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workbench_id: Option<String>,
+    /// Constitutional rule/right IDs this event enforces (e.g. `P-7.19`, `Ri-0.9`)
+    /// — first-class so channels can attribute a refusal/gate to its clause and
+    /// look the clause up, instead of parsing the payload.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub enforced_rules: Vec<String>,
 }
 
 impl TimelineRefs {

--- a/autonoetic-types/src/tool_error.rs
+++ b/autonoetic-types/src/tool_error.rs
@@ -528,6 +528,13 @@ pub mod tagged {
     }
 
     impl Tagged {
+        /// The constitutional rule/right IDs this refusal enforces (if any).
+        /// Lets a boundary (e.g. the JSON-RPC layer) surface them to clients
+        /// without consuming the error.
+        pub fn enforced_rules(&self) -> &[String] {
+            &self.enforced_rules
+        }
+
         /// Extracts the error type and message from this tagged error.
         pub fn into_parts(self) -> (ToolErrorType, String, Vec<String>) {
             (

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -218,6 +218,13 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
             "EMERGENCY STOP — {}",
             one_line(&field("reason").unwrap_or_else(|| "session halted".into()), 120)
         ),
+        // Bounded-progress (loop-guard) trip terminated the session (#287/P-7.x).
+        // The actor label shows which agent; the enforcing rule rides on refs.
+        "guard.tripped" => {
+            let reason = field("reason").unwrap_or_else(|| "tripped".into());
+            let rule = field("rule_id").map(|r| format!(" [{r}]")).unwrap_or_default();
+            format!("loop guard tripped: {reason}{rule}")
+        }
         other => other.to_string(),
     }
 }
@@ -623,6 +630,9 @@ pub fn format_detail(entry: &SessionTimelineEntry) -> Vec<String> {
     if !ref_parts.is_empty() {
         lines.push(format!("refs:      {}", ref_parts.join("  ")));
     }
+    if !refs.enforced_rules.is_empty() {
+        lines.push(format!("enforces:  {}", refs.enforced_rules.join(", ")));
+    }
 
     if let Some(payload) = &entry.payload {
         lines.push(String::new());
@@ -770,6 +780,34 @@ mod tests {
         assert!(line.starts_with("⚠"));
         assert!(line.contains("🧑 operator"));
         assert!(line.contains("approval denied (apr-9)"));
+    }
+
+    #[test]
+    fn renders_guard_tripped_with_rule_id() {
+        let e = entry(
+            SessionRole::Runtime,
+            Principal::agent("planner.default"),
+            "guard.tripped",
+            Altitude::Error,
+            serde_json::json!({ "reason": "no_progress", "rule_id": "P-7.19" }),
+        );
+        let line = render_line(&e);
+        assert!(line.starts_with("✗"), "guard trip should render at Error: {line}");
+        assert!(line.contains("loop guard tripped: no_progress [P-7.19]"), "got: {line}");
+    }
+
+    #[test]
+    fn detail_view_shows_enforced_rules() {
+        let mut e = entry(
+            SessionRole::Operator,
+            Principal::human("operator"),
+            "approval.rejected",
+            Altitude::Attention,
+            serde_json::json!({ "request_id": "apr-9" }),
+        );
+        e.refs.enforced_rules = vec!["Ri-0.9".into(), "P-2.25".into()];
+        let detail = format_detail(&e).join("\n");
+        assert!(detail.contains("enforces:  Ri-0.9, P-2.25"), "got: {detail}");
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -219,10 +219,16 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
             one_line(&field("reason").unwrap_or_else(|| "session halted".into()), 120)
         ),
         // Bounded-progress (loop-guard) trip terminated the session (#287/P-7.x).
-        // The actor label shows which agent; the enforcing rule rides on refs.
+        // The actor label shows which agent; the enforcing rule rides on refs
+        // (first-class) — fall back to the payload `rule_id` only for older
+        // events written before `enforced_rules` existed.
         "guard.tripped" => {
             let reason = field("reason").unwrap_or_else(|| "tripped".into());
-            let rule = field("rule_id").map(|r| format!(" [{r}]")).unwrap_or_default();
+            let rule = if !entry.refs.enforced_rules.is_empty() {
+                format!(" [{}]", entry.refs.enforced_rules.join(", "))
+            } else {
+                field("rule_id").map(|r| format!(" [{r}]")).unwrap_or_default()
+            };
             format!("loop guard tripped: {reason}{rule}")
         }
         other => other.to_string(),
@@ -783,7 +789,25 @@ mod tests {
     }
 
     #[test]
-    fn renders_guard_tripped_with_rule_id() {
+    fn renders_guard_tripped_from_first_class_refs() {
+        // The rule rides on the first-class `refs.enforced_rules`; the payload
+        // carries no `rule_id`, proving the renderer reads refs, not payload.
+        let mut e = entry(
+            SessionRole::Runtime,
+            Principal::agent("planner.default"),
+            "guard.tripped",
+            Altitude::Error,
+            serde_json::json!({ "reason": "no_progress" }),
+        );
+        e.refs.enforced_rules = vec!["P-7.19".into()];
+        let line = render_line(&e);
+        assert!(line.starts_with("✗"), "guard trip should render at Error: {line}");
+        assert!(line.contains("loop guard tripped: no_progress [P-7.19]"), "got: {line}");
+    }
+
+    #[test]
+    fn renders_guard_tripped_payload_rule_id_fallback() {
+        // Older events have no `refs.enforced_rules`; fall back to payload.
         let e = entry(
             SessionRole::Runtime,
             Principal::agent("planner.default"),
@@ -792,7 +816,6 @@ mod tests {
             serde_json::json!({ "reason": "no_progress", "rule_id": "P-7.19" }),
         );
         let line = render_line(&e);
-        assert!(line.starts_with("✗"), "guard trip should render at Error: {line}");
         assert!(line.contains("loop guard tripped: no_progress [P-7.19]"), "got: {line}");
     }
 


### PR DESCRIPTION
## Why

When the gateway refuses or terminates, clients couldn't reliably learn *which* constitutional clause caused it. Rule IDs were either buried in payload JSON, only on the causal firehose, or absent entirely. This wires them out to clients as first-class data.

## The three fixes

**(a) JSON-RPC errors carry `data.enforced_rules`.**
Added `JsonRpcResponse::error_with_rules()` and `Tagged::enforced_rules()`. `execute_agent_request` now returns a `(String, Vec<String>, Option<TraceSession>)` error tuple, downcasting the boxed error to a `Tagged` to recover its rule IDs, so `agent.spawn` and `event.ingest` failures report the refusing clause (e.g. `P-2.25`). Empty rules ⇒ no `data` envelope (back-compat with plain `error()`).

**(b) loop-guard trips are no longer a room blind spot.**
`guard.tripped` is now `Error` altitude. `lifecycle` emits a parallel live-digest timeline event alongside the causal one, carrying the rule ID as a first-class ref. The room renders it: `loop guard tripped: <reason> [P-7.19]`.

**(c) `TimelineRefs.enforced_rules` is first-class.**
Channels attribute a refusal/gate to its clause and look it up without parsing payloads; the detail view gains an `enforces:` line.

## Tests
- `error_with_rules` populates `data.enforced_rules`; empty omits `data`
- `guard.tripped` resolves to `Error` altitude
- room renders `guard.tripped` with rule ID at Error
- detail view shows `enforces:` line from `TimelineRefs.enforced_rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)