### PR TITLE
refactor(agents): migrate promotion_record protocol into guidance block (#466, part 2)

### DIFF
--- a/agents/specialists/auditor.default/SKILL.md
+++ b/agents/specialists/auditor.default/SKILL.md
@@ -111,10 +111,6 @@ Use this exact argument shape:
 }
 ```
 
-Mapping rule: `pass` must be the boolean equivalent of your audit decision (`auditor_pass`).
-
-Do NOT use alternate field names like `outcome`; `promotion_record` requires `role` and `pass`.
-
 ## Review Protocol
 
 1. **Security first**: secrets, privilege escalation, data leaks

--- a/agents/specialists/sealed_evaluator.default/SKILL.md
+++ b/agents/specialists/sealed_evaluator.default/SKILL.md
@@ -182,7 +182,7 @@ promotion_record({
 })
 ```
 
-This records the evaluation to the PromotionStore and causal chain. If your evaluation fails (evaluator_pass=false), you MUST still call `promotion_record` with pass=false to document the failure.
+This records the evaluation to the PromotionStore and causal chain.
 
 Exception: if execution is blocked on operator approval, do not call `promotion_record` until the evaluation is complete.
 

--- a/agents/specialists/static_evaluator.default/SKILL.md
+++ b/agents/specialists/static_evaluator.default/SKILL.md
@@ -111,8 +111,6 @@ After completing your evaluation, call `promotion_record`:
 }
 ```
 
-If your evaluation fails (evaluator_pass=false), you MUST still call `promotion_record` with pass=false to document the failure.
-
 ## Status Field Mapping
 
 When returning your final response JSON, map your evaluation result to the status field:

--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -102,6 +102,26 @@ impl NativeTool for PromotionRecordTool {
         is_promotion_agent(manifest)
     }
 
+    fn guidance(&self) -> Vec<crate::runtime::guidance::GuidanceBlock> {
+        use crate::runtime::guidance::{GuidanceBlock, GuidanceCondition};
+        // Centralized from static_evaluator/sealed_evaluator/auditor SKILL.md
+        // (#466): the call protocol is uniform across promotion agents.
+        // Role-specific exceptions (e.g. unit_test_runner's "no tests → don't
+        // call", sealed_evaluator's "defer until approval resolves") stay in
+        // those manifests.
+        vec![GuidanceBlock {
+            id: "promotion.record_protocol",
+            when: GuidanceCondition::ToolPresent("promotion_record"),
+            priority: 10,
+            prose: "**Recording your verdict.** When your evaluation/audit is complete, call \
+`promotion_record` with the `artifact_ref` you reviewed. Required fields are `role` and `pass` (plus \
+`findings` and `summary`) — do not use alternate names like `outcome`. `pass` is the boolean \
+equivalent of your verdict (`evaluator_pass` / `auditor_pass`). Record BOTH outcomes: on a failing \
+verdict you must still call it with `pass: false` to document the result."
+                .to_string(),
+        }]
+    }
+
     fn execute(
         &self,
         manifest: &AgentManifest,
@@ -513,5 +533,24 @@ impl NativeTool for PromotionQueryTool {
                 .map_err(Into::into)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod guidance_tests {
+    use super::*;
+    use crate::runtime::guidance::{compose_guidance, GuidanceContext};
+
+    #[test]
+    fn promotion_record_contributes_verdict_block() {
+        let blocks = PromotionRecordTool.guidance();
+        let tools = vec!["promotion_record".to_string()];
+        let ctx = GuidanceContext { active_tool_names: &tools, ..Default::default() };
+        let out = compose_guidance(&blocks, &ctx);
+        assert!(out.contains("Recording your verdict"), "block text missing: {out}");
+        assert!(out.contains("do not use alternate names"));
+
+        // Absent when promotion_record isn't in the advertised tool set.
+        assert_eq!(compose_guidance(&blocks, &GuidanceContext::default()), "");
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -113,11 +113,12 @@ impl NativeTool for PromotionRecordTool {
             id: "promotion.record_protocol",
             when: GuidanceCondition::ToolPresent("promotion_record"),
             priority: 10,
-            prose: "**Recording your verdict.** When your evaluation/audit is complete, call \
-`promotion_record` with the `artifact_ref` you reviewed. Required fields are `role` and `pass` (plus \
-`findings` and `summary`) — do not use alternate names like `outcome`. `pass` is the boolean \
-equivalent of your verdict (`evaluator_pass` / `auditor_pass`). Record BOTH outcomes: on a failing \
-verdict you must still call it with `pass: false` to document the result."
+            prose: "**Recording your verdict.** When your evaluation/audit reaches a verdict, call \
+`promotion_record` with the `artifact_ref` you reviewed. Only `role` and `pass` are required; include \
+`findings` and `summary` too. Use those exact field names — not alternates like `outcome`. `pass` is \
+the boolean equivalent of your verdict (`evaluator_pass` / `auditor_pass`); record a failing verdict \
+as well, with `pass: false`. (Your role may define cases where the gate is inapplicable and you should \
+NOT call this — e.g. no tests found; follow that role-specific guidance.)"
                 .to_string(),
         }]
     }
@@ -548,7 +549,7 @@ mod guidance_tests {
         let ctx = GuidanceContext { active_tool_names: &tools, ..Default::default() };
         let out = compose_guidance(&blocks, &ctx);
         assert!(out.contains("Recording your verdict"), "block text missing: {out}");
-        assert!(out.contains("do not use alternate names"));
+        assert!(out.contains("not alternates like `outcome`"));
 
         // Absent when promotion_record isn't in the advertised tool set.
         assert_eq!(compose_guidance(&blocks, &GuidanceContext::default()), "");


### PR DESCRIPTION
## What

Follow-up #2 to #466. Migrates **Cluster E** (the `promotion_record` call protocol) — duplicated near-verbatim across all four evaluators — into a single tool-contributed guidance block.

Partially addresses #466.

## How

- **`promotion_record.guidance()`** — the call protocol (required `role`+`pass`, `findings`/`summary`, no alias field names like `outcome`, `pass` = boolean verdict, record both pass/fail outcomes), gated `ToolPresent("promotion_record")` (the tool is only available to the four evaluator agents).
- Trimmed the duplicated sentences from `static_evaluator`, `sealed_evaluator`, and `auditor` `SKILL.md` (the "MUST still call with pass=false" and "don't use alternate field names" lines).

## Role-specific prose intentionally kept

- `unit_test_runner`: "no tests found → `unable_to_evaluate`, do **not** call `promotion_record`" — a documented exception, not covered by the general "record both outcomes" rule.
- `sealed_evaluator`: "if blocked on operator approval, defer until the evaluation is complete."
- Each evaluator's role-specific JSON example shape stays.

## Tests

`promotion_record_contributes_verdict_block`: the block renders iff `promotion_record` is in the advertised tool set. All prior guidance/foundation tests green.

## Remaining #466 clusters (further follow-ups)

approval-continuation (coder/sealed_evaluator), unittest policy (coder/unit_test_runner), resumption/reuse_guards, no-network sandbox, single-pass discovery. Done sequentially to avoid SKILL.md merge conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)