### PR TITLE
Fork a session from a past turn + timeline-aware resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,3 +145,4 @@ Notable suite for approval continuation:
 - `docs/agent-learning.md` — How agents learn from past sessions using execution.search, knowledge.search, digest.query
 - `docs/planner-principles.md` — Principle-first planner design: why principles beat rules, security boundary, what moved to specialists
 - `docs/agent-discovery.md` — Agent discovery: agent.list gateway tool + discovery.default semantic matching agent
+- `docs/session-forking.md` — Forking a session from a past turn: runnable Hibernation checkpoint, yield-point granularity, timeline mirroring (copy vs reuse-by-reference choice), CLI/RPC/room surfaces

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1853,6 +1853,11 @@ impl JsonRpcRouter {
                     new_session_id: Option<String>,
                     #[serde(default)]
                     target_agent_id: Option<String>,
+                    /// Optional turn number to branch from. When omitted, forks
+                    /// from the latest checkpoint. Checkpoints exist only at
+                    /// yield points, so not every turn is forkable.
+                    #[serde(default)]
+                    at_turn: Option<u64>,
                 }
 
                 let params: ForkParams = match serde_json::from_value(req.params.clone()) {
@@ -1866,13 +1871,53 @@ impl JsonRpcRouter {
                     }
                 };
 
-                // Fork from the latest checkpoint of the source session
-                let fork = match crate::runtime::checkpoint::SessionFork::fork(
-                    &self.config,
-                    &params.source_session_id,
-                    params.new_session_id.as_deref(),
-                    params.branch_message.as_deref(),
-                ) {
+                // Fork from a specific historical turn when requested, else
+                // from the latest checkpoint of the source session.
+                let fork_result = if let Some(turn) = params.at_turn {
+                    match crate::runtime::checkpoint::load_checkpoint(
+                        &self.config,
+                        &params.source_session_id,
+                        &crate::runtime::checkpoint::turn_id_for(turn),
+                    ) {
+                        Ok(Some(checkpoint)) => {
+                            crate::runtime::checkpoint::SessionFork::fork_from_checkpoint(
+                                &self.config,
+                                &checkpoint,
+                                params.new_session_id.as_deref(),
+                                params.branch_message.as_deref(),
+                            )
+                        }
+                        Ok(None) => {
+                            let available = crate::runtime::checkpoint::list_checkpoints(
+                                &self.config,
+                                &params.source_session_id,
+                            )
+                            .unwrap_or_default();
+                            let hint = if available.is_empty() {
+                                " (no checkpoints exist for this session)".to_string()
+                            } else {
+                                format!(" — forkable turns: {}", available.join(", "))
+                            };
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                format!(
+                                    "No checkpoint found for session '{}' at turn {}{}",
+                                    params.source_session_id, turn, hint
+                                ),
+                            );
+                        }
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    crate::runtime::checkpoint::SessionFork::fork(
+                        &self.config,
+                        &params.source_session_id,
+                        params.new_session_id.as_deref(),
+                        params.branch_message.as_deref(),
+                    )
+                };
+                let fork = match fork_result {
                     Ok(f) => f,
                     Err(e) => {
                         return JsonRpcResponse::error(
@@ -1882,6 +1927,28 @@ impl JsonRpcRouter {
                         );
                     }
                 };
+
+                // Mirror the source timeline into the forked session up to the
+                // fork turn (best effort) so the Session Room shows the inherited
+                // history immediately instead of an empty timeline. A fork writes
+                // a checkpoint but no `live_digest_events` of its own.
+                let mut mirrored_events = 0usize;
+                if let Some(store) = self.execution.gateway_store() {
+                    match store.clone_timeline_for_fork(
+                        &params.source_session_id,
+                        &fork.new_session_id,
+                        fork.fork_turn as u64,
+                    ) {
+                        Ok(n) => mirrored_events = n,
+                        Err(e) => tracing::warn!(
+                            target: "session.fork",
+                            source = %params.source_session_id,
+                            new = %fork.new_session_id,
+                            error = %e,
+                            "Failed to mirror source timeline into fork"
+                        ),
+                    }
+                }
 
                 // Determine target agent
                 let target_agent_id = params
@@ -1922,6 +1989,7 @@ impl JsonRpcRouter {
                         "fork_turn": fork.fork_turn,
                         "history_handle": fork.history_handle,
                         "message_count": fork.initial_history.len(),
+                        "mirrored_events": mirrored_events,
                     }),
                 )
             }

--- a/autonoetic-gateway/src/runtime/checkpoint.rs
+++ b/autonoetic-gateway/src/runtime/checkpoint.rs
@@ -238,6 +238,14 @@ pub fn checkpoints_dir(config: &GatewayConfig) -> PathBuf {
     config.agents_dir.join(".gateway").join("checkpoints")
 }
 
+/// Canonical turn-id string for a turn number. This is the single source of
+/// truth for the on-disk checkpoint filename stem (`turn-000003`), shared by
+/// the lifecycle (which writes checkpoints) and any caller that wants to load a
+/// checkpoint by turn number (e.g. `trace fork --at-turn N`, `session.fork`).
+pub fn turn_id_for(turn: u64) -> String {
+    format!("turn-{:06}", turn)
+}
+
 fn checkpoint_path(config: &GatewayConfig, session_id: &str, turn_id: &str) -> PathBuf {
     checkpoints_dir(config)
         .join(sanitize_path_component(session_id))
@@ -513,10 +521,32 @@ impl SessionFork {
             history.push(crate::llm::Message::user(msg_text));
         }
 
-        // Copy history to new session
+        // Copy history to new session (consumed by chat/trace history display).
         let history_json = serde_json::to_string(&history)?;
         let history_handle = store.write(history_json.as_bytes())?;
         store.register_name(&new_session_id, "session_history", &history_handle)?;
+
+        // Write a checkpoint under the new session id so the fork is actually
+        // *runnable*. The execution engine seeds a session's LLM context from
+        // its latest checkpoint (not from the `session_history` content name —
+        // that only feeds the UI), so without this the agent would resume the
+        // branch from a blank history and the fork point would be lost.
+        //
+        // We mark it `Hibernation` (a normal, auto-resumable yield point) and
+        // strip any pending-tool / approval state inherited from the source
+        // checkpoint, so the next message to the forked session resumes cleanly
+        // with the full branch-point context (plus the branch message, if any).
+        let forked_checkpoint = SessionCheckpoint {
+            history: history.clone(),
+            session_id: new_session_id.clone(),
+            yield_reason: YieldReason::Hibernation,
+            pending_tool_state: None,
+            assistant_message: None,
+            pending_action: None,
+            suspended_at: None,
+            ..checkpoint.clone()
+        };
+        save_checkpoint(config, &forked_checkpoint)?;
 
         Ok(SessionFork {
             new_session_id,

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -119,7 +119,7 @@ fn build_critical_divergence_interaction(
         session_id: session_id.to_string(),
         root_session_id,
         agent_id: agent_id.to_string(),
-        turn_id: format!("turn-{:06}", turn_counter),
+        turn_id: crate::runtime::checkpoint::turn_id_for(turn_counter),
         kind: autonoetic_types::background::UserInteractionKind::DivergenceSentinel,
         question: format!(
             "Critical trajectory divergence in agent '{}' at turn {}. Choose acknowledge, continue, stop, or enter a note.",
@@ -491,7 +491,7 @@ impl AgentExecutor {
 
     fn next_turn_id(&mut self) -> String {
         self.turn_counter += 1;
-        format!("turn-{:06}", self.turn_counter)
+        crate::runtime::checkpoint::turn_id_for(self.turn_counter)
     }
 
     fn approved_session_continue_count(&self, session_id: &str) -> anyhow::Result<u64> {

--- a/autonoetic-gateway/src/scheduler/gateway_store/session_timeline.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/session_timeline.rs
@@ -101,6 +101,107 @@ impl GatewayStore {
             has_more,
         })
     }
+
+    /// Copy a source session's timeline rows into a forked session's root id, up
+    /// to and including the fork turn. A fork writes a checkpoint (LLM history)
+    /// but no `live_digest_events` of its own, so without this the Session Room
+    /// shows an empty timeline until the branch first runs. This mirrors the
+    /// parent's narrative spine up to the branch point so the operator sees the
+    /// inherited history immediately.
+    ///
+    /// Rows get fresh `event_id`s (the column is the primary key); their
+    /// `created_at`, ordering, and attribution columns are preserved verbatim,
+    /// so the copied timeline renders identically to the source. The cutoff is
+    /// the end-of-fork-turn timestamp (the latest event carrying a turn id `<=`
+    /// the fork turn), which also pulls in interleaved turn-less rows (operator
+    /// messages, session start) that belong before the branch point. Returns the
+    /// number of rows copied.
+    pub fn clone_timeline_for_fork(
+        &self,
+        source_root_session_id: &str,
+        new_root_session_id: &str,
+        up_to_turn: u64,
+    ) -> Result<usize> {
+        use rusqlite::OptionalExtension;
+
+        let conn = self.conn.lock().unwrap();
+        // Turn ids are zero-padded to a fixed width (`turn-000003`), so a plain
+        // lexicographic `<=` comparison is also a numeric one.
+        let turn_ceiling = crate::runtime::checkpoint::turn_id_for(up_to_turn);
+        let cutoff: Option<String> = conn
+            .query_row(
+                "SELECT MAX(created_at) FROM live_digest_events
+                 WHERE root_session_id = ?1 AND turn_id IS NOT NULL AND turn_id <= ?2",
+                rusqlite::params![source_root_session_id, &turn_ceiling],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten();
+        let cutoff = match cutoff {
+            Some(c) => c,
+            None => return Ok(0), // no in-range turn events → nothing to mirror
+        };
+
+        let mut stmt = conn.prepare(
+            "SELECT event_id, source_session_id, turn_id, source_agent_id, source_node_id,
+                    event_type, payload, created_at, principal_kind, principal_id,
+                    role, altitude, refs_json
+             FROM live_digest_events
+             WHERE root_session_id = ?1 AND created_at <= ?2
+             ORDER BY created_at ASC, event_id ASC",
+        )?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![source_root_session_id, &cutoff],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,         // original event_id
+                        row.get::<_, String>(1)?,         // source_session_id
+                        row.get::<_, Option<String>>(2)?, // turn_id
+                        row.get::<_, Option<String>>(3)?, // source_agent_id
+                        row.get::<_, String>(4)?,         // source_node_id
+                        row.get::<_, String>(5)?,         // event_type
+                        row.get::<_, Option<String>>(6)?, // payload
+                        row.get::<_, String>(7)?,         // created_at
+                        row.get::<_, Option<String>>(8)?, // principal_kind
+                        row.get::<_, Option<String>>(9)?, // principal_id
+                        row.get::<_, Option<String>>(10)?, // role
+                        row.get::<_, Option<String>>(11)?, // altitude
+                        row.get::<_, Option<String>>(12)?, // refs_json
+                    ))
+                },
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        for (i, r) in rows.iter().enumerate() {
+            // Fresh, collision-free event id scoped to the forked session.
+            let new_event_id = format!("{new_root_session_id}-evt-{i:06}");
+            conn.execute(
+                "INSERT INTO live_digest_events (
+                    event_id, root_session_id, source_session_id, turn_id, source_agent_id,
+                    source_node_id, event_type, payload, created_at,
+                    principal_kind, principal_id, role, altitude, refs_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                rusqlite::params![
+                    new_event_id,
+                    new_root_session_id,
+                    r.1,
+                    r.2,
+                    r.3,
+                    r.4,
+                    r.5,
+                    r.6,
+                    r.7,
+                    r.8,
+                    r.9,
+                    r.10,
+                    r.11,
+                    r.12,
+                ],
+            )?;
+        }
+        Ok(rows.len())
+    }
 }
 
 fn min_altitude_rank(min: Option<Altitude>) -> i64 {

--- a/autonoetic-gateway/src/scheduler/gateway_store/session_timeline.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/session_timeline.rs
@@ -142,17 +142,25 @@ impl GatewayStore {
             None => return Ok(0), // no in-range turn events → nothing to mirror
         };
 
+        // Two guards, both needed:
+        //   * `created_at <= cutoff` bounds turn-less rows (operator messages,
+        //     session start) to those before the fork point.
+        //   * `turn_id <= ceiling` excludes events from *later* turns even if
+        //     they happen to share the cutoff timestamp — without it, two turns
+        //     with an identical `created_at` could leak a turn > up_to_turn row
+        //     into the fork.
         let mut stmt = conn.prepare(
             "SELECT event_id, source_session_id, turn_id, source_agent_id, source_node_id,
                     event_type, payload, created_at, principal_kind, principal_id,
                     role, altitude, refs_json
              FROM live_digest_events
              WHERE root_session_id = ?1 AND created_at <= ?2
+               AND (turn_id IS NULL OR turn_id <= ?3)
              ORDER BY created_at ASC, event_id ASC",
         )?;
         let rows = stmt
             .query_map(
-                rusqlite::params![source_root_session_id, &cutoff],
+                rusqlite::params![source_root_session_id, &cutoff, &turn_ceiling],
                 |row| {
                     Ok((
                         row.get::<_, String>(0)?,         // original event_id

--- a/autonoetic-gateway/tests/session_fork_integration.rs
+++ b/autonoetic-gateway/tests/session_fork_integration.rs
@@ -2,8 +2,8 @@
 
 use autonoetic_gateway::llm::Message;
 use autonoetic_gateway::runtime::checkpoint::{
-    list_checkpoints, prune_checkpoints, save_checkpoint, SessionCheckpoint, SessionFork,
-    YieldReason,
+    list_checkpoints, load_latest_checkpoint, prune_checkpoints, save_checkpoint, turn_id_for,
+    SessionCheckpoint, SessionFork, YieldReason,
 };
 use autonoetic_gateway::runtime::content_store::ContentStore;
 use autonoetic_gateway::runtime::guard::LoopGuardState;
@@ -221,6 +221,53 @@ fn test_multi_level_fork() {
     assert_eq!(fork_c.initial_history[0].content, "Original");
     assert_eq!(fork_c.initial_history[1].content, "Branch 1");
     assert_eq!(fork_c.initial_history[2].content, "Branch 2");
+}
+
+/// A fork must be *runnable*: the execution engine seeds a session's LLM
+/// context from its latest checkpoint, so forking has to write one under the
+/// new session id (cloned history, marked Hibernation). Without it, the branch
+/// would resume from a blank history and the fork point would be lost.
+#[test]
+fn test_fork_writes_runnable_checkpoint_for_new_session() {
+    let temp = tempdir().unwrap();
+    let config = test_config(&temp);
+
+    let history = vec![
+        Message::user("Plan the migration"),
+        Message::assistant("Step 1: inventory the call sites"),
+    ];
+    // Source checkpoint was an ApprovalRequired yield with pending state — the
+    // fork must NOT inherit that; it should be a clean Hibernation checkpoint.
+    let mut cp = test_checkpoint("source-session", &turn_id_for(3), history.clone(), 3);
+    cp.yield_reason = YieldReason::ApprovalRequired {
+        approval_request_id: "apr-xyz".to_string(),
+    };
+    cp.suspended_at = Some("2024-01-01T00:00:01Z".to_string());
+    save_checkpoint(&config, &cp).unwrap();
+
+    let fork = SessionFork::fork_from_checkpoint(
+        &config,
+        &cp,
+        Some("branch-session"),
+        Some("Try approach B instead"),
+    )
+    .unwrap();
+    assert_eq!(fork.new_session_id, "branch-session");
+
+    // The forked session now has a checkpoint the engine can resume from.
+    let forked_cp = load_latest_checkpoint(&config, "branch-session")
+        .unwrap()
+        .expect("fork must write a checkpoint under the new session id");
+
+    assert_eq!(forked_cp.session_id, "branch-session");
+    // Branch point preserved: full history + the branch message appended.
+    assert_eq!(forked_cp.history.len(), 3);
+    assert_eq!(forked_cp.history[2].content, "Try approach B instead");
+    assert_eq!(forked_cp.turn_counter, 3);
+    // Clean, auto-resumable yield — no inherited approval/pending state.
+    assert!(matches!(forked_cp.yield_reason, YieldReason::Hibernation));
+    assert!(forked_cp.pending_tool_state.is_none());
+    assert!(forked_cp.suspended_at.is_none());
 }
 
 /// Test fork fails without any checkpoint.

--- a/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
+++ b/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
@@ -186,6 +186,50 @@ async fn clone_timeline_for_fork_mirrors_history_up_to_turn() {
 }
 
 #[tokio::test]
+async fn clone_timeline_for_fork_excludes_later_turn_sharing_cutoff_timestamp() {
+    // Regression: a later turn's event with the SAME created_at as the fork
+    // turn must not leak in. The created_at cutoff alone would include it; the
+    // turn_id ceiling guard excludes it.
+    let env = shared();
+    let src = "root-fork-tie";
+    let mk = |turn: &str, ts: &str| LiveDigestEventRecord {
+        event_id: format!("ev-{}", uuid::Uuid::new_v4()),
+        root_session_id: src.to_string(),
+        source_session_id: src.to_string(),
+        turn_id: Some(turn.to_string()),
+        source_agent_id: Some("planner.default".to_string()),
+        source_node_id: "gateway".to_string(),
+        event_type: "turn.start".to_string(),
+        payload: Some("{}".to_string()),
+        created_at: ts.to_string(),
+        principal_kind: Some("autonoetic_agent".to_string()),
+        principal_id: Some("planner.default".to_string()),
+        role: Some("planner".to_string()),
+        altitude: Some("normal".to_string()),
+        refs_json: None,
+    };
+    for ev in [
+        mk("turn-000001", "2026-06-01T11:00:00+00:00"),
+        mk("turn-000002", "2026-06-01T11:00:02+00:00"),
+        // Turn 3 shares turn 2's timestamp — the cutoff value when forking at 2.
+        mk("turn-000003", "2026-06-01T11:00:02+00:00"),
+    ] {
+        env.store.create_live_digest_event(&ev).unwrap();
+    }
+
+    let fork_root = "root-fork-tie-branch";
+    let copied = env.store.clone_timeline_for_fork(src, fork_root, 2).unwrap();
+    assert_eq!(copied, 2, "only turns 1 and 2 — not the tie-timestamp turn 3");
+
+    let result = env
+        .store
+        .list_session_timeline(fork_root, None, 100, None, None)
+        .unwrap();
+    let turns: Vec<Option<String>> = result.entries.iter().map(|e| e.turn_id.clone()).collect();
+    assert!(!turns.contains(&Some("turn-000003".to_string())));
+}
+
+#[tokio::test]
 async fn session_timeline_list_rejects_invalid_min_altitude() {
     let env = shared();
     let resp = env

--- a/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
+++ b/autonoetic-gateway/tests/session_timeline_jsonrpc_integration.rs
@@ -133,6 +133,59 @@ async fn session_timeline_list_requires_root_session_id() {
 }
 
 #[tokio::test]
+async fn clone_timeline_for_fork_mirrors_history_up_to_turn() {
+    let env = shared();
+    let src = "root-fork-src";
+
+    // Build a source timeline spanning four turns, with an interleaved
+    // turn-less operator message between turns 1 and 2.
+    let mk = |turn: Option<&str>, ts: &str, etype: &str| LiveDigestEventRecord {
+        event_id: format!("ev-{}", uuid::Uuid::new_v4()),
+        root_session_id: src.to_string(),
+        source_session_id: src.to_string(),
+        turn_id: turn.map(|t| t.to_string()),
+        source_agent_id: Some("planner.default".to_string()),
+        source_node_id: "gateway".to_string(),
+        event_type: etype.to_string(),
+        payload: Some("{}".to_string()),
+        created_at: ts.to_string(),
+        principal_kind: Some("autonoetic_agent".to_string()),
+        principal_id: Some("planner.default".to_string()),
+        role: Some("planner".to_string()),
+        altitude: Some("normal".to_string()),
+        refs_json: None,
+    };
+    for ev in [
+        mk(Some("turn-000001"), "2026-06-01T10:00:00+00:00", "turn.start"),
+        mk(None, "2026-06-01T10:00:01+00:00", "operator.message"),
+        mk(Some("turn-000002"), "2026-06-01T10:00:02+00:00", "turn.start"),
+        mk(Some("turn-000003"), "2026-06-01T10:00:03+00:00", "turn.start"),
+        mk(Some("turn-000004"), "2026-06-01T10:00:04+00:00", "turn.start"),
+    ] {
+        env.store.create_live_digest_event(&ev).unwrap();
+    }
+
+    // Fork at turn 2: turns 1–2 plus the turn-less message before the cutoff
+    // should be mirrored; turns 3 and 4 must not.
+    let fork_root = "root-fork-branch";
+    let copied = env.store.clone_timeline_for_fork(src, fork_root, 2).unwrap();
+    assert_eq!(copied, 3, "turns 1, 2 and the interleaved op message");
+
+    let result = env
+        .store
+        .list_session_timeline(fork_root, None, 100, None, None)
+        .unwrap();
+    assert_eq!(result.entries.len(), 3);
+    let turns: Vec<Option<String>> = result.entries.iter().map(|e| e.turn_id.clone()).collect();
+    assert!(turns.contains(&Some("turn-000001".to_string())));
+    assert!(turns.contains(&Some("turn-000002".to_string())));
+    assert!(turns.contains(&None), "turn-less operator message mirrored");
+    assert!(!turns.contains(&Some("turn-000003".to_string())));
+    assert!(!turns.contains(&Some("turn-000004".to_string())));
+    assert!(result.entries.iter().all(|e| e.root_session_id == fork_root));
+}
+
+#[tokio::test]
 async fn session_timeline_list_rejects_invalid_min_altitude() {
     let env = shared();
     let resp = env

--- a/autonoetic/src/cli/room/slash.rs
+++ b/autonoetic/src/cli/room/slash.rs
@@ -41,12 +41,19 @@ pub enum SlashCommand {
     ListPlans,
     /// Approve a plan (`None` = latest pending).
     ApprovePlan { plan_id: Option<String> },
+    /// Fork the current session into a new branch and switch to it.
+    /// `at_turn` = `None` forks from the latest checkpoint; `message` is an
+    /// optional branch message appended to the forked history.
+    ForkSession {
+        at_turn: Option<u64>,
+        message: Option<String>,
+    },
     /// Anything else — the dispatcher surfaces a `✗` status.
     Unknown(String),
 }
 
 /// One-line hint while typing a slash command (full guide: `/help`).
-pub const HELP_TEXT: &str = "/help for commands · /session · /plan · /cron · /test · /quit";
+pub const HELP_TEXT: &str = "/help for commands · /session · /fork · /plan · /cron · /test · /quit";
 
 /// Full Session Room TUI reference — shown in the detail pane by `/help`.
 pub fn help_lines() -> Vec<String> {
@@ -67,6 +74,7 @@ pub fn help_lines() -> Vec<String> {
         "  a            cycle altitude floor (detail → normal → attention → error)".to_string(),
         "  s            toggle squash (fold routine detail events)".to_string(),
         "  R            toggle 💭 reasoning prefix on agent rows".to_string(),
+        "  F            fork from selected row's turn & switch to the branch".to_string(),
         String::new(),
         "Gates".to_string(),
         "  y / n        approve/reject approval · approve/request plan changes".to_string(),
@@ -86,6 +94,7 @@ pub fn help_lines() -> Vec<String> {
         "  /session <id>           switch to a root session".to_string(),
         "  /session list [agent]   list recent sessions (1–9 to pick)".to_string(),
         "  /session resume [agent] jump to most recent session".to_string(),
+        "  /fork [--at-turn N] [msg]  branch this session and switch to it".to_string(),
         "  /cron  /cron list       scheduled jobs for this session".to_string(),
         "  /plan  /plan approve [id]  list or approve pending PlanFrames".to_string(),
         "  /test <scenario>        inject synthetic events (dev)".to_string(),
@@ -116,6 +125,7 @@ pub fn parse(input: &str) -> SlashCommand {
     let tail = parts.next().unwrap_or("").trim();
     match head.as_str() {
         "session" => parse_session(tail),
+        "fork" => parse_fork(tail),
         "cron" => parse_cron(tail),
         "plan" => parse_plan(tail),
         "test" => {
@@ -126,6 +136,37 @@ pub fn parse(input: &str) -> SlashCommand {
         "help" | "?" => SlashCommand::Help,
         other => SlashCommand::Unknown(other.to_string()),
     }
+}
+
+fn parse_fork(tail: &str) -> SlashCommand {
+    // `/fork`                         — fork current session from latest checkpoint
+    // `/fork <message>`               — fork latest, append branch message
+    // `/fork --at-turn N`             — fork from a specific turn's checkpoint
+    // `/fork --at-turn N <message>`   — fork from turn N, append branch message
+    let trimmed = tail.trim();
+    let mut at_turn = None;
+    let mut rest = trimmed;
+    if let Some(after) = rest
+        .strip_prefix("--at-turn")
+        .or_else(|| rest.strip_prefix("--turn"))
+    {
+        let after = after.trim_start();
+        let (num, remainder) = match after.split_once(char::is_whitespace) {
+            Some((n, r)) => (n, r.trim()),
+            None => (after, ""),
+        };
+        match num.parse::<u64>() {
+            Ok(n) => {
+                at_turn = Some(n);
+                rest = remainder;
+            }
+            // `--at-turn` with no/invalid number is a usage error, not a branch
+            // message — surface it rather than silently forking from latest.
+            Err(_) => return SlashCommand::Unknown(format!("fork {trimmed}")),
+        }
+    }
+    let message = (!rest.trim().is_empty()).then(|| rest.trim().to_string());
+    SlashCommand::ForkSession { at_turn, message }
 }
 
 fn parse_cron(tail: &str) -> SlashCommand {
@@ -358,6 +399,51 @@ mod tests {
         assert_eq!(
             parse("/plan cancel"),
             SlashCommand::Unknown("plan cancel".into())
+        );
+    }
+
+    #[test]
+    fn parse_fork_variants() {
+        assert_eq!(
+            parse("/fork"),
+            SlashCommand::ForkSession {
+                at_turn: None,
+                message: None
+            }
+        );
+        assert_eq!(
+            parse("/fork try approach B"),
+            SlashCommand::ForkSession {
+                at_turn: None,
+                message: Some("try approach B".into())
+            }
+        );
+        assert_eq!(
+            parse("/fork --at-turn 5"),
+            SlashCommand::ForkSession {
+                at_turn: Some(5),
+                message: None
+            }
+        );
+        assert_eq!(
+            parse("/fork --at-turn 5 try approach B"),
+            SlashCommand::ForkSession {
+                at_turn: Some(5),
+                message: Some("try approach B".into())
+            }
+        );
+        assert_eq!(
+            parse("/fork --turn 3"),
+            SlashCommand::ForkSession {
+                at_turn: Some(3),
+                message: None
+            }
+        );
+        // `--at-turn` with no/invalid number is a usage error.
+        assert_eq!(parse("/fork --at-turn"), SlashCommand::Unknown("fork --at-turn".into()));
+        assert_eq!(
+            parse("/fork --at-turn abc"),
+            SlashCommand::Unknown("fork --at-turn abc".into())
         );
     }
 

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -1061,6 +1061,38 @@ pub fn run(
                                             );
                                         }
                                     }
+                                    SlashCommand::ForkSession { at_turn, message } => {
+                                        match fork_session(
+                                            client,
+                                            root_session_id,
+                                            at_turn,
+                                            message.as_deref(),
+                                        ) {
+                                            Ok((new_id, fork_turn)) => {
+                                                switch_session(
+                                                    client,
+                                                    &mut entries,
+                                                    &mut cursor,
+                                                    &mut selected,
+                                                    &mut detail,
+                                                    &mut follow,
+                                                    &mut resolved,
+                                                    &mut acted,
+                                                    &mut floor,
+                                                    root_session_id,
+                                                    target_agent_id,
+                                                    limit,
+                                                    &new_id,
+                                                    &mut force_timeline_refresh,
+                                                );
+                                                session_pick_list = None;
+                                                status = Some(format!(
+                                                    "→ forked at turn {fork_turn} → {new_id} · send a message to continue this branch"
+                                                ));
+                                            }
+                                            Err(e) => status = Some(e),
+                                        }
+                                    }
                                     SlashCommand::Unknown(verb) => {
                                         let v = if verb.is_empty() {
                                             "(empty)".to_string()
@@ -1366,6 +1398,50 @@ pub fn run(
                         // by the floor or by squash — but the toggle matters for
                         // any channel that doesn't filter on altitude).
                         KeyCode::Char('R') => show_reasoning = !show_reasoning,
+                        // F: fork the session from the selected row's turn and
+                        // switch to the new branch — backtrack to a past state to
+                        // try a different approach. Checkpoints exist only at
+                        // yield points, so the gateway rejects turns it has no
+                        // checkpoint for (it lists the forkable ones).
+                        KeyCode::Char('F') => {
+                            match selected_turn_id(&view_indexed, &view_visible, selected)
+                                .and_then(|tid| turn_number_of(&tid))
+                            {
+                                Some(turn) => {
+                                    match fork_session(client, root_session_id, Some(turn), None) {
+                                        Ok((new_id, fork_turn)) => {
+                                            switch_session(
+                                                client,
+                                                &mut entries,
+                                                &mut cursor,
+                                                &mut selected,
+                                                &mut detail,
+                                                &mut follow,
+                                                &mut resolved,
+                                                &mut acted,
+                                                &mut floor,
+                                                root_session_id,
+                                                target_agent_id,
+                                                limit,
+                                                &new_id,
+                                                &mut force_timeline_refresh,
+                                            );
+                                            session_pick_list = None;
+                                            status = Some(format!(
+                                                "→ forked at turn {fork_turn} → {new_id} · send a message to continue this branch"
+                                            ));
+                                        }
+                                        Err(e) => status = Some(e),
+                                    }
+                                }
+                                None => {
+                                    status = Some(
+                                        "✗ select a row with a turn to fork from (or use /fork --at-turn N)"
+                                            .to_string(),
+                                    )
+                                }
+                            }
+                        }
                         // i: compose a free-form message into the session (#405).
                         KeyCode::Char('i') => {
                             if let Some(g) =
@@ -2681,10 +2757,77 @@ fn switch_session(
 
 /// Fetch the most recent session id, optionally filtered by agent. Returns
 /// `None` when the gateway has no matching session.
+/// System sessions (e.g. scheduled system agents, auto-learning jobs, the
+/// sentinel) are recorded under the reserved `"system"` root id. The operator
+/// can't resume or switch into them, so `/session` hides them.
+fn is_system_session(root_session_id: &str) -> bool {
+    root_session_id == "system"
+}
+
+/// Turn id of the timeline row the cursor is on, if any. Maps the view cursor
+/// (`selected`) through the rendered-row → source-entry indirection; collapsed
+/// runs resolve to their first entry. Returns `None` for rows with no turn
+/// (operator messages, session-level events), which can't be forked from.
+fn selected_turn_id(
+    view_indexed: &[(RenderedRow, RowSource)],
+    view_visible: &[SessionTimelineEntry],
+    selected: usize,
+) -> Option<String> {
+    let (_, src) = view_indexed.get(selected)?;
+    let idx = match src {
+        RowSource::Single(i) => *i,
+        RowSource::Run { start, .. } => *start,
+    };
+    view_visible.get(idx)?.turn_id.clone()
+}
+
+/// Parse the numeric turn from a `turn-000003` id. Turn ids are zero-padded,
+/// but `parse::<u64>` handles the leading zeros directly.
+fn turn_number_of(turn_id: &str) -> Option<u64> {
+    turn_id.strip_prefix("turn-").and_then(|n| n.parse::<u64>().ok())
+}
+
+/// Fork the current root session into a new branch via `session.fork`.
+/// Returns `(new_session_id, fork_turn)` on success, or a ready-to-display
+/// `✗ …` status string on failure. `at_turn = None` forks from the latest
+/// checkpoint; checkpoints exist only at yield points, so the gateway rejects
+/// turns it has no checkpoint for (its error — listing forkable turns — is
+/// surfaced verbatim).
+fn fork_session(
+    client: &RoomClient,
+    source_session_id: &str,
+    at_turn: Option<u64>,
+    branch_message: Option<&str>,
+) -> Result<(String, u64), String> {
+    let mut params = serde_json::json!({ "source_session_id": source_session_id });
+    if let Some(turn) = at_turn {
+        params["at_turn"] = serde_json::json!(turn);
+    }
+    if let Some(msg) = branch_message {
+        params["branch_message"] = serde_json::json!(msg);
+    }
+    match rpc(client, "session.fork", params) {
+        Ok(value) => {
+            let new_id = value
+                .get("new_session_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    "✗ session.fork: malformed response (no new_session_id)".to_string()
+                })?;
+            let fork_turn = value.get("fork_turn").and_then(|v| v.as_u64()).unwrap_or(0);
+            Ok((new_id, fork_turn))
+        }
+        Err(e) => Err(format!("✗ /fork failed: {e}")),
+    }
+}
+
 fn resolve_latest_session(client: &RoomClient, agent: Option<&str>) -> Option<String> {
+    // Fetch a small batch (not just 1) so a leading system session doesn't
+    // shadow the most recent operator-resumable one.
     let params = serde_json::json!({
         "agent_id": agent,
-        "limit": 1,
+        "limit": 16,
     });
     let value = rpc(client, "session.list", params).ok()?;
     let parsed: serde_json::Result<autonoetic_types::session_timeline::SessionListResult> =
@@ -2693,8 +2836,8 @@ fn resolve_latest_session(client: &RoomClient, agent: Option<&str>) -> Option<St
         .ok()?
         .sessions
         .into_iter()
-        .next()
         .map(|e| e.root_session_id)
+        .find(|id| !is_system_session(id))
 }
 
 /// Build a multi-line session list for `/session` and `/session list [agent]`,
@@ -2945,40 +3088,53 @@ fn list_cron_detail(client: &RoomClient, root_session_id: &str) -> Vec<String> {
 fn list_sessions_detail(client: &RoomClient, agent: Option<&str>) -> (Vec<String>, Vec<String>) {
     let params = serde_json::json!({
         "agent_id": agent,
-        "limit": 9,
+        // Over-fetch a little so dropping non-resumable system sessions still
+        // leaves a full page of operator-resumable rows. Sessions arrive
+        // already ordered by most-recent activity (gateway: `last_ts DESC`).
+        "limit": 25,
     });
     match rpc(client, "session.list", params) {
         Ok(value) => match serde_json::from_value::<
             autonoetic_types::session_timeline::SessionListResult,
         >(value)
         {
-            Ok(parsed) if parsed.sessions.is_empty() => {
-                let hint = agent
-                    .map(|a| format!(" for agent '{a}'"))
-                    .unwrap_or_default();
-                (
-                    vec![format!("(no sessions{hint}) — /session <id> or start one with `autonoetic run`")],
-                    Vec::new(),
-                )
-            }
             Ok(parsed) => {
+                // System sessions can't be resumed/switched into — hide them.
+                // The remaining rows keep their most-recent-first ordering.
+                let sessions: Vec<_> = parsed
+                    .sessions
+                    .into_iter()
+                    .filter(|s| !is_system_session(&s.root_session_id))
+                    .take(9)
+                    .collect();
+                if sessions.is_empty() {
+                    let hint = agent
+                        .map(|a| format!(" for agent '{a}'"))
+                        .unwrap_or_default();
+                    return (
+                        vec![format!("(no sessions{hint}) — /session <id> or start one with `autonoetic run`")],
+                        Vec::new(),
+                    );
+                }
                 let mut lines = if let Some(a) = agent {
                     vec![format!("sessions for agent '{a}':")]
                 } else {
                     vec!["recent sessions:".to_string()]
                 };
-                let ids: Vec<String> = parsed
-                    .sessions
+                let ids: Vec<String> = sessions
                     .iter()
                     .map(|s| s.root_session_id.clone())
                     .collect();
-                for (i, s) in parsed.sessions.iter().enumerate() {
+                for (i, s) in sessions.iter().enumerate() {
+                    // The first row is the most recently active one — flag it.
+                    let latest = if i == 0 { "  ← latest" } else { "" };
                     lines.push(format!(
-                        "  [{}] {} [{}] @ {}",
+                        "  [{}] {} [{}] @ {}{}",
                         i + 1,
                         s.root_session_id,
                         s.agent_id,
-                        s.last_active_at
+                        s.last_active_at,
+                        latest
                     ));
                 }
                 lines.push("→ press a number to switch, or /session <id>".to_string());
@@ -3370,6 +3526,15 @@ fn wrap_spans(spans: &[Span], max_width: usize) -> Vec<Line<'static>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_sessions_are_hidden_from_session_list() {
+        // The reserved `"system"` root id is used by scheduled system agents,
+        // auto-learning jobs, and the sentinel — none are operator-resumable.
+        assert!(is_system_session("system"));
+        assert!(!is_system_session("session-abc123"));
+        assert!(!is_system_session("systematic-session"));
+    }
 
     #[test]
     fn main_list_page_step_accounts_for_chrome() {

--- a/autonoetic/src/cli/trace.rs
+++ b/autonoetic/src/cli/trace.rs
@@ -1481,13 +1481,27 @@ pub async fn handle_trace_fork(
         let checkpoint = autonoetic_gateway::runtime::checkpoint::load_checkpoint(
             &config,
             source_session_id,
-            &format!("turn-{:04}", turn),
+            &autonoetic_gateway::runtime::checkpoint::turn_id_for(turn as u64),
         )?
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "No checkpoint found for session '{}' at turn {}",
+            // Checkpoints exist only at yield points (hibernation, approval,
+            // budget, escalation…), not at every turn — so list the turns that
+            // can actually be forked from.
+            let available = autonoetic_gateway::runtime::checkpoint::list_checkpoints(
+                &config,
                 source_session_id,
-                turn
+            )
+            .unwrap_or_default();
+            let hint = if available.is_empty() {
+                " (no checkpoints exist for this session)".to_string()
+            } else {
+                format!(" — forkable turns: {}", available.join(", "))
+            };
+            anyhow::anyhow!(
+                "No checkpoint found for session '{}' at turn {}{}",
+                source_session_id,
+                turn,
+                hint
             )
         })?;
         autonoetic_gateway::runtime::checkpoint::SessionFork::fork_from_checkpoint(
@@ -1504,6 +1518,19 @@ pub async fn handle_trace_fork(
             branch_message,
         )?
     };
+
+    // Mirror the source timeline into the fork (best effort) so the Session Room
+    // shows the inherited history immediately rather than an empty timeline.
+    let gateway_dir = config.agents_dir.join(".gateway");
+    if let Ok(store) = autonoetic_gateway::scheduler::GatewayStore::open(&gateway_dir) {
+        if let Err(e) = store.clone_timeline_for_fork(
+            &fork.source_session_id,
+            &fork.new_session_id,
+            fork.fork_turn as u64,
+        ) {
+            eprintln!("warning: could not mirror source timeline into fork: {e}");
+        }
+    }
 
     if !json_output {
         println!("Session forked successfully!");

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -503,7 +503,8 @@ with the full branch-point context. Checkpoints exist only at yield points
 can only target a turn that has a checkpoint; otherwise it errors and lists the
 forkable turns. The same branch can be created from the Session Room with
 `/fork [--at-turn N] [message]` (it forks the current session and switches to
-the new one).
+the new one). See `docs/session-forking.md` for the full mechanism, including
+the timeline-mirroring design choice (copy vs reuse-by-reference).
 
 ### `autonoetic trace history`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -496,6 +496,15 @@ autonoetic trace fork session-123 --new-session-id my-fork --agent researcher.de
 | `--interactive` | Start interactive chat session after forking |
 | `--json` | Machine-readable JSON output |
 
+The fork writes a fresh checkpoint under the new session id, so the branch is
+immediately **runnable** — sending it a message resumes from the fork point
+with the full branch-point context. Checkpoints exist only at yield points
+(hibernation, approval, budget, escalation…), not at every turn, so `--at-turn`
+can only target a turn that has a checkpoint; otherwise it errors and lists the
+forkable turns. The same branch can be created from the Session Room with
+`/fork [--at-turn N] [message]` (it forks the current session and switches to
+the new one).
+
 ### `autonoetic trace history`
 
 Show conversation history for a session.

--- a/docs/session-forking.md
+++ b/docs/session-forking.md
@@ -1,0 +1,144 @@
+# Session Forking
+
+This document describes how a session is forked from a past turn so an operator
+or agent can **backtrack to an earlier state and try a different approach**.
+
+## Overview
+
+Forking creates a new, independent session that starts from the conversation
+state of a source session **as of a chosen turn**. It serves two purposes:
+
+- **A test/debug tool** — backtrack to a decision point and explore an
+  alternative path without disturbing the original session.
+- **The substrate for counterfactual self-evolution** — an agent can fork at
+  turn *N*, run "what if I had done X instead", and compare outcomes via the
+  causal chain.
+
+Every fork is a fully runnable session: sending it a message resumes execution
+from the fork point with the full branch-point context.
+
+## What a fork is built from
+
+A fork is derived from a **checkpoint**. Checkpoints are universal session
+snapshots written at every *yield point* (hibernation, approval, budget
+exhaustion, user input, escalation, emergency stop). Each captures the full LLM
+conversation history, the turn counter, loop-guard state, budgets, and
+reproducibility metadata, and is stored at:
+
+```
+.gateway/checkpoints/<session_id>/<turn_id>.checkpoint.json
+```
+
+Turn ids are zero-padded to a fixed width — `turn-000003` — via the single
+shared helper `checkpoint::turn_id_for(turn)`. Everything that needs to address
+a checkpoint by turn number (the lifecycle that writes them, `trace fork`, the
+`session.fork` RPC, the timeline mirror) uses this helper so the format cannot
+drift.
+
+### Yield-point granularity
+
+Checkpoints exist **only at yield points**, not at every turn. You can therefore
+fork only at a turn that has a checkpoint. A request for a turn with no
+checkpoint is rejected with an error that lists the forkable turns. This is a
+deliberate efficiency choice — checkpointing every turn would multiply storage
+and I/O for little benefit.
+
+## How a fork is made runnable
+
+`SessionFork::fork_from_checkpoint` does three things:
+
+1. Clones the source checkpoint's history (appending the optional branch
+   message) and writes it to the content store under the name `session_history`.
+   That blob is content-addressed (SHA-256), so identical history dedupes
+   automatically. This blob feeds the **UI** (chat/trace history hydration).
+2. **Writes a `Hibernation` checkpoint under the new session id**, with any
+   inherited approval/pending-tool state stripped. This is what makes the fork
+   runnable: the execution engine seeds a session's LLM context from its latest
+   checkpoint — *not* from the `session_history` content name — so without this
+   step the branch would resume from a blank history and the fork point would be
+   lost. Because the yield reason is `Hibernation` (a normal, auto-resumable
+   point), the next message to the fork resumes cleanly with the full
+   branch-point context.
+3. Mirrors the source timeline into the fork (see below).
+
+The forked session gets a new, independent `root_session_id` (e.g.
+`fork-ab12cd34`). It does **not** inherit the parent's root id — each branch is a
+self-contained root. (A lineage/children view linking a fork back to its parent
+would be a future enhancement.)
+
+## Timeline mirroring
+
+The Session Room renders a session's timeline from the `live_digest_events`
+table, filtered strictly by `root_session_id`. A fork writes a checkpoint but no
+`live_digest_events` of its own, so without further action the room would show
+an **empty timeline** until the branch first runs and emits events.
+
+To avoid that, `GatewayStore::clone_timeline_for_fork` copies the source
+session's timeline rows into the fork's `root_session_id`, **up to and including
+the fork turn**, with fresh `event_id`s and preserved timestamps/attribution.
+The cutoff is the end-of-fork-turn timestamp (the latest event whose `turn_id`
+is `<= turn-00000N`), which also pulls in interleaved turn-less rows (operator
+messages, session start) that belong before the branch point.
+
+### Design choice: copy rather than reuse-by-reference
+
+The timeline is **copied** into new rows in the existing `live_digest_events`
+table rather than reused in place from the parent. No new table is introduced,
+and the LLM history itself is reused (content-addressed); only the timeline rows
+are duplicated.
+
+The considered alternative was *reuse-by-reference*: store a
+`(parent_root_session_id, fork_turn)` lineage pointer and have the timeline
+reader UNION the parent's rows (`turn <= fork_turn`) with the fork's own rows,
+never copying. We chose **copy** deliberately:
+
+| | Copy (chosen) | Reuse-by-reference |
+|---|---|---|
+| Storage | duplicates timeline rows per fork | zero duplication |
+| Timeline read path | unchanged, simple | UNION + lineage lookup, hotter path |
+| Fork-of-fork | just works | needs a recursive lineage walk |
+| Cursor pagination | trivial (one root) | spans multiple roots, fiddly ordering |
+| Parent pruned later (retention) | **fork unaffected, self-contained** | fork loses its prefix |
+
+The decisive factors were keeping the *hottest* read path (timeline render)
+simple and making a fork **durable and self-contained** — a branch must not lose
+its inherited history when the parent's `live_digest_events` are pruned by the
+configurable retention policy. The cost is bounded row duplication (timeline
+rows are small and capped at the fork turn). If duplication ever becomes a
+concern, reuse-by-reference remains a viable evolution.
+
+## Surfaces
+
+Forking is exposed three ways, all backed by the same mechanism:
+
+### CLI
+
+```bash
+autonoetic trace fork <session_id>                       # fork from the latest checkpoint
+autonoetic trace fork <session_id> --at-turn 5           # fork from a specific turn
+autonoetic trace fork <session_id> --message "try B"     # append a branch message
+autonoetic trace fork <session_id> --at-turn 5 --interactive
+```
+
+### JSON-RPC
+
+`session.fork` parameters: `source_session_id` (required), optional
+`at_turn`, `branch_message`, `new_session_id`, `target_agent_id`. Returns
+`new_session_id`, `fork_turn`, `history_handle`, `message_count`, and
+`mirrored_events` (rows copied by the timeline mirror).
+
+### Session Room
+
+- `/fork [--at-turn N] [message]` — fork the current session and switch the room
+  to the new branch.
+- `F` on a selected timeline row — fork from that row's turn and switch to it.
+
+After forking, the room switches to the branch and shows its mirrored history;
+send a message to continue the branch from the fork point.
+
+## Related
+
+- `docs/cli-reference.md` — full `autonoetic trace fork` reference
+- `docs/content-store.md` — content-addressed `session_history` storage
+- `docs/session-room.md` / `docs/session-room-architecture.md` — the timeline UI
+- Checkpoints and the causal chain are described in `docs/ARCHITECTURE.md`


### PR DESCRIPTION
## What & why

Makes **"backtrack to a past state and try a different approach"** a real, runnable operation in the Session Room. It's both a test/debug tool and the substrate for counterfactual self-evolution (an agent forking at turn N to explore "what if I'd done X").

A fork API, RPC, and `trace fork` CLI already existed, but the feature didn't work end-to-end: a forked session ran from a **blank** history, `--at-turn` could never find a checkpoint, and the room showed an empty timeline. This PR closes those gaps and surfaces forking in the room.

## Core fixes

- **Forks are runnable.** `fork_from_checkpoint` now writes a `Hibernation` checkpoint under the new session id. Execution seeds a session's LLM context from its latest checkpoint (not the `session_history` content name — that only feeds the UI), so without this the branch resumed from an empty history and the fork point was lost.
- **`--at-turn` turn-id bug.** Checkpoints save as `turn-{:06}` but `trace fork --at-turn` loaded `turn-{:04}`, so it never matched. Added a shared `turn_id_for()` helper used everywhere the format is needed, so it can't drift again. Misses now list the forkable turns (checkpoints exist only at yield points).

## `session.fork` RPC

- New optional `at_turn` to branch from a specific historical turn.
- Mirrors the source timeline into the fork (`clone_timeline_for_fork`) up to the fork turn, so the room shows inherited history immediately. Wired into the RPC and `trace fork`.

## Session Room

- `/fork [--at-turn N] [message]` — fork the current session and switch to the branch.
- `F` on a timeline row — fork from that row's turn and switch to it.
- Both in `/help` and `docs/cli-reference.md`.

## Granularity

Yield-point only: you can fork at any turn that has a checkpoint (hibernation, approval, budget, escalation…); turns without one are rejected with the forkable turns listed.

## Tests

- `session_fork_integration`: fork writes a clean, runnable Hibernation checkpoint for the new session id (no inherited approval/pending state).
- `session_timeline_jsonrpc_integration`: `clone_timeline_for_fork` mirrors history up to the fork turn (includes interleaved turn-less rows, excludes later turns).
- All green locally: fork (9), timeline (4), checkpoint (12), room TUI (106), workspace build clean.

## Review notes

- Based on current `main` (`294a7537`, includes #428 and #432).
- Forked sessions get a new independent root id (no parent linkage in `root_session_id`) — matches the existing design. A lineage/children view could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)