### PR TITLE
feat(prompt): GuidanceBlock core + composer (#463)

### DIFF
--- a/autonoetic-gateway/src/runtime/context.rs
+++ b/autonoetic-gateway/src/runtime/context.rs
@@ -76,6 +76,17 @@ pub(crate) fn compose_foundation(manifest: &AgentManifest) -> String {
     parts.join("\n\n---\n\n")
 }
 
+/// Best-effort role for guidance gating: the agent id segment before the first
+/// `.` (e.g. `coder.default` → `coder`), or the whole id if there is none.
+fn role_from_manifest(manifest: &AgentManifest) -> Option<&str> {
+    let id = manifest.agent.id.as_str();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.split('.').next().unwrap_or(id))
+    }
+}
+
 const TOOL_BRIDGING_APPENDIX: &str = r#"---
 
 Tool Compatibility Notes (auto-generated from AgentSkills import)
@@ -192,7 +203,7 @@ pub(crate) fn inline_extended(core: &str, extended: Option<&str>) -> String {
 /// Layer order (each layer is structurally positioned so it cannot override
 /// the previous one — foundation constitutional rules always win):
 ///
-///   Foundation → Tool bridging → Persona → User profile → Agent instructions → Output contract
+///   Foundation → Guidance blocks → Tool bridging → Persona → User profile → Agent instructions → Output contract
 pub(crate) fn compose_system_instructions_full(
     agent_instructions: &str,
     manifest: &AgentManifest,
@@ -201,6 +212,25 @@ pub(crate) fn compose_system_instructions_full(
     persona: Option<&str>,
 ) -> String {
     let foundation = compose_foundation(manifest);
+
+    // Composable, targeted guidance blocks (issue #463). Empty until #464/#466
+    // migrate doctrine into blocks; active-tool/model-family inputs land in
+    // #464/#465. Renders to "" today, so this is a no-op on the prompt.
+    let guidance = {
+        let ctx = crate::runtime::guidance::GuidanceContext {
+            capabilities: &manifest.capabilities,
+            active_tool_names: &[],
+            model_family: None,
+            role: role_from_manifest(manifest),
+        };
+        let rendered =
+            crate::runtime::guidance::compose_guidance(&crate::runtime::guidance::builtin_blocks(), &ctx);
+        if rendered.is_empty() {
+            None
+        } else {
+            Some(format!("---\n\nGuidance\n\n{rendered}"))
+        }
+    };
 
     let tool_bridging = manifest
         .agentskills_import
@@ -217,6 +247,9 @@ pub(crate) fn compose_system_instructions_full(
     let base = {
         let trimmed = agent_instructions.trim();
         let mut parts = vec![foundation.as_str()];
+        if let Some(ref g) = guidance {
+            parts.push(g);
+        }
         if let Some(ref bridging) = tool_bridging {
             parts.push(bridging);
         }

--- a/autonoetic-gateway/src/runtime/context.rs
+++ b/autonoetic-gateway/src/runtime/context.rs
@@ -78,13 +78,15 @@ pub(crate) fn compose_foundation(manifest: &AgentManifest) -> String {
 
 /// Best-effort role for guidance gating: the agent id segment before the first
 /// `.` (e.g. `coder.default` → `coder`), or the whole id if there is none.
+/// Returns `None` for an empty id or one with an empty leading segment
+/// (e.g. `.coder`), so role-gated guidance never matches on `""`.
 fn role_from_manifest(manifest: &AgentManifest) -> Option<&str> {
-    let id = manifest.agent.id.as_str();
-    if id.is_empty() {
-        None
-    } else {
-        Some(id.split('.').next().unwrap_or(id))
-    }
+    manifest
+        .agent
+        .id
+        .split('.')
+        .next()
+        .filter(|seg| !seg.is_empty())
 }
 
 const TOOL_BRIDGING_APPENDIX: &str = r#"---

--- a/autonoetic-gateway/src/runtime/guidance.rs
+++ b/autonoetic-gateway/src/runtime/guidance.rs
@@ -1,0 +1,260 @@
+//! Composable, targeted prompt-guidance blocks (issue #463).
+//!
+//! Replaces hand-pasted per-`SKILL.md` doctrine with units of prose that declare
+//! *when* they apply. Blocks are contributed from several sources (the builtin
+//! set here, tools via #464, roles), collected, filtered against the live turn,
+//! ordered by priority, deduped by `id`, and rendered into one section of the
+//! system prompt (see `context::compose_system_instructions_full`).
+//!
+//! This module is the mechanism only. The block *content* (e.g. moving the
+//! editing doctrine out of `foundation_editing.md`) arrives in #464/#466, and
+//! model-family population of [`GuidanceContext`] in #465. Until then
+//! [`builtin_blocks`] is empty, so wiring it in is a no-op on the rendered
+//! prompt.
+
+use autonoetic_types::capability::Capability;
+use std::collections::HashSet;
+
+/// Predicate describing when a [`GuidanceBlock`] should be injected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuidanceCondition {
+    /// Always active.
+    Always,
+    /// The agent holds a capability of this kind (see [`capability_kind`]).
+    Capability(&'static str),
+    /// A tool with this exact name is in the active tool set this turn.
+    ToolPresent(&'static str),
+    /// The routed model's family matches one of these (case-insensitive
+    /// substring against the model id, e.g. `"claude"`, `"gpt"`).
+    ModelFamily(&'static [&'static str]),
+    /// The agent's role matches (e.g. `"coder"`).
+    Role(&'static str),
+    /// All sub-conditions hold.
+    All(Vec<GuidanceCondition>),
+    /// Any sub-condition holds.
+    Any(Vec<GuidanceCondition>),
+}
+
+/// A unit of prompt prose with a declarative activation condition.
+#[derive(Debug, Clone)]
+pub struct GuidanceBlock {
+    /// Stable identity; also the dedupe key.
+    pub id: &'static str,
+    /// The prose injected into the prompt when active.
+    pub prose: String,
+    /// When this block applies.
+    pub when: GuidanceCondition,
+    /// Render order — lower first. Foundation-like blocks low, role-specific high.
+    pub priority: i32,
+}
+
+/// The live-turn facts conditions are evaluated against.
+#[derive(Debug, Default, Clone)]
+pub struct GuidanceContext<'a> {
+    pub capabilities: &'a [Capability],
+    pub active_tool_names: &'a [String],
+    pub model_family: Option<&'a str>,
+    pub role: Option<&'a str>,
+}
+
+impl GuidanceCondition {
+    fn matches(&self, ctx: &GuidanceContext) -> bool {
+        match self {
+            GuidanceCondition::Always => true,
+            GuidanceCondition::Capability(kind) => {
+                ctx.capabilities.iter().any(|c| capability_kind(c) == *kind)
+            }
+            GuidanceCondition::ToolPresent(name) => {
+                ctx.active_tool_names.iter().any(|t| t == name)
+            }
+            GuidanceCondition::ModelFamily(families) => match ctx.model_family {
+                Some(model) => {
+                    let model = model.to_ascii_lowercase();
+                    families
+                        .iter()
+                        .any(|f| model.contains(&f.to_ascii_lowercase()))
+                }
+                None => false,
+            },
+            GuidanceCondition::Role(role) => ctx.role == Some(*role),
+            GuidanceCondition::All(conds) => conds.iter().all(|c| c.matches(ctx)),
+            GuidanceCondition::Any(conds) => conds.iter().any(|c| c.matches(ctx)),
+        }
+    }
+}
+
+/// Filter `blocks` against `ctx`, order by priority (then id for determinism),
+/// dedupe by id, and render the active prose joined by blank lines.
+///
+/// Returns an empty string when no block is active.
+pub fn compose_guidance(blocks: &[GuidanceBlock], ctx: &GuidanceContext) -> String {
+    let mut active: Vec<&GuidanceBlock> = blocks.iter().filter(|b| b.when.matches(ctx)).collect();
+    active.sort_by(|a, b| a.priority.cmp(&b.priority).then_with(|| a.id.cmp(b.id)));
+
+    let mut seen = HashSet::new();
+    let mut rendered = Vec::new();
+    for block in active {
+        if seen.insert(block.id) {
+            let prose = block.prose.trim();
+            if !prose.is_empty() {
+                rendered.push(prose.to_string());
+            }
+        }
+    }
+    rendered.join("\n\n")
+}
+
+/// The built-in guidance blocks. Empty until #464/#466 migrate doctrine here.
+pub fn builtin_blocks() -> Vec<GuidanceBlock> {
+    Vec::new()
+}
+
+/// Stable discriminant string for a capability, matched by
+/// [`GuidanceCondition::Capability`]. Exhaustive on purpose: adding a capability
+/// forces a decision here (and a chance to give it guidance).
+pub fn capability_kind(cap: &Capability) -> &'static str {
+    match cap {
+        Capability::SandboxFunctions { .. } => "sandbox_functions",
+        Capability::ReadAccess { .. } => "read_access",
+        Capability::WriteAccess { .. } => "write_access",
+        Capability::NetworkAccess { .. } => "network_access",
+        Capability::AgentSpawn { .. } => "agent_spawn",
+        Capability::AgentMessage { .. } => "agent_message",
+        Capability::BackgroundReevaluation { .. } => "background_reevaluation",
+        Capability::CodeExecution { .. } => "code_execution",
+        Capability::EmergencyStop => "emergency_stop",
+        Capability::AgentRevision { .. } => "agent_revision",
+        Capability::Evaluation { .. } => "evaluation",
+        Capability::ApprovalQueue { .. } => "approval_queue",
+        Capability::SchedulerSignal { .. } => "scheduler_signal",
+        Capability::CredentialAccess { .. } => "credential_access",
+        Capability::UserProfileAccess { .. } => "user_profile_access",
+        Capability::SchedulerAccess { .. } => "scheduler_access",
+        Capability::SkillInstall { .. } => "skill_install",
+        Capability::ConstitutionalProposal { .. } => "constitutional_proposal",
+        Capability::ReasoningAudit { .. } => "reasoning_audit",
+        Capability::BudgetNoPriceAvailableAllow => "budget_no_price_available_allow",
+        Capability::GithubIssueCreate { .. } => "github_issue_create",
+        Capability::SecurityRedTeam => "security_red_team",
+        Capability::CapsuleExport => "capsule_export",
+        Capability::WikiContribute => "wiki_contribute",
+        Capability::PlanFrameAccess { .. } => "plan_frame_access",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(id: &'static str, when: GuidanceCondition, priority: i32) -> GuidanceBlock {
+        GuidanceBlock { id, prose: id.to_string(), when, priority }
+    }
+
+    fn write_access() -> Vec<Capability> {
+        vec![Capability::WriteAccess { scopes: vec!["*".into()] }]
+    }
+
+    #[test]
+    fn always_matches() {
+        let ctx = GuidanceContext::default();
+        assert_eq!(compose_guidance(&[block("a", GuidanceCondition::Always, 0)], &ctx), "a");
+    }
+
+    #[test]
+    fn capability_gates() {
+        let caps = write_access();
+        let ctx = GuidanceContext { capabilities: &caps, ..Default::default() };
+        let blocks = vec![
+            block("w", GuidanceCondition::Capability("write_access"), 0),
+            block("n", GuidanceCondition::Capability("network_access"), 0),
+        ];
+        assert_eq!(compose_guidance(&blocks, &ctx), "w");
+    }
+
+    #[test]
+    fn tool_present_gates() {
+        let tools = vec!["content_patch".to_string()];
+        let ctx = GuidanceContext { active_tool_names: &tools, ..Default::default() };
+        let blocks = vec![
+            block("p", GuidanceCondition::ToolPresent("content_patch"), 0),
+            block("x", GuidanceCondition::ToolPresent("missing_tool"), 0),
+        ];
+        assert_eq!(compose_guidance(&blocks, &ctx), "p");
+    }
+
+    #[test]
+    fn model_family_substring_case_insensitive() {
+        let ctx = GuidanceContext { model_family: Some("claude-opus-4-8"), ..Default::default() };
+        let claude = block("c", GuidanceCondition::ModelFamily(&["claude", "sonnet"]), 0);
+        let gpt = block("g", GuidanceCondition::ModelFamily(&["gpt"]), 0);
+        assert_eq!(compose_guidance(&[claude, gpt], &ctx), "c");
+    }
+
+    #[test]
+    fn model_family_none_never_matches() {
+        let ctx = GuidanceContext::default();
+        let b = block("c", GuidanceCondition::ModelFamily(&["claude"]), 0);
+        assert_eq!(compose_guidance(&[b], &ctx), "");
+    }
+
+    #[test]
+    fn role_gates() {
+        let ctx = GuidanceContext { role: Some("coder"), ..Default::default() };
+        let blocks = vec![
+            block("c", GuidanceCondition::Role("coder"), 0),
+            block("a", GuidanceCondition::Role("auditor"), 0),
+        ];
+        assert_eq!(compose_guidance(&blocks, &ctx), "c");
+    }
+
+    #[test]
+    fn all_and_any_compose() {
+        let caps = write_access();
+        let tools = vec!["content_patch".to_string()];
+        let ctx = GuidanceContext { capabilities: &caps, active_tool_names: &tools, ..Default::default() };
+        let both = GuidanceCondition::All(vec![
+            GuidanceCondition::Capability("write_access"),
+            GuidanceCondition::ToolPresent("content_patch"),
+        ]);
+        let either = GuidanceCondition::Any(vec![
+            GuidanceCondition::Capability("network_access"),
+            GuidanceCondition::ToolPresent("content_patch"),
+        ]);
+        let neither = GuidanceCondition::All(vec![
+            GuidanceCondition::Capability("write_access"),
+            GuidanceCondition::ToolPresent("missing"),
+        ]);
+        assert_eq!(compose_guidance(&[block("both", both, 0)], &ctx), "both");
+        assert_eq!(compose_guidance(&[block("either", either, 0)], &ctx), "either");
+        assert_eq!(compose_guidance(&[block("neither", neither, 0)], &ctx), "");
+    }
+
+    #[test]
+    fn orders_by_priority_then_id() {
+        let ctx = GuidanceContext::default();
+        let blocks = vec![
+            block("z", GuidanceCondition::Always, 10),
+            block("a", GuidanceCondition::Always, 10),
+            block("first", GuidanceCondition::Always, -5),
+        ];
+        assert_eq!(compose_guidance(&blocks, &ctx), "first\n\na\n\nz");
+    }
+
+    #[test]
+    fn dedupes_by_id_keeping_one() {
+        let ctx = GuidanceContext::default();
+        let blocks = vec![
+            GuidanceBlock { id: "dup", prose: "low".into(), when: GuidanceCondition::Always, priority: 0 },
+            GuidanceBlock { id: "dup", prose: "high".into(), when: GuidanceCondition::Always, priority: 5 },
+        ];
+        // Lower priority wins (rendered first, dedupe keeps first).
+        assert_eq!(compose_guidance(&blocks, &ctx), "low");
+    }
+
+    #[test]
+    fn empty_when_nothing_active() {
+        let ctx = GuidanceContext::default();
+        let b = block("n", GuidanceCondition::Capability("network_access"), 0);
+        assert_eq!(compose_guidance(&[b], &ctx), "");
+    }
+}

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3551,7 +3551,7 @@ mod tests {
             .clone()
             .expect("system message should be captured");
         assert!(system.contains("Foundation Core"));
-        assert!(system.contains("content.write(name, content)"));
+        assert!(system.contains("content_write(name, content)"));
         assert!(system.contains("Agent local rules"));
     }
 

--- a/autonoetic-gateway/src/runtime/mod.rs
+++ b/autonoetic-gateway/src/runtime/mod.rs
@@ -24,6 +24,7 @@ pub mod eval_stats;
 pub mod failure_classification;
 pub mod fuzzy_match;
 pub mod guard;
+pub mod guidance;
 pub mod history_persist;
 pub mod inference_profile;
 pub mod human_gate;


### PR DESCRIPTION
## What

First piece of Track B (the modular, model-family-aware prompt-guidance mechanism from `docs/design/edit-tooling-and-guidance-roadmap.md`). Adds the **mechanism only** — composable guidance blocks that will replace hand-pasted per-`SKILL.md` doctrine.

Resolves #463.

## How

- **`runtime/guidance.rs`** —
  - `GuidanceBlock { id, prose, when: GuidanceCondition, priority }`
  - `GuidanceCondition`: `Always` / `Capability` / `ToolPresent` / `ModelFamily` / `Role` / `All` / `Any`
  - `compose_guidance(blocks, ctx)`: filters by a `GuidanceContext { capabilities, active_tool_names, model_family, role }`, orders by priority then id, dedupes by id, renders prose joined by blank lines.
  - `capability_kind()` maps each `Capability` to a stable string and is **exhaustive**, so adding a capability forces a decision (and a chance to give it guidance).
- **`context.rs`** — wires a `Guidance` layer into `compose_system_instructions_full`, right after foundation.

## No-op today, by design

`builtin_blocks()` is empty until #466 migrates doctrine into blocks; `active_tool_names`/`model_family` inputs are plumbed but populated by #464/#465. So `compose_guidance` renders `""` and the live prompt is unchanged. The seam is in place and fully unit-tested.

## Drive-by

Fixed a stale assertion in `test_execute_loop_includes_foundation_in_system_prompt` (`content.write` → `content_write`; the tool was renamed). It was one of the pre-existing full-suite failures and lives in the exact code I'm touching. Verified it fails identically on clean `main` and passes after the fix.

## Tests

10 new unit tests: each condition (capability/tool/model-family/role/all/any), priority+id ordering, dedupe-by-id, and empty render. The foundation prompt test now passes.

## Follow-ups (Track B)

- #464 `NativeTool::guidance()` hook (feeds `builtin_blocks` from tools; sets `active_tool_names`)
- #465 model-family derivation → populates `GuidanceContext.model_family`
- #466 migrate `SKILL.md`/`foundation_editing.md` doctrine into blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)