### PR TITLE
feat(constitution): expose the constitution to clients (constitution.get)

### DIFF
--- a/autonoetic-gateway/src/constitution_digest.rs
+++ b/autonoetic-gateway/src/constitution_digest.rs
@@ -193,6 +193,47 @@ pub fn canonical_rule_enforcement_table() -> BTreeMap<String, String> {
     runtime_arc().rules_enforcement.clone()
 }
 
+/// Build the client-facing constitution view (`constitution.get`): lock
+/// metadata + one gloss per `P-*`/`Ri-*` clause, with enforcement citations
+/// where the gateway mechanically enforces a clause. `include_text` attaches
+/// the full markdown. Source of truth is the loaded constitution text, so the
+/// gloss can never drift from what was signed.
+pub fn constitution_profile(
+    include_text: bool,
+) -> autonoetic_types::constitution::ConstitutionGetResult {
+    use autonoetic_types::constitution::{ConstitutionClause, ConstitutionGetResult};
+    let rt = runtime_arc();
+    let lock = rt.lock.as_ref();
+    let glossary = extract_rule_glossary(&rt.text);
+    let clauses = glossary
+        .into_iter()
+        .map(|(id, gloss)| {
+            let (binds, enforcement) = if id.starts_with("Ri-") {
+                ("gateway", rt.rights_enforcement.get(&id).cloned())
+            } else {
+                ("agent", rt.rules_enforcement.get(&id).cloned())
+            };
+            ConstitutionClause {
+                id,
+                binds: binds.to_string(),
+                gloss,
+                enforcement,
+            }
+        })
+        .collect();
+    ConstitutionGetResult {
+        version: lock.constitution_version.clone(),
+        digest: rt.digest.to_string(),
+        format_version: lock.format_version,
+        signer_id: lock.signature.as_ref().map(|s| s.signer_id.clone()),
+        signed: lock.signature.is_some(),
+        rule_enforcement_count: lock.rule_enforcement_count,
+        right_enforcement_count: lock.right_enforcement_count,
+        clauses,
+        text: include_text.then(|| rt.text.to_string()),
+    }
+}
+
 pub fn canonical_constitution_profile() -> autonoetic_ofp::wire::ConstitutionProfile {
     autonoetic_ofp::wire::ConstitutionProfile {
         rules_enforcement: canonical_rule_enforcement_table(),
@@ -649,6 +690,34 @@ mod tests {
     fn constitution_lock_matches_canonical_digest_and_counts() {
         init_default_constitution();
         verify_constitution_lock_integrity().expect("constitution lock integrity should hold");
+    }
+
+    #[test]
+    fn constitution_profile_exposes_clauses_and_metadata() {
+        init_default_constitution();
+        let lock = constitution_lock();
+
+        // Lightweight by default: no full text, metadata mirrors the lock.
+        let p = constitution_profile(false);
+        assert!(p.text.is_none(), "include_text=false must omit the markdown");
+        assert_eq!(p.version, lock.constitution_version);
+        assert_eq!(p.digest.as_str(), constitution_digest().as_ref());
+        assert!(p.signed && p.signer_id.as_deref() == Some("autonoetic:constitution:v1"));
+        assert_eq!(p.rule_enforcement_count, lock.rule_enforcement_count);
+        assert_eq!(p.right_enforcement_count, lock.right_enforcement_count);
+        assert!(p.clauses.len() > 100, "expected the full clause set");
+
+        // A P- rule binds the agent and carries an enforcement citation; an
+        // Ri- right binds the gateway.
+        let p11 = p.clauses.iter().find(|c| c.id == "P-1.1").expect("P-1.1");
+        assert_eq!(p11.binds, "agent");
+        assert!(p11.enforcement.as_deref().unwrap_or("").contains("tool_call_processor"));
+        let ri = p.clauses.iter().find(|c| c.id == "Ri-0.10").expect("Ri-0.10");
+        assert_eq!(ri.binds, "gateway");
+
+        // include_text attaches the full markdown.
+        let full = constitution_profile(true);
+        assert!(full.text.as_deref().unwrap_or("").contains("| P-1.1 |"));
     }
 
     #[test]

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -465,6 +465,28 @@ impl JsonRpcRouter {
                     "constitution_format_version": crate::constitution_digest::constitution_format_version(),
                 }),
             ),
+            "constitution.get" => {
+                let params: autonoetic_types::constitution::ConstitutionGetParams =
+                    if req.params.is_null() {
+                        Default::default()
+                    } else {
+                        match serde_json::from_value(req.params) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                return JsonRpcResponse::error(
+                                    req.id,
+                                    -32602,
+                                    format!("Invalid params for constitution.get: {}", e),
+                                );
+                            }
+                        }
+                    };
+                let result = crate::constitution_digest::constitution_profile(params.include_text);
+                JsonRpcResponse::success(
+                    req.id,
+                    serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+                )
+            }
             "interaction.answer" => {
                 let params: crate::interaction_answer::InteractionAnswerParams =
                     match serde_json::from_value(req.params) {
@@ -2163,6 +2185,45 @@ mod tests {
         assert!(result["gateway_version"].is_string());
         assert!(result["constitution_version"].is_string());
         assert!(result["constitution_format_version"].is_u64());
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_constitution_get() {
+        let (_temp, router) = test_router();
+        // Null params (no body) must default to the lightweight view.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: "cg".to_string(),
+            method: "constitution.get".to_string(),
+            params: serde_json::Value::Null,
+            auth_token: None,
+        };
+        let resp = router.dispatch(req).await;
+        let result = resp.result.expect("constitution.get should return payload");
+        assert_eq!(result["digest"].as_str().map(str::len), Some(64));
+        assert!(result["version"].is_string());
+        assert!(result["signed"].as_bool().unwrap_or(false));
+        assert!(result["text"].is_null(), "default view omits the markdown");
+        let clauses = result["clauses"].as_array().expect("clauses array");
+        assert!(clauses.len() > 100);
+        assert!(clauses
+            .iter()
+            .any(|c| c["id"] == "P-1.1" && c["binds"] == "agent"));
+
+        // include_text attaches the full markdown.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: "cg2".to_string(),
+            method: "constitution.get".to_string(),
+            params: serde_json::json!({ "include_text": true }),
+            auth_token: None,
+        };
+        let result = router
+            .dispatch(req)
+            .await
+            .result
+            .expect("constitution.get should return payload");
+        assert!(result["text"].as_str().unwrap_or("").contains("P-1.1"));
     }
 
     #[tokio::test]

--- a/autonoetic-types/src/constitution.rs
+++ b/autonoetic-types/src/constitution.rs
@@ -1,0 +1,62 @@
+//! Client-facing constitution exposure (`constitution.get`).
+//!
+//! The signed constitution is the contract every actor lives under, but it was
+//! previously only visible as a digest (`gateway.info`) or buried in the repo.
+//! This surfaces it to any channel/SDK: lightweight metadata plus a one-line
+//! gloss per clause for those interested in the principles, with the full
+//! markdown available on request (`include_text`).
+
+use serde::{Deserialize, Serialize};
+
+/// Parameters for `constitution.get`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConstitutionGetParams {
+    /// Include the full constitution markdown in the response. Off by default —
+    /// the metadata + per-clause gloss is the lightweight view; the full text
+    /// can be large.
+    #[serde(default)]
+    pub include_text: bool,
+}
+
+/// One clause of the constitution, lightweight: its ID, who it binds, a
+/// one-line gloss (first sentence from the source), and — when the gateway
+/// mechanically enforces it — the code/test citation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstitutionClause {
+    /// Clause ID, e.g. `P-7.19` (a rule) or `Ri-0.10` (a right).
+    pub id: String,
+    /// `agent` for a `P-*` principle/rule, `gateway` for an `Ri-*` right.
+    pub binds: String,
+    /// One-line statement — the first sentence of the clause in the source.
+    pub gloss: String,
+    /// Enforcement citation (code/test site) when the clause is mechanically
+    /// enforced; `None` for declarative clauses with no enforcement row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enforcement: Option<String>,
+}
+
+/// Result of `constitution.get`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConstitutionGetResult {
+    /// Constitution version, e.g. `2026.06.04`.
+    pub version: String,
+    /// Canonical SHA-256 digest (64 hex chars) of the signed payload.
+    pub digest: String,
+    /// Lock format version.
+    pub format_version: u32,
+    /// Signer id from the lock (e.g. `autonoetic:constitution:v1`); `None` if unsigned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer_id: Option<String>,
+    /// Whether the lock carries a signature.
+    pub signed: bool,
+    /// Number of `P-*` rules with an enforcement citation (matches the lock).
+    pub rule_enforcement_count: usize,
+    /// Number of `Ri-*` rights with an enforcement citation (matches the lock).
+    pub right_enforcement_count: usize,
+    /// Every `P-*`/`Ri-*` clause, one line each — the lightweight "by clause"
+    /// view, sorted by ID.
+    pub clauses: Vec<ConstitutionClause>,
+    /// Full constitution markdown — present only when `include_text` was set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}

--- a/autonoetic-types/src/lib.rs
+++ b/autonoetic-types/src/lib.rs
@@ -12,6 +12,7 @@ pub mod capsule;
 pub mod causal_chain;
 pub mod channel;
 pub mod config;
+pub mod constitution;
 pub mod disclosure;
 pub mod escalation;
 pub mod evaluation;

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -392,6 +392,16 @@ pub enum GatewayCommands {
 
 #[derive(Subcommand)]
 pub enum GatewayConstitutionCommands {
+    /// Show the active constitution: version, digest, signer, and a one-line
+    /// gloss per clause (the same view clients get from `constitution.get`).
+    Show {
+        /// Include the full constitution markdown text.
+        #[arg(long)]
+        include_text: bool,
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// List amendment proposals.
     Proposals {
         #[command(subcommand)]

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -2080,8 +2080,14 @@ pub async fn handle_gateway_constitution(
     command: &super::common::GatewayConstitutionCommands,
 ) -> anyhow::Result<()> {
     let config = autonoetic_gateway::config::load_config(config_path)?;
-    let gateway_dir = std::path::PathBuf::from(&config.agents_dir).join(".gateway");
-    let store = autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?;
+    // The SQLite store is opened lazily — only the proposal subcommands need
+    // it. `show` is read-only (config + signed constitution text) and must not
+    // touch the DB or run migrations, so it works on a read-only/permissionless
+    // filesystem.
+    let open_store = || -> anyhow::Result<_> {
+        let gateway_dir = std::path::PathBuf::from(&config.agents_dir).join(".gateway");
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)
+    };
 
     match command {
         super::common::GatewayConstitutionCommands::Show {
@@ -2117,10 +2123,10 @@ pub async fn handle_gateway_constitution(
             Ok(())
         }
         super::common::GatewayConstitutionCommands::Proposals { command } => {
-            handle_constitution_proposals(&store, command)
+            handle_constitution_proposals(&open_store()?, command)
         }
         super::common::GatewayConstitutionCommands::Release { tag, json } => {
-            let ids = store.publish_approved_proposals(tag)?;
+            let ids = open_store()?.publish_approved_proposals(tag)?;
             if *json {
                 println!(
                     "{}",

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -2084,6 +2084,38 @@ pub async fn handle_gateway_constitution(
     let store = autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?;
 
     match command {
+        super::common::GatewayConstitutionCommands::Show {
+            include_text,
+            json,
+        } => {
+            autonoetic_gateway::constitution_digest::initialize_constitution(&config)?;
+            let profile =
+                autonoetic_gateway::constitution_digest::constitution_profile(*include_text);
+            if *json {
+                println!("{}", serde_json::to_string_pretty(&profile)?);
+                return Ok(());
+            }
+            println!("Constitution {}", profile.version);
+            println!("  Digest:  {}", profile.digest);
+            println!("  Format:  v{}", profile.format_version);
+            match (&profile.signer_id, profile.signed) {
+                (Some(signer), true) => println!("  Signed:  yes (signer {signer})"),
+                _ => println!("  Signed:  no"),
+            }
+            println!(
+                "  Enforced: {} rules (P-*), {} rights (Ri-*)",
+                profile.rule_enforcement_count, profile.right_enforcement_count
+            );
+            println!("\nClauses ({}):", profile.clauses.len());
+            for c in &profile.clauses {
+                let mark = if c.enforcement.is_some() { "✓" } else { " " };
+                println!("  {mark} {:<8} [{}] {}", c.id, c.binds, c.gloss);
+            }
+            if let Some(text) = &profile.text {
+                println!("\n--- constitution.md ---\n{text}");
+            }
+            Ok(())
+        }
         super::common::GatewayConstitutionCommands::Proposals { command } => {
             handle_constitution_proposals(&store, command)
         }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,6 +102,18 @@ Show gateway status including connected agents, MCP servers, and scheduler state
 autonoetic gateway status [--json]
 ```
 
+### `autonoetic gateway constitution show`
+
+Show the active constitution: version, canonical digest, signer, enforcement
+counts, and a one-line gloss for every clause (`P-*` rules bind the agent,
+`Ri-*` rights bind the gateway). A `✓` marks clauses the gateway mechanically
+enforces. This is the same lightweight view clients get from the
+`constitution.get` JSON-RPC method; pass `--include-text` for the full markdown.
+
+```bash
+autonoetic gateway constitution show [--include-text] [--json]
+```
+
 ### `autonoetic gateway approvals`
 
 Manage pending approval requests for `agent_revision_promote` and `sandbox_exec` actions.


### PR DESCRIPTION
> Stacked on #423 (base = `feat/rule-id-reporting`). Retarget to `main` once #423 merges.

## Why

The signed constitution is the contract every actor lives under, yet clients could only see its **digest** (`gateway.info`) — the actual principles were buried in the repo. This exposes it for "those interested in the principles": lightweight metadata + a one-line gloss per clause, with the full text on request.

## What

**New JSON-RPC method `constitution.get`** — params `{ include_text?: bool }` (defaults to the lightweight view):
- `version`, `digest` (canonical SHA-256), `format_version`
- `signer_id` + `signed`
- `rule_enforcement_count` / `right_enforcement_count` (mirror the lock)
- `clauses[]` — every `P-*`/`Ri-*` clause as `{ id, binds: agent|gateway, gloss, enforcement? }`
- `text` — full markdown, only when `include_text` is set

`constitution_profile()` builds this from the **loaded, signed** constitution text via the existing `extract_rule_glossary` + enforcement tables — the same source of truth as the compiled-in glossary, so it can't drift from the law.

**CLI:** `autonoetic gateway constitution show [--include-text] [--json]` renders it (`✓` marks mechanically-enforced clauses).

**Types:** `ConstitutionGetParams` / `ConstitutionClause` / `ConstitutionGetResult` in `autonoetic-types` so SDKs share the shape.

## Relationship to existing surfaces
- Complements the agent-facing `constitution_read()` tool (full text + `section` scoping) — this is the lightweight, by-clause view for **external/operator** clients.
- Complements `gateway.info` (digest/version only).

## Sample output
```
Constitution 2026.06.04
  Digest:  47252a1e…
  Signed:  yes (signer autonoetic:constitution:v1)
  Enforced: 172 rules (P-*), 14 rights (Ri-*)
Clauses (186):
  ✓ P-1.1   [agent]   Every tool call matches a declared capability
  ✓ Ri-0.10 [gateway] …
```

## Tests
- `constitution_profile`: metadata mirrors the lock, full clause set, `binds`/enforcement per clause, `include_text` attaches markdown
- `constitution.get` dispatch: null params ⇒ lightweight (no text); `include_text` ⇒ markdown

Note: the new `constitution.get` dispatch test follows the established `test_router()` pattern — these gateway dispatch tests run one-process-per-test (the global constitution `RUNTIME` singleton); each passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)