### PR TITLE
docs(agents): steer test-authoring to stdlib unittest (no test-framework deps)

### DIFF
--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -96,6 +96,14 @@ def test_fetch(mock_request):
 
 If the task fundamentally requires a running server or real network integration testing, return `clarification_needed` or signal to the planner to delegate that part to `executor.default`.
 
+## CRITICAL: Test with the standard library — no test-framework dependencies
+
+Write gate tests with Python's built-in **`unittest`** (and `unittest.mock`), run as `python3 -m unittest`. Do **NOT** add `pytest`, `nose`, `hypothesis`, or any third-party test framework to `requirements.txt` / `pyproject.toml`.
+
+Why: the promotion test run (`unit_test_runner`) executes in a **no-network sandbox** that mounts only the agent's **runtime dependency layers** — and those layers become the shipped capsule. A test-only framework would therefore have to be baked into the runtime layers just to import (no network to install it at test time), bloating every capsule with a dependency the agent never uses at runtime and widening its supply-chain surface. `unittest` ships with Python, so it needs no dependency at all.
+
+A library the agent **already** depends on at runtime is fine to use in tests — it's already in the closure. The rule is only: don't introduce a dependency *for tests*.
+
 ## Behavior
 - Write clean, documented code
 - **Scripts that need API keys or secrets must read them from environment variables** (`os.environ.get("API_KEY")`), never from command-line arguments or hardcoded values. The gateway injects credentials at runtime via the `credential_env` parameter — the secret never reaches LLM context. The env var name is derived mechanically from the service name: e.g. service `"my-service"` → `"MY_SERVICE_SECRET"`. If the planner delegates with `service: "my-service"`, your script must use `os.environ["MY_SERVICE_SECRET"]`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -600,6 +600,8 @@ and `console.log` output is captured as the script result.
 - When `io.accepts` is absent, the `message` is passed through unchanged. The author is responsible for parsing it inside the script.
 - There is no auto-generated default schema; the shape of the input is entirely the author's choice.
 
+**Test dependencies — use the standard library.** Write promotion-gate tests with Python's built-in `unittest` (run as `python3 -m unittest`), not `pytest`/`nose`/`hypothesis`. The `unit_test_runner` runs in a **no-network sandbox** that mounts only the agent's runtime dependency layers — and those layers *are* the shipped capsule. A test-only framework would have to be baked into the runtime layers to import at all, bloating every capsule with a dependency the agent never uses at runtime. The dependency model is currently single-grade (no separate dev/test scope); a future dev/test-dependency grade is tracked in `docs/design/`. Until then: don't add a dependency just for tests.
+
 ### Reasoning Agent Requirements
 
 ```yaml


### PR DESCRIPTION
Immediate guidance change: gate tests use stdlib `unittest`, not third-party test frameworks.

**Why:** the `unit_test_runner` runs in a **no-network sandbox** that mounts only the agent's **runtime dependency layers**, and those layers become the shipped capsule. So a test-only framework (pytest/nose/hypothesis) would have to be baked into the runtime closure just to import — bloating every capsule with a dependency the agent never uses at runtime and widening its supply-chain surface. The dependency model is single-grade today (no dev/test scope), so there's no mechanism to strip it. `unittest` ships with Python → zero dependency.

**Changes:**
- `coder.default/SKILL.md` — new "Test with the standard library" rule (the coder already uses `unittest.mock`; this makes the no-extra-dep rule explicit).
- `docs/AGENTS.md` — same guidance in the script-agent requirements, noting the future dev/test-dependency grade.

A proper **dev/test-dependency grade** (so test deps can exist for the gate run but stay out of the capsule) is the separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)