### PR TITLE
feat(gateway): host capability preflight (sandbox tiers + language toolchains)

### DIFF
--- a/autonoetic-gateway/src/host_capabilities.rs
+++ b/autonoetic-gateway/src/host_capabilities.rs
@@ -1,0 +1,200 @@
+//! Host capability preflight.
+//!
+//! The gateway runs agents on whichever sandbox tier each agent's manifest
+//! declares (`runtime.sandbox`: bubblewrap / docker / microvm / wasm) and in
+//! whichever language the agent ships. Most tiers and language toolchains need a
+//! host tool present on `PATH` (`bwrap`, `docker`, `javy`, …); the wasm tier is
+//! in-process and instead needs the `wasm-tier` build feature.
+//!
+//! This module probes what the host can actually run so the operator learns
+//! about a missing toolchain at gateway start (or on demand via the preflight
+//! command) rather than at the first agent spawn that needs it. Probing is
+//! read-only: it scans `PATH` for an executable, it does not run anything.
+
+/// Whether an executable named `tool` exists on `PATH`.
+///
+/// Read-only and cheap: scans `PATH` entries for a file with the execute bit,
+/// without spawning the tool (so it can't have side effects or hang).
+pub fn tool_on_path(tool: &str) -> bool {
+    tool_on_given_path(std::env::var_os("PATH").as_deref(), tool)
+}
+
+/// `tool_on_path` against an explicit `PATH` value — the testable core, so tests
+/// never mutate the process-global `PATH` (which would race the rest of the suite).
+fn tool_on_given_path(path: Option<&std::ffi::OsStr>, tool: &str) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+    std::env::split_paths(path).any(|dir| is_executable(&dir.join(tool)))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
+/// Whether this build embeds the in-process wasm tier (`wasm-tier` feature).
+pub const fn wasm_tier_built() -> bool {
+    cfg!(feature = "wasm-tier")
+}
+
+/// Convenience probes used across the codebase and tests.
+pub fn is_bwrap_available() -> bool {
+    tool_on_path("bwrap")
+}
+pub fn is_docker_available() -> bool {
+    tool_on_path("docker")
+}
+/// Javy is the JS→wasm compiler used to bundle JavaScript agents for the wasm tier.
+pub fn is_javy_available() -> bool {
+    tool_on_path("javy")
+}
+
+/// One probed capability: a sandbox tier or a language toolchain, the host
+/// requirement it depends on, and whether that requirement is satisfied.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct Capability {
+    /// What the capability enables (e.g. `"sandbox: docker"`, `"language: javascript (wasm via javy)"`).
+    pub name: String,
+    /// The host requirement it depends on (e.g. `"docker on PATH"`, `"wasm-tier build feature"`).
+    pub requirement: String,
+    /// Whether the requirement is satisfied on this host/build.
+    pub available: bool,
+}
+
+/// A snapshot of what this host+build can run: sandbox tiers and language toolchains.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct HostCapabilities {
+    pub sandbox_tiers: Vec<Capability>,
+    pub languages: Vec<Capability>,
+}
+
+impl HostCapabilities {
+    /// Probe the host and the build features for every supported tier/toolchain.
+    pub fn gather() -> Self {
+        let sandbox_tiers = vec![
+            Capability {
+                name: "sandbox: bubblewrap".into(),
+                requirement: "bwrap on PATH".into(),
+                available: is_bwrap_available(),
+            },
+            Capability {
+                name: "sandbox: docker".into(),
+                requirement: "docker on PATH".into(),
+                available: is_docker_available(),
+            },
+            Capability {
+                name: "sandbox: microvm".into(),
+                requirement: "firecracker on PATH".into(),
+                available: tool_on_path("firecracker"),
+            },
+            Capability {
+                name: "sandbox: wasm".into(),
+                requirement: "wasm-tier build feature".into(),
+                available: wasm_tier_built(),
+            },
+        ];
+        let languages = vec![
+            Capability {
+                name: "language: python".into(),
+                requirement: "python3 on PATH".into(),
+                available: tool_on_path("python3"),
+            },
+            Capability {
+                name: "language: javascript (wasm via javy)".into(),
+                requirement: "javy on PATH".into(),
+                available: is_javy_available(),
+            },
+            Capability {
+                name: "language: javascript (process via node)".into(),
+                requirement: "node on PATH".into(),
+                available: tool_on_path("node"),
+            },
+        ];
+        Self {
+            sandbox_tiers,
+            languages,
+        }
+    }
+
+    /// True when at least one execution tier is runnable — otherwise the gateway
+    /// can host no agents at all.
+    pub fn has_any_sandbox_tier(&self) -> bool {
+        self.sandbox_tiers.iter().any(|c| c.available)
+    }
+
+    /// Human-readable lines for logging at startup or printing on demand.
+    pub fn summary_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        lines.push("Host capabilities — sandbox tiers:".to_string());
+        for c in &self.sandbox_tiers {
+            lines.push(format!("  {} {} ({})", mark(c.available), c.name, c.requirement));
+        }
+        lines.push("Host capabilities — language toolchains:".to_string());
+        for c in &self.languages {
+            lines.push(format!("  {} {} ({})", mark(c.available), c.name, c.requirement));
+        }
+        lines
+    }
+}
+
+fn mark(available: bool) -> &'static str {
+    if available {
+        "[ok]"
+    } else {
+        "[--]"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn tool_on_path_finds_an_executable_and_ignores_non_exec() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().as_os_str();
+        let plain = dir.path().join("toolx");
+        std::fs::write(&plain, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(
+            !tool_on_given_path(Some(path), "toolx"),
+            "non-executable file must not count"
+        );
+        assert!(!tool_on_given_path(Some(path), "does-not-exist"));
+        assert!(!tool_on_given_path(None, "toolx"), "no PATH → nothing found");
+
+        // Now make it executable → found.
+        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            tool_on_given_path(Some(path), "toolx"),
+            "executable on PATH must be found"
+        );
+    }
+
+    #[test]
+    fn gather_reports_all_tiers_and_languages_with_stable_shape() {
+        let caps = HostCapabilities::gather();
+        assert_eq!(caps.sandbox_tiers.len(), 4);
+        assert_eq!(caps.languages.len(), 3);
+        // The wasm tier's availability is decided by the build feature, not PATH.
+        let wasm = caps
+            .sandbox_tiers
+            .iter()
+            .find(|c| c.name.contains("wasm"))
+            .unwrap();
+        assert_eq!(wasm.available, cfg!(feature = "wasm-tier"));
+        // Summary covers every probed capability plus the two section headers.
+        assert_eq!(caps.summary_lines().len(), 4 + 3 + 2);
+    }
+}

--- a/autonoetic-gateway/src/lib.rs
+++ b/autonoetic-gateway/src/lib.rs
@@ -16,6 +16,7 @@ pub mod enforcement_register;
 pub mod exec_request;
 pub mod execution;
 pub mod fail_mode;
+pub mod host_capabilities;
 pub mod interaction_answer;
 pub mod layer_store;
 pub mod llm;

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -357,6 +357,12 @@ pub enum GatewayCommands {
     },
     /// Gracefully terminates a background Gateway daemon
     Stop,
+    /// Probe host capabilities (sandbox tiers + language toolchains) without starting.
+    Preflight {
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// Outputs a table of Gateway health, loaded policies, etc.
     Status {
         /// Emit machine-readable JSON output.

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -59,7 +59,7 @@ pub fn handle_gateway_stop() {
 }
 
 /// Probe and report host capabilities (sandbox tiers + language toolchains).
-/// Exit code is non-zero when no execution tier is runnable at all.
+/// Exit code is non-zero when no sandbox tier is runnable at all.
 pub fn handle_gateway_preflight(json: bool) -> anyhow::Result<()> {
     let caps = autonoetic_gateway::host_capabilities::HostCapabilities::gather();
     if json {
@@ -71,7 +71,7 @@ pub fn handle_gateway_preflight(json: bool) -> anyhow::Result<()> {
     }
     if !caps.has_any_sandbox_tier() {
         anyhow::bail!(
-            "No sandbox tier is runnable on this host — install bwrap or docker, or build with the wasm-tier feature."
+            "No sandbox tier is runnable on this host — install bwrap, docker, or firecracker, or build with the wasm-tier feature."
         );
     }
     Ok(())

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -34,6 +34,17 @@ pub async fn handle_gateway_start(
         info!("{}", line);
     }
 
+    let caps = autonoetic_gateway::host_capabilities::HostCapabilities::gather();
+    for line in caps.summary_lines() {
+        info!("{}", line);
+    }
+    if !caps.has_any_sandbox_tier() {
+        tracing::warn!(
+            "No sandbox tier is runnable on this host (no bwrap/docker/firecracker, no wasm-tier build) — \
+             agents will fail to spawn. Run `autonoetic gateway preflight` for details."
+        );
+    }
+
     let server = autonoetic_gateway::GatewayServer::new(config);
     let _mcp_runtime = mcp_runtime;
     if let Err(e) = server.run().await {
@@ -45,6 +56,25 @@ pub async fn handle_gateway_start(
 
 pub fn handle_gateway_stop() {
     info!("Stopping Gateway");
+}
+
+/// Probe and report host capabilities (sandbox tiers + language toolchains).
+/// Exit code is non-zero when no execution tier is runnable at all.
+pub fn handle_gateway_preflight(json: bool) -> anyhow::Result<()> {
+    let caps = autonoetic_gateway::host_capabilities::HostCapabilities::gather();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&caps)?);
+    } else {
+        for line in caps.summary_lines() {
+            println!("{line}");
+        }
+    }
+    if !caps.has_any_sandbox_tier() {
+        anyhow::bail!(
+            "No sandbox tier is runnable on this host — install bwrap or docker, or build with the wasm-tier feature."
+        );
+    }
+    Ok(())
 }
 
 pub async fn handle_gateway_status(config_path: &Path, json_output: bool) -> anyhow::Result<()> {

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -135,6 +135,9 @@ async fn main() -> anyhow::Result<()> {
             cli::common::GatewayCommands::Stop => {
                 cli::gateway::handle_gateway_stop();
             }
+            cli::common::GatewayCommands::Preflight { json } => {
+                cli::gateway::handle_gateway_preflight(*json)?;
+            }
             cli::common::GatewayCommands::Status { json } => {
                 cli::gateway::handle_gateway_status(&config_path, *json).await?;
             }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,6 +102,17 @@ Show gateway status including connected agents, MCP servers, and scheduler state
 autonoetic gateway status [--json]
 ```
 
+### `autonoetic gateway preflight`
+
+Probe host capabilities without starting the gateway: which sandbox tiers
+(bubblewrap, docker, microvm, wasm) and language toolchains (python, javascript)
+are runnable on this host/build. The same summary is logged at `gateway start`.
+Exits non-zero when no sandbox tier is runnable at all.
+
+```bash
+autonoetic gateway preflight [--json]
+```
+
 ### `autonoetic gateway constitution show`
 
 Show the active constitution: version, canonical digest, signer, enforcement


### PR DESCRIPTION
First of two PRs toward first-class JavaScript agents. This one adds the **host capability preflight** the operator asked for: check that the host has the tools needed to run the gateway's agents (per sandbox tier and per language), instead of discovering a missing toolchain at first spawn.

The sandbox driver is chosen **per agent** (`runtime.sandbox` in SKILL.md), and language support depends on host toolchains, so there's no single "configured driver" to check — the preflight probes them all and reports.

## What's here
- **`host_capabilities` module** — read-only `PATH` probe (`tool_on_path`, never spawns the tool) + `HostCapabilities::gather()`:
  - Sandbox tiers: `bubblewrap`→`bwrap`, `docker`→`docker`, `microvm`→`firecracker`, `wasm`→**build feature** (`wasm-tier`), each with its requirement + availability.
  - Language toolchains: `python`→`python3`, `javascript (wasm via javy)`→`javy`, `javascript (process via node)`→`node`.
  - Public helpers `is_bwrap_available()` / `is_docker_available()` / `is_javy_available()`.
- **`gateway start`** logs the capability summary and warns if no tier is runnable.
- **`autonoetic gateway preflight [--json]`** — check on demand; exits non-zero when no sandbox tier is runnable.

## Example (this host)
```
Host capabilities — sandbox tiers:
  [ok] sandbox: bubblewrap (bwrap on PATH)
  [ok] sandbox: docker (docker on PATH)
  [--] sandbox: microvm (firecracker on PATH)
  [--] sandbox: wasm (wasm-tier build feature)
Host capabilities — language toolchains:
  [ok] language: python (python3 on PATH)
  [--] language: javascript (wasm via javy) (javy on PATH)
  [--] language: javascript (process via node) (node on PATH)
```

## Why now
Seeds **JS-via-Javy** (next PR): `is_javy_available()` is the gate the JS→wasm bundling step will use, and the preflight makes the javy dependency discoverable.

## Tests
`tool_on_path` (executable vs non-exec vs missing PATH, no global-env mutation) and the report shape (incl. wasm tier keyed off the build feature). Workspace builds default + `wasm-tier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)