### PR TITLE
P1: SDK transport abstraction + docker bridge parity

### DIFF
--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -1439,6 +1439,7 @@ fn validate_dependency_package(pkg: &str) -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use serial_test::serial;
 
     #[test]
     fn test_parse_driver_kind() {
@@ -1473,6 +1474,7 @@ mod tests {
     }
 
     #[test]
+    #[serial] // mutates AUTONOETIC_DOCKER_IMAGE (process-global)
     fn test_docker_command_requires_env() {
         let old = std::env::var(DOCKER_IMAGE_ENV).ok();
         std::env::remove_var(DOCKER_IMAGE_ENV);
@@ -1488,6 +1490,7 @@ mod tests {
     }
 
     #[test]
+    #[serial] // mutates AUTONOETIC_DOCKER_IMAGE (process-global)
     fn test_docker_command_emits_socket_volume_and_env() {
         // P1: the SDK socket + its env must reach the container via `-v`/`-e`
         // (the container does not inherit the gateway process env).
@@ -1545,13 +1548,14 @@ mod tests {
 
     #[test]
     fn test_sdk_socket_sandbox_path_per_driver() {
+        let expected_bwrap = format!("{}/s.sock", BWRAP_WORKSPACE_DIR);
         assert_eq!(
-            sdk_socket_sandbox_path(SandboxDriverKind::Bubblewrap, "s.sock").as_deref(),
-            Some(format!("{}/s.sock", BWRAP_WORKSPACE_DIR).as_str())
+            sdk_socket_sandbox_path(SandboxDriverKind::Bubblewrap, "s.sock"),
+            Some(expected_bwrap)
         );
         assert_eq!(
-            sdk_socket_sandbox_path(SandboxDriverKind::Docker, "s.sock").as_deref(),
-            Some(DOCKER_SDK_SOCKET_PATH)
+            sdk_socket_sandbox_path(SandboxDriverKind::Docker, "s.sock"),
+            Some(DOCKER_SDK_SOCKET_PATH.to_string())
         );
         // microvm has no bridge yet (P5)
         assert!(sdk_socket_sandbox_path(SandboxDriverKind::MicroVm, "s.sock").is_none());

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -22,6 +22,14 @@ pub const SDK_BRIDGE_MAX_PAYLOAD_BYTES: usize = 1_048_576;
 const DOCKER_IMAGE_ENV: &str = "AUTONOETIC_DOCKER_IMAGE";
 const FIRECRACKER_CONFIG_ENV: &str = "AUTONOETIC_FIRECRACKER_CONFIG";
 pub(crate) const BWRAP_WORKSPACE_DIR: &str = "/tmp";
+/// In-container path the SDK socket is mounted at for the docker driver (P1).
+/// Bubblewrap exposes it under `BWRAP_WORKSPACE_DIR`; docker bind-mounts to a
+/// fixed path outside `/workspace` so the agent_dir mount can't shadow it.
+const DOCKER_SDK_SOCKET_PATH: &str = "/run/autonoetic-sdk.sock";
+/// In-container path the Python SDK source is mounted at for the docker driver.
+/// (For bubblewrap the host `/` is ro-bind-mounted, so the host SDK path is
+/// already visible; docker images are separate, so the SDK is mounted in.)
+const DOCKER_SDK_PYTHONPATH: &str = "/opt/autonoetic-sdk";
 const PYTHONPATH_ENV: &str = "PYTHONPATH";
 const PYTHON_SDK_PATH_ENV: &str = "AUTONOETIC_PYTHON_SDK_PATH";
 const CCOS_SOCKET_ENV: &str = "CCOS_SOCKET_PATH";
@@ -242,22 +250,14 @@ impl SandboxRunner {
             anyhow::bail!("MicroVM dependency bootstrap is not implemented yet");
         }
 
-        let mut sdk_bridge = None;
+        // Wire the SDK socket transport once; the helper produces driver-specific
+        // plumbing (bubblewrap bind mount vs docker `-v`/`-e`). Now wired for
+        // bubblewrap AND docker (P1) — previously bubblewrap-only.
+        let wiring = wire_sdk_bridge(driver, agent_dir, root_session_id)?;
+        let socket_path_sandbox = wiring.socket_path_sandbox.clone();
         let mut socket_mounts: Vec<SandboxMount> = Vec::new();
-
-        // Start SDK bridge for bubblewrap and prepare socket mount so it's
-        // visible inside the sandbox (the agent_dir bind-mount at /tmp would
-        // otherwise shadow the socket file).
-        let mut socket_path_sandbox: Option<String> = None;
-        if driver == SandboxDriverKind::Bubblewrap {
-            let bridge = start_sdk_bridge(agent_dir, root_session_id.map(|s| s.to_string()))?;
-            socket_path_sandbox = Some(bridge.socket_path_sandbox.clone());
-            socket_mounts.push(SandboxMount {
-                source: bridge.guard.socket_path_host.clone(),
-                dest: bridge.socket_path_sandbox.clone(),
-                readonly: false,
-            });
-            sdk_bridge = Some(bridge.guard);
+        if let Some(mount) = wiring.bwrap_mount {
+            socket_mounts.push(mount);
         }
 
         let composed_entrypoint = compose_entrypoint(entrypoint, dependencies)?;
@@ -274,7 +274,18 @@ impl SandboxRunner {
                     bubblewrap_shell_command(agent_dir, entrypoint, &socket_mounts, overrides)?
                 }
             }
-            SandboxDriverKind::Docker => docker_command(agent_dir, &composed_entrypoint)?,
+            SandboxDriverKind::Docker => {
+                // Container env does NOT inherit the gateway process env, so the
+                // socket path / PYTHONPATH / extra_env must be passed as `-e`.
+                let mut docker_env = wiring.docker_env.clone();
+                merge_docker_env(&mut docker_env, extra_env);
+                docker_command(
+                    agent_dir,
+                    &composed_entrypoint,
+                    &wiring.docker_volumes,
+                    &docker_env,
+                )?
+            }
             SandboxDriverKind::MicroVm => microvm_command(&composed_entrypoint)?,
         };
 
@@ -285,28 +296,13 @@ impl SandboxRunner {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        if driver == SandboxDriverKind::Bubblewrap {
-            if let Some(sdk_path) = resolve_python_sdk_path() {
-                inject_pythonpath(&mut command, &sdk_path);
-            }
-            if let Some(ref path) = socket_path_sandbox {
-                command.env(CCOS_SOCKET_ENV, path);
-            }
-        }
-
-        for (key, value) in extra_env {
-            if key == PYTHONPATH_ENV {
-                inject_pythonpath_value(&mut command, value);
-            } else {
-                command.env(key, value);
-            }
-        }
+        apply_child_env(&mut command, driver, socket_path_sandbox.as_deref(), extra_env);
 
         let child = command.spawn()?;
         Ok(Self {
             process: child,
             driver,
-            _sdk_bridge: sdk_bridge,
+            _sdk_bridge: wiring.guard,
         })
     }
 
@@ -350,19 +346,13 @@ impl SandboxRunner {
             anyhow::bail!("MicroVM dependency bootstrap is not implemented yet");
         }
 
-        let mut sdk_bridge = None;
         let mut all_mounts = session_content_mounts;
-        let mut socket_path_sandbox: Option<String> = None;
 
-        if driver == SandboxDriverKind::Bubblewrap {
-            let bridge = start_sdk_bridge(agent_dir, root_session_id.map(|s| s.to_string()))?;
-            socket_path_sandbox = Some(bridge.socket_path_sandbox.clone());
-            all_mounts.push(SandboxMount {
-                source: bridge.guard.socket_path_host.clone(),
-                dest: bridge.socket_path_sandbox.clone(),
-                readonly: false,
-            });
-            sdk_bridge = Some(bridge.guard);
+        // SDK socket transport, wired for bubblewrap AND docker (P1).
+        let wiring = wire_sdk_bridge(driver, agent_dir, root_session_id)?;
+        let socket_path_sandbox = wiring.socket_path_sandbox.clone();
+        if let Some(mount) = wiring.bwrap_mount {
+            all_mounts.push(mount);
         }
 
         let composed_entrypoint = compose_entrypoint(entrypoint, dependencies)?;
@@ -370,7 +360,16 @@ impl SandboxRunner {
             SandboxDriverKind::Bubblewrap => {
                 bubblewrap_shell_command(agent_dir, &composed_entrypoint, &all_mounts, overrides)?
             }
-            SandboxDriverKind::Docker => docker_command(agent_dir, &composed_entrypoint)?,
+            SandboxDriverKind::Docker => {
+                let mut docker_env = wiring.docker_env.clone();
+                merge_docker_env(&mut docker_env, extra_env);
+                docker_command(
+                    agent_dir,
+                    &composed_entrypoint,
+                    &wiring.docker_volumes,
+                    &docker_env,
+                )?
+            }
             SandboxDriverKind::MicroVm => microvm_command(&composed_entrypoint)?,
         };
 
@@ -381,34 +380,22 @@ impl SandboxRunner {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        if driver == SandboxDriverKind::Bubblewrap {
-            if let Some(sdk_path) = resolve_python_sdk_path() {
-                inject_pythonpath(&mut command, &sdk_path);
-            }
-            if let Some(ref path) = socket_path_sandbox {
-                command.env(CCOS_SOCKET_ENV, path);
-            }
-        }
-
-        for (key, value) in extra_env {
-            if key == PYTHONPATH_ENV {
-                inject_pythonpath_value(&mut command, value);
-            } else {
-                command.env(key, value);
-            }
-        }
+        apply_child_env(&mut command, driver, socket_path_sandbox.as_deref(), extra_env);
 
         let child = command.spawn()?;
         Ok(Self {
             process: child,
             driver,
-            _sdk_bridge: sdk_bridge,
+            _sdk_bridge: wiring.guard,
         })
     }
 }
 
 struct StartedSdkBridge {
-    socket_path_sandbox: String,
+    /// Socket file name (e.g. `autonoetic-<hash>.sock`). The in-sandbox mount
+    /// path is driver-specific and computed by the caller via
+    /// [`sdk_socket_sandbox_path`], so the bridge itself stays driver-agnostic.
+    socket_name: String,
     guard: SdkBridgeGuard,
 }
 
@@ -451,13 +438,147 @@ fn start_sdk_bridge(
     });
 
     Ok(StartedSdkBridge {
-        socket_path_sandbox: format!("{}/{}", BWRAP_WORKSPACE_DIR, socket_name),
+        socket_name,
         guard: SdkBridgeGuard {
             stop,
             handle: Some(handle),
             socket_path_host: host_socket_path,
         },
     })
+}
+
+/// In-sandbox path where the SDK socket is exposed for a given driver.
+/// Bubblewrap binds it under the workspace dir; docker bind-mounts it to a
+/// fixed path. Returns `None` for drivers that don't run the bridge yet
+/// (microvm — deferred to P5).
+fn sdk_socket_sandbox_path(driver: SandboxDriverKind, socket_name: &str) -> Option<String> {
+    match driver {
+        SandboxDriverKind::Bubblewrap => Some(format!("{}/{}", BWRAP_WORKSPACE_DIR, socket_name)),
+        SandboxDriverKind::Docker => Some(DOCKER_SDK_SOCKET_PATH.to_string()),
+        SandboxDriverKind::MicroVm => None,
+    }
+}
+
+/// Centralized SDK-bridge wiring shared by every spawn path. Starts the bridge
+/// (the socket transport) once and produces the driver-specific plumbing:
+/// bubblewrap takes a bind `SandboxMount` + host-inherited env; docker takes
+/// `docker run` `-v`/`-e` flags (its container env does **not** inherit the
+/// gateway process env, so socket path + PYTHONPATH must be passed explicitly).
+/// The bridge is not started for drivers without socket support yet (microvm).
+#[derive(Default)]
+struct SdkBridgeWiring {
+    guard: Option<SdkBridgeGuard>,
+    /// In-sandbox socket path; `Some` whenever the bridge was started.
+    socket_path_sandbox: Option<String>,
+    /// Bubblewrap: bind mount to add to the mount list.
+    bwrap_mount: Option<SandboxMount>,
+    /// Docker: extra `(host, container, readonly)` volumes for `docker run -v`.
+    docker_volumes: Vec<(String, String, bool)>,
+    /// Docker: env vars for `docker run -e` (the container won't inherit them).
+    docker_env: Vec<(String, String)>,
+}
+
+fn wire_sdk_bridge(
+    driver: SandboxDriverKind,
+    agent_dir: &str,
+    root_session_id: Option<&str>,
+) -> anyhow::Result<SdkBridgeWiring> {
+    let mut wiring = SdkBridgeWiring::default();
+    // Drivers without socket support yet (microvm) run no bridge.
+    if sdk_socket_sandbox_path(driver, "").is_none() {
+        return Ok(wiring);
+    }
+
+    let bridge = start_sdk_bridge(agent_dir, root_session_id.map(|s| s.to_string()))?;
+    let host_socket = bridge.guard.socket_path_host.clone();
+    let sandbox_socket = sdk_socket_sandbox_path(driver, &bridge.socket_name)
+        .expect("driver supports the bridge (checked above)");
+    wiring.socket_path_sandbox = Some(sandbox_socket.clone());
+
+    match driver {
+        SandboxDriverKind::Bubblewrap => {
+            wiring.bwrap_mount = Some(SandboxMount {
+                source: host_socket,
+                dest: sandbox_socket,
+                readonly: false,
+            });
+        }
+        SandboxDriverKind::Docker => {
+            wiring.docker_volumes.push((
+                host_socket.to_string_lossy().to_string(),
+                sandbox_socket.clone(),
+                false,
+            ));
+            wiring
+                .docker_env
+                .push((CCOS_SOCKET_ENV.to_string(), sandbox_socket));
+            // The Python SDK isn't in the docker image; mount it read-only and
+            // point PYTHONPATH at the mount so the in-container client resolves.
+            if let Some(sdk_path) = resolve_python_sdk_path() {
+                wiring.docker_volumes.push((
+                    sdk_path,
+                    DOCKER_SDK_PYTHONPATH.to_string(),
+                    true,
+                ));
+                wiring
+                    .docker_env
+                    .push((PYTHONPATH_ENV.to_string(), DOCKER_SDK_PYTHONPATH.to_string()));
+            }
+        }
+        SandboxDriverKind::MicroVm => {}
+    }
+    wiring.guard = Some(bridge.guard);
+    Ok(wiring)
+}
+
+/// Merge `extra_env` into a docker env list, concatenating `PYTHONPATH` (the SDK
+/// path must stay on the path) rather than overwriting it.
+fn merge_docker_env(base: &mut Vec<(String, String)>, extra_env: &[(String, String)]) {
+    for (key, value) in extra_env {
+        if key == PYTHONPATH_ENV {
+            if let Some(existing) = base.iter_mut().find(|(k, _)| k == PYTHONPATH_ENV) {
+                existing.1 = format!("{}:{}", value, existing.1);
+                continue;
+            }
+        }
+        base.push((key.clone(), value.clone()));
+    }
+}
+
+/// Apply child-process env per driver. Bubblewrap inherits the gateway env, so
+/// the SDK PYTHONPATH, socket path, and `extra_env` go on the `Command`. Docker
+/// bakes its env into the `docker run` argv (`-e`, in `docker_command`) since the
+/// container doesn't inherit this process's env, so nothing is set here. MicroVm
+/// keeps prior behavior (`extra_env` on the `Command`).
+fn apply_child_env(
+    command: &mut Command,
+    driver: SandboxDriverKind,
+    socket_path_sandbox: Option<&str>,
+    extra_env: &[(String, String)],
+) {
+    match driver {
+        SandboxDriverKind::Bubblewrap => {
+            if let Some(sdk_path) = resolve_python_sdk_path() {
+                inject_pythonpath(command, &sdk_path);
+            }
+            if let Some(path) = socket_path_sandbox {
+                command.env(CCOS_SOCKET_ENV, path);
+            }
+            for (key, value) in extra_env {
+                if key == PYTHONPATH_ENV {
+                    inject_pythonpath_value(command, value);
+                } else {
+                    command.env(key, value);
+                }
+            }
+        }
+        SandboxDriverKind::Docker => {}
+        SandboxDriverKind::MicroVm => {
+            for (key, value) in extra_env {
+                command.env(key, value);
+            }
+        }
+    }
 }
 
 fn run_sdk_bridge_loop(
@@ -1199,11 +1320,20 @@ fn parse_bwrap_dev_mode(value: Option<&str>) -> BwrapDevMode {
     }
 }
 
-fn docker_command(agent_dir: &str, entrypoint: &str) -> anyhow::Result<(String, Vec<String>)> {
+/// Build the `docker run` invocation. `volumes` are extra `(host, container,
+/// readonly)` bind mounts (e.g. the SDK socket + SDK source); `env` are vars
+/// passed via `-e` (the container does not inherit the gateway process env, so
+/// the SDK socket path / PYTHONPATH must be passed explicitly here).
+fn docker_command(
+    agent_dir: &str,
+    entrypoint: &str,
+    volumes: &[(String, String, bool)],
+    env: &[(String, String)],
+) -> anyhow::Result<(String, Vec<String>)> {
     let image = std::env::var(DOCKER_IMAGE_ENV).map_err(|_| {
         anyhow::anyhow!("Missing required environment variable {}", DOCKER_IMAGE_ENV)
     })?;
-    let argv = vec![
+    let mut argv = vec![
         "run".to_string(),
         "--rm".to_string(),
         "--network".to_string(),
@@ -1212,11 +1342,23 @@ fn docker_command(agent_dir: &str, entrypoint: &str) -> anyhow::Result<(String, 
         format!("{}:/workspace", agent_dir),
         "--workdir".to_string(),
         "/workspace".to_string(),
-        image,
-        "sh".to_string(),
-        "-c".to_string(), // Non-login shell - don't source /etc/profile.d/*
-        entrypoint.to_string(),
     ];
+    for (host, container, readonly) in volumes {
+        argv.push("--volume".to_string());
+        argv.push(if *readonly {
+            format!("{}:{}:ro", host, container)
+        } else {
+            format!("{}:{}", host, container)
+        });
+    }
+    for (key, value) in env {
+        argv.push("--env".to_string());
+        argv.push(format!("{}={}", key, value));
+    }
+    argv.push(image);
+    argv.push("sh".to_string());
+    argv.push("-c".to_string()); // Non-login shell - don't source /etc/profile.d/*
+    argv.push(entrypoint.to_string());
     Ok(("docker".to_string(), argv))
 }
 
@@ -1334,7 +1476,7 @@ mod tests {
     fn test_docker_command_requires_env() {
         let old = std::env::var(DOCKER_IMAGE_ENV).ok();
         std::env::remove_var(DOCKER_IMAGE_ENV);
-        let err = docker_command("/tmp/agent", "python main.py")
+        let err = docker_command("/tmp/agent", "python main.py", &[], &[])
             .expect_err("docker command should fail without env");
         assert!(
             err.to_string().contains(DOCKER_IMAGE_ENV),
@@ -1343,6 +1485,76 @@ mod tests {
         if let Some(v) = old {
             std::env::set_var(DOCKER_IMAGE_ENV, v);
         }
+    }
+
+    #[test]
+    fn test_docker_command_emits_socket_volume_and_env() {
+        // P1: the SDK socket + its env must reach the container via `-v`/`-e`
+        // (the container does not inherit the gateway process env).
+        let old = std::env::var(DOCKER_IMAGE_ENV).ok();
+        std::env::set_var(DOCKER_IMAGE_ENV, "test-image:latest");
+        let volumes = vec![
+            (
+                "/tmp/autonoetic-abc.sock".to_string(),
+                DOCKER_SDK_SOCKET_PATH.to_string(),
+                false,
+            ),
+            (
+                "/host/sdk".to_string(),
+                DOCKER_SDK_PYTHONPATH.to_string(),
+                true,
+            ),
+        ];
+        let env = vec![
+            (CCOS_SOCKET_ENV.to_string(), DOCKER_SDK_SOCKET_PATH.to_string()),
+            (PYTHONPATH_ENV.to_string(), DOCKER_SDK_PYTHONPATH.to_string()),
+        ];
+        let (program, argv) =
+            docker_command("/tmp/agent", "python main.py", &volumes, &env).expect("docker command");
+        assert_eq!(program, "docker");
+        let joined = argv.join(" ");
+        // socket mounted read-write, SDK source read-only
+        assert!(joined.contains(&format!("/tmp/autonoetic-abc.sock:{}", DOCKER_SDK_SOCKET_PATH)));
+        assert!(joined.contains(&format!("/host/sdk:{}:ro", DOCKER_SDK_PYTHONPATH)));
+        // env passed via -e, not inherited
+        assert!(joined.contains(&format!("{}={}", CCOS_SOCKET_ENV, DOCKER_SDK_SOCKET_PATH)));
+        assert!(joined.contains(&format!("{}={}", PYTHONPATH_ENV, DOCKER_SDK_PYTHONPATH)));
+        // image + shell entrypoint preserved, after the flags
+        assert!(argv.contains(&"test-image:latest".to_string()));
+        assert_eq!(argv.last().unwrap(), "python main.py");
+        match old {
+            Some(v) => std::env::set_var(DOCKER_IMAGE_ENV, v),
+            None => std::env::remove_var(DOCKER_IMAGE_ENV),
+        }
+    }
+
+    #[test]
+    fn test_merge_docker_env_concatenates_pythonpath() {
+        let mut base = vec![(PYTHONPATH_ENV.to_string(), "/opt/autonoetic-sdk".to_string())];
+        merge_docker_env(
+            &mut base,
+            &[
+                (PYTHONPATH_ENV.to_string(), "/extra".to_string()),
+                ("FOO".to_string(), "bar".to_string()),
+            ],
+        );
+        let pp = base.iter().find(|(k, _)| k == PYTHONPATH_ENV).unwrap();
+        assert_eq!(pp.1, "/extra:/opt/autonoetic-sdk");
+        assert!(base.iter().any(|(k, v)| k == "FOO" && v == "bar"));
+    }
+
+    #[test]
+    fn test_sdk_socket_sandbox_path_per_driver() {
+        assert_eq!(
+            sdk_socket_sandbox_path(SandboxDriverKind::Bubblewrap, "s.sock").as_deref(),
+            Some(format!("{}/s.sock", BWRAP_WORKSPACE_DIR).as_str())
+        );
+        assert_eq!(
+            sdk_socket_sandbox_path(SandboxDriverKind::Docker, "s.sock").as_deref(),
+            Some(DOCKER_SDK_SOCKET_PATH)
+        );
+        // microvm has no bridge yet (P5)
+        assert!(sdk_socket_sandbox_path(SandboxDriverKind::MicroVm, "s.sock").is_none());
     }
 
     #[test]

--- a/autonoetic-gateway/tests/p1_sdk_transport_integration.rs
+++ b/autonoetic-gateway/tests/p1_sdk_transport_integration.rs
@@ -35,3 +35,58 @@ fn driver_availability_probes_do_not_panic() {
     let _ = is_bwrap_available();
     let _ = is_docker_available();
 }
+
+/// P1 acceptance: a **docker** agent can reach the SDK bridge (closes the
+/// bubblewrap-only gap). A stdlib-only Python probe inside the docker sandbox
+/// connects to the bridge socket (exposed via `-v` + `CCOS_SOCKET_PATH` `-e`)
+/// and performs one JSON-RPC round-trip. It uses an unknown method on purpose:
+/// the bridge replies with a structured JSON-RPC *error*, which still proves the
+/// transport end-to-end without depending on the Python SDK package layout or
+/// gateway session state. Skipped unless docker is available.
+#[test]
+fn docker_agent_reaches_sdk_bridge() {
+    if !is_docker_available() {
+        eprintln!("skipping docker_agent_reaches_sdk_bridge: docker not available");
+        return;
+    }
+    use autonoetic_gateway::sandbox::SandboxRunner;
+    use std::io::Read;
+
+    let image =
+        std::env::var("AUTONOETIC_DOCKER_IMAGE").unwrap_or_else(|_| "python:3.12-slim".to_string());
+    std::env::set_var("AUTONOETIC_DOCKER_IMAGE", &image);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let probe = r#"import os, socket, json, sys
+path = os.environ["CCOS_SOCKET_PATH"]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(path)
+s.sendall((json.dumps({"jsonrpc": "2.0", "id": 1, "method": "p1.probe", "params": {}}) + "\n").encode())
+sys.stdout.write(s.recv(65536).decode())
+sys.stdout.flush()
+"#;
+    std::fs::write(dir.path().join("p1_probe.py"), probe).expect("write probe");
+    let agent_dir = dir.path().to_str().expect("utf8 path");
+
+    let mut runner =
+        SandboxRunner::spawn_for_driver("docker", agent_dir, "python3 /workspace/p1_probe.py")
+            .expect("spawn docker sandbox");
+    let mut stdout = String::new();
+    runner
+        .process
+        .stdout
+        .take()
+        .expect("piped stdout")
+        .read_to_string(&mut stdout)
+        .expect("read stdout");
+    let status = runner.process.wait().expect("wait for docker sandbox");
+
+    assert!(
+        status.success(),
+        "docker sandbox exited non-zero; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"jsonrpc\""),
+        "expected a JSON-RPC response from the docker SDK bridge, got: {stdout}"
+    );
+}

--- a/autonoetic-gateway/tests/p1_sdk_transport_integration.rs
+++ b/autonoetic-gateway/tests/p1_sdk_transport_integration.rs
@@ -10,6 +10,8 @@
 //! This file seeds the phase with the driver-availability helpers the P1 tests
 //! build on. The end-to-end bridge-parity assertions land with the refactor.
 
+use serial_test::serial;
+
 /// True when `bwrap --version` succeeds (bubblewrap installed).
 pub fn is_bwrap_available() -> bool {
     std::process::Command::new("bwrap")
@@ -44,16 +46,19 @@ fn driver_availability_probes_do_not_panic() {
 /// transport end-to-end without depending on the Python SDK package layout or
 /// gateway session state. Skipped unless docker is available.
 #[test]
+#[serial] // mutates AUTONOETIC_DOCKER_IMAGE (process-global); don't race other env tests
 fn docker_agent_reaches_sdk_bridge() {
     if !is_docker_available() {
         eprintln!("skipping docker_agent_reaches_sdk_bridge: docker not available");
         return;
     }
     use autonoetic_gateway::sandbox::SandboxRunner;
-    use std::io::Read;
 
-    let image =
-        std::env::var("AUTONOETIC_DOCKER_IMAGE").unwrap_or_else(|_| "python:3.12-slim".to_string());
+    // Capture + restore so we don't leak global env to later tests.
+    let prev_image = std::env::var("AUTONOETIC_DOCKER_IMAGE").ok();
+    let image = prev_image
+        .clone()
+        .unwrap_or_else(|| "python:3.12-slim".to_string());
     std::env::set_var("AUTONOETIC_DOCKER_IMAGE", &image);
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -68,25 +73,30 @@ sys.stdout.flush()
     std::fs::write(dir.path().join("p1_probe.py"), probe).expect("write probe");
     let agent_dir = dir.path().to_str().expect("utf8 path");
 
-    let mut runner =
+    let runner =
         SandboxRunner::spawn_for_driver("docker", agent_dir, "python3 /workspace/p1_probe.py")
             .expect("spawn docker sandbox");
-    let mut stdout = String::new();
-    runner
+    // `wait_with_output` drains BOTH stdout and stderr — reading only stdout
+    // could deadlock if the child fills the stderr pipe. The bridge guard stays
+    // alive in `runner` (SandboxRunner has no Drop) until end of scope.
+    let output = runner
         .process
-        .stdout
-        .take()
-        .expect("piped stdout")
-        .read_to_string(&mut stdout)
-        .expect("read stdout");
-    let status = runner.process.wait().expect("wait for docker sandbox");
+        .wait_with_output()
+        .expect("wait for docker sandbox");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    match prev_image {
+        Some(v) => std::env::set_var("AUTONOETIC_DOCKER_IMAGE", v),
+        None => std::env::remove_var("AUTONOETIC_DOCKER_IMAGE"),
+    }
 
     assert!(
-        status.success(),
-        "docker sandbox exited non-zero; stdout: {stdout}"
+        output.status.success(),
+        "docker sandbox exited non-zero.\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(
         stdout.contains("\"jsonrpc\""),
-        "expected a JSON-RPC response from the docker SDK bridge, got: {stdout}"
+        "expected a JSON-RPC response from the docker SDK bridge.\nstdout: {stdout}\nstderr: {stderr}"
     );
 }

--- a/autonoetic-gateway/tests/p1_sdk_transport_integration.rs
+++ b/autonoetic-gateway/tests/p1_sdk_transport_integration.rs
@@ -1,0 +1,37 @@
+//! P1 — SDK transport abstraction (issue #439).
+//!
+//! The SDK bridge today is wired for **bubblewrap only** (`sandbox.rs:252`,
+//! `if driver == SandboxDriverKind::Bubblewrap`). P1 extracts a transport
+//! abstraction and brings **docker** to parity so a docker agent can call SDK
+//! methods too. Per RFC §4.1, every early-phase acceptance check runs on **both**
+//! bubblewrap and docker, availability-gated so a contributor with only one
+//! driver still gets a green local run.
+//!
+//! This file seeds the phase with the driver-availability helpers the P1 tests
+//! build on. The end-to-end bridge-parity assertions land with the refactor.
+
+/// True when `bwrap --version` succeeds (bubblewrap installed).
+pub fn is_bwrap_available() -> bool {
+    std::process::Command::new("bwrap")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// True when `docker version` succeeds (docker CLI + reachable daemon).
+pub fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn driver_availability_probes_do_not_panic() {
+    // Probing is side-effect free and must never panic, so availability-gated
+    // tests can call it unconditionally to decide skip-vs-run.
+    let _ = is_bwrap_available();
+    let _ = is_docker_available();
+}


### PR DESCRIPTION
Implements **P1** of the portable-execution-tier RFC (#437). Closes #439 · part of #438.

## Goal

Extract an `SdkTransport` abstraction so the JSON-RPC SDK bridge isn't bound to a Unix socket, and **bring docker to bridge parity** — today the bridge is bubblewrap-only (`sandbox.rs:252`), so docker agents can't call SDK methods.

## Implementation breakdown (grounded in current code)

1. **Generalize `start_sdk_bridge`** (`sandbox.rs:~190`) to return the host socket path + socket name; let the caller compute the in-sandbox path per driver (today it hardcodes `BWRAP_WORKSPACE_DIR`).
2. **Start the bridge for docker too** — lift the `if driver == Bubblewrap` gate at `sandbox.rs:252` (and the second spawn fn, `spawn_with_session_content` ~355).
3. **Mount the socket into docker** — `docker_command` (`sandbox.rs:1202`) gains a socket mount: add `-v <host_socket>:<container_socket>` and set the container path (e.g. `/run/autonoetic/sdk.sock`).
4. **Env-injection subtlety** — for bubblewrap, env reaches the sandbox via `command.env(CCOS_SOCKET_ENV, …)` (`sandbox.rs:293`); **docker ignores that** (it sets env on the `docker` CLI, not the container). So `docker_command` must emit `-e CCOS_SOCKET_ENV=…` (and `-e PYTHONPATH=…`) in the `docker run` argv. This is the core signature change.
5. **`SdkTransport` type** — wrap today's socket bridge as `SdkTransport::Socket`; both drivers share the same `dispatch_sdk_method` (`sandbox.rs:727`). (Leaves room for P4's `HostFunctions` variant.)
6. **Tests** — availability-gated on `is_bwrap_available()` / `is_docker_available()` (seeded here); unit-test docker argv (asserts `-v` socket mount + `-e CCOS_SOCKET_ENV`); e2e: a docker agent calls an SDK method; bubblewrap behavior unchanged.

Firecracker transport is **out of scope** (deferred to P5).

## Acceptance (RFC §11)

- [ ] A docker agent can call SDK methods (closes the bubblewrap-only gap).
- [ ] Bubblewrap behavior byte-for-byte unchanged.
- [ ] Tests gated on bwrap/docker availability, skip-if-absent.

## Status

Draft. Seeded with the bwrap+docker availability-gating test scaffold; the transport extraction + docker wiring land next. End-to-end docker verification needs a docker daemon (operator has one locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)