### PR TITLE
fix(wiki): emit wiki.withdrawn timeline event on agent withdrawal

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/approval.rs
+++ b/autonoetic-gateway/src/runtime/tools/approval.rs
@@ -234,6 +234,37 @@ impl NativeTool for ApprovalWithdrawTool {
                     }
                 }
 
+                if matches!(r.action, autonoetic_types::background::ScheduledAction::WikiProposal { .. }) {
+                    let role = crate::runtime::session_timeline::derive_role(&r.agent_id);
+                    let principal = autonoetic_types::principal::Principal::agent(r.agent_id.clone());
+                    let refs = autonoetic_types::session_timeline::TimelineRefs::default();
+                    let (page_id, title) = match &r.action {
+                        autonoetic_types::background::ScheduledAction::WikiProposal { page_id, title, .. } => (page_id.clone(), title.clone()),
+                        _ => unreachable!(),
+                    };
+                    let payload = serde_json::json!({
+                        "page_id": page_id,
+                        "title": title,
+                        "decided_by": format!("agent:{}", manifest.agent.id),
+                        "cancelled_by": manifest.agent.id,
+                        "reason": reason,
+                    });
+                    let event = crate::runtime::session_timeline::build_timeline_event(
+                        r.root_session_id.clone().unwrap_or_else(|| r.session_id.clone()),
+                        r.session_id.clone(),
+                        None,
+                        &principal,
+                        &role,
+                        "wiki.withdrawn",
+                        None,
+                        Some(payload),
+                        refs,
+                    );
+                    if let Err(e) = store.create_live_digest_event(&event) {
+                        tracing::debug!(target: "session_timeline", error = %e, "wiki.withdrawn timeline emit failed");
+                    }
+                }
+
                 tracing::info!(
                     target: "approval_withdraw",
                     request_id = %args.request_id,

--- a/autonoetic-gateway/src/runtime/tools/approval.rs
+++ b/autonoetic-gateway/src/runtime/tools/approval.rs
@@ -246,7 +246,7 @@ impl NativeTool for ApprovalWithdrawTool {
                         "page_id": page_id,
                         "title": title,
                         "decided_by": format!("agent:{}", manifest.agent.id),
-                        "cancelled_by": manifest.agent.id,
+                        "cancelled_by": format!("agent:{}", manifest.agent.id),
                         "reason": reason,
                     });
                     let event = crate::runtime::session_timeline::build_timeline_event(

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -1029,6 +1029,7 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
         "wiki.proposed" => format!("wiki proposed: {} ({})", field("title").unwrap_or_default(), field("page_id").unwrap_or_default()),
         "wiki.promoted" => format!("wiki promoted: {} ({})", field("title").unwrap_or_default(), field("page_id").unwrap_or_default()),
         "wiki.rejected" => format!("wiki rejected: {} — {}", field("title").unwrap_or_default(), field("reason").unwrap_or_else(|| "no reason".into())),
+        "wiki.withdrawn" => format!("wiki withdrawn: {} ({})", field("title").unwrap_or_default(), field("page_id").unwrap_or_default()),
         "divergence.intervention" => format!(
             "divergence: {} (turn {})",
             field("level").unwrap_or_else(|| "?".into()),
@@ -1440,6 +1441,7 @@ pub fn render_spec(entry: &SessionTimelineEntry) -> RowSpec {
         "wiki.proposed" => wiki_lifecycle_card(entry, "📝 WIKI PROPOSED"),
         "wiki.promoted" => wiki_lifecycle_card(entry, "✅ WIKI PROMOTED"),
         "wiki.rejected" => wiki_lifecycle_card(entry, "❌ WIKI REJECTED"),
+        "wiki.withdrawn" => wiki_lifecycle_card(entry, "↩️ WIKI WITHDRAWN"),
         _ => (summarize(entry), detail_preview(entry)),
     };
     let actor = actor_kind(&entry.role);
@@ -1523,7 +1525,7 @@ pub fn row_tone(event_type: &str) -> RowTone {
 pub fn tone_for_entry(entry: &SessionTimelineEntry) -> RowTone {
     match entry.event_type.as_str() {
         "plan.pending" | "approval.pending" | "user.ask.pending" | "escalation.pending"
-        | "wiki.proposed" | "wiki.promoted" | "wiki.rejected" => {
+        | "wiki.proposed" | "wiki.promoted" | "wiki.rejected" | "wiki.withdrawn" => {
             RowTone::OperatorGate
         }
         "agent.message" | "operator.message" if extract_plan_proposal_id(entry).is_some() => {


### PR DESCRIPTION
### Problem

When an agent withdraws a wiki proposal via `approval.withdraw`, the proposal silently disappears from the review queue with no wiki-specific timeline event. The tool bypasses `cancel_request()` and calls `store.cancel_approval()` directly, skipping the `emit_wiki_timeline_event()` call.

### Fix

- Emit `wiki.withdrawn` timeline event in `ApprovalWithdrawTool` when the action is `ScheduledAction::WikiProposal`
- Wire `wiki.withdrawn` in Room TUI render (line text, gate card, tone classification)
- Event payload includes `page_id`, `title`, `cancelled_by`, `decided_by`, `reason`

### Issue #427 audit trail gap

This addresses the partial implementation of item 5 (audit trail): propose/promote/reject already had events, but withdraw was missing.

### Verification
- `cargo build` passes
- `cargo test -p autonoetic -- slash::tests` — 16/16 pass
- Pre-existing test failure `workflow_bound_approval_skips_direct_session_notification` is unrelated (fails on main too)