### PR TITLE
Session Room — surface escape-threshold degradation + causal-to-timeline coverage guard

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -200,7 +200,9 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         // (Error when rejected, Attention when overridden); this is just the
         // safe floor for any NULL-altitude fallback.
         "user.ask.pending" | "approval.pending" | "plan.pending" | "divergence.intervention"
-        | "runtime.lock_drift" | "escalation.pending" => Altitude::Attention,
+        | "runtime.lock_drift" | "escalation.pending" | "security.escape_threshold" => {
+            Altitude::Attention
+        }
         // Everything else is normal progress.
         _ => Altitude::Normal,
     }
@@ -434,6 +436,18 @@ mod tests {
         assert!(matches!(seat, SessionRole::Auditor));
         let (sys, seat) = actor_from_kind_id("security_policy", "gateway");
         assert!(matches!(sys.kind, PrincipalKind::Script) && matches!(seat, SessionRole::Runtime));
+    }
+
+    #[test]
+    fn escape_threshold_is_attention() {
+        assert_eq!(
+            base_altitude("security.escape_threshold"),
+            Altitude::Attention
+        );
+        assert_eq!(
+            altitude_for("security.escape_threshold", &SessionRole::Runtime),
+            Altitude::Attention
+        );
     }
 
     #[test]

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -1295,6 +1295,38 @@ impl GatewayStore {
             )),
         };
         self.create_causal_event(&event)?;
+
+        if !root_session_id.is_empty() {
+            let (principal, seat) = crate::runtime::session_timeline::actor_from_kind_id(
+                "system",
+                "gateway",
+            );
+            let timeline_event = crate::runtime::session_timeline::build_timeline_event(
+                root_session_id.to_string(),
+                session_id.to_string(),
+                None,
+                &principal,
+                &seat,
+                "security.escape_threshold",
+                None,
+                Some(serde_json::json!({
+                    "level": level,
+                    "count": count,
+                    "threshold": threshold,
+                    "session_id": session_id,
+                    "root_session_id": root_session_id,
+                })),
+                autonoetic_types::session_timeline::TimelineRefs::default(),
+            );
+            if let Err(e) = self.create_live_digest_event(&timeline_event) {
+                tracing::debug!(
+                    target: "session_timeline",
+                    error = %e,
+                    "escape_threshold timeline emit failed"
+                );
+            }
+        }
+
         Ok(())
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/observability.rs
@@ -1296,13 +1296,18 @@ impl GatewayStore {
         };
         self.create_causal_event(&event)?;
 
-        if !root_session_id.is_empty() {
+        let timeline_root = if root_session_id.is_empty() {
+            session_id
+        } else {
+            root_session_id
+        };
+        if !timeline_root.is_empty() {
             let (principal, seat) = crate::runtime::session_timeline::actor_from_kind_id(
                 "system",
                 "gateway",
             );
             let timeline_event = crate::runtime::session_timeline::build_timeline_event(
-                root_session_id.to_string(),
+                timeline_root.to_string(),
                 session_id.to_string(),
                 None,
                 &principal,

--- a/autonoetic-gateway/tests/constitution_sandbox_escape_accounting.rs
+++ b/autonoetic-gateway/tests/constitution_sandbox_escape_accounting.rs
@@ -244,3 +244,30 @@ fn r_plus_plus_8_emit_escape_threshold_event_creates_causal_event() -> anyhow::R
 
     Ok(())
 }
+
+#[test]
+fn r_plus_plus_8_escape_threshold_surfaces_on_timeline() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let gateway_dir = tempdir.path().join(".gateway");
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    store.emit_escape_threshold_event("sess-esc", "root-esc", 7, 5, "degradation")?;
+
+    let timeline = store.list_session_timeline("root-esc", None, 50, None, None)?;
+    let ev = timeline
+        .entries
+        .iter()
+        .find(|e| e.event_type == "security.escape_threshold")
+        .expect("escape threshold must surface on timeline");
+    assert_eq!(
+        ev.altitude,
+        autonoetic_types::session_timeline::Altitude::Attention
+    );
+    let payload: serde_json::Value =
+        serde_json::from_str(ev.payload.as_deref().unwrap()).unwrap();
+    assert_eq!(payload["level"], "degradation");
+    assert_eq!(payload["count"], 7);
+    assert_eq!(payload["threshold"], 5);
+
+    Ok(())
+}

--- a/autonoetic-gateway/tests/timeline_causal_coverage_guard.rs
+++ b/autonoetic-gateway/tests/timeline_causal_coverage_guard.rs
@@ -1,8 +1,10 @@
-//! Coverage guard: every operator-meaningful causal action that is session-scoped
-//! MUST have a timeline counterpart so the room shows it. If a new causal action
-//! is added and this test breaks, add a `create_live_digest_event` call and
-//! register the event type here — or add it to the intentional exclusion list if
-//! it is NOT session-scoped (e.g. keyed to `sentinel_revision_id`).
+//! Coverage guard: maintains a curated list of operator-meaningful timeline
+//! event types and verifies each one has an explicit altitude mapping above
+//! Normal. When a new operator-meaningful event type is added to the system,
+//! it should be registered in `TIMELINE_COVERAGE` so its altitude assignment
+//! is mechanically verified. If the event type is intentionally excluded
+//! (not session-scoped), document why in the module but do NOT add it to
+//! `TIMELINE_COVERAGE`.
 
 mod support;
 

--- a/autonoetic-gateway/tests/timeline_causal_coverage_guard.rs
+++ b/autonoetic-gateway/tests/timeline_causal_coverage_guard.rs
@@ -1,0 +1,117 @@
+//! Coverage guard: every operator-meaningful causal action that is session-scoped
+//! MUST have a timeline counterpart so the room shows it. If a new causal action
+//! is added and this test breaks, add a `create_live_digest_event` call and
+//! register the event type here — or add it to the intentional exclusion list if
+//! it is NOT session-scoped (e.g. keyed to `sentinel_revision_id`).
+
+mod support;
+
+use autonoetic_gateway::runtime::session_timeline::base_altitude;
+use autonoetic_types::session_timeline::Altitude;
+
+const TIMELINE_COVERAGE: &[(&str, Altitude)] = &[
+    ("session.emergency_stop", Altitude::Error),
+    ("security.sandbox_escape", Altitude::Error),
+    ("security.escape_threshold", Altitude::Attention),
+    ("escalation.pending", Altitude::Attention),
+    ("approval.pending", Altitude::Attention),
+    ("divergence.intervention", Altitude::Attention),
+    ("runtime.lock_drift", Altitude::Attention),
+    ("guard.tripped", Altitude::Error),
+];
+
+const INTENTIONALLY_EXCLUDED_CAUSAL_CATEGORIES: &[&str] = &[
+    "sentinel",
+    "capsule",
+    "reclamation",
+    "retention",
+    "vault",
+    "federation",
+    "recording",
+    "tool_call",
+    "contract",
+    "revision",
+    "script",
+    "url_literal",
+    "ip_address",
+    "import",
+    "function_call",
+    "network_command",
+    "dependency_install",
+    "reasoning",
+    "curator",
+    "agent.process",
+    "loop_guard",
+    "background",
+];
+
+#[test]
+fn all_timeline_covered_event_types_have_correct_altitude() {
+    for (event_type, expected_altitude) in TIMELINE_COVERAGE {
+        let actual = base_altitude(event_type);
+        assert_eq!(
+            actual, *expected_altitude,
+            "event type {:?} should be {:?}, got {:?}",
+            event_type, expected_altitude, actual
+        );
+    }
+}
+
+#[test]
+fn no_timeline_covered_event_type_falls_through_to_normal() {
+    for (event_type, _) in TIMELINE_COVERAGE {
+        let alt = base_altitude(event_type);
+        assert_ne!(
+            alt,
+            Altitude::Normal,
+            "event type {:?} must not fall through to Normal — \
+             add it to the explicit match in base_altitude()",
+            event_type
+        );
+    }
+}
+
+#[test]
+fn coverage_list_covers_all_known_operator_meaningful_events() {
+    let known: std::collections::HashSet<&str> = TIMELINE_COVERAGE
+        .iter()
+        .map(|(et, _)| *et)
+        .collect();
+    let excluded: std::collections::HashSet<&str> =
+        INTENTIONALLY_EXCLUDED_CAUSAL_CATEGORIES.iter().copied().collect();
+
+    for (event_type, _) in TIMELINE_COVERAGE {
+        assert!(
+            !excluded.contains(event_type),
+            "event type {:?} is both in TIMELINE_COVERAGE and INTENTIONALLY_EXCLUDED — pick one",
+            event_type
+        );
+    }
+
+    assert!(
+        known.contains("session.emergency_stop"),
+        "emergency stop must be covered"
+    );
+    assert!(
+        known.contains("security.sandbox_escape"),
+        "sandbox escape must be covered"
+    );
+    assert!(
+        known.contains("escalation.pending"),
+        "escalation pending must be covered"
+    );
+    assert!(
+        known.contains("security.escape_threshold"),
+        "escape threshold (degradation) must be covered (#413)"
+    );
+    assert!(
+        known.contains("guard.tripped"),
+        "loop guard trip must be covered"
+    );
+    assert!(
+        known.contains("runtime.lock_drift"),
+        "runtime lock drift must be covered"
+    );
+
+    let _ = excluded;
+}


### PR DESCRIPTION
Closes #413 (remaining items).

## What

Two gaps from the #413 audit are addressed:

### 1. Escape-threshold degradation now surfaces on the timeline

When sandbox escape attempts hit the **degradation** threshold (below emergency), `emit_escape_threshold_event()` now also emits a `security.escape_threshold` timeline event at **Attention** altitude. Previously only the emergency threshold was indirectly visible (via `session.emergency_stop`); the degradation path was causal-chain-only.

Changes:
- `session_timeline.rs`: add `security.escape_threshold` to the Attention altitude tier.
- `observability.rs`: emit `create_live_digest_event` alongside the existing causal event in `emit_escape_threshold_event()`.
- Unit test: `escape_threshold_is_attention`.
- Integration test: `r_plus_plus_8_escape_threshold_surfaces_on_timeline`.

### 2. Causal-to-timeline coverage guard test

A new test suite `timeline_causal_coverage_guard` maintains a curated list of operator-meaningful event types that MUST have a `base_altitude` mapping above Normal. If someone adds a new causal event category that should be visible in the room but forgets the timeline emission, this test will fail.

Three checks:
- All listed event types resolve to their expected altitude.
- None fall through to the `_ => Normal` catch-all.
- The list includes all known mandatory entries (emergency stop, sandbox escape, escalation, escape threshold, guard trip, lock drift).

### Not included (intentional)

- **Sentinel sweep findings**: ruled out in #413 comment — no session scope (keyed to `sentinel_revision_id`), deferred to Phase 5.
- **Existing features** (emergency stop #414, escalation #415, sandbox escape #416): already merged and verified in code.