### PR TITLE
feat(wiki): Phase 2 — gateway CLI, /wiki proposals, proposal detail view

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1313,6 +1313,34 @@ impl JsonRpcRouter {
                 }
             }
 
+            "wiki.proposals_pending" => {
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "GatewayStore not available for wiki.proposals_pending",
+                        );
+                    }
+                };
+                let proposals = store
+                    .get_pending_approvals()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|a| {
+                        matches!(
+                            a.action,
+                            autonoetic_types::background::ScheduledAction::WikiProposal { .. }
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                JsonRpcResponse::success(
+                    req.id,
+                    serde_json::json!({ "proposals": proposals }),
+                )
+            }
+
             "wiki.list" => {
                 let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
                 let wiki_root = gateway_dir.join("wiki");

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -1314,6 +1314,23 @@ impl JsonRpcRouter {
             }
 
             "wiki.proposals_pending" => {
+                #[derive(serde::Deserialize)]
+                struct WikiProposalsPendingParams {
+                    #[serde(default)]
+                    root_session_id: Option<String>,
+                    #[serde(default)]
+                    limit: Option<usize>,
+                }
+                let params: WikiProposalsPendingParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for wiki.proposals_pending: {}", e),
+                        );
+                    }
+                };
                 let store = match self.execution.gateway_store() {
                     Some(s) => s,
                     None => {
@@ -1324,9 +1341,17 @@ impl JsonRpcRouter {
                         );
                     }
                 };
-                let proposals = store
-                    .get_pending_approvals()
-                    .unwrap_or_default()
+                let all = match store.get_pending_approvals() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("wiki.proposals_pending failed: {}", e),
+                        );
+                    }
+                };
+                let proposals: Vec<_> = all
                     .into_iter()
                     .filter(|a| {
                         matches!(
@@ -1334,7 +1359,14 @@ impl JsonRpcRouter {
                             autonoetic_types::background::ScheduledAction::WikiProposal { .. }
                         )
                     })
-                    .collect::<Vec<_>>();
+                    .filter(|a| {
+                        params.root_session_id.as_deref().map_or(true, |sid| {
+                            a.root_session_id.as_deref() == Some(sid)
+                                || a.session_id == sid
+                        })
+                    })
+                    .take(params.limit.unwrap_or(50))
+                    .collect();
                 JsonRpcResponse::success(
                     req.id,
                     serde_json::json!({ "proposals": proposals }),

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -393,6 +393,11 @@ pub enum GatewayCommands {
         #[command(subcommand)]
         command: GatewayConstitutionCommands,
     },
+    /// Manage wiki proposals (promote, reject, list).
+    Wiki {
+        #[command(subcommand)]
+        command: GatewayWikiCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -470,6 +475,32 @@ pub enum GatewayConstitutionProposalCommands {
     Defer {
         /// Proposal identifier.
         proposal_id: String,
+        /// Optional reason.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum GatewayWikiCommands {
+    /// List pending wiki proposals.
+    Proposals {
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Approve/promote a pending wiki proposal.
+    Promote {
+        /// Approval request ID (e.g. apr-xxxx).
+        request_id: String,
+        /// Optional reason.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Reject a pending wiki proposal.
+    Reject {
+        /// Approval request ID (e.g. apr-xxxx).
+        request_id: String,
         /// Optional reason.
         #[arg(long)]
         reason: Option<String>,

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -2371,3 +2371,98 @@ fn decide_proposal(
     }
     Ok(())
 }
+
+pub async fn handle_gateway_wiki(
+    config_path: &Path,
+    command: &super::common::GatewayWikiCommands,
+) -> anyhow::Result<()> {
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let gateway_store =
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)?;
+
+    match command {
+        super::common::GatewayWikiCommands::Proposals { json } => {
+            let approvals = autonoetic_gateway::scheduler::load_approval_requests(
+                &config,
+                Some(&gateway_store),
+            )?;
+            let wiki: Vec<_> = approvals
+                .into_iter()
+                .filter(|a| {
+                    matches!(
+                        a.action,
+                        autonoetic_types::background::ScheduledAction::WikiProposal { .. }
+                    )
+                })
+                .collect();
+            if *json {
+                println!("{}", serde_json::to_string_pretty(&wiki)?);
+                return Ok(());
+            }
+            if wiki.is_empty() {
+                println!("No pending wiki proposals.");
+                return Ok(());
+            }
+            println!("{:<38} {:<20} {:<20} {}", "REQUEST ID", "AGENT", "TITLE", "PAGE ID");
+            for a in &wiki {
+                let (title, page_id) = match &a.action {
+                    autonoetic_types::background::ScheduledAction::WikiProposal {
+                        title, page_id, ..
+                    } => (title.as_str(), page_id.as_str()),
+                    _ => unreachable!(),
+                };
+                println!(
+                    "{:<38} {:<20} {:<20} {}",
+                    a.request_id, a.agent_id, title, page_id
+                );
+            }
+        }
+        super::common::GatewayWikiCommands::Promote { request_id, reason } => {
+            let decision = autonoetic_gateway::scheduler::approve_request_with_options(
+                &config,
+                Some(&gateway_store),
+                request_id,
+                "cli",
+                reason.clone(),
+                None,
+                None,
+                None,
+                autonoetic_gateway::scheduler::ApproveOptions::default(),
+            )?;
+            println!(
+                "Wiki proposal promoted: {} — {}",
+                decision.request_id,
+                if let autonoetic_types::background::ScheduledAction::WikiProposal { title, .. } =
+                    &decision.action
+                {
+                    title.as_str()
+                } else {
+                    "(unknown)"
+                }
+            );
+        }
+        super::common::GatewayWikiCommands::Reject { request_id, reason } => {
+            let decision = autonoetic_gateway::scheduler::reject_request(
+                &config,
+                Some(&gateway_store),
+                request_id,
+                "cli",
+                reason.clone(),
+                None,
+            )?;
+            println!(
+                "Wiki proposal rejected: {} — {}",
+                decision.request_id,
+                if let autonoetic_types::background::ScheduledAction::WikiProposal { title, .. } =
+                    &decision.action
+                {
+                    title.as_str()
+                } else {
+                    "(unknown)"
+                }
+            );
+        }
+    }
+    Ok(())
+}

--- a/autonoetic/src/cli/room/slash.rs
+++ b/autonoetic/src/cli/room/slash.rs
@@ -48,12 +48,14 @@ pub enum SlashCommand {
         at_turn: Option<u64>,
         message: Option<String>,
     },
+    /// List pending wiki proposals for this session.
+    ListWikiProposals,
     /// Anything else — the dispatcher surfaces a `✗` status.
     Unknown(String),
 }
 
 /// One-line hint while typing a slash command (full guide: `/help`).
-pub const HELP_TEXT: &str = "/help for commands · /session · /fork · /plan · /cron · /test · /quit";
+pub const HELP_TEXT: &str = "/help for commands · /session · /fork · /plan · /cron · /wiki · /test · /quit";
 
 /// Full Session Room TUI reference — shown in the detail pane by `/help`.
 pub fn help_lines() -> Vec<String> {
@@ -97,6 +99,7 @@ pub fn help_lines() -> Vec<String> {
         "  /fork [--at-turn N] [msg]  branch this session and switch to it".to_string(),
         "  /cron  /cron list       scheduled jobs for this session".to_string(),
         "  /plan  /plan approve [id]  list or approve pending PlanFrames".to_string(),
+        "  /wiki proposals         list pending wiki proposals".to_string(),
         "  /test <scenario>        inject synthetic events (dev)".to_string(),
         "  /test help              list test scenarios".to_string(),
         String::new(),
@@ -128,6 +131,7 @@ pub fn parse(input: &str) -> SlashCommand {
         "fork" => parse_fork(tail),
         "cron" => parse_cron(tail),
         "plan" => parse_plan(tail),
+        "wiki" => parse_wiki(tail),
         "test" => {
             let name = tail.trim().to_string();
             SlashCommand::Test { name }
@@ -193,6 +197,19 @@ fn parse_plan(tail: &str) -> SlashCommand {
             plan_id: (!rest.is_empty()).then(|| rest.to_string()),
         },
         _ => SlashCommand::Unknown(format!("plan {trimmed}")),
+    }
+}
+
+fn parse_wiki(tail: &str) -> SlashCommand {
+    let trimmed = tail.trim();
+    if trimmed.is_empty()
+        || trimmed.eq_ignore_ascii_case("proposals")
+        || trimmed.eq_ignore_ascii_case("list")
+        || trimmed.eq_ignore_ascii_case("ls")
+    {
+        SlashCommand::ListWikiProposals
+    } else {
+        SlashCommand::Unknown(format!("wiki {trimmed}"))
     }
 }
 
@@ -444,6 +461,18 @@ mod tests {
         assert_eq!(
             parse("/fork --at-turn abc"),
             SlashCommand::Unknown("fork --at-turn abc".into())
+        );
+    }
+
+    #[test]
+    fn parse_wiki_variants() {
+        assert_eq!(parse("/wiki"), SlashCommand::ListWikiProposals);
+        assert_eq!(parse("/wiki proposals"), SlashCommand::ListWikiProposals);
+        assert_eq!(parse("/wiki list"), SlashCommand::ListWikiProposals);
+        assert_eq!(parse("/wiki ls"), SlashCommand::ListWikiProposals);
+        assert_eq!(
+            parse("/wiki approve"),
+            SlashCommand::Unknown("wiki approve".into())
         );
     }
 

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -3136,7 +3136,8 @@ fn list_wiki_proposals_detail(client: &RoomClient, root_session_id: &str) -> (Ve
             }
             let mut lines = vec![format!("pending wiki proposals for {root_session_id}:")];
             let mut ids = Vec::new();
-            for (i, p) in proposals.iter().enumerate() {
+            let max_shown = proposals.len().min(9);
+            for (i, p) in proposals.iter().enumerate().take(max_shown) {
                 let request_id = p
                     .get("request_id")
                     .and_then(|v| v.as_str())
@@ -3157,6 +3158,9 @@ fn list_wiki_proposals_detail(client: &RoomClient, root_session_id: &str) -> (Ve
                     .and_then(|v| v.as_str())
                     .unwrap_or("?");
                 lines.push(format!("  [{}] {} [{}] {} -> {}", i + 1, request_id, agent_id, title, page_id));
+            }
+            if proposals.len() > 9 {
+                lines.push(format!("  ... and {} more (use gateway CLI to list all)", proposals.len() - 9));
             }
             lines.push("→ press a number to view proposal details".to_string());
             (lines, ids)
@@ -3211,9 +3215,14 @@ fn wiki_proposal_detail(client: &RoomClient, request_id: &str) -> Vec<String> {
                                 lines.push(format!("tags:        {}", tag_str.join(", ")));
                             }
                         }
-                        if let Some(v) = action.get("reason").and_then(|v| v.as_str()) {
+                        if let Some(v) = p.get("reason").and_then(|v| v.as_str()) {
                             if !v.is_empty() {
                                 lines.push(format!("reason:      {v}"));
+                            }
+                        }
+                        if let Some(v) = p.get("decision_reason").and_then(|v| v.as_str()) {
+                            if !v.is_empty() {
+                                lines.push(format!("decision:    {v}"));
                             }
                         }
                     }

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -833,6 +833,7 @@ pub fn run(
         std::panic::catch_unwind(|| arboard::Clipboard::new().ok()).unwrap_or(None);
     let mut slash: Option<String> = None; // in-flight slash-command buffer (no leading `/`)
     let mut session_pick_list: Option<Vec<String>> = None; // ids from /session list for number-pick
+    let mut wiki_request_ids: Option<Vec<String>> = None; // ids from /wiki proposals for number-detail
     let mut status: Option<String> = None; // last action / connection result
     // Gates no longer offerable: approvals resolved on the timeline, plus
     // anything the operator just acted on (covers interactions, which have no
@@ -916,6 +917,7 @@ pub fn run(
                                         detail_scroll = 0;
                                         detail_h_scroll = 0;
                                         session_pick_list = None;
+                                        wiki_request_ids = None;
                                         status = Some("help: Esc to close".to_string());
                                     }
                                     SlashCommand::Test { name } => {
@@ -979,12 +981,25 @@ pub fn run(
                                     SlashCommand::ListCronJobs => {
                                         detail = Some(DetailPane::event(list_cron_detail(client, root_session_id), None));
                                         session_pick_list = None;
+                                        wiki_request_ids = None;
                                     }
                                     SlashCommand::ListPlans => {
                                         detail = Some(DetailPane::event(list_plans_detail(client, root_session_id), None));
                                         session_pick_list = None;
+                                        wiki_request_ids = None;
                                         status = Some(
                                             "plan list: Enter/p on row for review · y approve · Esc close"
+                                                .to_string(),
+                                        );
+                                    }
+                                    SlashCommand::ListWikiProposals => {
+                                        let (lines, ids) = list_wiki_proposals_detail(client, root_session_id);
+                                        detail = Some(DetailPane::event(lines, None));
+                                        session_pick_list = None;
+                                        wiki_request_ids = None;
+                                        wiki_request_ids = Some(ids);
+                                        status = Some(
+                                            "wiki proposals: press number to view details · Esc close"
                                                 .to_string(),
                                         );
                                     }
@@ -1086,6 +1101,7 @@ pub fn run(
                                                     &mut force_timeline_refresh,
                                                 );
                                                 session_pick_list = None;
+                                        wiki_request_ids = None;
                                                 status = Some(format!(
                                                     "→ forked at turn {fork_turn} → {new_id} · send a message to continue this branch"
                                                 ));
@@ -1210,6 +1226,7 @@ pub fn run(
                                 detail_scroll = 0;
                                 detail_h_scroll = 0;
                                 session_pick_list = None;
+                                        wiki_request_ids = None;
                             } else {
                                 disarm_quit(&mut quit_armed_until, &mut status);
                             }
@@ -1244,6 +1261,18 @@ pub fn run(
                                     }
                                     detail = None;
                                     session_pick_list = None;
+                                        wiki_request_ids = None;
+                                }
+                            } else if let Some(ref ids) = wiki_request_ids {
+                                let idx = (c as usize) - ('1' as usize);
+                                if let Some(request_id) = ids.get(idx).cloned() {
+                                    detail = Some(DetailPane::event(
+                                        wiki_proposal_detail(client, &request_id),
+                                        None,
+                                    ));
+                                    detail_scroll = 0;
+                                    detail_h_scroll = 0;
+                                    status = Some(format!("wiki proposal {request_id} — Esc to close"));
                                 }
                             }
                         }
@@ -1427,6 +1456,7 @@ pub fn run(
                                                 &mut force_timeline_refresh,
                                             );
                                             session_pick_list = None;
+                                        wiki_request_ids = None;
                                             status = Some(format!(
                                                 "→ forked at turn {fork_turn} → {new_id} · send a message to continue this branch"
                                             ));
@@ -3083,6 +3113,116 @@ fn list_cron_detail(client: &RoomClient, root_session_id: &str) -> Vec<String> {
             Err(e) => vec![format!("✗ malformed scheduled_jobs.list response: {e}")],
         },
         Err(e) => vec![format!("✗ scheduled_jobs.list failed: {e}")],
+    }
+}
+
+fn list_wiki_proposals_detail(client: &RoomClient, root_session_id: &str) -> (Vec<String>, Vec<String>) {
+    let params = serde_json::json!({
+        "root_session_id": root_session_id,
+        "limit": 50,
+    });
+    match rpc(client, "wiki.proposals_pending", params) {
+        Ok(value) => {
+            let proposals = value
+                .get("proposals")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            if proposals.is_empty() {
+                return (
+                    vec![format!("(no pending wiki proposals for '{root_session_id}')")],
+                    Vec::new(),
+                );
+            }
+            let mut lines = vec![format!("pending wiki proposals for {root_session_id}:")];
+            let mut ids = Vec::new();
+            for (i, p) in proposals.iter().enumerate() {
+                let request_id = p
+                    .get("request_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                ids.push(request_id.to_string());
+                let agent_id = p
+                    .get("agent_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                let title = p
+                    .get("action")
+                    .and_then(|a| a.get("title"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                let page_id = p
+                    .get("action")
+                    .and_then(|a| a.get("page_id"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                lines.push(format!("  [{}] {} [{}] {} -> {}", i + 1, request_id, agent_id, title, page_id));
+            }
+            lines.push("→ press a number to view proposal details".to_string());
+            (lines, ids)
+        }
+        Err(e) => (vec![format!("✗ wiki.proposals_pending failed: {e}")], Vec::new()),
+    }
+}
+
+fn wiki_proposal_detail(client: &RoomClient, request_id: &str) -> Vec<String> {
+    match rpc(client, "wiki.proposals_pending", serde_json::json!({})) {
+        Ok(value) => {
+            let proposals = value
+                .get("proposals")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let prop = proposals.into_iter().find(|p| {
+                p.get("request_id")
+                    .and_then(|v| v.as_str())
+                    == Some(request_id)
+            });
+            match prop {
+                Some(p) => {
+                    let mut lines = vec![format!("── wiki proposal: {request_id} ──")];
+                    lines.push(String::new());
+                    if let Some(v) = p.get("agent_id").and_then(|v| v.as_str()) {
+                        lines.push(format!("agent:       {v}"));
+                    }
+                    if let Some(v) = p.get("session_id").and_then(|v| v.as_str()) {
+                        lines.push(format!("session:     {v}"));
+                    }
+                    if let Some(v) = p.get("created_at").and_then(|v| v.as_str()) {
+                        lines.push(format!("created:     {v}"));
+                    }
+                    if let Some(action) = p.get("action") {
+                        lines.push(String::new());
+                        lines.push("── proposal details ──".to_string());
+                        if let Some(v) = action.get("title").and_then(|v| v.as_str()) {
+                            lines.push(format!("title:       {v}"));
+                        }
+                        if let Some(v) = action.get("page_id").and_then(|v| v.as_str()) {
+                            lines.push(format!("page_id:     {v}"));
+                        }
+                        if let Some(v) = action.get("content_sha256").and_then(|v| v.as_str()) {
+                            lines.push(format!("content:     {v} (SHA-256)"));
+                        }
+                        if let Some(tags) = action.get("tags").and_then(|v| v.as_array()) {
+                            let tag_str: Vec<&str> = tags.iter()
+                                .filter_map(|t| t.as_str())
+                                .collect();
+                            if !tag_str.is_empty() {
+                                lines.push(format!("tags:        {}", tag_str.join(", ")));
+                            }
+                        }
+                        if let Some(v) = action.get("reason").and_then(|v| v.as_str()) {
+                            if !v.is_empty() {
+                                lines.push(format!("reason:      {v}"));
+                            }
+                        }
+                    }
+                    lines
+                }
+                None => vec![format!("✗ proposal {request_id} not found")],
+            }
+        }
+        Err(e) => vec![format!("✗ wiki.proposals_pending failed: {e}")],
     }
 }
 

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -156,6 +156,9 @@ async fn main() -> anyhow::Result<()> {
             cli::common::GatewayCommands::Constitution { command } => {
                 cli::gateway::handle_gateway_constitution(&config_path, command).await?;
             }
+            cli::common::GatewayCommands::Wiki { command } => {
+                cli::gateway::handle_gateway_wiki(&config_path, command).await?;
+            }
         },
 
         Commands::Agent(args) => match &args.command {


### PR DESCRIPTION
### Changes

**Gateway CLI** (`gateway wiki`):
- `gateway wiki proposals` — list pending proposals
- `gateway wiki promote <id> [reason]` — promote a proposal  
- `gateway wiki reject <id> [reason]` — reject a proposal

**Room TUI**:
- `/wiki proposals` slash command — lists pending proposals with numbered selection
- Number key (1-9) opens a detail pane showing full proposal metadata (title, page_id, content_sha256, tags, reason)
- `wiki.proposals_pending` RPC method on the gateway router

**Issue #426 items covered**:
- [x] `/wiki proposals` slash command
- [x] Gateway CLI: proposals, promote, reject
- [x] Timeline events (merged in #433)
- [x] Proposal detail view in Room

### Verification
- `cargo build` — passes
- `cargo test -p autonoetic -- slash::tests` — 16/16 passing