### PR TITLE
P3: hermetic-export dependency-lock guard + packager determinism design note

### DIFF
--- a/autonoetic-gateway/src/capsule/export.rs
+++ b/autonoetic-gateway/src/capsule/export.rs
@@ -91,6 +91,11 @@ pub fn export(req: ExportRequest, ctx: ExportContext<'_>) -> Result<ExportOutcom
     let revision = resolve_revision(&req, ctx.gateway_store.as_ref())?;
     let revision_dir = revision_dir(ctx.gateway_dir, &revision.agent_id, &revision.revision_id);
 
+    // Hermetic/Replay capsules are imported offline, so every dependency must be
+    // embedded as a pinned layer — a runtime-pip (dev-mode) closure can't be
+    // reproduced without network on the receiver. Fail fast with guidance.
+    require_locked_dependencies_for_hermetic(&revision_dir, req.mode)?;
+
     let staging = tempfile::tempdir().context("creating capsule staging dir")?;
     let staging_path = staging.path();
 
@@ -440,6 +445,38 @@ fn mode_str(mode: CapsuleMode) -> &'static str {
     }
 }
 
+/// Hermetic/Replay capsules embed their closure for offline import, so the
+/// agent must be **dependency-locked** (deps baked into pinned layers, no
+/// runtime-pip step). Reject the export otherwise, with guidance. Thin/Headless
+/// modes carry references and are unaffected. A missing/unparseable lock is not
+/// blocked here (there's nothing we can positively flag as runtime-pip).
+fn require_locked_dependencies_for_hermetic(
+    revision_dir: &Path,
+    mode: CapsuleMode,
+) -> Result<()> {
+    if !mode.is_hermetic() {
+        return Ok(());
+    }
+    let lock_path = revision_dir.join("runtime.lock");
+    let Ok(content) = std::fs::read_to_string(&lock_path) else {
+        return Ok(());
+    };
+    let Ok(lock) = serde_yaml::from_str::<autonoetic_types::runtime_lock::RuntimeLock>(&content)
+    else {
+        return Ok(());
+    };
+    if lock.has_runtime_pip_dependencies() {
+        anyhow::bail!(
+            "{}-mode export requires a dependency-locked agent, but its runtime.lock declares \
+             runtime-installed (pip) dependencies. Hermetic/Replay capsules import offline, so \
+             dependencies must be baked into pinned layers first (locked mode). \
+             See docs/rfc/portable-wasm-execution-tier.md §5.4.1.",
+            mode_str(mode)
+        );
+    }
+    Ok(())
+}
+
 fn emit_export_event(
     store: &GatewayStore,
     capsule_id: &str,
@@ -480,6 +517,39 @@ fn emit_export_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const LOCK_WITH_PIP: &str = "gateway:\n  artifact: \"\"\n  version: \"\"\n  sha256: \"\"\n  signature: null\nsdk:\n  version: \"\"\nsandbox:\n  backend: bubblewrap\ndependencies:\n  - runtime: python\n    packages: [requests]\n";
+    const LOCK_NO_DEPS: &str = "gateway:\n  artifact: \"\"\n  version: \"\"\n  sha256: \"\"\n  signature: null\nsdk:\n  version: \"\"\nsandbox:\n  backend: bubblewrap\n";
+
+    #[test]
+    fn hermetic_export_rejects_runtime_pip_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("runtime.lock"), LOCK_WITH_PIP).unwrap();
+        // Hermetic + Replay reject; Thin + Headless are unaffected.
+        let err = require_locked_dependencies_for_hermetic(dir.path(), CapsuleMode::Hermetic)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("dependency-locked"), "got: {err}");
+        assert!(require_locked_dependencies_for_hermetic(dir.path(), CapsuleMode::Replay).is_err());
+        assert!(require_locked_dependencies_for_hermetic(dir.path(), CapsuleMode::Thin).is_ok());
+        assert!(
+            require_locked_dependencies_for_hermetic(dir.path(), CapsuleMode::Headless).is_ok()
+        );
+    }
+
+    #[test]
+    fn hermetic_export_allows_locked_closure() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("runtime.lock"), LOCK_NO_DEPS).unwrap();
+        assert!(require_locked_dependencies_for_hermetic(dir.path(), CapsuleMode::Hermetic).is_ok());
+    }
+
+    #[test]
+    fn hermetic_export_lenient_when_no_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // No runtime.lock present → nothing to positively flag as runtime-pip.
+        assert!(require_locked_dependencies_for_hermetic(dir.path(), CapsuleMode::Hermetic).is_ok());
+    }
 
     #[test]
     fn redact_file_if_text_masks_text_secrets() {

--- a/autonoetic-types/src/runtime_lock.rs
+++ b/autonoetic-types/src/runtime_lock.rs
@@ -114,3 +114,66 @@ pub struct RuntimeLock {
     #[serde(default)]
     pub credentials: Vec<LockedCredentialMount>,
 }
+
+impl RuntimeLock {
+    /// True when the closure declares runtime-installed (e.g. `pip install`)
+    /// dependencies. These are resolved *at spawn time* and need network — the
+    /// opposite of an embedded, content-addressed [`LockedLayerMount`].
+    pub fn has_runtime_pip_dependencies(&self) -> bool {
+        !self.dependencies.is_empty()
+    }
+
+    /// True when the closure is **dependency-locked**: every dependency is baked
+    /// into a pinned, content-addressed `layers` mount (or there are none), with
+    /// no runtime-install step. Locked closures are reproducible and importable
+    /// offline — a precondition for `CapsuleMode::Hermetic`/`Replay` export.
+    pub fn is_dependency_locked(&self) -> bool {
+        !self.has_runtime_pip_dependencies()
+    }
+}
+
+#[cfg(test)]
+mod lock_state_tests {
+    use super::*;
+
+    fn empty_lock() -> RuntimeLock {
+        RuntimeLock {
+            gateway: LockedGateway {
+                artifact: String::new(),
+                version: String::new(),
+                sha256: String::new(),
+                binary_sha256: None,
+                build_tag: None,
+                signature: None,
+            },
+            sdk: LockedSdk {
+                version: String::new(),
+            },
+            sandbox: LockedSandbox {
+                backend: String::new(),
+            },
+            dependencies: vec![],
+            artifacts: vec![],
+            layers: vec![],
+            credentials: vec![],
+        }
+    }
+
+    #[test]
+    fn no_deps_is_locked() {
+        let lock = empty_lock();
+        assert!(lock.is_dependency_locked());
+        assert!(!lock.has_runtime_pip_dependencies());
+    }
+
+    #[test]
+    fn runtime_pip_deps_are_not_locked() {
+        let mut lock = empty_lock();
+        lock.dependencies.push(LockedDependencySet {
+            runtime: "python".to_string(),
+            packages: vec!["requests".to_string()],
+        });
+        assert!(!lock.is_dependency_locked());
+        assert!(lock.has_runtime_pip_dependencies());
+    }
+}

--- a/docs/design/packager-dependency-determinism.md
+++ b/docs/design/packager-dependency-determinism.md
@@ -1,0 +1,120 @@
+# Packager dependency determinism: resolve → validate → pin-on-promotion
+
+- **Status:** Design (agreed direction; implementation scoped below)
+- **Related:** RFC `docs/rfc/portable-wasm-execution-tier.md` §5.4 (P3), PR #447, constitution P-3.6 (read-only layers), promotion/approval machinery
+- **Supersedes:** the RFC's standalone "bake step" (P3 increment 2/3) — see §1
+
+## Context
+
+While implementing P3 ("pinned dependency layers + lock/dev modes") we discovered
+the proposed *bake step* (install deps → capture layer → rewrite `runtime.lock`)
+was **redundant** with the existing packager flow, which already produces a
+fully-locked closure end to end:
+
+1. **packager** (`agents/specialists/packager.default/SKILL.md`) runs
+   `sandbox.exec(..., capture_paths)` → installs deps (`pip install -r
+   requirements.txt --target /tmp/venv`) → `LayerStore::create_from_dir` captures
+   them as a content-addressed layer (`layer_id` + `digest`).
+2. **`artifact.build`** embeds those layers into the artifact (`ArtifactBundle.layers`).
+3. **`scaffold_runtime_lock_with_scopes`** (`runtime/install_contract.rs`) writes
+   the artifact's layers into `runtime.lock.layers`; `agent_revision` **validates**
+   `runtime.lock.layers == artifact.layers`.
+4. At spawn, `script_execute` mounts those layers + sets `PYTHONPATH` — no pip.
+
+So a properly-packaged script-agent already has `dependencies: []` and pinned
+`layers: [...]`. The bake/lock code was therefore dropped from P3; what remains
+in PR #447 is the genuinely-new, non-redundant piece: the **Hermetic-export
+guard** (`RuntimeLock::is_dependency_locked()` + capsule export rejecting
+runtime-pip deps), which *enforces* what the packager *produces*.
+
+The real open problem — the subject of this note — is **determinism for
+autonomy**: can the packager determine deps, build the layer, and lock the bundle
+reliably enough to run unattended?
+
+## Two determinism guarantees (keep them separate)
+
+- **Run-time closure determinism — already solid.** The layer is the SHA-256 of
+  its compressed contents; `runtime.lock` pins that digest; `agent_revision`
+  validates lock == artifact; the runtime mounts exactly those bytes. A built
+  closure runs identically forever, offline, tamper-evident — *independent of how
+  non-deterministic the agent that built it was.*
+- **Build determinism — not guaranteed.** Two sources of non-determinism:
+  1. **Which deps** — from `requirements.txt` (not free LLM inference), but the
+     agent/author still authors it.
+  2. **Which versions** — `pip install -r requirements.txt --target` resolves
+     *latest at install time* unless pinned. The layer digest freezes whatever
+     resolved, but a *re-build* later yields different versions/digest, and the
+     layer stores **no human-readable resolved-version manifest** (digest only).
+
+## The model: resolve → validate → pin-on-promotion
+
+Pinning is a **consequence of a validated, approved run — never a precondition.**
+Do **not** block on an unpinned `requirements.txt`.
+
+1. **Build (unpinned OK, non-blocking).** Packager installs whatever resolves →
+   the layer digest pins the content. **Also capture the resolved set** (e.g.
+   `pip freeze` of the layer's `site-packages` / dist-info) as **read-only
+   provenance** stored with the layer. Cheap, non-blocking, and it makes the run
+   auditable.
+2. **Run + audit.** The agent executes against that layer; execution traces /
+   causal chain record it (existing machinery).
+3. **Validate + promote + approve.** The existing promotion gate runs; the
+   approver sees the **concrete resolved versions** being blessed
+   (`requests==2.31.0`, …), not a vague "latest".
+4. **Pin-on-promotion ("bless the found versions").** On approval, record the
+   resolved set as the agent's blessed dependency lock. The digest was always the
+   runtime pin; this adds the reproducible, human-readable version manifest —
+   *earned by validation.*
+
+This fits the separation of powers: the agent stays semantic/free during
+iteration; the **freeze is mechanical, at the promotion boundary**, gated by
+audit + approval.
+
+### Caveat designed for
+
+Capture provenance **at build (always)**, not only at promotion — otherwise an
+unblessed-but-working agent whose layer is later pruned by the retention policy
+becomes unrecoverable. Build-time capture is the safety net (always
+reconstructable); promotion is the trust/freeze. "Unpinned" must never mean
+"unrecoverable", only "not yet blessed".
+
+### Verification gate
+
+"Validated" must be concrete: a post-bake check that the layer actually satisfies
+the agent — imports resolve / smoke test passes (reuse `unit_test_runner` /
+evaluator/auditor) — **before** promotion. An autonomous build must not be able
+to ship a broken-but-locked closure.
+
+## Implementation plan (increments)
+
+1. **Build-time resolved-version provenance.** After the packager captures a
+   dependency layer, record the resolved set (`pip freeze` equivalent) into the
+   layer metadata/manifest (`autonoetic-types/src/layer.rs`, `LayerStore`).
+   Read-only; no behavior change to install or run.
+2. **Surface resolved versions at the approval boundary.** Include the layer's
+   resolved-version manifest in the promotion/approval payload so the operator
+   blesses a concrete set.
+3. **Bless-on-promotion.** On approval, persist the blessed pinned set on the
+   agent revision (see open question below).
+4. **Verification gate.** Wire a post-bake import/smoke check into the
+   promotion flow; block promotion (not build) on failure.
+
+Each increment is independently shippable and verified on bubblewrap + docker
+(availability-gated, RFC §4.1).
+
+## Open questions (proposed defaults)
+
+- **Where the blessed pin lives.** *Default:* resolved-version **provenance
+  manifest inside the layer** (always, at build) + a **blessed lock recorded on
+  the revision** at promotion. (Alternative considered: a re-derived
+  `requirements.lock` in the artifact bundle.)
+- **Re-bake from the blessed pin** (cross-arch / portability). *Default:* out of
+  scope now; revisit in P4, where WASI layers need a reproducible rebuild from the
+  pinned set anyway.
+
+## Non-goals
+
+- Replacing the packager or the `capture_paths` → `artifact.build` flow (it stays
+  the mechanism).
+- Forcing upfront version pins / hash-pinning as a precondition (rejected — see
+  the model).


### PR DESCRIPTION
Implements **P3** of the portable-execution-tier RFC (#437). Part of #438 · closes #441.

## What this PR is now (trimmed after review)

Review found that the originally-planned **bake/lock step was redundant** with the existing packager flow, which already produces a fully-locked closure end to end:
`packager → sandbox.exec(capture_paths) → LayerStore::create_from_dir → artifact.build(layers) → scaffold_runtime_lock (layers, deps:[]) → validated by agent_revision → mounted at spawn (no pip)`.

So the bake/lock machinery (former increments 2a/2b/3) was **dropped**. What remains is the genuinely-new, non-redundant piece plus a design note for the real open problem.

## Landed
1. **Hermetic-export dependency-lock guard** — `RuntimeLock::is_dependency_locked()` / `has_runtime_pip_dependencies()`, and capsule export now **rejects** Hermetic/Replay when the lock carries runtime-pip deps (RFC §5.4.1). The existing flow *produces* locked closures; this *enforces* it at the export boundary. *5 tests.*
2. **Design note** — `docs/design/packager-dependency-determinism.md`: the agreed **resolve → validate → pin-on-promotion** model (capture resolved versions at build, non-blocking even when unpinned; bless the found versions at promotion/approval; verification gate). Pinning is a consequence of validation, never a precondition.

## Acceptance (RFC §11, native slice)
- [x] Hermetic export of a runtime-pip (unlocked) agent fails with an actionable error.
- [x] Properly-packaged agents (deps as pinned layers) are unaffected and exportable.

## Note
Force-pushed to trim the redundant bake/lock commits per the review discussion — the export guard is unchanged; the bake/lock exploration is preserved in the PR thread, not in main history. The determinism hardening (provenance-at-build, bless-at-promotion, verification gate) is scoped in the design note as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)