### PR TITLE
feat(wasm): deliver stdin to the WASI tier (close script-agent stdin gap)

### DIFF
--- a/autonoetic-gateway/src/runtime/script_execute.rs
+++ b/autonoetic-gateway/src/runtime/script_execute.rs
@@ -252,7 +252,9 @@ pub(crate) async fn execute_script_in_sandbox(
         // Stdin mode delivers the payload on the module's stdin (Args mode already
         // carries it in argv); mirrors the process tier's stdin handling.
         let stdin_bytes = match input_mode {
-            autonoetic_types::agent::ScriptInputMode::Stdin => Some(normalized_input.as_bytes()),
+            autonoetic_types::agent::ScriptInputMode::Stdin => {
+                Some(normalized_input.clone().into_bytes())
+            }
             autonoetic_types::agent::ScriptInputMode::Args => None,
         };
         let result = crate::sandbox::SandboxRunner::run_to_output(

--- a/autonoetic-gateway/src/runtime/script_execute.rs
+++ b/autonoetic-gateway/src/runtime/script_execute.rs
@@ -249,6 +249,12 @@ pub(crate) async fn execute_script_in_sandbox(
             source: crate::exec_request::CodeSource::Entry(entry_relative),
             args: script_args,
         };
+        // Stdin mode delivers the payload on the module's stdin (Args mode already
+        // carries it in argv); mirrors the process tier's stdin handling.
+        let stdin_bytes = match input_mode {
+            autonoetic_types::agent::ScriptInputMode::Stdin => Some(normalized_input.as_bytes()),
+            autonoetic_types::agent::ScriptInputMode::Args => None,
+        };
         let result = crate::sandbox::SandboxRunner::run_to_output(
             driver,
             &agent_dir.to_string_lossy(),
@@ -257,6 +263,7 @@ pub(crate) async fn execute_script_in_sandbox(
             Some(&overrides),
             &autonoetic_env,
             None,
+            stdin_bytes,
         );
         invocation_files.cleanup();
         let out = result?;

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -217,7 +217,7 @@ impl SandboxRunner {
         overrides: Option<&BwrapIsolationOverrides>,
         extra_env: &[(String, String)],
         root_session_id: Option<&str>,
-        stdin: Option<&[u8]>,
+        stdin: Option<Vec<u8>>,
     ) -> anyhow::Result<ExecOutput> {
         if driver == SandboxDriverKind::Wasm {
             return run_wasm_request(agent_dir, request, extra_env, stdin);
@@ -235,7 +235,7 @@ impl SandboxRunner {
         if let Some(input) = stdin {
             if let Some(mut child_stdin) = runner.process.stdin.take() {
                 use std::io::Write;
-                child_stdin.write_all(input)?;
+                child_stdin.write_all(&input)?;
             }
         }
         let out = runner.process.wait_with_output()?;
@@ -667,7 +667,7 @@ fn run_wasm_request(
     agent_dir: &str,
     request: &ExecutionKind,
     extra_env: &[(String, String)],
-    stdin: Option<&[u8]>,
+    stdin: Option<Vec<u8>>,
 ) -> anyhow::Result<ExecOutput> {
     use crate::exec_request::CodeSource;
     let (entry, args) = match request {
@@ -705,7 +705,7 @@ fn run_wasm_request(
         BWRAP_WORKSPACE_DIR,
         &args,
         extra_env,
-        stdin.unwrap_or(&[]),
+        stdin.unwrap_or_default(),
         &crate::wasm_backend::WasmLimits::default(),
     )?;
     Ok(ExecOutput {
@@ -720,7 +720,7 @@ fn run_wasm_request(
     _agent_dir: &str,
     _request: &ExecutionKind,
     _extra_env: &[(String, String)],
-    _stdin: Option<&[u8]>,
+    _stdin: Option<Vec<u8>>,
 ) -> anyhow::Result<ExecOutput> {
     anyhow::bail!("wasm sandbox tier requires the `wasm-tier` build feature")
 }

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -217,11 +217,12 @@ impl SandboxRunner {
         overrides: Option<&BwrapIsolationOverrides>,
         extra_env: &[(String, String)],
         root_session_id: Option<&str>,
+        stdin: Option<&[u8]>,
     ) -> anyhow::Result<ExecOutput> {
         if driver == SandboxDriverKind::Wasm {
-            return run_wasm_request(agent_dir, request, extra_env);
+            return run_wasm_request(agent_dir, request, extra_env, stdin);
         }
-        let runner = Self::spawn_with_driver_and_dependencies_and_env(
+        let mut runner = Self::spawn_with_driver_and_dependencies_and_env(
             driver,
             agent_dir,
             request,
@@ -230,6 +231,13 @@ impl SandboxRunner {
             extra_env,
             root_session_id,
         )?;
+        // Feed stdin (closed by dropping the handle) before draining the child.
+        if let Some(input) = stdin {
+            if let Some(mut child_stdin) = runner.process.stdin.take() {
+                use std::io::Write;
+                child_stdin.write_all(input)?;
+            }
+        }
         let out = runner.process.wait_with_output()?;
         Ok(ExecOutput {
             exit_code: out.status.code().unwrap_or(-1),
@@ -659,6 +667,7 @@ fn run_wasm_request(
     agent_dir: &str,
     request: &ExecutionKind,
     extra_env: &[(String, String)],
+    stdin: Option<&[u8]>,
 ) -> anyhow::Result<ExecOutput> {
     use crate::exec_request::CodeSource;
     let (entry, args) = match request {
@@ -696,6 +705,7 @@ fn run_wasm_request(
         BWRAP_WORKSPACE_DIR,
         &args,
         extra_env,
+        stdin.unwrap_or(&[]),
         &crate::wasm_backend::WasmLimits::default(),
     )?;
     Ok(ExecOutput {
@@ -710,6 +720,7 @@ fn run_wasm_request(
     _agent_dir: &str,
     _request: &ExecutionKind,
     _extra_env: &[(String, String)],
+    _stdin: Option<&[u8]>,
 ) -> anyhow::Result<ExecOutput> {
     anyhow::bail!("wasm sandbox tier requires the `wasm-tier` build feature")
 }

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -8,7 +8,7 @@
 
 use wasmtime::{Config, Engine, Instance, Module, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::p1::{add_to_linker_sync, WasiP1Ctx};
-use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
+use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
 
 /// Result of a WASI module run: captured streams + the process exit code.
@@ -52,9 +52,10 @@ const WASI_PIPE_CAP: usize = 1 << 20;
 
 /// Run a WASI Preview 1 command module (`_start`) in-process: the host directory
 /// is preopened at the guest path `guest_dir`, `args`/`env` are passed through,
-/// stdout/stderr are captured, and CPU/memory are bounded by `limits` (P-3.7).
-/// Network is not granted. WASI `proc_exit` surfaces as `I32Exit` → exit code;
-/// fuel/limit exhaustion surfaces as a trap (mapped to a clear error).
+/// stdout/stderr are captured, `stdin` is fed to the module, and CPU/memory are
+/// bounded by `limits` (P-3.7). Network is not granted. WASI `proc_exit` surfaces
+/// as `I32Exit` → exit code; fuel/limit exhaustion surfaces as a trap (mapped to
+/// a clear error).
 ///
 /// `guest_dir` is the path the workspace appears at *inside* the module. The
 /// agent execution path passes the same workspace path the process tiers use
@@ -67,6 +68,7 @@ pub fn run_wasi_module(
     guest_dir: &str,
     args: &[String],
     env: &[(String, String)],
+    stdin: &[u8],
     limits: &WasmLimits,
 ) -> anyhow::Result<WasiRunOutput> {
     let mut config = Config::new();
@@ -82,6 +84,7 @@ pub fn run_wasi_module(
     let mut builder = WasiCtxBuilder::new();
     builder.stdout(stdout.clone());
     builder.stderr(stderr.clone());
+    builder.stdin(MemoryInputPipe::new(stdin.to_vec()));
     builder.arg("program"); // argv[0]
     for a in args {
         builder.arg(a);
@@ -190,11 +193,45 @@ mod tests {
     (i32.store (i32.const 4) (i32.const 3))
     (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 20)))))"#;
         let dir = tempfile::tempdir().unwrap();
-        let out = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &WasmLimits::default())
+        let out = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &[], &WasmLimits::default())
             .expect("wasi module should run");
         assert_eq!(out.exit_code, 0);
         assert_eq!(String::from_utf8_lossy(&out.stdout), "hi\n");
         assert!(out.stderr.is_empty());
+    }
+
+    #[test]
+    fn wasi_module_stdin_is_delivered() {
+        // Echo module: read up to 16 bytes from fd 0 (stdin) into a buffer, then
+        // write `nread` bytes from that buffer to fd 1 (stdout). Proves the stdin
+        // pipe reaches the guest. Layout: iovec for read at addr 0 → {ptr:16,len:16};
+        // nread written at addr 8; iovec for write at addr 0 reused → {ptr:16,len:nread}.
+        let wat = r#"(module
+  (import "wasi_snapshot_preview1" "fd_read"
+    (func $fd_read (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (func (export "_start")
+    (i32.store (i32.const 0) (i32.const 16))
+    (i32.store (i32.const 4) (i32.const 16))
+    (drop (call $fd_read (i32.const 0) (i32.const 0) (i32.const 1) (i32.const 8)))
+    (i32.store (i32.const 0) (i32.const 16))
+    (i32.store (i32.const 4) (i32.load (i32.const 8)))
+    (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 12)))))"#;
+        let dir = tempfile::tempdir().unwrap();
+        let out = run_wasi_module(
+            wat.as_bytes(),
+            dir.path(),
+            "/tmp",
+            &[],
+            &[],
+            b"ping\n",
+            &WasmLimits::default(),
+        )
+        .expect("wasi module should run");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ping\n");
     }
 
     #[test]
@@ -206,7 +243,7 @@ mod tests {
             fuel: 100_000,
             ..WasmLimits::default()
         };
-        let err = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &limits)
+        let err = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &[], &limits)
             .expect_err("infinite loop should hit the fuel bound");
         assert!(
             err.to_string().contains("resource limit") || err.to_string().contains("fuel"),

--- a/autonoetic-gateway/src/wasm_backend.rs
+++ b/autonoetic-gateway/src/wasm_backend.rs
@@ -68,7 +68,7 @@ pub fn run_wasi_module(
     guest_dir: &str,
     args: &[String],
     env: &[(String, String)],
-    stdin: &[u8],
+    stdin: Vec<u8>,
     limits: &WasmLimits,
 ) -> anyhow::Result<WasiRunOutput> {
     let mut config = Config::new();
@@ -84,7 +84,7 @@ pub fn run_wasi_module(
     let mut builder = WasiCtxBuilder::new();
     builder.stdout(stdout.clone());
     builder.stderr(stderr.clone());
-    builder.stdin(MemoryInputPipe::new(stdin.to_vec()));
+    builder.stdin(MemoryInputPipe::new(stdin)); // Vec<u8> → Bytes is a move, no copy
     builder.arg("program"); // argv[0]
     for a in args {
         builder.arg(a);
@@ -193,7 +193,7 @@ mod tests {
     (i32.store (i32.const 4) (i32.const 3))
     (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 20)))))"#;
         let dir = tempfile::tempdir().unwrap();
-        let out = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &[], &WasmLimits::default())
+        let out = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], vec![], &WasmLimits::default())
             .expect("wasi module should run");
         assert_eq!(out.exit_code, 0);
         assert_eq!(String::from_utf8_lossy(&out.stdout), "hi\n");
@@ -226,7 +226,7 @@ mod tests {
             "/tmp",
             &[],
             &[],
-            b"ping\n",
+            b"ping\n".to_vec(),
             &WasmLimits::default(),
         )
         .expect("wasi module should run");
@@ -243,7 +243,7 @@ mod tests {
             fuel: 100_000,
             ..WasmLimits::default()
         };
-        let err = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], &[], &limits)
+        let err = run_wasi_module(wat.as_bytes(), dir.path(), "/tmp", &[], &[], vec![], &limits)
             .expect_err("infinite loop should hit the fuel bound");
         assert!(
             err.to_string().contains("resource limit") || err.to_string().contains("fuel"),

--- a/autonoetic-gateway/tests/wasm_tier_integration.rs
+++ b/autonoetic-gateway/tests/wasm_tier_integration.rs
@@ -80,7 +80,7 @@ fn wasm_agent_receives_stdin_through_run_to_output() {
         None,
         &[],
         None,
-        Some(b"pong\n"),
+        Some(b"pong\n".to_vec()),
     )
     .expect("wasm agent should receive stdin via run_to_output");
 

--- a/autonoetic-gateway/tests/wasm_tier_integration.rs
+++ b/autonoetic-gateway/tests/wasm_tier_integration.rs
@@ -38,12 +38,54 @@ fn wasm_agent_entry_runs_through_run_to_output() {
         None,
         &[],
         None,
+        None,
     )
     .expect("wasm agent entry should run via run_to_output");
 
     assert_eq!(out.exit_code, 0);
     assert_eq!(String::from_utf8_lossy(&out.stdout), "hi\n");
     assert!(out.stderr.is_empty());
+}
+
+#[test]
+fn wasm_agent_receives_stdin_through_run_to_output() {
+    let dir = tempdir().unwrap();
+    // Echo entry: read up to 16 bytes from stdin, write them back to stdout.
+    let wat = r#"(module
+  (import "wasi_snapshot_preview1" "fd_read"
+    (func $fd_read (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (func (export "_start")
+    (i32.store (i32.const 0) (i32.const 16))
+    (i32.store (i32.const 4) (i32.const 16))
+    (drop (call $fd_read (i32.const 0) (i32.const 0) (i32.const 1) (i32.const 8)))
+    (i32.store (i32.const 0) (i32.const 16))
+    (i32.store (i32.const 4) (i32.load (i32.const 8)))
+    (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 12)))))"#;
+    std::fs::write(dir.path().join("main.wasm"), wat).unwrap();
+
+    let request = ExecutionKind::Code {
+        language: None,
+        source: CodeSource::Entry("main.wasm".to_string()),
+        args: vec![],
+    };
+
+    let out = SandboxRunner::run_to_output(
+        SandboxDriverKind::Wasm,
+        dir.path().to_str().unwrap(),
+        &request,
+        None,
+        None,
+        &[],
+        None,
+        Some(b"pong\n"),
+    )
+    .expect("wasm agent should receive stdin via run_to_output");
+
+    assert_eq!(out.exit_code, 0);
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "pong\n");
 }
 
 #[test]
@@ -57,6 +99,7 @@ fn wasm_tier_rejects_free_form_shell() {
         None,
         None,
         &[],
+        None,
         None,
     )
     .expect_err("wasm tier must reject free-form shell");
@@ -82,6 +125,7 @@ fn wasm_tier_rejects_path_traversal_entry() {
         None,
         None,
         &[],
+        None,
         None,
     )
     .expect_err("wasm tier must reject path-traversal entries");


### PR DESCRIPTION
Closes the stdin gap flagged in #453: the wasm caller branch handled `Args` input mode but silently delivered nothing in `Stdin` mode, because `run_wasi_module` had no stdin. This is the prerequisite for **JS-via-Javy** (Javy reads program input from stdin) and benefits a future `python.wasm`.

## What changed
- **`run_wasi_module`** — new `stdin: &[u8]` argument, fed to the guest via `MemoryInputPipe` (impls `StdinStream`).
- **`run_to_output`** — new `stdin: Option<&[u8]>` argument, completing the unified entry for **both** tiers:
  - process path writes it to the child's (already-`Stdio::piped()`) stdin, then drops the handle to close it before draining stdout/stderr;
  - wasm path forwards it to `run_wasm_request` → `run_wasi_module`.
- **`execute_script_in_sandbox`** (wasm branch) — passes the payload on stdin in `Stdin` mode; `Args` mode still carries it in argv, mirroring the process tier.

## Tests (`--features wasm-tier`)
- `wasi_module_stdin_is_delivered` — backend-level echo (WASI `fd_read`→`fd_write`) round-trips stdin→stdout.
- `wasm_agent_receives_stdin_through_run_to_output` — same, end-to-end through the unified entry.
- Existing wasm tests + default build remain green (default build never pulls wasmtime).

## Scope
Feature-gated; zero impact on the native build. Next: JS-via-Javy (packager build step + e2e), then the `python.wasm` bundling decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)