### PR TITLE
Determinism inc 1: build-time resolved-dependency provenance

### DIFF
--- a/autonoetic-gateway/src/layer_store.rs
+++ b/autonoetic-gateway/src/layer_store.rs
@@ -176,7 +176,12 @@ impl LayerStore {
         fs::write(&archive_path, &archive_buffer)?;
 
         // Count files and size for manifest
-        let (file_count, size_bytes) = Self::count_dir(source_dir)?;
+        let (file_count, size_bytes) = Self::count_dir(source_dir.clone())?;
+
+        // Build-time dependency provenance (read-only, best-effort): record the
+        // resolved versions present in the captured tree. The digest already
+        // pins the bytes; this makes the closure auditable and blessable.
+        let resolved_packages = Self::scan_resolved_packages(&source_dir);
 
         // Create and persist manifest
         let manifest = LayerManifest {
@@ -187,6 +192,7 @@ impl LayerStore {
             size_bytes,
             created_at: chrono::Utc::now().to_rfc3339(),
             approval_scope: approval_scope.clone(),
+            resolved_packages: resolved_packages.clone(),
         };
         let manifest_path = layer_dir.join(MANIFEST_FILENAME);
         let manifest_json = serde_json::to_string_pretty(&manifest)?;
@@ -216,6 +222,7 @@ impl LayerStore {
             file_count,
             size_bytes,
             approval_scope,
+            resolved_packages,
         })
     }
 
@@ -234,7 +241,59 @@ impl LayerStore {
             file_count: manifest.file_count,
             size_bytes: manifest.size_bytes,
             approval_scope: manifest.approval_scope,
+            resolved_packages: manifest.resolved_packages,
         })
+    }
+
+    /// Scan a captured tree for resolved dependency versions (build-time
+    /// provenance). Recursively finds Python `*.dist-info` directories (both
+    /// `pip --target` and venv layouts produce these) and parses `name==version`
+    /// from the directory stem. Read-only and bounded. (Node `node_modules`
+    /// provenance is a follow-up.)
+    fn scan_resolved_packages(dir: &Path) -> Vec<autonoetic_types::layer::ResolvedPackage> {
+        use autonoetic_types::layer::ResolvedPackage;
+        let mut found: Vec<ResolvedPackage> = Vec::new();
+        let mut stack = vec![dir.to_path_buf()];
+        let mut visited = 0usize;
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                visited += 1;
+                if visited > 500_000 {
+                    return Self::finalize_resolved(found); // safety bound
+                }
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let fname = entry.file_name();
+                let name = fname.to_string_lossy();
+                if let Some(stem) = name.strip_suffix(".dist-info") {
+                    if let Some((pkg, ver)) = stem.rsplit_once('-') {
+                        if !pkg.is_empty() && !ver.is_empty() {
+                            found.push(ResolvedPackage {
+                                name: pkg.to_string(),
+                                version: ver.to_string(),
+                            });
+                        }
+                    }
+                    // Don't descend into the dist-info directory itself.
+                    continue;
+                }
+                stack.push(path);
+            }
+        }
+        Self::finalize_resolved(found)
+    }
+
+    fn finalize_resolved(
+        mut v: Vec<autonoetic_types::layer::ResolvedPackage>,
+    ) -> Vec<autonoetic_types::layer::ResolvedPackage> {
+        v.sort_by(|a, b| a.name.cmp(&b.name).then(a.version.cmp(&b.version)));
+        v.dedup();
+        v
     }
 
     fn count_dir(dir: PathBuf) -> anyhow::Result<(usize, u64)> {
@@ -374,6 +433,45 @@ mod tests {
         let gw = temp.join(".gateway");
         fs::create_dir_all(&gw).unwrap();
         LayerStore::new(&gw, LayerLimits::default()).unwrap()
+    }
+
+    #[test]
+    fn create_from_dir_records_resolved_package_provenance() {
+        let temp = tempdir().unwrap();
+        let store = create_test_store(temp.path());
+
+        // A captured tree mixing a flat `pip --target` layout and a venv layout.
+        let src = temp.path().join("deps");
+        fs::create_dir_all(src.join("requests-2.31.0.dist-info")).unwrap();
+        fs::create_dir_all(
+            src.join("lib/python3.12/site-packages/rich-13.7.0.dist-info"),
+        )
+        .unwrap();
+        // A non-dist-info dir should be ignored (and descended into).
+        fs::create_dir_all(src.join("requests")).unwrap();
+        fs::write(src.join("requests/__init__.py"), b"").unwrap();
+
+        let captured = store
+            .create_from_dir(&src, "python-deps", "/opt/autonoetic-deps", None)
+            .unwrap();
+
+        let names: Vec<(String, String)> = captured
+            .resolved_packages
+            .iter()
+            .map(|p| (p.name.clone(), p.version.clone()))
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                ("requests".to_string(), "2.31.0".to_string()),
+                ("rich".to_string(), "13.7.0".to_string()),
+            ],
+            "resolved packages parsed from dist-info, sorted by name"
+        );
+
+        // Provenance is persisted in the manifest too.
+        let manifest = store.inspect(&captured.layer_id).unwrap();
+        assert_eq!(manifest.resolved_packages.len(), 2);
     }
 
     #[test]

--- a/autonoetic-gateway/src/layer_store.rs
+++ b/autonoetic-gateway/src/layer_store.rs
@@ -262,10 +262,22 @@ impl LayerStore {
             for entry in entries.flatten() {
                 visited += 1;
                 if visited > 500_000 {
-                    return Self::finalize_resolved(found); // safety bound
+                    // Don't return silently — truncated provenance must be
+                    // detectable so it can't read as "complete" in an audit.
+                    tracing::warn!(
+                        target: "layer_store",
+                        root = %dir.display(),
+                        "resolved-package provenance scan hit the entry bound; results may be truncated"
+                    );
+                    return Self::finalize_resolved(found);
                 }
-                let path = entry.path();
-                if !path.is_dir() {
+                // `file_type()` does NOT follow symlinks (unlike `path.is_dir()`),
+                // so a symlinked dir / cycle can't traverse outside the capture
+                // root or leak host package names into the manifest.
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if !file_type.is_dir() {
                     continue;
                 }
                 let fname = entry.file_name();
@@ -282,7 +294,7 @@ impl LayerStore {
                     // Don't descend into the dist-info directory itself.
                     continue;
                 }
-                stack.push(path);
+                stack.push(entry.path());
             }
         }
         Self::finalize_resolved(found)
@@ -525,6 +537,27 @@ mod tests {
         assert!(store
             .aggregate_resolved_packages(&["nope".to_string()])
             .is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_does_not_follow_symlinked_dirs() {
+        let temp = tempdir().unwrap();
+        // External dist-info that must NOT be captured via a symlink.
+        let external = temp.path().join("external");
+        fs::create_dir_all(external.join("evil-1.0.dist-info")).unwrap();
+        // Capture root: a real package + a symlink pointing outside.
+        let src = temp.path().join("src");
+        fs::create_dir_all(src.join("good-2.0.dist-info")).unwrap();
+        std::os::unix::fs::symlink(&external, src.join("link")).unwrap();
+
+        let found = LayerStore::scan_resolved_packages(&src);
+        let names: Vec<String> = found.iter().map(|p| p.name.clone()).collect();
+        assert_eq!(
+            names,
+            vec!["good".to_string()],
+            "symlinked external dist-info must not be traversed"
+        );
     }
 
     #[test]

--- a/autonoetic-gateway/src/layer_store.rs
+++ b/autonoetic-gateway/src/layer_store.rs
@@ -296,6 +296,24 @@ impl LayerStore {
         v
     }
 
+    /// Aggregate resolved-package provenance across a set of layers (e.g. all the
+    /// dependency layers in an agent's `runtime.lock`) into one deduplicated,
+    /// sorted set — the resolved dependency closure. This is what the approval
+    /// boundary surfaces and what bless-on-promotion freezes (determinism inc
+    /// 2/3). Missing layers or layers without provenance contribute nothing.
+    pub fn aggregate_resolved_packages(
+        &self,
+        layer_ids: &[String],
+    ) -> Vec<autonoetic_types::layer::ResolvedPackage> {
+        let mut all = Vec::new();
+        for id in layer_ids {
+            if let Ok(manifest) = self.inspect(id) {
+                all.extend(manifest.resolved_packages);
+            }
+        }
+        Self::finalize_resolved(all)
+    }
+
     fn count_dir(dir: PathBuf) -> anyhow::Result<(usize, u64)> {
         let mut file_count = 0usize;
         let mut size_bytes = 0u64;
@@ -472,6 +490,41 @@ mod tests {
         // Provenance is persisted in the manifest too.
         let manifest = store.inspect(&captured.layer_id).unwrap();
         assert_eq!(manifest.resolved_packages.len(), 2);
+    }
+
+    #[test]
+    fn aggregate_resolved_packages_merges_and_dedups_across_layers() {
+        let temp = tempdir().unwrap();
+        let store = create_test_store(temp.path());
+
+        let a = temp.path().join("a");
+        fs::create_dir_all(a.join("requests-2.31.0.dist-info")).unwrap();
+        let layer_a = store.create_from_dir(&a, "a", "/opt/a", None).unwrap();
+
+        let b = temp.path().join("b");
+        fs::create_dir_all(b.join("rich-13.7.0.dist-info")).unwrap();
+        // Overlap with layer a — should dedup, not double-count.
+        fs::create_dir_all(b.join("requests-2.31.0.dist-info")).unwrap();
+        let layer_b = store.create_from_dir(&b, "b", "/opt/b", None).unwrap();
+
+        let merged =
+            store.aggregate_resolved_packages(&[layer_a.layer_id, layer_b.layer_id]);
+        let pairs: Vec<(String, String)> = merged
+            .iter()
+            .map(|p| (p.name.clone(), p.version.clone()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("requests".to_string(), "2.31.0".to_string()),
+                ("rich".to_string(), "13.7.0".to_string()),
+            ]
+        );
+
+        // Unknown layer ids are skipped silently.
+        assert!(store
+            .aggregate_resolved_packages(&["nope".to_string()])
+            .is_empty());
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/promotion_store.rs
+++ b/autonoetic-gateway/src/runtime/promotion_store.rs
@@ -107,6 +107,7 @@ impl PromotionStore {
                 sealed_evaluator_findings: vec![],
                 sealed_evaluator_timestamp: None,
                 promotion_gate_version: "2.1".to_string(),
+                blessed_packages: vec![],
             });
 
         if let Some(artifact_digest) = artifact_digest {
@@ -184,6 +185,25 @@ impl PromotionStore {
         self.save()?;
 
         Ok(record)
+    }
+
+    /// Bless the resolved dependency closure for a promoted artifact: freeze the
+    /// versions the validated, approved run used (determinism inc 3). No-op if no
+    /// record exists for the artifact. The set is typically derived from the
+    /// artifact's layers via `LayerStore::aggregate_resolved_packages`.
+    pub fn set_blessed_packages(
+        &self,
+        artifact_id: &str,
+        packages: Vec<autonoetic_types::layer::ResolvedPackage>,
+    ) -> anyhow::Result<bool> {
+        let mut records = self.records.lock().unwrap();
+        let Some(record) = records.get_mut(artifact_id) else {
+            return Ok(false);
+        };
+        record.blessed_packages = packages;
+        drop(records);
+        self.save()?;
+        Ok(true)
     }
 
     /// If a promotion record exists but has no bound content digest yet, attach one.
@@ -503,6 +523,46 @@ mod tests {
             assert!(record.evaluator_pass);
             assert_eq!(record.evaluator_id, Some("evaluator.default".to_string()));
         }
+    }
+
+    #[test]
+    fn blessed_packages_persist_and_no_op_when_missing() {
+        use autonoetic_types::layer::ResolvedPackage;
+        let temp = tempdir().unwrap();
+        let artifact_id = "art_bless".to_string();
+
+        let store = PromotionStore::new(temp.path()).unwrap();
+        // No record yet → no-op (false), nothing to bless.
+        assert!(!store
+            .set_blessed_packages(&artifact_id, vec![])
+            .unwrap());
+
+        store
+            .record_promotion(
+                artifact_id.clone(),
+                None,
+                None,
+                PromotionRole::Evaluator,
+                "evaluator.default",
+                true,
+                vec![],
+                None,
+            )
+            .unwrap();
+        let blessed = vec![ResolvedPackage {
+            name: "requests".into(),
+            version: "2.31.0".into(),
+        }];
+        assert!(store
+            .set_blessed_packages(&artifact_id, blessed.clone())
+            .unwrap());
+
+        // Survives a reload from disk.
+        let reloaded = PromotionStore::new(temp.path()).unwrap();
+        assert_eq!(
+            reloaded.get_promotion(&artifact_id).unwrap().blessed_packages,
+            blessed
+        );
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -3048,6 +3048,7 @@ fn capture_layers_from_paths(
                     "file_count": layer.file_count,
                     "size_bytes": layer.size_bytes,
                     "approval_scope": layer.approval_scope,
+                    "resolved_packages": layer.resolved_packages,
                 }));
             }
             Err(e) => {

--- a/autonoetic-types/src/layer.rs
+++ b/autonoetic-types/src/layer.rs
@@ -26,6 +26,15 @@ pub struct LayerApprovalScope {
     pub captured_at: String,
 }
 
+/// A resolved dependency captured at build time (provenance). The layer digest
+/// already pins the content; this records the *human-readable* version that was
+/// resolved, so the closure is auditable and can be blessed/pinned at promotion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedPackage {
+    pub name: String,
+    pub version: String,
+}
+
 /// A layer manifest stored alongside the compressed archive.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LayerManifest {
@@ -47,6 +56,11 @@ pub struct LayerManifest {
     /// None for layers built before this feature was added (treated as no network scope).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approval_scope: Option<LayerApprovalScope>,
+    /// Dependencies resolved into this layer at build time (name==version),
+    /// captured for audit and pin-on-promotion. Empty for non-dependency layers
+    /// or layers built before this feature.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolved_packages: Vec<ResolvedPackage>,
 }
 
 /// A reference to a layer within an artifact manifest.
@@ -82,4 +96,7 @@ pub struct CapturedLayer {
     /// Approval scope recorded at capture time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approval_scope: Option<LayerApprovalScope>,
+    /// Dependencies resolved into this layer at build time (name==version).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolved_packages: Vec<ResolvedPackage>,
 }

--- a/autonoetic-types/src/promotion.rs
+++ b/autonoetic-types/src/promotion.rs
@@ -104,6 +104,13 @@ pub struct PromotionRecord {
     #[serde(default)]
     pub sealed_evaluator_timestamp: Option<String>,
     pub promotion_gate_version: String,
+    /// The resolved dependency closure (name==version) **blessed** at promotion:
+    /// the versions the validated, approved run actually used, frozen here so the
+    /// pin is earned by validation rather than demanded up front. Empty until
+    /// blessed, or for agents with no dependency layers.
+    /// See `docs/design/packager-dependency-determinism.md`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blessed_packages: Vec<crate::layer::ResolvedPackage>,
 }
 
 impl PromotionRecord {


### PR DESCRIPTION
First increment of the packager-determinism work. Part of #449 · design: `docs/design/packager-dependency-determinism.md`.

## Goal
Make the locked closure **auditable**: when a dependency layer is captured, record the resolved versions (the digest already pins the bytes; this records *which* versions). Read-only, non-blocking — the **capture-at-build** half of "capture-at-build → bless-at-promotion".

## Changes
- `ResolvedPackage { name, version }` + `resolved_packages` on `LayerManifest` and `CapturedLayer` (serde-default; back-compatible with existing layers).
- `LayerStore::create_from_dir` scans the captured tree for Python `*.dist-info` (flat `pip --target` **and** venv layouts), parses `name==version`, persists it in the manifest and returns it. Bounded + read-only.
- Surfaced in the `sandbox.exec` `captured_layers` response for audit.

## Non-goals (later increments, #449)
2. Surface resolved versions at the approval boundary.
3. Bless-on-promotion (persist the blessed pinned set on the revision).
4. Verification gate (post-bake import/smoke check).
Node `node_modules` provenance is a follow-up to this increment.

## Tests
dist-info parsing across flat + venv layouts + manifest persistence; `sandbox_capture_integration` (real bwrap) green; full suite compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)