### PR TITLE
P4: WASM execution tier — driver, wasmtime, WASI, unified run entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -66,6 +66,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -265,6 +271,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "wasmtime",
+ "wasmtime-wasi",
  "zstd",
 ]
 
@@ -450,6 +457,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix 1.1.4",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +568,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -661,6 +747,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -908,7 +1003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1257,6 +1352,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1535,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1871,6 +1978,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2106,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
 
 [[package]]
 name = "leb128fmt"
@@ -2098,6 +2227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2388,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2626,6 +2761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2808,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2945,6 +3097,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3257,7 +3419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3339,12 +3501,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3627,9 +3789,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3644,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4504,6 +4666,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-wasi"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d0c0121dcc5152390d099fb853b9a0d79e7e0a172c12cc668ea8c5d8f883c2"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-std",
+ "cap-time-ext",
+ "cfg-if",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rand 0.10.1",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02ca2fd53dbd62f5f95b470b43ff1e711933e8f30ebc89d9050351a72f6e5c28"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "tracing",
+ "wasmtime",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wast"
 version = "251.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,7 +4736,7 @@ version = "1.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
 dependencies = [
- "wast",
+ "wast 251.0.0",
 ]
 
 [[package]]
@@ -4559,6 +4773,46 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wiggle"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4cd8015611a3bc95e449ad198dfd133b7488759b0dc49b515052101eb954587"
+dependencies = [
+ "bitflags",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wasmtime-environ",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0f655ec3eba7df68408018796911a6acdda3a41e67d6551a3766563495e333"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-environ",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a22f38e7b0f2a3b58bae4dd655dcedd65d56f257916a5eda5f08c40910ee9d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
+]
 
 [[package]]
 name = "winapi"
@@ -4927,6 +5181,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,6 +5295,18 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,12 +258,13 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tower-http",
  "tracing",
  "url",
  "uuid",
  "walkdir",
+ "wasmtime",
  "zstd",
 ]
 
@@ -411,6 +427,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -558,6 +577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +664,148 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5694aa8a2eb2571a15b3feee38d16ccaf2712200e7b5c9ae0479069bdfb46949"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab349d30a5fad9699440ee7ccb435374e8a8735dcca26696a4245bcefcc47e"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e95970bdb51d145c828a114a1084cb8b63e65569a51600ad398cb49fa78b062"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8414b8ecc81f89f8a3f2c5cbc785b9ed690200cd6f9d780e96a92f88879704"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c6e92c825abfbb739a4beaa5db3988f98a96a68d6ea656f562098efc142976"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e57cd185782abada9ab2606bfe88d0abc0d42d83a7d432dcf69991e17fe76e"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0f17e48d15e29552e2f264d302c31a661a830196d879bbdaf4d7b2bf2f7011"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "407b80b46934c9dce9a6581f0e80d079b7a69e11372fb03d7dce4c7ba3fee4e3"
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a40e056e421d9a6c757983f2184f765ae1c28a51555d3877e98afc97ce5705b"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdbadda21e49798825a1ec795dab30bcb03235891f662b5ccf23fa45b39682f"
 
 [[package]]
 name = "crc32fast"
@@ -642,6 +821,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -765,6 +963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +1002,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,8 +1028,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -871,6 +1099,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -972,6 +1212,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1105,6 +1351,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "gray_matter"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1514,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1546,12 +1829,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1619,10 +1902,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "jni"
@@ -1680,9 +1992,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1756,6 +2074,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +2102,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "mime"
@@ -1912,6 +2248,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2325,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2391,18 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -2115,6 +2485,29 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6ccdd6fc70f6c33eb21cb8fe05a71a5f7ee4cbef7a093a8a87dd8a908697cd"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00101fdb6fcaf9ea98a1994be11861d7e0c910c718c41bae373c44179e3160c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pxfm"
@@ -2291,13 +2684,33 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2320,6 +2733,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -2327,6 +2751,20 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -2461,6 +2899,12 @@ dependencies = [
  "smallvec",
  "sqlite-wasm-rs",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -2678,6 +3122,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2740,6 +3188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2876,6 +3333,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3019,16 +3479,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.26.0"
+name = "target-lexicon"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3208,9 +3683,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3223,6 +3713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,10 +3729,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3241,6 +3749,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3404,7 +3918,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -3614,13 +4128,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-compose"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wat",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -3631,8 +4182,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -3658,6 +4209,320 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c191891081c3bf9f10cb579819b32b0e81695641dc639eef34b57cf10c59ad81"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "fxprof-processed-profile",
+ "gimli",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 1.1.4",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f337d68a62d868f3c297517b46d20dc7e293f0da36bbee2f6ec3c30eab938bd"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f45a4fb2a6a269100b845404f2210d874eaee9ecd9efb6fc6c1e80896fab40f"
+dependencies = [
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1cc8df1940657960571d7bc9bc0eadf869c0eb95cff831a6554409f89b25b0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73ccd2e0e6bd91fb0161a17ee5e2d7badbeba6eb7461d0e0e3991492bd3835d"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110bf85122cd451d3b9ff67f8911d428ec9b729208abe950a0333c3244660e88"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0236a21553c5b30ee953f413a8dc99729548b747219eef7e70f8288ed313ebe"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccd50931b61ad593ae91e62d41a96b997b26c9308305cae4523cfef9301d9e8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a52ca7429272234b44f81fdf80d4793593e5c368b0f960d41fd401b1117bec"
+dependencies = [
+ "cc",
+ "object",
+ "rustix 1.1.4",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa6818a4864719772680694f4e4649a8600bb5efcf71111ebaf7419b266463e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdc6a69c42fbbf13104ccbf0d3c096d0392f00102e2c70b542d9fca402eb162"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0bd1cd696ec4b7e6f46357c0479e7739c3858e54afb69a15765402bbc1f9dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2ca01234ef55acd10c0fa5a2f96c3fd422eba03b221e2e9572944d19a476a7"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b3d8cfaad2d33a92ec4ed93d69e9836c04f7eb5b8dfe1dde9df47c41f20b7"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "heck",
+ "indexmap",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wast"
+version = "251.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.0",
+ "wasm-encoder 0.251.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -3725,6 +4590,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "45.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fdfab04a4d446c558a9ea994ded662d35580a17b15385b862002703aa43245"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+]
 
 [[package]]
 name = "windows-core"
@@ -4037,6 +4921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,7 +4943,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -4100,10 +4990,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -4121,7 +5011,26 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]

--- a/autonoetic-gateway/Cargo.toml
+++ b/autonoetic-gateway/Cargo.toml
@@ -49,7 +49,7 @@ tempfile = "3.26.0"
 aes-gcm = "0.10.3"
 rand = "0.8"
 wasmtime = { version = "45.0.1", optional = true }
-wasmtime-wasi = { version = "45", optional = true }
+wasmtime-wasi = { version = "45.0.1", optional = true }
 
 [[bin]]
 name = "mock-moltbook"

--- a/autonoetic-gateway/Cargo.toml
+++ b/autonoetic-gateway/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 default = []
 # Enables `reset_constitution_runtime_for_tests` (dependency crates can enable under `cfg(test)` only).
 test-utils = []
+# Portable WASM execution tier (RFC docs/rfc/portable-wasm-execution-tier.md, P4).
+# Off by default — the native build doesn't pay wasmtime's compile/binary cost.
+wasm-tier = ["dep:wasmtime"]
 
 [dependencies]
 autonoetic-types.workspace = true
@@ -45,6 +48,7 @@ zstd = "0.13"
 tempfile = "3.26.0"
 aes-gcm = "0.10.3"
 rand = "0.8"
+wasmtime = { version = "45.0.1", optional = true }
 
 [[bin]]
 name = "mock-moltbook"

--- a/autonoetic-gateway/Cargo.toml
+++ b/autonoetic-gateway/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 test-utils = []
 # Portable WASM execution tier (RFC docs/rfc/portable-wasm-execution-tier.md, P4).
 # Off by default — the native build doesn't pay wasmtime's compile/binary cost.
-wasm-tier = ["dep:wasmtime"]
+wasm-tier = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [dependencies]
 autonoetic-types.workspace = true
@@ -49,6 +49,7 @@ tempfile = "3.26.0"
 aes-gcm = "0.10.3"
 rand = "0.8"
 wasmtime = { version = "45.0.1", optional = true }
+wasmtime-wasi = { version = "45", optional = true }
 
 [[bin]]
 name = "mock-moltbook"

--- a/autonoetic-gateway/src/lib.rs
+++ b/autonoetic-gateway/src/lib.rs
@@ -31,6 +31,9 @@ pub mod sentinel;
 pub mod server;
 pub mod tracing;
 pub mod vault;
+/// WASM execution backend — only compiled with the `wasm-tier` feature (P4).
+#[cfg(feature = "wasm-tier")]
+pub mod wasm_backend;
 
 pub use agent::{cached, scan_agents, AgentRepository, LoadedAgent};
 pub use artifact_store::ArtifactStore;

--- a/autonoetic-gateway/src/runtime/script_execute.rs
+++ b/autonoetic-gateway/src/runtime/script_execute.rs
@@ -196,16 +196,18 @@ pub(crate) async fn execute_script_in_sandbox(
         Err(_) => script_path.to_string_lossy().to_string(),
     };
 
+    let script_args = match input_mode {
+        autonoetic_types::agent::ScriptInputMode::Args => vec![normalized_input.clone()],
+        autonoetic_types::agent::ScriptInputMode::Stdin => vec![],
+    };
+
     // Script-mode is intent-based exec: run the declared entry file. `language:
     // None` execs it directly (shebang-driven), matching prior behavior; the
     // Process backend renders it back to a shell line.
     let exec_kind = crate::exec_request::ExecutionKind::Code {
         language: None,
         source: crate::exec_request::CodeSource::Entry(entrypoint_relative),
-        args: match input_mode {
-            autonoetic_types::agent::ScriptInputMode::Args => vec![normalized_input.clone()],
-            autonoetic_types::agent::ScriptInputMode::Stdin => vec![],
-        },
+        args: script_args.clone(),
     };
 
     // Primary contract for script agents: file-backed payload + metadata paths.
@@ -231,6 +233,46 @@ pub(crate) async fn execute_script_in_sandbox(
         prepare_runtime_lock_layer_mounts(agent_dir, runtime_lock_rel_path, gateway_dir)?;
     if !layer_python_paths.is_empty() {
         autonoetic_env.push(("PYTHONPATH".to_string(), layer_python_paths.join(":")));
+    }
+
+    // WASM tier runs in-process, not via the POSIX spawn path: route it through
+    // the unified `run_to_output` entry. The entry must be the workspace-relative
+    // path (the backend joins it onto `agent_dir`), not the `BWRAP_WORKSPACE_DIR`-
+    // prefixed path the process backend renders into a shell line.
+    if driver == crate::sandbox::SandboxDriverKind::Wasm {
+        let entry_relative = script_path
+            .strip_prefix(agent_dir)
+            .map(|relative| relative.to_string_lossy().to_string())
+            .unwrap_or_else(|_| script_path.to_string_lossy().to_string());
+        let wasm_request = crate::exec_request::ExecutionKind::Code {
+            language: None,
+            source: crate::exec_request::CodeSource::Entry(entry_relative),
+            args: script_args,
+        };
+        let result = crate::sandbox::SandboxRunner::run_to_output(
+            driver,
+            &agent_dir.to_string_lossy(),
+            &wasm_request,
+            None,
+            Some(&overrides),
+            &autonoetic_env,
+            None,
+        );
+        invocation_files.cleanup();
+        let out = result?;
+        let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+        if out.exit_code != 0 {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            tracing::error!(stderr = %stderr, stdout = %stdout, exit_code = out.exit_code, "WASM script execution failed");
+            anyhow::bail!(
+                "Script execution failed with code {}: stdout={}, stderr={}",
+                out.exit_code,
+                stdout,
+                stderr
+            );
+        }
+        tracing::info!(stdout_len = stdout.len(), "WASM script execution completed");
+        return Ok(stdout);
     }
 
     let mut runner = match crate::sandbox::SandboxRunner::spawn_with_session_content_and_env(

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -156,9 +156,10 @@ pub enum SandboxDriverKind {
     Docker,
     MicroVm,
     /// In-process WebAssembly (WASI) tier — the portable execution backend
-    /// (RFC `docs/rfc/portable-wasm-execution-tier.md`, P4). The driver surface
-    /// and manifest value (`sandbox: "wasm"`) land first; the wasmtime-backed
-    /// execution is wired in subsequent increments.
+    /// (RFC `docs/rfc/portable-wasm-execution-tier.md`, P4). Selected via
+    /// `sandbox: "wasm"`; runs declared modules in-process through
+    /// [`SandboxRunner::run_to_output`] when built with the `wasm-tier` feature
+    /// (without it, selecting this driver returns a clear build-feature error).
     Wasm,
 }
 
@@ -674,6 +675,16 @@ fn run_wasm_request(
             anyhow::bail!("wasm tier does not support free-form shell execution")
         }
     };
+    // Keep the module strictly under the agent dir: reject absolute paths and any
+    // `..` traversal so a manifest entry can't read/execute outside the bundle.
+    let entry_path = Path::new(&entry);
+    anyhow::ensure!(
+        entry_path.is_relative()
+            && !entry_path
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir)),
+        "wasm entry must be a relative path within the agent dir (no `..`): {entry}"
+    );
     let wasm_path = Path::new(agent_dir).join(&entry);
     let wasm = std::fs::read(&wasm_path)
         .map_err(|e| anyhow::anyhow!("reading wasm entry {}: {e}", wasm_path.display()))?;
@@ -689,8 +700,8 @@ fn run_wasm_request(
     )?;
     Ok(ExecOutput {
         exit_code: out.exit_code,
-        stdout: out.stdout.into_bytes(),
-        stderr: out.stderr.into_bytes(),
+        stdout: out.stdout,
+        stderr: out.stderr,
     })
 }
 

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -155,6 +155,11 @@ pub enum SandboxDriverKind {
     Bubblewrap,
     Docker,
     MicroVm,
+    /// In-process WebAssembly (WASI) tier — the portable execution backend
+    /// (RFC `docs/rfc/portable-wasm-execution-tier.md`, P4). The driver surface
+    /// and manifest value (`sandbox: "wasm"`) land first; the wasmtime-backed
+    /// execution is wired in subsequent increments.
+    Wasm,
 }
 
 impl SandboxDriverKind {
@@ -163,6 +168,7 @@ impl SandboxDriverKind {
             "bubblewrap" | "bwrap" => Ok(Self::Bubblewrap),
             "docker" => Ok(Self::Docker),
             "microvm" | "firecracker" => Ok(Self::MicroVm),
+            "wasm" | "wasi" => Ok(Self::Wasm),
             other => anyhow::bail!("Unsupported sandbox driver '{}'", other),
         }
     }
@@ -290,6 +296,11 @@ impl SandboxRunner {
                 )?
             }
             SandboxDriverKind::MicroVm => microvm_command(&composed_entrypoint)?,
+            // The WASM tier is in-process (not a host `(program, args)`); its
+            // wasmtime-backed execution lands in a later P4 increment.
+            SandboxDriverKind::Wasm => {
+                anyhow::bail!("wasm sandbox tier is not yet implemented (P4 in progress)")
+            }
         };
 
         let mut command = Command::new(program);
@@ -376,6 +387,9 @@ impl SandboxRunner {
                 )?
             }
             SandboxDriverKind::MicroVm => microvm_command(&composed_entrypoint)?,
+            SandboxDriverKind::Wasm => {
+                anyhow::bail!("wasm sandbox tier is not yet implemented (P4 in progress)")
+            }
         };
 
         let mut command = Command::new(program);
@@ -460,7 +474,8 @@ fn sdk_socket_sandbox_path(driver: SandboxDriverKind, socket_name: &str) -> Opti
     match driver {
         SandboxDriverKind::Bubblewrap => Some(format!("{}/{}", BWRAP_WORKSPACE_DIR, socket_name)),
         SandboxDriverKind::Docker => Some(DOCKER_SDK_SOCKET_PATH.to_string()),
-        SandboxDriverKind::MicroVm => None,
+        // microvm deferred (P5); wasm uses host-function imports, not a socket bridge (P4).
+        SandboxDriverKind::MicroVm | SandboxDriverKind::Wasm => None,
     }
 }
 
@@ -530,7 +545,9 @@ fn wire_sdk_bridge(
                     .push((PYTHONPATH_ENV.to_string(), DOCKER_SDK_PYTHONPATH.to_string()));
             }
         }
-        SandboxDriverKind::MicroVm => {}
+        // Not reached (the early guard returns for drivers without a socket
+        // bridge), but the match must stay exhaustive.
+        SandboxDriverKind::MicroVm | SandboxDriverKind::Wasm => {}
     }
     wiring.guard = Some(bridge.guard);
     Ok(wiring)
@@ -583,6 +600,10 @@ fn apply_child_env(
                 command.env(key, value);
             }
         }
+        // Wasm runs in-process (no child `Command`); env is applied to the
+        // wasmtime store in the WASM backend, not here. Not reached today (the
+        // spawn match bails first), but the match must stay exhaustive.
+        SandboxDriverKind::Wasm => {}
     }
 }
 
@@ -1460,6 +1481,25 @@ mod tests {
             SandboxDriverKind::parse("microvm").expect("microvm should parse"),
             SandboxDriverKind::MicroVm
         );
+        assert_eq!(
+            SandboxDriverKind::parse("wasm").expect("wasm should parse"),
+            SandboxDriverKind::Wasm
+        );
+        assert_eq!(
+            SandboxDriverKind::parse("wasi").expect("wasi alias should parse"),
+            SandboxDriverKind::Wasm
+        );
+        assert!(SandboxDriverKind::parse("nope").is_err());
+    }
+
+    #[test]
+    fn wasm_driver_not_yet_executable() {
+        // P4 increment 1: the driver parses, but execution bails clearly until
+        // the wasmtime backend is wired.
+        let result = SandboxRunner::spawn_for_driver("wasm", "/tmp/agent", "python main.py");
+        assert!(result.is_err(), "wasm execution should not be implemented yet");
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("not yet implemented"), "got: {err}");
     }
 
     #[test]
@@ -1564,6 +1604,8 @@ mod tests {
         );
         // microvm has no bridge yet (P5)
         assert!(sdk_socket_sandbox_path(SandboxDriverKind::MicroVm, "s.sock").is_none());
+        // wasm uses host-function imports, not a socket bridge.
+        assert!(sdk_socket_sandbox_path(SandboxDriverKind::Wasm, "s.sock").is_none());
     }
 
     #[test]

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -677,8 +677,13 @@ fn run_wasm_request(
     let wasm_path = Path::new(agent_dir).join(&entry);
     let wasm = std::fs::read(&wasm_path)
         .map_err(|e| anyhow::anyhow!("reading wasm entry {}: {e}", wasm_path.display()))?;
-    let out =
-        crate::wasm_backend::run_wasi_module(&wasm, Path::new(agent_dir), &args, extra_env)?;
+    let out = crate::wasm_backend::run_wasi_module(
+        &wasm,
+        Path::new(agent_dir),
+        &args,
+        extra_env,
+        &crate::wasm_backend::WasmLimits::default(),
+    )?;
     Ok(ExecOutput {
         exit_code: out.exit_code,
         stdout: out.stdout.into_bytes(),

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -194,7 +194,49 @@ pub struct SandboxRunner {
     _sdk_bridge: Option<SdkBridgeGuard>,
 }
 
+/// Captured result of a completed sandbox execution, tier-agnostic.
+#[derive(Debug, Clone)]
+pub struct ExecOutput {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
 impl SandboxRunner {
+    /// Run a request to completion and capture its output, dispatching by tier:
+    /// the **process** drivers (bubblewrap/docker/microvm) spawn a child and
+    /// wait; the **wasm** tier runs in-process via the WASI backend. This is the
+    /// unified entry the agent execution path migrates onto (P4 inc 2c); the
+    /// `spawn_*` methods remain the process-only path used today.
+    pub fn run_to_output(
+        driver: SandboxDriverKind,
+        agent_dir: &str,
+        request: &ExecutionKind,
+        dependencies: Option<&DependencyPlan>,
+        overrides: Option<&BwrapIsolationOverrides>,
+        extra_env: &[(String, String)],
+        root_session_id: Option<&str>,
+    ) -> anyhow::Result<ExecOutput> {
+        if driver == SandboxDriverKind::Wasm {
+            return run_wasm_request(agent_dir, request, extra_env);
+        }
+        let runner = Self::spawn_with_driver_and_dependencies_and_env(
+            driver,
+            agent_dir,
+            request,
+            dependencies,
+            overrides,
+            extra_env,
+            root_session_id,
+        )?;
+        let out = runner.process.wait_with_output()?;
+        Ok(ExecOutput {
+            exit_code: out.status.code().unwrap_or(-1),
+            stdout: out.stdout,
+            stderr: out.stderr,
+        })
+    }
+
     /// Spawn with the default bubblewrap driver.
     pub fn spawn(agent_dir: &str, entrypoint: &str) -> anyhow::Result<Self> {
         Self::spawn_with_driver(SandboxDriverKind::Bubblewrap, agent_dir, entrypoint)
@@ -299,7 +341,7 @@ impl SandboxRunner {
             // The WASM tier is in-process (not a host `(program, args)`); its
             // wasmtime-backed execution lands in a later P4 increment.
             SandboxDriverKind::Wasm => {
-                anyhow::bail!("wasm sandbox tier is not yet implemented (P4 in progress)")
+                anyhow::bail!("wasm tier runs in-process via SandboxRunner::run_to_output, not the process spawn path")
             }
         };
 
@@ -388,7 +430,7 @@ impl SandboxRunner {
             }
             SandboxDriverKind::MicroVm => microvm_command(&composed_entrypoint)?,
             SandboxDriverKind::Wasm => {
-                anyhow::bail!("wasm sandbox tier is not yet implemented (P4 in progress)")
+                anyhow::bail!("wasm tier runs in-process via SandboxRunner::run_to_output, not the process spawn path")
             }
         };
 
@@ -605,6 +647,52 @@ fn apply_child_env(
         // spawn match bails first), but the match must stay exhaustive.
         SandboxDriverKind::Wasm => {}
     }
+}
+
+/// Run a request on the WASM tier (`wasm-tier` feature): resolve the `Code`
+/// entry to a `.wasm` file under the agent dir and execute it via the WASI
+/// backend, preopening the agent dir. Free-form shell / inline source are
+/// rejected — the portable tier runs declared code, not arbitrary shell.
+#[cfg(feature = "wasm-tier")]
+fn run_wasm_request(
+    agent_dir: &str,
+    request: &ExecutionKind,
+    extra_env: &[(String, String)],
+) -> anyhow::Result<ExecOutput> {
+    use crate::exec_request::CodeSource;
+    let (entry, args) = match request {
+        ExecutionKind::Code {
+            source: CodeSource::Entry(path),
+            args,
+            ..
+        } => (path.clone(), args.clone()),
+        ExecutionKind::Code {
+            source: CodeSource::Inline(_),
+            ..
+        } => anyhow::bail!("wasm tier: inline source is not supported yet (declare a .wasm entry)"),
+        ExecutionKind::Shell { .. } => {
+            anyhow::bail!("wasm tier does not support free-form shell execution")
+        }
+    };
+    let wasm_path = Path::new(agent_dir).join(&entry);
+    let wasm = std::fs::read(&wasm_path)
+        .map_err(|e| anyhow::anyhow!("reading wasm entry {}: {e}", wasm_path.display()))?;
+    let out =
+        crate::wasm_backend::run_wasi_module(&wasm, Path::new(agent_dir), &args, extra_env)?;
+    Ok(ExecOutput {
+        exit_code: out.exit_code,
+        stdout: out.stdout.into_bytes(),
+        stderr: out.stderr.into_bytes(),
+    })
+}
+
+#[cfg(not(feature = "wasm-tier"))]
+fn run_wasm_request(
+    _agent_dir: &str,
+    _request: &ExecutionKind,
+    _extra_env: &[(String, String)],
+) -> anyhow::Result<ExecOutput> {
+    anyhow::bail!("wasm sandbox tier requires the `wasm-tier` build feature")
 }
 
 fn run_sdk_bridge_loop(
@@ -1493,13 +1581,13 @@ mod tests {
     }
 
     #[test]
-    fn wasm_driver_not_yet_executable() {
-        // P4 increment 1: the driver parses, but execution bails clearly until
-        // the wasmtime backend is wired.
+    fn wasm_uses_run_to_output_not_the_process_spawn_path() {
+        // The process spawn path is for bwrap/docker/microvm; wasm runs in-process
+        // via run_to_output, so spawn_for_driver("wasm") bails with that guidance.
         let result = SandboxRunner::spawn_for_driver("wasm", "/tmp/agent", "python main.py");
-        assert!(result.is_err(), "wasm execution should not be implemented yet");
+        assert!(result.is_err(), "wasm must not use the process spawn path");
         let err = result.err().unwrap().to_string();
-        assert!(err.contains("not yet implemented"), "got: {err}");
+        assert!(err.contains("run_to_output"), "got: {err}");
     }
 
     #[test]

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -680,6 +680,9 @@ fn run_wasm_request(
     let out = crate::wasm_backend::run_wasi_module(
         &wasm,
         Path::new(agent_dir),
+        // Same guest workspace path the process tiers use, so input-file env
+        // vars (built against BWRAP_WORKSPACE_DIR) resolve inside the module too.
+        BWRAP_WORKSPACE_DIR,
         &args,
         extra_env,
         &crate::wasm_backend::WasmLimits::default(),

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -49,13 +49,20 @@ struct WasmStoreData {
 const WASI_PIPE_CAP: usize = 1 << 20;
 
 /// Run a WASI Preview 1 command module (`_start`) in-process: the host directory
-/// is preopened at the guest path `/workspace`, `args`/`env` are passed through,
+/// is preopened at the guest path `guest_dir`, `args`/`env` are passed through,
 /// stdout/stderr are captured, and CPU/memory are bounded by `limits` (P-3.7).
 /// Network is not granted. WASI `proc_exit` surfaces as `I32Exit` → exit code;
 /// fuel/limit exhaustion surfaces as a trap (mapped to a clear error).
+///
+/// `guest_dir` is the path the workspace appears at *inside* the module. The
+/// agent execution path passes the same workspace path the process tiers use
+/// (`BWRAP_WORKSPACE_DIR`), so input-file env vars resolve identically across
+/// tiers — a libc-based module (e.g. python.wasm) maps an absolute guest path
+/// onto this preopen by prefix.
 pub fn run_wasi_module(
     wasm: &[u8],
     preopen_host_dir: &std::path::Path,
+    guest_dir: &str,
     args: &[String],
     env: &[(String, String)],
     limits: &WasmLimits,
@@ -81,12 +88,7 @@ pub fn run_wasi_module(
         builder.env(k, v);
     }
     builder
-        .preopened_dir(
-            preopen_host_dir,
-            "/workspace",
-            DirPerms::all(),
-            FilePerms::all(),
-        )
+        .preopened_dir(preopen_host_dir, guest_dir, DirPerms::all(), FilePerms::all())
         .map_err(|e| anyhow::anyhow!("preopening workspace dir: {e}"))?;
 
     let data = WasmStoreData {
@@ -186,7 +188,7 @@ mod tests {
     (i32.store (i32.const 4) (i32.const 3))
     (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 20)))))"#;
         let dir = tempfile::tempdir().unwrap();
-        let out = run_wasi_module(wat.as_bytes(), dir.path(), &[], &[], &WasmLimits::default())
+        let out = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &WasmLimits::default())
             .expect("wasi module should run");
         assert_eq!(out.exit_code, 0);
         assert_eq!(out.stdout, "hi\n");
@@ -202,7 +204,7 @@ mod tests {
             fuel: 100_000,
             ..WasmLimits::default()
         };
-        let err = run_wasi_module(wat.as_bytes(), dir.path(), &[], &[], &limits)
+        let err = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &limits)
             .expect_err("infinite loop should hit the fuel bound");
         assert!(
             err.to_string().contains("resource limit") || err.to_string().contains("fuel"),

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -1,10 +1,10 @@
 //! WASM execution backend (RFC `docs/rfc/portable-wasm-execution-tier.md`, P4).
 //!
 //! Gated behind the `wasm-tier` Cargo feature so the native build never pays
-//! wasmtime's compile-time/binary-size cost. This first increment embeds the
-//! runtime and proves a module instantiates and runs in-process; WASI preopens,
-//! stdout/stderr capture, the host-function SDK bridge, and resource limits land
-//! in subsequent increments.
+//! wasmtime's compile-time/binary-size cost. Runs a WASI Preview 1 command
+//! module in-process with a preopened workspace, captured stdout/stderr, and
+//! CPU/memory bounds (P-3.7). The host-function SDK bridge and a WASI layer ABI
+//! for embedded dependencies land in subsequent increments.
 
 use wasmtime::{Config, Engine, Instance, Module, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::p1::{add_to_linker_sync, WasiP1Ctx};
@@ -12,11 +12,13 @@ use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
 
 /// Result of a WASI module run: captured streams + the process exit code.
+/// Streams are raw bytes (like the process tiers' `ExecOutput`) — UTF-8 decoding
+/// is left to higher layers so non-UTF-8 output isn't silently corrupted.
 #[derive(Debug, Clone)]
 pub struct WasiRunOutput {
     pub exit_code: i32,
-    pub stdout: String,
-    pub stderr: String,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
 }
 
 /// Resource bounds for a WASM run (constitution P-3.7). `fuel` caps CPU work
@@ -127,8 +129,8 @@ pub fn run_wasi_module(
 
     Ok(WasiRunOutput {
         exit_code,
-        stdout: String::from_utf8_lossy(&stdout.contents()).into_owned(),
-        stderr: String::from_utf8_lossy(&stderr.contents()).into_owned(),
+        stdout: stdout.contents().to_vec(),
+        stderr: stderr.contents().to_vec(),
     })
 }
 
@@ -191,8 +193,8 @@ mod tests {
         let out = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &WasmLimits::default())
             .expect("wasi module should run");
         assert_eq!(out.exit_code, 0);
-        assert_eq!(out.stdout, "hi\n");
-        assert_eq!(out.stderr, "");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "hi\n");
+        assert!(out.stderr.is_empty());
     }
 
     #[test]

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -1,0 +1,52 @@
+//! WASM execution backend (RFC `docs/rfc/portable-wasm-execution-tier.md`, P4).
+//!
+//! Gated behind the `wasm-tier` Cargo feature so the native build never pays
+//! wasmtime's compile-time/binary-size cost. This first increment embeds the
+//! runtime and proves a module instantiates and runs in-process; WASI preopens,
+//! stdout/stderr capture, the host-function SDK bridge, and resource limits land
+//! in subsequent increments.
+
+use wasmtime::{Engine, Instance, Module, Store};
+
+/// Instantiate a WebAssembly module (raw `.wasm` bytes, or `.wat` text when the
+/// runtime's `wat` support is enabled) and call an exported `() -> i32` function.
+/// Minimal, version-robust smoke over the core engine/module/instance API —
+/// the seam the full WASI-backed executor builds on.
+///
+/// `wasmtime::Error` is the runtime's own (vendored) error type, so we map it
+/// into this crate's `anyhow` via its `Display` rather than `?`/`.context()`.
+pub fn run_export_i32(wasm: &[u8], func: &str) -> anyhow::Result<i32> {
+    let engine = Engine::default();
+    let module =
+        Module::new(&engine, wasm).map_err(|e| anyhow::anyhow!("compiling wasm module: {e}"))?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])
+        .map_err(|e| anyhow::anyhow!("instantiating wasm module: {e}"))?;
+    let typed = instance
+        .get_typed_func::<(), i32>(&mut store, func)
+        .map_err(|e| anyhow::anyhow!("resolving exported fn '{func}' as () -> i32: {e}"))?;
+    typed
+        .call(&mut store, ())
+        .map_err(|e| anyhow::anyhow!("calling exported fn '{func}': {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runs_a_trivial_wasm_module() {
+        // Inline WAT compiled by the runtime — proves wasmtime is embedded and
+        // can instantiate + call an export in-process.
+        let wat = r#"(module (func (export "run") (result i32) i32.const 42))"#;
+        let result = run_export_i32(wat.as_bytes(), "run").expect("module should run");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn missing_export_errors_clearly() {
+        let wat = r#"(module (func (export "run") (result i32) i32.const 1))"#;
+        let err = run_export_i32(wat.as_bytes(), "nope").unwrap_err().to_string();
+        assert!(err.contains("nope"), "error should name the missing export: {err}");
+    }
+}

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -6,16 +6,43 @@
 //! stdout/stderr capture, the host-function SDK bridge, and resource limits land
 //! in subsequent increments.
 
-use wasmtime::{Engine, Instance, Module, Store};
+use wasmtime::{Config, Engine, Instance, Module, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::p1::{add_to_linker_sync, WasiP1Ctx};
 use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
 
 /// Result of a WASI module run: captured streams + the process exit code.
+#[derive(Debug, Clone)]
 pub struct WasiRunOutput {
     pub exit_code: i32,
     pub stdout: String,
     pub stderr: String,
+}
+
+/// Resource bounds for a WASM run (constitution P-3.7). `fuel` caps CPU work
+/// (instructions); `max_memory_bytes` caps linear-memory growth. Tunables live
+/// in code, not the constitution.
+#[derive(Debug, Clone, Copy)]
+pub struct WasmLimits {
+    pub fuel: u64,
+    pub max_memory_bytes: usize,
+}
+
+impl Default for WasmLimits {
+    fn default() -> Self {
+        // Generous enough for real interpreter runs (e.g. python.wasm), finite
+        // so a runaway can't spin or balloon unbounded.
+        Self {
+            fuel: 20_000_000_000,
+            max_memory_bytes: 512 << 20, // 512 MiB
+        }
+    }
+}
+
+/// Store data for a WASI run: the WASI context plus the resource limiter.
+struct WasmStoreData {
+    wasi: WasiP1Ctx,
+    limits: StoreLimits,
 }
 
 /// Per-stream capture cap (1 MiB) — bounds in-memory stdout/stderr buffering.
@@ -23,16 +50,20 @@ const WASI_PIPE_CAP: usize = 1 << 20;
 
 /// Run a WASI Preview 1 command module (`_start`) in-process: the host directory
 /// is preopened at the guest path `/workspace`, `args`/`env` are passed through,
-/// and stdout/stderr are captured. Network is not granted. WASI `proc_exit`
-/// surfaces as `I32Exit`, which we map to the exit code. (P4 inc 2b — the path
-/// `python.wasm` will run through.)
+/// stdout/stderr are captured, and CPU/memory are bounded by `limits` (P-3.7).
+/// Network is not granted. WASI `proc_exit` surfaces as `I32Exit` → exit code;
+/// fuel/limit exhaustion surfaces as a trap (mapped to a clear error).
 pub fn run_wasi_module(
     wasm: &[u8],
     preopen_host_dir: &std::path::Path,
     args: &[String],
     env: &[(String, String)],
+    limits: &WasmLimits,
 ) -> anyhow::Result<WasiRunOutput> {
-    let engine = Engine::default();
+    let mut config = Config::new();
+    config.consume_fuel(true); // enables the CPU bound via set_fuel
+    let engine =
+        Engine::new(&config).map_err(|e| anyhow::anyhow!("building wasm engine: {e}"))?;
     let module =
         Module::new(&engine, wasm).map_err(|e| anyhow::anyhow!("compiling wasm module: {e}"))?;
 
@@ -57,12 +88,23 @@ pub fn run_wasi_module(
             FilePerms::all(),
         )
         .map_err(|e| anyhow::anyhow!("preopening workspace dir: {e}"))?;
-    let wasi = builder.build_p1();
 
-    let mut linker: wasmtime::Linker<WasiP1Ctx> = wasmtime::Linker::new(&engine);
-    add_to_linker_sync(&mut linker, |t| t)
+    let data = WasmStoreData {
+        wasi: builder.build_p1(),
+        limits: StoreLimitsBuilder::new()
+            .memory_size(limits.max_memory_bytes)
+            .build(),
+    };
+
+    let mut linker: wasmtime::Linker<WasmStoreData> = wasmtime::Linker::new(&engine);
+    add_to_linker_sync(&mut linker, |d: &mut WasmStoreData| &mut d.wasi)
         .map_err(|e| anyhow::anyhow!("adding wasi to linker: {e}"))?;
-    let mut store = Store::new(&engine, wasi);
+    let mut store = Store::new(&engine, data);
+    store.limiter(|d| &mut d.limits);
+    store
+        .set_fuel(limits.fuel)
+        .map_err(|e| anyhow::anyhow!("setting fuel: {e}"))?;
+
     let instance = linker
         .instantiate(&mut store, &module)
         .map_err(|e| anyhow::anyhow!("instantiating wasi module: {e}"))?;
@@ -75,7 +117,8 @@ pub fn run_wasi_module(
         // `proc_exit` is reported as I32Exit, not a real trap.
         Err(e) => match e.downcast_ref::<I32Exit>() {
             Some(exit) => exit.0,
-            None => return Err(anyhow::anyhow!("wasm _start trapped: {e}")),
+            // Includes fuel exhaustion ("all fuel consumed") and memory-limit traps.
+            None => return Err(anyhow::anyhow!("wasm execution failed (trap or resource limit): {e}")),
         },
     };
     drop(store); // release the pipe writers before reading
@@ -143,10 +186,27 @@ mod tests {
     (i32.store (i32.const 4) (i32.const 3))
     (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 20)))))"#;
         let dir = tempfile::tempdir().unwrap();
-        let out = run_wasi_module(wat.as_bytes(), dir.path(), &[], &[])
+        let out = run_wasi_module(wat.as_bytes(), dir.path(), &[], &[], &WasmLimits::default())
             .expect("wasi module should run");
         assert_eq!(out.exit_code, 0);
         assert_eq!(out.stdout, "hi\n");
         assert_eq!(out.stderr, "");
+    }
+
+    #[test]
+    fn fuel_exhaustion_is_bounded_not_hung() {
+        // An infinite loop must be stopped by the fuel bound (P-3.7), not hang.
+        let wat = r#"(module (func (export "_start") (loop br 0)))"#;
+        let dir = tempfile::tempdir().unwrap();
+        let limits = WasmLimits {
+            fuel: 100_000,
+            ..WasmLimits::default()
+        };
+        let err = run_wasi_module(wat.as_bytes(), dir.path(), &[], &[], &limits)
+            .expect_err("infinite loop should hit the fuel bound");
+        assert!(
+            err.to_string().contains("resource limit") || err.to_string().contains("fuel"),
+            "got: {err}"
+        );
     }
 }

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -7,6 +7,85 @@
 //! in subsequent increments.
 
 use wasmtime::{Engine, Instance, Module, Store};
+use wasmtime_wasi::p1::{add_to_linker_sync, WasiP1Ctx};
+use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
+use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
+
+/// Result of a WASI module run: captured streams + the process exit code.
+pub struct WasiRunOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Per-stream capture cap (1 MiB) — bounds in-memory stdout/stderr buffering.
+const WASI_PIPE_CAP: usize = 1 << 20;
+
+/// Run a WASI Preview 1 command module (`_start`) in-process: the host directory
+/// is preopened at the guest path `/workspace`, `args`/`env` are passed through,
+/// and stdout/stderr are captured. Network is not granted. WASI `proc_exit`
+/// surfaces as `I32Exit`, which we map to the exit code. (P4 inc 2b — the path
+/// `python.wasm` will run through.)
+pub fn run_wasi_module(
+    wasm: &[u8],
+    preopen_host_dir: &std::path::Path,
+    args: &[String],
+    env: &[(String, String)],
+) -> anyhow::Result<WasiRunOutput> {
+    let engine = Engine::default();
+    let module =
+        Module::new(&engine, wasm).map_err(|e| anyhow::anyhow!("compiling wasm module: {e}"))?;
+
+    let stdout = MemoryOutputPipe::new(WASI_PIPE_CAP);
+    let stderr = MemoryOutputPipe::new(WASI_PIPE_CAP);
+
+    let mut builder = WasiCtxBuilder::new();
+    builder.stdout(stdout.clone());
+    builder.stderr(stderr.clone());
+    builder.arg("program"); // argv[0]
+    for a in args {
+        builder.arg(a);
+    }
+    for (k, v) in env {
+        builder.env(k, v);
+    }
+    builder
+        .preopened_dir(
+            preopen_host_dir,
+            "/workspace",
+            DirPerms::all(),
+            FilePerms::all(),
+        )
+        .map_err(|e| anyhow::anyhow!("preopening workspace dir: {e}"))?;
+    let wasi = builder.build_p1();
+
+    let mut linker: wasmtime::Linker<WasiP1Ctx> = wasmtime::Linker::new(&engine);
+    add_to_linker_sync(&mut linker, |t| t)
+        .map_err(|e| anyhow::anyhow!("adding wasi to linker: {e}"))?;
+    let mut store = Store::new(&engine, wasi);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .map_err(|e| anyhow::anyhow!("instantiating wasi module: {e}"))?;
+    let start = instance
+        .get_typed_func::<(), ()>(&mut store, "_start")
+        .map_err(|e| anyhow::anyhow!("resolving _start: {e}"))?;
+
+    let exit_code = match start.call(&mut store, ()) {
+        Ok(()) => 0,
+        // `proc_exit` is reported as I32Exit, not a real trap.
+        Err(e) => match e.downcast_ref::<I32Exit>() {
+            Some(exit) => exit.0,
+            None => return Err(anyhow::anyhow!("wasm _start trapped: {e}")),
+        },
+    };
+    drop(store); // release the pipe writers before reading
+
+    Ok(WasiRunOutput {
+        exit_code,
+        stdout: String::from_utf8_lossy(&stdout.contents()).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr.contents()).into_owned(),
+    })
+}
 
 /// Instantiate a WebAssembly module (raw `.wasm` bytes, or `.wat` text when the
 /// runtime's `wat` support is enabled) and call an exported `() -> i32` function.
@@ -48,5 +127,26 @@ mod tests {
         let wat = r#"(module (func (export "run") (result i32) i32.const 1))"#;
         let err = run_export_i32(wat.as_bytes(), "nope").unwrap_err().to_string();
         assert!(err.contains("nope"), "error should name the missing export: {err}");
+    }
+
+    #[test]
+    fn wasi_module_stdout_is_captured() {
+        // Minimal WASI p1 module: write "hi\n" to fd 1 (stdout) via fd_write.
+        // iovec at addr 0 → {ptr: 8, len: 3}; payload "hi\n" at addr 8.
+        let wat = r#"(module
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 8) "hi\n")
+  (func (export "_start")
+    (i32.store (i32.const 0) (i32.const 8))
+    (i32.store (i32.const 4) (i32.const 3))
+    (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 20)))))"#;
+        let dir = tempfile::tempdir().unwrap();
+        let out = run_wasi_module(wat.as_bytes(), dir.path(), &[], &[])
+            .expect("wasi module should run");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout, "hi\n");
+        assert_eq!(out.stderr, "");
     }
 }

--- a/autonoetic-gateway/tests/wasm_tier_integration.rs
+++ b/autonoetic-gateway/tests/wasm_tier_integration.rs
@@ -1,0 +1,67 @@
+//! P4 inc 2c — the wasm tier wired into the unified execution entry.
+//! A `sandbox: "wasm"` request runs in-process through `run_to_output` end to
+//! end (no child process), capturing stdout + exit code. Compiles only with the
+//! `wasm-tier` feature.
+#![cfg(feature = "wasm-tier")]
+
+use autonoetic_gateway::exec_request::{CodeSource, ExecutionKind};
+use autonoetic_gateway::sandbox::{SandboxDriverKind, SandboxRunner};
+use tempfile::tempdir;
+
+#[test]
+fn wasm_agent_entry_runs_through_run_to_output() {
+    let dir = tempdir().unwrap();
+    // The agent's entry is a WASI module that writes "hi\n" to stdout. The
+    // runtime compiles WAT directly, so the entry file can carry WAT text.
+    let wat = r#"(module
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 8) "hi\n")
+  (func (export "_start")
+    (i32.store (i32.const 0) (i32.const 8))
+    (i32.store (i32.const 4) (i32.const 3))
+    (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 20)))))"#;
+    std::fs::write(dir.path().join("main.wasm"), wat).unwrap();
+
+    let request = ExecutionKind::Code {
+        language: None,
+        source: CodeSource::Entry("main.wasm".to_string()),
+        args: vec![],
+    };
+
+    let out = SandboxRunner::run_to_output(
+        SandboxDriverKind::Wasm,
+        dir.path().to_str().unwrap(),
+        &request,
+        None,
+        None,
+        &[],
+        None,
+    )
+    .expect("wasm agent entry should run via run_to_output");
+
+    assert_eq!(out.exit_code, 0);
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "hi\n");
+    assert!(out.stderr.is_empty());
+}
+
+#[test]
+fn wasm_tier_rejects_free_form_shell() {
+    let dir = tempdir().unwrap();
+    let request = ExecutionKind::shell("echo hi");
+    let err = SandboxRunner::run_to_output(
+        SandboxDriverKind::Wasm,
+        dir.path().to_str().unwrap(),
+        &request,
+        None,
+        None,
+        &[],
+        None,
+    )
+    .expect_err("wasm tier must reject free-form shell");
+    assert!(
+        err.to_string().contains("shell"),
+        "error should explain shell is unsupported: {err}"
+    );
+}

--- a/autonoetic-gateway/tests/wasm_tier_integration.rs
+++ b/autonoetic-gateway/tests/wasm_tier_integration.rs
@@ -65,3 +65,28 @@ fn wasm_tier_rejects_free_form_shell() {
         "error should explain shell is unsupported: {err}"
     );
 }
+
+#[test]
+fn wasm_tier_rejects_path_traversal_entry() {
+    let dir = tempdir().unwrap();
+    // A `..` entry must not escape the agent dir to read/execute a foreign module.
+    let request = ExecutionKind::Code {
+        language: None,
+        source: CodeSource::Entry("../escape.wasm".to_string()),
+        args: vec![],
+    };
+    let err = SandboxRunner::run_to_output(
+        SandboxDriverKind::Wasm,
+        dir.path().to_str().unwrap(),
+        &request,
+        None,
+        None,
+        &[],
+        None,
+    )
+    .expect_err("wasm tier must reject path-traversal entries");
+    assert!(
+        err.to_string().contains(".."),
+        "error should explain the entry must stay within the agent dir: {err}"
+    );
+}


### PR DESCRIPTION
**P4 — WASM execution tier** (#442). RFC: `docs/rfc/portable-wasm-execution-tier.md` §5.5. Reaches a complete, reviewable point: WASM runs end to end behind the `wasm-tier` Cargo feature, including the script-agent caller.

## What landed
1. **Driver surface** — `SandboxDriverKind::Wasm` + `parse` ("wasm"/"wasi"); `sandbox: "wasm"` is a recognized manifest value, handled across every match site. WASM routes around the Unix-socket SDK bridge (it'll use host-function imports).
2. **wasmtime embedded (feature-gated)** — `wasm-tier` feature (off by default) → optional `wasmtime`/`wasmtime-wasi` v45. The native build never pays the cost (verified: default build excludes wasmtime entirely).
3. **WASI execution + capture** — `run_wasi_module` runs a WASI p1 `_start` module in-process: host dir preopened at an explicit `guest_dir`, args/env passed, stdout/stderr captured, `proc_exit`→exit code, **no network**. Written against the real v45 API.
4. **Unified execution entry** — `SandboxRunner::run_to_output` dispatches by tier: process drivers spawn+wait; the wasm tier runs in-process via the WASI backend. A `sandbox: "wasm"` request runs end to end. Shell/inline rejected on the wasm tier.
5. **Resource limits (P-3.7)** — the wasm tier enforces a `fuel` (CPU) bound and a `StoreLimits` memory cap; fuel/limit exhaustion is a clear error, not a hang. `WasmLimits` defaults (20B fuel / 512 MiB) are code-level tunables.
6. **Script-agent caller migration** — `execute_script_in_sandbox` now branches a `sandbox: "wasm"` agent onto `run_to_output` (before the POSIX spawn, so process drivers are untouched), passing the workspace-relative entry. The wasm tier preopens the workspace at `BWRAP_WORKSPACE_DIR` — the same path the process tiers use — so the script invocation's input-file env vars resolve identically inside a libc-based module.

## Safety / scoping
- Off by default — zero impact on the native build/binary.
- The existing spawn path (bwrap/docker/microvm) is unchanged; wasm goes through the new `run_to_output` entry.
- **Not yet done (clear follow-ups):** migrate the remaining callers (`sandbox.exec` / `artifact_exec`) onto `run_to_output`; host-function SDK bridge; escape accounting for wasm traps; `python.wasm` bundling (to run Python, not just precompiled `.wasm`) — **needs an operator decision** (~20 MB artifact + licensing/build choice); WASI layer ABI for the bake step.

## Tests (`--features wasm-tier`)
module instantiate + call; WASI `fd_write`→stdout capture; fuel exhaustion bounded (not hung); a `.wasm` agent entry runs through `run_to_output` (stdout "hi\n", exit 0); shell rejected on wasm tier. Default build clean; bwrap + script-agent regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)