### PR TITLE
feat(prompt): model-family-aware guidance (#465)

### DIFF
--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -898,7 +898,10 @@ impl AgentExecutor {
         let ctx = crate::runtime::guidance::GuidanceContext {
             capabilities: &self.manifest.capabilities,
             active_tool_names,
-            model_family: None, // populated by #465
+            // The configured model id; `ModelFamily` substring-matches it
+            // (e.g. ["claude"] matches "claude-opus-4-8"). None when unset, so
+            // family-gated guidance simply doesn't fire (#465).
+            model_family: self.manifest.llm_config.as_ref().map(|c| c.model.as_str()),
             role: crate::runtime::context::role_from_manifest(&self.manifest),
         };
         crate::runtime::guidance::compose_guidance(&blocks, &ctx)

--- a/autonoetic-gateway/src/runtime/tools/content_patch.rs
+++ b/autonoetic-gateway/src/runtime/tools/content_patch.rs
@@ -173,17 +173,24 @@ impl NativeTool for ContentPatchTool {
     }
 
     fn guidance(&self) -> Vec<GuidanceBlock> {
-        vec![GuidanceBlock {
-            id: "editing.content_patch",
-            // Gating is belt-and-suspenders: collect_guidance only reaches here
-            // when content_patch is available (WriteAccess), but the explicit
-            // condition keeps the block self-describing.
-            when: GuidanceCondition::All(vec![
+        // The general doctrine is family-agnostic; the format hints below are
+        // model-family-specific (#465), mirroring the Hermes finding that
+        // different model families drive different edit formats most reliably.
+        let present = || {
+            GuidanceCondition::All(vec![
                 GuidanceCondition::Capability("write_access"),
                 GuidanceCondition::ToolPresent("content_patch"),
-            ]),
-            priority: 10,
-            prose: "**Editing existing content.** Two tools put content in the store: `content_write` \
+            ])
+        };
+        vec![
+            GuidanceBlock {
+                id: "editing.content_patch",
+                // Gating is belt-and-suspenders: collect_guidance only reaches
+                // here when content_patch is available (WriteAccess), but the
+                // explicit condition keeps the block self-describing.
+                when: present(),
+                priority: 10,
+                prose: "**Editing existing content.** Two tools put content in the store: `content_write` \
 authors a NEW entry; `content_patch` edits an EXISTING one. To change an entry you already wrote, \
 prefer `content_patch` — send only the changed region, never the whole file. \
 `content_patch(mode=\"replace\", name, old_string, new_string)` matches a unique snippet (tolerant of \
@@ -192,8 +199,31 @@ several places. Use `mode=\"v4a\"` only when one logical edit spans several entr
 `content_write` to edit only when authoring a brand-new entry, or when the region genuinely can't be \
 uniquely anchored. If a patch fails to match, `resolve` the entry to re-read its current content before \
 retrying — don't guess variations of the same snippet."
-                .to_string(),
-        }]
+                    .to_string(),
+            },
+            GuidanceBlock {
+                id: "editing.content_patch.format.claude",
+                when: GuidanceCondition::All(vec![
+                    present(),
+                    GuidanceCondition::ModelFamily(&["claude", "sonnet", "opus", "haiku"]),
+                ]),
+                priority: 11,
+                prose: "Edit format: prefer `mode=\"replace\"` — match a unique snippet and swap it. \
+Reach for `mode=\"v4a\"` only when one edit genuinely spans several entries at once."
+                    .to_string(),
+            },
+            GuidanceBlock {
+                id: "editing.content_patch.format.gpt",
+                when: GuidanceCondition::All(vec![
+                    present(),
+                    GuidanceCondition::ModelFamily(&["gpt", "codex"]),
+                ]),
+                priority: 11,
+                prose: "Edit format: for edits spanning several entries prefer `mode=\"v4a\"` (the \
+multi-entry diff format you handle most reliably); use `mode=\"replace\"` for a single small swap."
+                    .to_string(),
+            },
+        ]
     }
 }
 
@@ -577,6 +607,38 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&res).unwrap();
         assert_eq!(v["ok"], false);
         assert!(res.contains("invalid Add File name"));
+    }
+
+    #[test]
+    fn guidance_selects_family_specific_format_hint() {
+        use crate::runtime::guidance::{compose_guidance, GuidanceContext};
+        let blocks = ContentPatchTool.guidance();
+        let caps = vec![Capability::WriteAccess { scopes: vec!["*".to_string()] }];
+        let tools = vec!["content_patch".to_string()];
+        let base = GuidanceContext {
+            capabilities: &caps,
+            active_tool_names: &tools,
+            model_family: None,
+            role: None,
+        };
+
+        // Claude → replace-first hint, not the v4a-first one.
+        let claude = GuidanceContext { model_family: Some("claude-opus-4-8"), ..base.clone() };
+        let out = compose_guidance(&blocks, &claude);
+        assert!(out.contains("Editing existing content"));
+        assert!(out.contains("prefer `mode=\"replace\"`"));
+        assert!(!out.contains("most reliably"));
+
+        // GPT → v4a-for-multi-entry hint, not the replace-first one.
+        let gpt = GuidanceContext { model_family: Some("gpt-4o"), ..base.clone() };
+        let out = compose_guidance(&blocks, &gpt);
+        assert!(out.contains("most reliably"));
+        assert!(!out.contains("Edit format: prefer `mode=\"replace\"`"));
+
+        // No model family → general doctrine only, no format hint.
+        let out = compose_guidance(&blocks, &base);
+        assert!(out.contains("Editing existing content"));
+        assert!(!out.contains("Edit format:"));
     }
 }
 


### PR DESCRIPTION
## What

Track B #465 — the model-family branching that's the core gap vs Hermes. Resolves #465.

## How

- **`GuidanceContext.model_family`** is now populated from the agent's configured model id (`manifest.llm_config.model`) in `render_tool_guidance`. The `ModelFamily` condition (from #463) substring-matches it, so `["claude"]` matches `claude-opus-4-8`. `None` when unset → family-gated guidance simply doesn't fire.
- **`ContentPatchTool` family-specific edit-format hints** (Hermes parity, on top of the family-agnostic doctrine):
  - Claude family (`claude`/`sonnet`/`opus`/`haiku`) → "prefer `mode=\"replace\"`; reach for `v4a` only for multi-entry edits."
  - GPT/Codex → "for multi-entry edits prefer `mode=\"v4a\"`; `replace` for a single swap."

Why source from the configured model rather than the per-turn routed model: routing can swap models for cost/capability, but the agent's configured model is the stable basis for edit-format guidance, and it's known before the prompt is composed.

## Tests

`guidance_selects_family_specific_format_hint`: claude → replace hint only; gpt → v4a hint only; no family → general doctrine only, no format hint. `runtime::guidance` (10) and `content_patch` (10) suites green; lifecycle guidance/foundation tests green.

## Track B status

- #463 GuidanceBlock core — merged (#468)
- #464 tool-contributed guidance — merged (#469)
- **#465 model-family — this PR**
- #466 migrate specialist `SKILL.md` doctrine into blocks — remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)