### PR TITLE
feat(js): first-class JavaScript agents via Javy (compile to wasm at bootstrap)

### DIFF
--- a/autonoetic-gateway/src/bootstrap.rs
+++ b/autonoetic-gateway/src/bootstrap.rs
@@ -116,8 +116,9 @@ fn bootstrap_agent_inner(
 
     let skill_content = std::fs::read(&skill_path)?;
     let skill_text = String::from_utf8_lossy(&skill_content);
-    let (parsed_manifest, _instructions) = crate::runtime::parser::SkillParser::parse(&skill_text)
-        .map_err(|e| anyhow::anyhow!("Failed to parse SKILL.md for '{}': {}", agent_id, e))?;
+    let (mut parsed_manifest, _instructions) =
+        crate::runtime::parser::SkillParser::parse(&skill_text)
+            .map_err(|e| anyhow::anyhow!("Failed to parse SKILL.md for '{}': {}", agent_id, e))?;
 
     let lock_rel_path = &parsed_manifest.runtime.runtime_lock;
     let lock_path = agent_dir.join(lock_rel_path);
@@ -221,6 +222,62 @@ fn bootstrap_agent_inner(
                 let modified_bytes = modified.into_bytes();
                 file_map.insert("SKILL.md".to_string(), modified_bytes.clone());
                 std::fs::write(&skill_path, &modified_bytes)?;
+            }
+        }
+    }
+
+    // JavaScript agents run on the wasm tier: compile the `.js` entry to a
+    // self-contained `.wasm` module at bundle time (Javy), bundle it, and
+    // repoint the manifest's `script_entry` at it. The compiled module is
+    // content-addressed in the revision like any other bundled file, so the
+    // runtime executes it unchanged. Runs after the preset merge so the
+    // `script_entry` rewrite lands on the final bundled SKILL.md.
+    if matches!(parsed_manifest.execution_mode, ExecutionMode::Script) {
+        if let Some(entry) = parsed_manifest.script_entry.clone() {
+            if is_javascript_entry(&entry) {
+                anyhow::ensure!(
+                    parsed_manifest.runtime.sandbox == "wasm",
+                    "Agent '{}' declares a JavaScript entry '{}' but sandbox '{}': \
+                     JavaScript agents run on the wasm tier — set `sandbox: wasm`.",
+                    agent_id,
+                    entry,
+                    parsed_manifest.runtime.sandbox
+                );
+                anyhow::ensure!(
+                    crate::host_capabilities::is_javy_available(),
+                    "Agent '{}' needs the Javy compiler (`javy`) on PATH to build JavaScript \
+                     entry '{}' into wasm. Install Javy, then re-run; `autonoetic gateway \
+                     preflight` shows toolchain availability.",
+                    agent_id,
+                    entry
+                );
+                let wasm_bytes = compile_js_to_wasm(&agent_dir.join(&entry)).map_err(|e| {
+                    anyhow::anyhow!(
+                        "Compiling JavaScript entry '{}' for agent '{}': {}",
+                        entry,
+                        agent_id,
+                        e
+                    )
+                })?;
+                let wasm_entry = wasm_entry_for(&entry);
+                file_map.insert(wasm_entry.clone(), wasm_bytes);
+
+                let skill_now = file_map
+                    .get("SKILL.md")
+                    .map(|b| String::from_utf8_lossy(b).into_owned())
+                    .unwrap_or_else(|| skill_text.to_string());
+                let rewritten =
+                    set_script_entry_in_skill(&skill_now, &wasm_entry).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Could not repoint script_entry to '{}' in SKILL.md for agent '{}'",
+                            wasm_entry,
+                            agent_id
+                        )
+                    })?;
+                file_map.insert("SKILL.md".to_string(), rewritten.into_bytes());
+                // Keep the in-memory manifest in sync for the execute-bit step
+                // and the stored revision metadata below.
+                parsed_manifest.script_entry = Some(wasm_entry);
             }
         }
     }
@@ -434,6 +491,80 @@ fn normalize_path_label(path: &Path) -> String {
 /// already present in the agent's config.
 /// Returns `None` if no modification was needed or if the frontmatter couldn't
 /// be parsed.
+/// Whether a script entry is JavaScript (compiled to wasm via Javy at bootstrap).
+fn is_javascript_entry(entry: &str) -> bool {
+    let lower = entry.to_ascii_lowercase();
+    lower.ends_with(".js") || lower.ends_with(".mjs")
+}
+
+/// The bundled wasm entry name for a JavaScript source entry (`main.js` →
+/// `main.wasm`, preserving any subdirectory).
+fn wasm_entry_for(js_entry: &str) -> String {
+    std::path::Path::new(js_entry)
+        .with_extension("wasm")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Compile a JavaScript file to a self-contained WASI module with Javy.
+///
+/// Uses `-C deterministic=y` (fixed clocks, zero-filled RNG during
+/// pre-initialization) so identical source yields an identical module — the
+/// compiled `.wasm` is content-addressed in the revision, so determinism keeps
+/// rebuilds from churning the revision digest. The default (non-`dynamic`) build
+/// embeds the QuickJS runtime, producing a standalone `_start` module the wasm
+/// tier runs without a separate plugin.
+fn compile_js_to_wasm(js_path: &Path) -> Result<Vec<u8>> {
+    let out = tempfile::Builder::new().suffix(".wasm").tempfile()?;
+    let result = std::process::Command::new("javy")
+        .arg("build")
+        .arg(js_path)
+        .arg("-o")
+        .arg(out.path())
+        .arg("-C")
+        .arg("deterministic=y")
+        .output()
+        .map_err(|e| anyhow::anyhow!("spawning javy: {e}"))?;
+    anyhow::ensure!(
+        result.status.success(),
+        "javy build failed ({}): {}",
+        result.status,
+        String::from_utf8_lossy(&result.stderr).trim()
+    );
+    Ok(std::fs::read(out.path())?)
+}
+
+/// Repoint `metadata.autonoetic.script_entry` in a SKILL.md's YAML frontmatter to
+/// `new_entry`, returning the rewritten file. Mirrors `merge_preset_into_skill`'s
+/// frontmatter handling. Returns `None` if there's no frontmatter or no
+/// `metadata.autonoetic` mapping to update.
+fn set_script_entry_in_skill(skill_text: &str, new_entry: &str) -> Option<String> {
+    let (fm_start, fm_end) = {
+        let t = skill_text.trim_start();
+        if !t.starts_with("---") {
+            return None;
+        }
+        let rest = &t[3..];
+        let first_nl = rest.find(|c: char| c == '\n' || c == '\r')?;
+        let after_first = &rest[first_nl..];
+        let end = after_first.find("\n---")?;
+        (3 + first_nl, 3 + first_nl + end)
+    };
+    let frontmatter = &skill_text[fm_start..fm_end];
+    let mut yaml: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
+    let autonoetic = yaml
+        .get_mut("metadata")
+        .and_then(|m| m.get_mut("autonoetic"))
+        .and_then(|a| a.as_mapping_mut())?;
+    autonoetic.insert(
+        serde_yaml::Value::String("script_entry".to_string()),
+        serde_yaml::Value::String(new_entry.to_string()),
+    );
+    let new_frontmatter = serde_yaml::to_string(&yaml).ok()?;
+    let body = &skill_text[fm_end + 4..];
+    Some(format!("---\n{}---{}\n", new_frontmatter, body))
+}
+
 fn merge_preset_into_skill(skill_text: &str, preset: &LlmPreset) -> Option<String> {
     let (fm_start, fm_end) = {
         let t = skill_text.trim_start();
@@ -728,6 +859,49 @@ fn seed_missing(src: &Path, dst: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn javascript_entry_detection_and_wasm_naming() {
+        assert!(is_javascript_entry("main.js"));
+        assert!(is_javascript_entry("scripts/agent.MJS"));
+        assert!(!is_javascript_entry("main.py"));
+        assert!(!is_javascript_entry("main.wasm"));
+        assert_eq!(wasm_entry_for("main.js"), "main.wasm");
+        assert_eq!(wasm_entry_for("scripts/agent.mjs"), "scripts/agent.wasm");
+    }
+
+    #[test]
+    fn set_script_entry_rewrites_autonoetic_frontmatter() {
+        let skill = "---\nmetadata:\n  autonoetic:\n    execution_mode: script\n    script_entry: main.js\n    runtime:\n      sandbox: wasm\n---\nbody text\n";
+        let out = set_script_entry_in_skill(skill, "main.wasm").expect("should rewrite");
+        // Re-parse and confirm the entry flipped, body preserved.
+        let yaml: serde_yaml::Value = {
+            let fm = out.trim_start().strip_prefix("---").unwrap();
+            let end = fm.find("\n---").unwrap();
+            serde_yaml::from_str(&fm[..end]).unwrap()
+        };
+        assert_eq!(
+            yaml["metadata"]["autonoetic"]["script_entry"].as_str(),
+            Some("main.wasm")
+        );
+        assert!(out.contains("body text"));
+        // No metadata.autonoetic mapping → nothing to rewrite.
+        assert!(set_script_entry_in_skill("---\nfoo: bar\n---\nx\n", "main.wasm").is_none());
+        assert!(set_script_entry_in_skill("no frontmatter", "main.wasm").is_none());
+    }
+
+    #[test]
+    fn compile_js_to_wasm_produces_a_wasm_module() {
+        if !crate::host_capabilities::is_javy_available() {
+            eprintln!("skipping: javy not on PATH");
+            return;
+        }
+        let dir = tempdir().unwrap();
+        let js = dir.path().join("main.js");
+        std::fs::write(&js, "console.log('hi');").unwrap();
+        let bytes = compile_js_to_wasm(&js).expect("javy build should succeed");
+        assert_eq!(&bytes[0..4], b"\0asm", "output must be a wasm module");
+    }
 
     fn minimal_skill(agent_id: &str) -> String {
         format!(

--- a/autonoetic-gateway/src/bootstrap.rs
+++ b/autonoetic-gateway/src/bootstrap.rs
@@ -235,6 +235,19 @@ fn bootstrap_agent_inner(
     if matches!(parsed_manifest.execution_mode, ExecutionMode::Script) {
         if let Some(entry) = parsed_manifest.script_entry.clone() {
             if is_javascript_entry(&entry) {
+                // Keep the entry strictly under the agent dir: it's used both to
+                // read the source (`agent_dir.join(entry)`) and to name the
+                // bundled output, which is later materialized under revision_dir.
+                let entry_path = std::path::Path::new(&entry);
+                anyhow::ensure!(
+                    entry_path.is_relative()
+                        && !entry_path
+                            .components()
+                            .any(|c| matches!(c, std::path::Component::ParentDir)),
+                    "Agent '{}' script_entry '{}' must be a relative path within the agent dir (no `..`).",
+                    agent_id,
+                    entry
+                );
                 anyhow::ensure!(
                     parsed_manifest.runtime.sandbox == "wasm",
                     "Agent '{}' declares a JavaScript entry '{}' but sandbox '{}': \
@@ -534,10 +547,12 @@ fn compile_js_to_wasm(js_path: &Path) -> Result<Vec<u8>> {
     Ok(std::fs::read(out.path())?)
 }
 
-/// Repoint `metadata.autonoetic.script_entry` in a SKILL.md's YAML frontmatter to
-/// `new_entry`, returning the rewritten file. Mirrors `merge_preset_into_skill`'s
-/// frontmatter handling. Returns `None` if there's no frontmatter or no
-/// `metadata.autonoetic` mapping to update.
+/// Repoint `script_entry` in a SKILL.md's YAML frontmatter to `new_entry`,
+/// returning the rewritten file. Handles both SKILL.md shapes the parser accepts:
+/// the Autonoetic-native format (top-level `script_entry`) and the AgentSkills
+/// format (`metadata.autonoetic.script_entry`) — preferring top-level, matching
+/// the parser's native-first precedence. Returns `None` if there's no
+/// frontmatter or no place to write `script_entry`.
 fn set_script_entry_in_skill(skill_text: &str, new_entry: &str) -> Option<String> {
     let (fm_start, fm_end) = {
         let t = skill_text.trim_start();
@@ -552,14 +567,24 @@ fn set_script_entry_in_skill(skill_text: &str, new_entry: &str) -> Option<String
     };
     let frontmatter = &skill_text[fm_start..fm_end];
     let mut yaml: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
-    let autonoetic = yaml
-        .get_mut("metadata")
-        .and_then(|m| m.get_mut("autonoetic"))
-        .and_then(|a| a.as_mapping_mut())?;
-    autonoetic.insert(
-        serde_yaml::Value::String("script_entry".to_string()),
-        serde_yaml::Value::String(new_entry.to_string()),
-    );
+    let key = serde_yaml::Value::String("script_entry".to_string());
+    let value = serde_yaml::Value::String(new_entry.to_string());
+
+    let top = yaml.as_mapping_mut()?;
+    if top.contains_key(&key) {
+        // Autonoetic-native: top-level script_entry.
+        top.insert(key, value);
+    } else if let Some(autonoetic) = top
+        .get_mut(serde_yaml::Value::String("metadata".to_string()))
+        .and_then(|m| m.get_mut(serde_yaml::Value::String("autonoetic".to_string())))
+        .and_then(|a| a.as_mapping_mut())
+    {
+        // AgentSkills format: metadata.autonoetic.script_entry.
+        autonoetic.insert(key, value);
+    } else {
+        return None;
+    }
+
     let new_frontmatter = serde_yaml::to_string(&yaml).ok()?;
     let body = &skill_text[fm_end + 4..];
     Some(format!("---\n{}---{}\n", new_frontmatter, body))
@@ -870,22 +895,38 @@ mod tests {
         assert_eq!(wasm_entry_for("scripts/agent.mjs"), "scripts/agent.wasm");
     }
 
+    fn reparse_frontmatter(out: &str) -> serde_yaml::Value {
+        let fm = out.trim_start().strip_prefix("---").unwrap();
+        let end = fm.find("\n---").unwrap();
+        serde_yaml::from_str(&fm[..end]).unwrap()
+    }
+
     #[test]
-    fn set_script_entry_rewrites_autonoetic_frontmatter() {
+    fn set_script_entry_rewrites_agentskills_frontmatter() {
+        // AgentSkills format: metadata.autonoetic.script_entry.
         let skill = "---\nmetadata:\n  autonoetic:\n    execution_mode: script\n    script_entry: main.js\n    runtime:\n      sandbox: wasm\n---\nbody text\n";
         let out = set_script_entry_in_skill(skill, "main.wasm").expect("should rewrite");
-        // Re-parse and confirm the entry flipped, body preserved.
-        let yaml: serde_yaml::Value = {
-            let fm = out.trim_start().strip_prefix("---").unwrap();
-            let end = fm.find("\n---").unwrap();
-            serde_yaml::from_str(&fm[..end]).unwrap()
-        };
+        let yaml = reparse_frontmatter(&out);
         assert_eq!(
             yaml["metadata"]["autonoetic"]["script_entry"].as_str(),
             Some("main.wasm")
         );
         assert!(out.contains("body text"));
-        // No metadata.autonoetic mapping → nothing to rewrite.
+    }
+
+    #[test]
+    fn set_script_entry_rewrites_native_top_level_frontmatter() {
+        // Autonoetic-native format: top-level script_entry.
+        let skill = "---\nexecution_mode: script\nscript_entry: main.js\nruntime:\n  sandbox: wasm\n---\nnative body\n";
+        let out = set_script_entry_in_skill(skill, "main.wasm").expect("should rewrite");
+        let yaml = reparse_frontmatter(&out);
+        assert_eq!(yaml["script_entry"].as_str(), Some("main.wasm"));
+        assert!(out.contains("native body"));
+    }
+
+    #[test]
+    fn set_script_entry_returns_none_when_no_target() {
+        // No top-level script_entry and no metadata.autonoetic mapping.
         assert!(set_script_entry_in_skill("---\nfoo: bar\n---\nx\n", "main.wasm").is_none());
         assert!(set_script_entry_in_skill("no frontmatter", "main.wasm").is_none());
     }

--- a/autonoetic-gateway/tests/wasm_tier_integration.rs
+++ b/autonoetic-gateway/tests/wasm_tier_integration.rs
@@ -8,6 +8,58 @@ use autonoetic_gateway::exec_request::{CodeSource, ExecutionKind};
 use autonoetic_gateway::sandbox::{SandboxDriverKind, SandboxRunner};
 use tempfile::tempdir;
 
+/// End-to-end JS support: a Javy-compiled JavaScript module runs on the wasm
+/// tier through the unified entry, capturing `console.log` on stdout. Skips when
+/// the Javy compiler isn't installed (mirrors the docker availability gating).
+#[test]
+fn javy_compiled_javascript_runs_through_run_to_output() {
+    if !autonoetic_gateway::host_capabilities::is_javy_available() {
+        eprintln!("skipping javy e2e: `javy` not on PATH");
+        return;
+    }
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("main.js"),
+        "console.log('js-agent-ran');",
+    )
+    .unwrap();
+    let wasm = dir.path().join("main.wasm");
+    let status = std::process::Command::new("javy")
+        .arg("build")
+        .arg(dir.path().join("main.js"))
+        .arg("-o")
+        .arg(&wasm)
+        .arg("-C")
+        .arg("deterministic=y")
+        .status()
+        .expect("spawn javy");
+    assert!(status.success(), "javy build should succeed");
+
+    let request = ExecutionKind::Code {
+        language: None,
+        source: CodeSource::Entry("main.wasm".to_string()),
+        args: vec![],
+    };
+    let out = SandboxRunner::run_to_output(
+        SandboxDriverKind::Wasm,
+        dir.path().to_str().unwrap(),
+        &request,
+        None,
+        None,
+        &[],
+        None,
+        None,
+    )
+    .expect("javy-compiled module should run on the wasm tier");
+
+    assert_eq!(out.exit_code, 0, "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("js-agent-ran"),
+        "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
 #[test]
 fn wasm_agent_entry_runs_through_run_to_output() {
     let dir = tempdir().unwrap();

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -584,6 +584,16 @@ script_entry: "scripts/main.py"  # Must exist and be executable
 
 The injected Python / TypeScript SDK includes input helpers. Prefer `load_invocation()` / `load_input()` over open-coding `os.environ["AUTONOETIC_INPUT"]`.
 
+**JavaScript agents (wasm tier):** a `script_entry` ending in `.js`/`.mjs` is a
+JavaScript agent and **must declare `sandbox: "wasm"`**. At bootstrap the gateway
+compiles the entry to a self-contained `.wasm` module with [Javy](https://github.com/bytecodealliance/javy)
+(`javy build … -C deterministic=y`) and bundles that module — the compiled
+`.wasm` is content-addressed in the revision and runs on the in-process wasm
+tier. The host needs `javy` on `PATH` (check with `autonoetic gateway preflight`);
+bootstrap fails with a clear hint otherwise. The JS runtime is QuickJS (ES2020-ish,
+no Node APIs); input arrives on stdin (or argv with `script_input_mode: args`)
+and `console.log` output is captured as the script result.
+
 **Input schema contract:**
 - The agent author declares `io.accepts` (and optionally `io.returns`) in the manifest to describe the input the script expects. The gateway exposes this schema through `agent.describe` so callers (including the planner) can translate natural-language intent into matching fields before calling `agent_spawn`.
 - When `io.accepts` is present, the gateway validates the caller's `message` at spawn time. On mismatch the call is rejected with a structured tool error that includes `expected_schema`, per-field errors, and a repair hint — the calling LLM reads this and retries with a corrected payload.


### PR DESCRIPTION
Second of the two PRs toward JavaScript agents (after #456's preflight). A script agent whose `script_entry` ends in `.js`/`.mjs` is now a **first-class JavaScript agent** that runs on the wasm tier — no Node, no process sandbox.

## How it works
At **bootstrap** (bundle build), for a `.js`/`.mjs` entry:
1. Require `sandbox: "wasm"` and `javy` on PATH (via `host_capabilities::is_javy_available`) — each with a clear, actionable error.
2. Compile the entry to a self-contained `.wasm` with `javy build … -C deterministic=y`.
3. Bundle the `.wasm` into `file_map` and repoint the bundled SKILL.md's `metadata.autonoetic.script_entry` at it.

The compiled module is then **content-addressed in the revision** like any other bundled file, and the existing wasm tier runs it unchanged via `run_to_output` — the runtime needs no JS-awareness.

## Why this shape
- **No gateway-side interpreter to ship.** Unlike `python.wasm` (a shared ~20 MB runtime), Javy embeds QuickJS *per agent* at build time, so each agent's `.wasm` is standalone — it fits the content-addressed packager and runs on the `_start` path we already have.
- **Deterministic.** `-C deterministic=y` (fixed clocks, zero-filled RNG during pre-init) means identical source → identical module → stable revision digests across rebuilds, aligning with the packager-determinism work.
- **stdin/argv + stdout** reuse the existing script-agent I/O contract (stdin wiring landed in #455).

## Constraints (documented in AGENTS.md)
QuickJS runtime: ES2020-ish, **no Node APIs / npm native modules**. Input on stdin (or argv with `script_input_mode: args`); `console.log` is captured as the result.

## Tests
- Unit: JS-entry detection, `.js`→`.wasm` naming, `set_script_entry_in_skill` frontmatter rewrite, and a javy-gated `compile_js_to_wasm` (asserts wasm magic).
- **End-to-end (`--features wasm-tier`)**: compiles a real `console.log('js-agent-ran')` agent with Javy and runs it through `run_to_output` — verifies QuickJS instantiates within the tier's fuel/memory bounds and stdout is captured. Verified locally with Javy 8.1.1.
- Default build unaffected; javy-dependent tests skip when `javy` is absent (mirrors the docker gating).

Closes the JS half of the polyglot-agents goal; `python.wasm` (shared interpreter, needs the bundling decision) remains the separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)