### PR TITLE
Agent wiki contributions: wiki.propose tool via existing gate pipeline

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1362,6 +1362,168 @@ impl JsonRpcRouter {
                 }
             }
 
+            "wiki.propose" => {
+                #[derive(Deserialize)]
+                struct WikiProposeParams {
+                    id: String,
+                    title: String,
+                    content: String,
+                    #[serde(default)]
+                    tags: Vec<String>,
+                    #[serde(default)]
+                    session_id: Option<String>,
+                    #[serde(default)]
+                    turn_id: Option<String>,
+                    #[serde(default)]
+                    agent_id: Option<String>,
+                }
+
+                let params: WikiProposeParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for wiki.propose: {}", e),
+                        );
+                    }
+                };
+
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "GatewayStore not available".to_string(),
+                        );
+                    }
+                };
+
+                // Resolve agent_id from session binding or parameter
+                let resolved_agent_id = if let Some(aid) = &params.agent_id {
+                    aid.clone()
+                } else if let Some(sid) = &params.session_id {
+                    match store.get_session_agent_binding(sid) {
+                        Ok(Some(binding)) => binding.agent_id,
+                        _ => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                "Could not resolve agent_id from session; provide agent_id explicitly".to_string(),
+                            );
+                        }
+                    }
+                } else {
+                    return JsonRpcResponse::error(
+                        req.id,
+                        -32602,
+                        "agent_id or session_id is required".to_string(),
+                    );
+                };
+
+                let (manifest, _agent_dir) = match self.execution.load_agent_manifest(&resolved_agent_id) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("Failed to load agent manifest for '{}': {}", resolved_agent_id, e),
+                        );
+                    }
+                };
+
+                let is_edit = crate::runtime::tools::wiki::resolve_wiki_dir(
+                    Some(&crate::execution::gateway_root_dir(self.config.as_ref())),
+                )
+                .map(|dir| dir.join(format!("{}.md", &params.id)).exists())
+                .unwrap_or(false);
+
+                let gate_kind = crate::runtime::human_gate::GateKind::WikiProposal {
+                    page_id: params.id.clone(),
+                    title: params.title.clone(),
+                    content: params.content.clone(),
+                    tags: params.tags.clone(),
+                    is_edit,
+                    proposed_by_agent: manifest.agent.id.clone(),
+                    proposed_by_session: params.session_id.clone().unwrap_or_else(|| "unknown".to_string()),
+                };
+
+                let gate = crate::runtime::human_gate::GateService::new(store);
+                let gate_req = crate::runtime::human_gate::GateRequest {
+                    kind: gate_kind,
+                    manifest: &manifest,
+                    session_id: params.session_id.as_deref(),
+                    run_context: None,
+                    config: Some(self.config.as_ref()),
+                    reason: if is_edit {
+                        format!("Edit wiki page '{}': {}", params.id, params.title)
+                    } else {
+                        format!("Propose new wiki page '{}': {}", params.id, params.title)
+                    },
+                    summary: format!("Wiki proposal: {}", params.title),
+                    approval_ref: None,
+                    pre_validated: false,
+                    turn_id: params.turn_id.as_deref(),
+                };
+
+                match gate.check(gate_req) {
+                    Ok(result) => match result {
+                        crate::runtime::human_gate::GateResult::Cleared { .. }
+                        | crate::runtime::human_gate::GateResult::PolicyAllowed => {
+                            JsonRpcResponse::success(
+                                req.id,
+                                serde_json::json!({
+                                    "ok": true,
+                                    "id": params.id,
+                                    "is_edit": is_edit,
+                                    "status": "approved",
+                                }),
+                            )
+                        }
+                        crate::runtime::human_gate::GateResult::AlreadyPending { gate_id, .. } => {
+                            JsonRpcResponse::success(
+                                req.id,
+                                serde_json::json!({
+                                    "ok": true,
+                                    "id": params.id,
+                                    "gate_id": gate_id,
+                                    "is_edit": is_edit,
+                                    "status": "pending",
+                                    "proposed_at": chrono::Utc::now().to_rfc3339(),
+                                }),
+                            )
+                        }
+                        crate::runtime::human_gate::GateResult::Suspended { response_json, .. } => {
+                            match serde_json::from_str::<serde_json::Value>(&response_json) {
+                                Ok(mut resp) => {
+                                    if let Some(obj) = resp.as_object_mut() {
+                                        obj.insert("id".to_string(), serde_json::Value::String(params.id));
+                                        obj.insert("is_edit".to_string(), serde_json::Value::Bool(is_edit));
+                                    }
+                                    JsonRpcResponse::success(req.id, resp)
+                                }
+                                Err(_) => JsonRpcResponse::success(
+                                    req.id,
+                                    serde_json::json!({
+                                        "ok": true,
+                                        "id": params.id,
+                                        "gate_id": null,
+                                        "is_edit": is_edit,
+                                        "status": "pending",
+                                    }),
+                                ),
+                            }
+                        }
+                    },
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("wiki.propose failed: {}", e),
+                    ),
+                }
+            }
+
             "channel.bind" => {
                 // #393 (P3.c): bind an external conversation (Discord thread,
                 // WhatsApp chat) to a room so it survives reconnects and routes

--- a/autonoetic-gateway/src/runtime/analysis/mod.rs
+++ b/autonoetic-gateway/src/runtime/analysis/mod.rs
@@ -145,6 +145,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::SecurityRedTeam => "SecurityRedTeam",
         Capability::CapsuleExport => "CapsuleExport",
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
+        Capability::WikiContribute => "WikiContribute",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/capability_inference.rs
+++ b/autonoetic-gateway/src/runtime/capability_inference.rs
@@ -272,6 +272,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::SecurityRedTeam => "SecurityRedTeam",
         Capability::CapsuleExport => "CapsuleExport",
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
+        Capability::WikiContribute => "WikiContribute",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -50,6 +50,16 @@ pub enum GateKind {
     Escalation {
         reason: String,
     },
+    /// Agent proposes a wiki page addition/update.
+    WikiProposal {
+        page_id: String,
+        title: String,
+        content: String,
+        tags: Vec<String>,
+        is_edit: bool,
+        proposed_by_agent: String,
+        proposed_by_session: String,
+    },
 }
 
 /// How strictly an `approval_ref` must match the current request.
@@ -196,6 +206,7 @@ impl GateService {
             } => self.check_approval(&req, action, targets, *match_strategy),
             GateKind::UserInput { .. } => self.check_user_input(&req),
             GateKind::Escalation { .. } => self.check_escalation(&req),
+            GateKind::WikiProposal { .. } => self.check_wiki_proposal(&req),
         }
     }
 
@@ -424,6 +435,88 @@ impl GateService {
     }
 
     // -----------------------------------------------------------------------
+    // WikiProposal pipeline
+    // -----------------------------------------------------------------------
+
+    fn check_wiki_proposal(&self, req: &GateRequest<'_>) -> Result<GateResult> {
+        let GateKind::WikiProposal {
+            page_id,
+            title,
+            content,
+            tags,
+            is_edit,
+            proposed_by_agent,
+            proposed_by_session,
+        } = &req.kind
+        else {
+            unreachable!()
+        };
+
+        // 1. Capability check.
+        let has_cap = req.manifest.capabilities.iter().any(|c| {
+            matches!(c, autonoetic_types::capability::Capability::WikiContribute)
+        });
+        if !has_cap {
+            anyhow::bail!("Missing capability: WikiContribute");
+        }
+
+        // 2. Pending dedup.
+        if let Some(sid) = req.session_id {
+            if !sid.is_empty() {
+                if let Some(pending_id) = self.find_pending_wiki_proposal(sid, page_id)? {
+                    return Ok(GateResult::AlreadyPending {
+                        gate_id: pending_id,
+                        enforced_rules: vec!["P-2.3"],
+                    });
+                }
+            }
+        }
+
+        // 3. Compute content SHA-256.
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        let content_sha256 = Some(format!("{:x}", hasher.finalize()));
+
+        // 4. Create approval row.
+        let action = ScheduledAction::WikiProposal {
+            page_id: page_id.clone(),
+            title: title.clone(),
+            content: content.clone(),
+            tags: tags.clone(),
+            content_sha256,
+            proposed_by_agent: proposed_by_agent.clone(),
+            proposed_by_session: Some(proposed_by_session.clone()),
+        };
+        let gate_id = self.create_approval_row(req, &action)?;
+
+        // 5. Seed enrichment message.
+        let edit_label = if *is_edit { "edit" } else { "new" };
+        let seed = format!(
+            "Wiki proposal ({}) — page_id: {}, title: {}, proposed by: {}",
+            edit_label, page_id, title, proposed_by_agent
+        );
+        let _ = self.add_gate_message(&gate_id, "system", &seed);
+
+        // 6. Build suspension JSON (tool will NOT suspend — it returns ok:true).
+        let response_json = serde_json::json!({
+            "ok": true,
+            "id": page_id,
+            "gate_id": gate_id,
+            "is_edit": is_edit,
+            "status": "pending",
+            "proposed_at": chrono::Utc::now().to_rfc3339(),
+        })
+        .to_string();
+
+        Ok(GateResult::Suspended {
+            gate_id,
+            response_json,
+            enforced_rules: vec!["P-2.1"],
+        })
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers — approval_ref validation
     // -----------------------------------------------------------------------
 
@@ -566,6 +659,30 @@ impl GateService {
                     req_hosts.iter().any(|h| extract_host_from_target(h) == t_host)
                 });
                 if overlap {
+                    return Ok(Some(req.request_id.clone()));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Find an existing pending wiki proposal for the same session + page_id.
+    fn find_pending_wiki_proposal(
+        &self,
+        session_id: &str,
+        page_id: &str,
+    ) -> Result<Option<String>> {
+        let pending = crate::scheduler::approval::pending_approval_requests_for_session(
+            &autonoetic_types::config::GatewayConfig::default(),
+            Some(&self.store),
+            session_id,
+        )?;
+        for req in &pending {
+            if let ScheduledAction::WikiProposal {
+                page_id: ref pid, ..
+            } = &req.action
+            {
+                if pid == page_id {
                     return Ok(Some(req.request_id.clone()));
                 }
             }

--- a/autonoetic-gateway/src/runtime/reevaluation_state.rs
+++ b/autonoetic-gateway/src/runtime/reevaluation_state.rs
@@ -153,6 +153,9 @@ pub fn execute_scheduled_action(
         ScheduledAction::RevisionPromote { .. } => anyhow::bail!(
             "RevisionPromote is not directly executable; it only gates agent_revision_promote by operator approval (R++2)"
         ),
+        ScheduledAction::WikiProposal { .. } => anyhow::bail!(
+            "WikiProposal is not directly executable; it is materialized by the gateway on operator approval"
+        ),
     }
 }
 

--- a/autonoetic-gateway/src/runtime/state_attestation.rs
+++ b/autonoetic-gateway/src/runtime/state_attestation.rs
@@ -249,6 +249,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::SecurityRedTeam => "SecurityRedTeam",
         Capability::CapsuleExport => "CapsuleExport",
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
+        Capability::WikiContribute => "WikiContribute",
     }
     .to_string()
 }

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -613,6 +613,7 @@ pub(crate) fn capability_type_name(cap: &Capability) -> String {
         Capability::SecurityRedTeam => "SecurityRedTeam".to_string(),
         Capability::CapsuleExport => "CapsuleExport".to_string(),
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess".to_string(),
+        Capability::WikiContribute => "WikiContribute".to_string(),
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/wiki.rs
+++ b/autonoetic-gateway/src/runtime/tools/wiki.rs
@@ -1,9 +1,11 @@
 use crate::llm::ToolDefinition;
 use crate::policy::PolicyEngine;
 use crate::runtime::active_execution_registry::NativeToolRunContext;
+use crate::runtime::human_gate::{GateKind, GateRequest, GateResult, GateService};
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use crate::scheduler::gateway_store::GatewayStore;
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::capability::Capability;
 use autonoetic_types::wiki::{WikiGetResult, WikiListResult, WikiPageEntry};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -12,6 +14,7 @@ use std::sync::Arc;
 pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(WikiListTool));
     registry.register(Box::new(WikiGetTool));
+    registry.register(Box::new(WikiProposeTool));
 }
 
 pub fn resolve_wiki_dir(gateway_dir: Option<&Path>) -> Option<PathBuf> {
@@ -199,5 +202,187 @@ impl NativeTool for WikiGetTool {
         })?;
         let result = get_page(gateway_dir, &args.id)?;
         Ok(serde_json::to_string(&result)?)
+    }
+}
+
+pub struct WikiProposeTool;
+
+impl NativeTool for WikiProposeTool {
+    fn name(&self) -> &'static str {
+        "wiki.propose"
+    }
+
+    fn is_available(&self, manifest: &AgentManifest) -> bool {
+        manifest
+            .capabilities
+            .iter()
+            .any(|c| matches!(c, Capability::WikiContribute))
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name().to_string(),
+            description: "Propose a new wiki page or edit an existing one. \
+                Requires WikiContribute capability. The proposal creates a gate \
+                that the operator must approve before the page is published. \
+                Returns immediately with the gate reference — the agent is NOT \
+                suspended. Use approval.status to check if the proposal is still \
+                pending, approved, or rejected."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                        "description": "Page ID (lowercase, hyphens allowed, e.g. 'runbook-agent-creation')"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Human-readable page title"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Full markdown content (max 64 KiB)"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional tags for categorization"
+                    }
+                },
+                "required": ["id", "title", "content"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        manifest: &AgentManifest,
+        _policy: &PolicyEngine,
+        _agent_dir: &Path,
+        gateway_dir: Option<&Path>,
+        arguments_json: &str,
+        session_id: Option<&str>,
+        _turn_id: Option<&str>,
+        config: Option<&autonoetic_types::config::GatewayConfig>,
+        gateway_store: Option<Arc<GatewayStore>>,
+        run_context: Option<&NativeToolRunContext>,
+    ) -> anyhow::Result<String> {
+        #[derive(Deserialize)]
+        struct ProposeArgs {
+            id: String,
+            title: String,
+            content: String,
+            #[serde(default)]
+            tags: Vec<String>,
+        }
+        let args: ProposeArgs = serde_json::from_str(arguments_json).map_err(|e| {
+            anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e)
+        })?;
+
+        // Validate id pattern
+        let re = regex::Regex::new(r"^[a-z0-9]+(-[a-z0-9]+)*$").unwrap();
+        if !re.is_match(&args.id) {
+            anyhow::bail!(
+                "Invalid page id '{}': must match pattern [a-z0-9]+(-[a-z0-9]+)*",
+                args.id
+            );
+        }
+
+        // Validate content size
+        if args.content.is_empty() {
+            anyhow::bail!("Content must not be empty");
+        }
+        if args.content.len() > 65536 {
+            anyhow::bail!("Content exceeds maximum size of 64 KiB");
+        }
+
+        // Check if this is an edit (page already exists)
+        let is_edit = resolve_wiki_dir(gateway_dir)
+            .map(|dir| dir.join(format!("{}.md", &args.id)).exists())
+            .unwrap_or(false);
+
+        // Get session reference
+        let sid = session_id.unwrap_or("unknown").to_string();
+        let agent_id = manifest.agent.id.clone();
+
+        // Build GateKind
+        let kind = GateKind::WikiProposal {
+            page_id: args.id.clone(),
+            title: args.title.clone(),
+            content: args.content.clone(),
+            tags: args.tags.clone(),
+            is_edit,
+            proposed_by_agent: agent_id,
+            proposed_by_session: sid,
+        };
+
+        // Run through GateService
+        let store = gateway_store
+            .ok_or_else(|| anyhow::anyhow!("GatewayStore not available"))?;
+        let gate = GateService::new(store);
+        let gate_req = GateRequest {
+            kind,
+            manifest,
+            session_id,
+            run_context,
+            config,
+            reason: if is_edit {
+                format!("Edit wiki page '{}': {}", args.id, args.title)
+            } else {
+                format!("Propose new wiki page '{}': {}", args.id, args.title)
+            },
+            summary: format!("Wiki proposal: {}", args.title),
+            approval_ref: None,
+            pre_validated: false,
+            turn_id: None,
+        };
+
+        let result = gate.check(gate_req)?;
+
+        match result {
+            GateResult::Cleared { .. } => {
+                // Should not happen for WikiProposal; return success with no gate_id
+                Ok(serde_json::json!({
+                    "ok": true,
+                    "id": args.id,
+                    "is_edit": is_edit,
+                    "status": "approved"
+                })
+                .to_string())
+            }
+            GateResult::AlreadyPending { gate_id, .. } => {
+                Ok(serde_json::json!({
+                    "ok": true,
+                    "id": args.id,
+                    "gate_id": gate_id,
+                    "is_edit": is_edit,
+                    "status": "pending",
+                    "proposed_at": chrono::Utc::now().to_rfc3339(),
+                })
+                .to_string())
+            }
+            GateResult::Suspended { gate_id, response_json, .. } => {
+                // Return the gate_id — the agent is NOT suspended for wiki proposals
+                let mut resp: serde_json::Value =
+                    serde_json::from_str(&response_json).unwrap_or_default();
+                if let Some(obj) = resp.as_object_mut() {
+                    obj.insert("id".to_string(), serde_json::Value::String(args.id));
+                    obj.insert("is_edit".to_string(), serde_json::Value::Bool(is_edit));
+                }
+                Ok(resp.to_string())
+            }
+            GateResult::PolicyAllowed => {
+                Ok(serde_json::json!({
+                    "ok": true,
+                    "id": args.id,
+                    "is_edit": is_edit,
+                    "status": "approved"
+                })
+                .to_string())
+            }
+        }
     }
 }

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -440,6 +440,110 @@ pub fn approve_request_with_options(
         }
     }
 
+    // WikiProposal materialization
+    if let ScheduledAction::WikiProposal {
+        page_id,
+        title,
+        content,
+        tags,
+        content_sha256,
+        proposed_by_agent,
+        proposed_by_session,
+    } = &decision.action
+    {
+        if matches!(decision.status, ApprovalStatus::Approved) {
+            let wiki_dir = crate::execution::gateway_root_dir(config).join("wiki");
+            if let Err(e) = std::fs::create_dir_all(&wiki_dir) {
+                anyhow::bail!("Failed to create wiki directory: {}", e);
+            }
+            // Write .md file atomically via temp rename
+            let md_path = wiki_dir.join(format!("{}.md", page_id));
+            let tmp_path = wiki_dir.join(format!("{}.md.tmp", page_id));
+            if let Err(e) = std::fs::write(&tmp_path, content.as_bytes()) {
+                anyhow::bail!("Failed to write wiki page: {}", e);
+            }
+            if let Err(e) = std::fs::rename(&tmp_path, &md_path) {
+                let _ = std::fs::remove_file(&tmp_path);
+                anyhow::bail!("Failed to rename wiki page: {}", e);
+            }
+            // Update index.toml
+            let index_path = wiki_dir.join("index.toml");
+            let mut index: Vec<toml::Value> = if index_path.exists() {
+                let index_content = std::fs::read_to_string(&index_path).unwrap_or_default();
+                match index_content.parse::<toml::Value>() {
+                    Ok(v) => v.get("pages").and_then(|p| p.as_array().cloned()).unwrap_or_default(),
+                    Err(_) => Vec::new(),
+                }
+            } else {
+                Vec::new()
+            };
+            let entry = toml::Value::Table({
+                let mut m = toml::map::Map::new();
+                m.insert("id".to_string(), toml::Value::String(page_id.clone()));
+                m.insert("title".to_string(), toml::Value::String(title.clone()));
+                m.insert("file".to_string(), toml::Value::String(format!("{}.md", page_id)));
+                m.insert("tags".to_string(), toml::Value::Array(
+                    tags.iter().map(|t| toml::Value::String(t.clone())).collect()
+                ));
+                m
+            });
+            if let Some(pos) = index.iter().position(|e| {
+                e.get("id").and_then(|v| v.as_str()) == Some(page_id.as_str())
+            }) {
+                index[pos] = entry;
+            } else {
+                index.push(entry);
+            }
+            let index_content = toml::Value::Table({
+                let mut m = toml::map::Map::new();
+                m.insert("pages".to_string(), toml::Value::Array(index));
+                m
+            });
+            let toml_str = index_content.to_string();
+            let tmp_index = wiki_dir.join("index.toml.tmp");
+            if let Err(e) = std::fs::write(&tmp_index, &toml_str) {
+                anyhow::bail!("Failed to write index.toml: {}", e);
+            }
+            if let Err(e) = std::fs::rename(&tmp_index, &index_path) {
+                let _ = std::fs::remove_file(&tmp_index);
+                anyhow::bail!("Failed to rename index.toml: {}", e);
+            }
+            tracing::info!(
+                target: "approval",
+                page_id = %page_id,
+                title = %title,
+                "Wiki page promoted via approval"
+            );
+            // Emit causal event
+            let causal_logger = crate::execution::init_gateway_causal_logger(config)?;
+            let mut trace_session = crate::tracing::TraceSession::create_with_session_id(
+                crate::tracing::SessionId::from_string(decision.session_id.clone()),
+                std::sync::Arc::new(causal_logger),
+                crate::execution::gateway_actor_id(),
+                crate::tracing::EventScope::Session,
+            );
+            let _ = trace_session.log_completed(
+                "wiki.promoted",
+                None,
+                Some(serde_json::json!({
+                    "page_id": page_id,
+                    "title": title,
+                    "content_sha256": content_sha256,
+                    "proposed_by_agent": proposed_by_agent,
+                    "proposed_by_session": proposed_by_session,
+                    "approved_by": decision.decided_by,
+                })),
+            );
+        } else {
+            tracing::info!(
+                target: "approval",
+                page_id = %page_id,
+                status = ?decision.status,
+                "Wiki proposal rejected or cancelled; content discarded"
+            );
+        }
+    }
+
     // Lawful Gate model: notify the waiting session, do not auto-execute.
     if should_resume_waiting_session(&decision) {
         if let Err(e) =

--- a/autonoetic-gateway/src/scheduler/approval_hardening.rs
+++ b/autonoetic-gateway/src/scheduler/approval_hardening.rs
@@ -38,6 +38,7 @@ pub fn classify_approval_risk(action: &ScheduledAction) -> ApprovalRisk {
         ScheduledAction::SessionContinue { .. } => ApprovalRisk::Standard,
         ScheduledAction::ProfileShare { .. } => ApprovalRisk::Standard,
         ScheduledAction::WriteFile { .. } => ApprovalRisk::Standard,
+        ScheduledAction::WikiProposal { .. } => ApprovalRisk::Standard,
     }
 }
 

--- a/autonoetic-types/src/background.rs
+++ b/autonoetic-types/src/background.rs
@@ -275,6 +275,20 @@ pub enum ScheduledAction {
         #[serde(default)]
         payload: Option<serde_json::Value>,
     },
+    /// Wiki page contribution proposal. Approval subject only — not executed
+    /// by the scheduler. On operator approval, the gateway materializes the
+    /// page into .gateway/wiki/.
+    WikiProposal {
+        page_id: String,
+        title: String,
+        content: String,
+        tags: Vec<String>,
+        #[serde(default)]
+        content_sha256: Option<String>,
+        proposed_by_agent: String,
+        #[serde(default)]
+        proposed_by_session: Option<String>,
+    },
 }
 
 impl ScheduledAction {
@@ -290,6 +304,7 @@ impl ScheduledAction {
                 | Self::SessionEscalate { .. }
                 | Self::LayerMount { .. }
                 | Self::RevisionPromote { .. }
+                | Self::WikiProposal { .. }
         )
     }
 
@@ -311,7 +326,8 @@ impl ScheduledAction {
             | Self::ProfileShare { .. }
             | Self::SessionEscalate { .. }
             | Self::LayerMount { .. }
-            | Self::RevisionPromote { .. } => true,
+            | Self::RevisionPromote { .. }
+            | Self::WikiProposal { .. } => true,
         }
     }
 
@@ -348,6 +364,7 @@ impl ScheduledAction {
             Self::SessionEscalate { .. } => "session_escalate",
             Self::LayerMount { .. } => "layer_mount",
             Self::RevisionPromote { .. } => "revision_promote",
+            Self::WikiProposal { .. } => "wiki_propose",
         }
     }
 
@@ -365,7 +382,8 @@ impl ScheduledAction {
             | Self::ProfileShare { .. }
             | Self::SessionEscalate { .. }
             | Self::LayerMount { .. }
-            | Self::RevisionPromote { .. } => None,
+            | Self::RevisionPromote { .. }
+            | Self::WikiProposal { .. } => None,
         }
     }
 
@@ -387,7 +405,8 @@ impl ScheduledAction {
             | Self::ProfileShare { .. }
             | Self::SessionEscalate { .. }
             | Self::LayerMount { .. }
-            | Self::RevisionPromote { .. } => {}
+            | Self::RevisionPromote { .. }
+            | Self::WikiProposal { .. } => {}
         }
         self
     }

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -171,6 +171,11 @@ pub enum Capability {
     /// `docs/cognitive-capsule.md`.
     CapsuleExport,
 
+    /// Propose new wiki pages (docs) to be curated into the platform wiki.
+    /// Writing durable documentation is a trust boundary — requires judgment.
+    /// Only agents with this capability can call wiki.propose.
+    WikiContribute,
+
     /// Access to PlanFrame operations (propose, amend, approve, list, get).
     /// Controls whether an agent can create and modify collaborative plans.
     /// The `patterns` field restricts which operations are allowed.
@@ -325,6 +330,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::SecurityRedTeam => "SecurityRedTeam".to_string(),
         Capability::CapsuleExport => "CapsuleExport".to_string(),
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess".to_string(),
+        Capability::WikiContribute => "WikiContribute".to_string(),
     }
 }
 

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -8217,6 +8217,13 @@ fn format_scheduled_action_detail_lines(action: &ScheduledAction) -> Vec<String>
             }
             v
         }
+        ScheduledAction::WikiProposal {
+            page_id, title, ..
+        } => vec![
+            "type: wiki_propose".to_string(),
+            format!("  page_id: {}", clamp_chat_field(page_id)),
+            format!("  title: {}", clamp_chat_field(title)),
+        ],
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a  tool that lets agents contribute wiki pages through the existing operator approval pipeline. This is Phase 1 (Core Pipeline) of the wiki contributions design in `docs/design/agent-wiki-contributions.md`.

## What's implemented

- **`Capability::WikiContribute`** — trust boundary; declared in SKILL.md, not a default capability
- **`ScheduledAction::WikiProposal`** — approval subject variant (not executable by scheduler)
- **`GateKind::WikiProposal`** — new gate variant flowing through existing `GateService` dedup/flood-cap/session-grant infrastructure
- **`wiki.propose(id, title, content, tags?)`** NativeTool:
  - Validates id matches `[a-z0-9]+(-[a-z0-9]+)*`
  - Validates content ≤ 64 KiB
  - Detects is_edit (page ID already exists in `.gateway/wiki/`)
  - Returns immediately with gate reference (no session suspension)
  - Dedup: same page_id while pending → AlreadyPending
- **Materialization** on operator `approvals.approve`:
  - Atomic write of `{page_id}.md` to `.gateway/wiki/`
  - Updates `index.toml` (add or replace entry)
- **Causal event**: `wiki.proposed` enrichment on creation

## Files changed

13 files, +611/−3 lines.

## Testing

```
cargo build          ✓
cargo test -p autonoetic-gateway --lib  1156 pass, 30 pre-existing failures
```

No regressions.

## Next phases (not in this PR)

- Phase 2: Operator UX (Room TUI wiki gate display, keybindings)
- Phase 3: Quality governance (content heuristics, similarity scoring, auto-expiry)

Closes #425