### PR TITLE
feat(wiki): quality governance — auto-expiry, heuristics, duplicate detection (#427)

### DIFF
--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -494,14 +494,14 @@ impl GateService {
         let mut quality_warnings: Vec<String> = Vec::new();
         if let Some(cfg) = req.config {
             if cfg.wiki_proposal.quality_heuristics_enabled {
-                if content.len() < cfg.wiki_proposal.min_content_length {
+                if content.chars().count() < cfg.wiki_proposal.min_content_length {
                     quality_warnings.push(format!(
                         "Short content ({} chars, recommended minimum: {})",
-                        content.len(),
+                        content.chars().count(),
                         cfg.wiki_proposal.min_content_length
                     ));
                 }
-                let heading_count = content.lines().filter(|l| l.starts_with("# ")).count();
+                let heading_count = content.lines().filter(|l| l.trim_start().starts_with('#') && l.trim_start().chars().nth(1).map_or(true, |c| c == ' ' || c == '#')).count();
                 if heading_count < cfg.wiki_proposal.min_headings {
                     quality_warnings.push(format!(
                         "Few markdown headings ({} found, recommended minimum: {})",

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -490,6 +490,67 @@ impl GateService {
         };
         let gate_id = self.create_approval_row(req, &action)?;
 
+        // 4b. Advisory quality heuristics + duplicate detection.
+        let mut quality_warnings: Vec<String> = Vec::new();
+        if let Some(cfg) = req.config {
+            if cfg.wiki_proposal.quality_heuristics_enabled {
+                if content.len() < cfg.wiki_proposal.min_content_length {
+                    quality_warnings.push(format!(
+                        "Short content ({} chars, recommended minimum: {})",
+                        content.len(),
+                        cfg.wiki_proposal.min_content_length
+                    ));
+                }
+                let heading_count = content.lines().filter(|l| l.starts_with("# ")).count();
+                if heading_count < cfg.wiki_proposal.min_headings {
+                    quality_warnings.push(format!(
+                        "Few markdown headings ({} found, recommended minimum: {})",
+                        heading_count, cfg.wiki_proposal.min_headings
+                    ));
+                }
+            }
+            if cfg.wiki_proposal.duplicate_detection_enabled {
+                if let Ok(recent) = self.store.get_pending_approvals() {
+                    let new_req = autonoetic_types::background::ApprovalRequest {
+                        request_id: gate_id.clone(),
+                        agent_id: req.manifest.agent.id.clone(),
+                        session_id: req.session_id.unwrap_or("unknown").to_string(),
+                        action: action.clone(),
+                        created_at: String::new(),
+                        reason: None,
+                        evidence_ref: None,
+                        root_session_id: None,
+                        workflow_id: None,
+                        task_id: None,
+                        status: None,
+                        decided_at: None,
+                        decided_by: None,
+                        decision_reason: None,
+                        approval_level: autonoetic_types::background::ApprovalLevel::Operator,
+                        similar_to_request_id: None,
+                        similarity_score: None,
+                        code_excerpts: None,
+                        risk_summary: None,
+                        confirm_phrase: None,
+                        min_dwell_ms: None,
+                    };
+                    let similar = crate::scheduler::approval_similarity::find_similar_approvals(
+                        &new_req,
+                        &recent,
+                        3,
+                        cfg.wiki_proposal.duplicate_threshold,
+                    );
+                    for s in &similar {
+                        quality_warnings.push(format!(
+                            "Similar to existing proposal {} (score {:.0}%)",
+                            s.request_id,
+                            s.score * 100.0
+                        ));
+                    }
+                }
+            }
+        }
+
         // 5. Surface on timeline.
         {
             let role = crate::runtime::session_timeline::derive_role(&req.manifest.agent.id);
@@ -529,6 +590,17 @@ impl GateService {
             edit_label, page_id, title, proposed_by_agent
         );
         let _ = self.add_gate_message(&gate_id, "system", &seed);
+
+        // 6b. Advisory quality warnings for operator.
+        if !quality_warnings.is_empty() {
+            let warning_text = format!("⚠ Quality advisory (advisory only, does not block):\n{}",
+                quality_warnings.iter()
+                    .map(|w| format!("  • {w}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+            let _ = self.add_gate_message(&gate_id, "system", &warning_text);
+        }
 
         // 6. Build suspension JSON (tool will NOT suspend — it returns ok:true).
         let response_json = serde_json::json!({

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -331,7 +331,16 @@ async fn check_wiki_proposal_expiry(
         }
         let created = match chrono::DateTime::parse_from_rfc3339(&req.created_at) {
             Ok(dt) => dt.with_timezone(&chrono::Utc),
-            Err(_) => continue,
+            Err(e) => {
+                tracing::warn!(
+                    target: "wiki_proposal_expiry",
+                    request_id = %req.request_id,
+                    created_at = %req.created_at,
+                    error = %e,
+                    "Skipping wiki proposal with unparseable created_at"
+                );
+                continue;
+            }
         };
         if (now - created).num_seconds() > ttl_secs as i64 {
             match crate::scheduler::approval::cancel_request(
@@ -339,7 +348,7 @@ async fn check_wiki_proposal_expiry(
                 Some(&store),
                 &req.request_id,
                 "system",
-                Some("Wiki proposal auto-expired".to_string()),
+                Some("auto-expired".to_string()),
                 None,
             ) {
                 Ok(_) => {

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -261,6 +261,11 @@ async fn run_scheduler_tick_at(
         tracing::warn!(error = %e, "Failed to check approval timeouts");
     }
 
+    // Wiki proposal auto-expiry: cancel proposals older than configured TTL.
+    if let Err(e) = check_wiki_proposal_expiry(execution.clone()).await {
+        tracing::warn!(error = %e, "Failed to check wiki proposal expiry");
+    }
+
     // Detect and resolve tasks stuck in Running state (child session completed but task status not updated).
     if let Err(e) = check_stuck_running_tasks(execution.clone()).await {
         tracing::warn!(error = %e, "Failed to check stuck running tasks");
@@ -302,6 +307,63 @@ async fn run_scheduler_tick_at(
         tracing::warn!(error = %e, "Failed to resume answered standalone interactions");
     }
 
+    Ok(())
+}
+
+async fn check_wiki_proposal_expiry(
+    execution: Arc<crate::execution::GatewayExecutionService>,
+) -> anyhow::Result<()> {
+    let config = execution.config();
+    let ttl_secs = config.wiki_proposal.auto_expire_secs;
+    if ttl_secs == 0 {
+        return Ok(());
+    }
+    let store = match execution.gateway_store() {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+    let pending = store.get_pending_approvals()?;
+    let now = chrono::Utc::now();
+    let mut expired = 0;
+    for req in &pending {
+        if !matches!(req.action, autonoetic_types::background::ScheduledAction::WikiProposal { .. }) {
+            continue;
+        }
+        let created = match chrono::DateTime::parse_from_rfc3339(&req.created_at) {
+            Ok(dt) => dt.with_timezone(&chrono::Utc),
+            Err(_) => continue,
+        };
+        if (now - created).num_seconds() > ttl_secs as i64 {
+            match crate::scheduler::approval::cancel_request(
+                &config,
+                Some(&store),
+                &req.request_id,
+                "system",
+                Some("Wiki proposal auto-expired".to_string()),
+                None,
+            ) {
+                Ok(_) => {
+                    expired += 1;
+                    tracing::info!(
+                        target: "wiki_proposal_expiry",
+                        request_id = %req.request_id,
+                        "Auto-expired wiki proposal"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "wiki_proposal_expiry",
+                        request_id = %req.request_id,
+                        error = %e,
+                        "Failed to cancel expired wiki proposal"
+                    );
+                }
+            }
+        }
+    }
+    if expired > 0 {
+        tracing::info!(target: "wiki_proposal_expiry", expired, "Wiki proposal auto-expiry sweep completed");
+    }
     Ok(())
 }
 

--- a/autonoetic-gateway/src/scheduler/approval_similarity.rs
+++ b/autonoetic-gateway/src/scheduler/approval_similarity.rs
@@ -44,6 +44,38 @@ pub fn compute_action_similarity(a: &ScheduledAction, b: &ScheduledAction) -> f6
 
             0.7 * cmd_sim + 0.3 * host_sim
         }
+        (
+            ScheduledAction::WikiProposal {
+                content: content_a,
+                title: title_a,
+                tags: tags_a,
+                ..
+            },
+            ScheduledAction::WikiProposal {
+                content: content_b,
+                title: title_b,
+                tags: tags_b,
+                ..
+            },
+        ) => {
+            let tokens_a: HashSet<&str> = content_a.split_whitespace().collect();
+            let tokens_b: HashSet<&str> = content_b.split_whitespace().collect();
+            let content_sim = jaccard(&tokens_a, &tokens_b);
+
+            let title_a_set: HashSet<&str> = title_a.split_whitespace().collect();
+            let title_b_set: HashSet<&str> = title_b.split_whitespace().collect();
+            let title_sim = jaccard(&title_a_set, &title_b_set);
+
+            let tags_a_set: HashSet<&str> = tags_a.iter().map(|s| s.as_str()).collect();
+            let tags_b_set: HashSet<&str> = tags_b.iter().map(|s| s.as_str()).collect();
+            let tags_sim = if tags_a_set.is_empty() && tags_b_set.is_empty() {
+                1.0
+            } else {
+                jaccard(&tags_a_set, &tags_b_set)
+            };
+
+            0.5 * content_sim + 0.3 * title_sim + 0.2 * tags_sim
+        }
         _ => {
             if a.kind() == b.kind() {
                 0.5
@@ -160,5 +192,51 @@ mod tests {
             detected_hosts: None,
         };
         assert!(compute_action_similarity(&a, &b) > 0.99);
+    }
+
+    #[test]
+    fn test_identical_wiki_proposals_high_similarity() {
+        let a = ScheduledAction::WikiProposal {
+            page_id: "page-1".into(),
+            title: "Getting Started".into(),
+            content: "# Getting Started\n\nInstall the SDK with pip.".into(),
+            tags: vec!["sdk".into(), "install".into()],
+            content_sha256: None,
+            proposed_by_agent: "agent-1".into(),
+            proposed_by_session: Some("session-1".into()),
+        };
+        let b = ScheduledAction::WikiProposal {
+            page_id: "page-2".into(),
+            title: "Getting Started".into(),
+            content: "# Getting Started\n\nInstall the SDK with pip.".into(),
+            tags: vec!["sdk".into(), "install".into()],
+            content_sha256: None,
+            proposed_by_agent: "agent-2".into(),
+            proposed_by_session: Some("session-2".into()),
+        };
+        assert!(compute_action_similarity(&a, &b) > 0.95);
+    }
+
+    #[test]
+    fn test_different_wiki_proposals_low_similarity() {
+        let a = ScheduledAction::WikiProposal {
+            page_id: "page-1".into(),
+            title: "Getting Started".into(),
+            content: "Install the SDK with pip install autonoetic-sdk".into(),
+            tags: vec!["sdk".into()],
+            content_sha256: None,
+            proposed_by_agent: "agent-1".into(),
+            proposed_by_session: Some("session-1".into()),
+        };
+        let b = ScheduledAction::WikiProposal {
+            page_id: "page-2".into(),
+            title: "Architecture Overview".into(),
+            content: "The system uses a gateway agent pattern with SQLite storage".into(),
+            tags: vec!["architecture".into()],
+            content_sha256: None,
+            proposed_by_agent: "agent-2".into(),
+            proposed_by_session: Some("session-2".into()),
+        };
+        assert!(compute_action_similarity(&a, &b) < 0.5);
     }
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1212,6 +1212,10 @@ pub struct GatewayConfig {
     /// Default: `persona.md` next to the config file (used only if the file exists).
     #[serde(default)]
     pub persona_path: Option<PathBuf>,
+
+    /// Wiki proposal governance: auto-expiry, quality heuristics, duplicate detection.
+    #[serde(default)]
+    pub wiki_proposal: WikiProposalConfig,
 }
 
 fn default_approval_dwell_multiplier() -> f64 {
@@ -1975,6 +1979,63 @@ fn default_roster_repeat_floor() -> u32 {
     3
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WikiProposalConfig {
+    /// Auto-expiry TTL in seconds for pending wiki proposals. 0 = disabled.
+    /// Expired proposals are automatically cancelled.
+    #[serde(default = "default_wiki_proposal_auto_expire_secs")]
+    pub auto_expire_secs: u64,
+
+    /// Enable advisory quality heuristics (warn but don't block).
+    #[serde(default = "default_true")]
+    pub quality_heuristics_enabled: bool,
+
+    /// Minimum content length in characters for advisory warning.
+    #[serde(default = "default_wiki_proposal_min_content_length")]
+    pub min_content_length: usize,
+
+    /// Minimum number of markdown headings (# ) for advisory warning.
+    #[serde(default = "default_wiki_proposal_min_headings")]
+    pub min_headings: usize,
+
+    /// Enable duplicate detection against existing wiki pages.
+    #[serde(default = "default_true")]
+    pub duplicate_detection_enabled: bool,
+
+    /// Jaccard similarity threshold for flagging duplicates (0.0–1.0).
+    #[serde(default = "default_wiki_proposal_duplicate_threshold")]
+    pub duplicate_threshold: f64,
+}
+
+fn default_wiki_proposal_auto_expire_secs() -> u64 {
+    604800
+}
+
+fn default_wiki_proposal_min_content_length() -> usize {
+    100
+}
+
+fn default_wiki_proposal_min_headings() -> usize {
+    1
+}
+
+fn default_wiki_proposal_duplicate_threshold() -> f64 {
+    0.7
+}
+
+impl Default for WikiProposalConfig {
+    fn default() -> Self {
+        Self {
+            auto_expire_secs: default_wiki_proposal_auto_expire_secs(),
+            quality_heuristics_enabled: true,
+            min_content_length: default_wiki_proposal_min_content_length(),
+            min_headings: default_wiki_proposal_min_headings(),
+            duplicate_detection_enabled: true,
+            duplicate_threshold: default_wiki_proposal_duplicate_threshold(),
+        }
+    }
+}
+
 /// Configuration for pluggable code analysis.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodeAnalysisConfig {
@@ -2667,6 +2728,7 @@ impl Default for GatewayConfig {
             profile: Profile::default(),
             auto_learning: AutoLearningConfig::default(),
             persona_path: None,
+            wiki_proposal: WikiProposalConfig::default(),
         }
     }
 }

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -627,3 +627,18 @@ context_compression:
 #     - agent-factory.default
 #     - specialized_builder.default
 #     - evolution-orchestrator.default
+
+# ── Wiki Proposal Governance ─────────────────────────────────────────
+# Quality heuristics are advisory (warn, don't block) — operator always has final say.
+# Duplicate detection flags similar proposals for reviewer attention, doesn't auto-reject.
+#
+# wiki_proposal:
+#   # Auto-expiry TTL for pending proposals (0 = disabled). Default: 7 days.
+#   auto_expire_secs: 604800
+#   # Advisory content quality checks.
+#   quality_heuristics_enabled: true
+#   min_content_length: 100
+#   min_headings: 1
+#   # Duplicate detection via Jaccard similarity over content tokens.
+#   duplicate_detection_enabled: true
+#   duplicate_threshold: 0.7


### PR DESCRIPTION
### Issue #427 — Wiki: quality governance (timeout, dedup, content validation)

**3 of 4 items implemented** (item 4 — constitutional rule — is explicitly a non-goal per design doc).

| Item | Status |
|------|--------|
| Proposal auto-expiry (configurable TTL) | ✅ |
| Content quality heuristics (advisory) | ✅ |
| Duplicate detection (Jaccard similarity) | ✅ |
| Constitutional rule for wiki governance | Skipped (non-goal) |
| Audit trail (propose/promote/reject/withdraw) | ✅ (done in #446) |

### Changes

**Config** (`WikiProposalConfig`):
- `auto_expire_secs` — default 604800 (7 days), 0 = disabled
- `quality_heuristics_enabled` — advisory content checks
- `min_content_length` — warn if below (default 100 chars)
- `min_headings` — warn if below (default 1)
- `duplicate_detection_enabled` — Jaccard similarity check
- `duplicate_threshold` — flag threshold (default 0.7)

**Auto-expiry reaper** (`scheduler.rs`):
- Runs in scheduler tick loop after approval timeout check
- Scans pending WikiProposal approvals, cancels expired via `cancel_request()`
- Emits `wiki.rejected` timeline event with reason "auto-expired"

**Quality heuristics** (`human_gate.rs`):
- Advisory warnings appended to gate enrichment message (operator sees them during review)
- Does NOT block proposals — operator always has final say

**Duplicate detection** (`approval_similarity.rs`):
- Weighted Jaccard: 50% content tokens + 30% title tokens + 20% tags
- Flags similar pending proposals in gate enrichment message
- Does NOT auto-reject — reviewer attention only

### Verification
- `cargo build` passes
- 5/5 similarity tests pass (including 2 new wiki-specific)