### PR TITLE
refactor(agents): migrate approval-continuation doctrine into guidance block (#466, part 3)

### DIFF
--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -66,8 +66,6 @@ When you wake up after any interruption (approval, timeout, hibernation):
 3. If you were mid-task (e.g., wrote files but didn't build artifact), continue from where you left off.
 4. **Never EndTurn immediately after resumption** — if building an agent script, you MUST call `artifact_build` and return the `artifact_ref` before ending.
 
-Approval retry: if `sandbox_exec` previously returned `approval_required: true` with an `approval_ref`, retry the **exact same command** with `approval_ref` set to the approved request ID.
-
 ## CRITICAL: No Network Access — Your Sandbox Has NO Network
 
 You do **NOT** have `NetworkAccess`. The sandbox is network-isolated. The gateway runs **static analysis** on your code and test files — it scans for URL strings, hostnames, IP addresses, and HTTP client calls **inside the source code itself**, not just the command. If any pattern is detected, `sandbox_exec` is blocked.
@@ -158,7 +156,6 @@ When the planner asks you to create an agent (e.g. "create a weather agent"):
    On success (`status: "ok"`): include `artifact_ref` and the install intent payload via `reason` or optional fields. The returned `artifact_ref` is the canonical install handoff. Prefer it over loose `cnt_...` handles for downstream packaging, validation, or installation.
 8. Suggested handoff text:
   "Artifact ready with semantic install intent. Reuse this artifact_ref for downstream packaging/install; do not rebuild from loose content. Ask agent-factory.default to continue the full pipeline, or specialized_builder.default only if you are already at the final install step."
-9. If a tool returns **`approval_required: true`**, **stop** and return the **exact** approval id fields to the planner — **never** invent an `approval_ref` or retry with a guessed id.
 
 <!-- extended -->
 
@@ -360,13 +357,7 @@ The gateway's LoopGuard will block `sandbox_exec` after too many failures. To av
 
 When your command may hit the network/API approval gate, **always** pass `"intent"` on `sandbox_exec`: one clear sentence for the operator (what runs, why it is needed, and whether traffic is real or mocked).
 
-When `sandbox_exec` returns `approval_required: true` with `request_id`, the gateway will suspend your session until the operator approves.
-
-**After resumption (approval resolved):**
-
-1. Retry `sandbox_exec` with the `approval_ref` set to the approved `request_id`. The gateway will use the approved command automatically.
-2. Use the output from this retried command to continue your work.
-3. Do NOT `EndTurn` immediately after approval — review your history and finish your task (build artifact, return artifact_ref, etc.).
+(The approval-continuation protocol — retry with `approval_ref` after resumption — is in the shared `sandbox_exec` guidance. After resumption, finish your task: build the artifact and return its `artifact_ref` before ending.)
 
 ## Permission Denied
 

--- a/agents/specialists/sealed_evaluator.default/SKILL.md
+++ b/agents/specialists/sealed_evaluator.default/SKILL.md
@@ -106,7 +106,7 @@ This has three consequences:
 When you wake up after any interruption:
 
 1. Call `workflow_state` to check current status.
-2. If approval was pending and is now resolved, retry the **exact same** exec command with `approval_ref` set to the approved request ID.
+2. If approval was pending and is now resolved, retry the blocked exec per the shared approval-continuation guidance.
 3. Complete the evaluation and call `promotion_record`.
 
 ## Behavior

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3672,6 +3672,10 @@ mod tests {
             system.contains("Forbidden shell commands"),
             "sandbox_exec forbidden-commands block missing"
         );
+        assert!(
+            system.contains("Approval continuation"),
+            "exec approval-continuation block missing"
+        );
     }
 
     struct ApprovalRequiredLifecycleTool;

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -154,6 +154,12 @@ impl NativeTool for ArtifactExecTool {
         })
     }
 
+    fn guidance(&self) -> Vec<crate::runtime::guidance::GuidanceBlock> {
+        // Same approval-continuation block as sandbox_exec (deduped by id at
+        // compose), so artifact_exec-only agents still get it (#466).
+        vec![crate::runtime::tools::sandbox::exec_approval_continuation_block()]
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -783,6 +783,27 @@ fn collect_layer_scope_issues(
     Ok(issues)
 }
 
+/// Shared approval-continuation doctrine (#466), contributed by both
+/// `sandbox_exec` and `artifact_exec` (same `id`, deduped at compose). Centralized
+/// from coder/sealed_evaluator SKILL.md.
+pub(crate) fn exec_approval_continuation_block() -> crate::runtime::guidance::GuidanceBlock {
+    use crate::runtime::guidance::{GuidanceBlock, GuidanceCondition};
+    GuidanceBlock {
+        id: "exec.approval_continuation",
+        when: GuidanceCondition::Any(vec![
+            GuidanceCondition::ToolPresent("sandbox_exec"),
+            GuidanceCondition::ToolPresent("artifact_exec"),
+        ]),
+        priority: 11,
+        prose: "**Approval continuation.** If `sandbox_exec`/`artifact_exec` returns \
+`approval_required: true` with an `approval_ref`, do not invent or guess an id — return the exact \
+approval fields to your caller and stop. After the operator approves and you resume, retry the \
+**exact same** command with `approval_ref` set to the approved `request_id`, then continue your task; \
+do NOT `EndTurn` immediately after resumption."
+            .to_string(),
+    }
+}
+
 impl NativeTool for SandboxExecTool {
     fn name(&self) -> &'static str {
         "sandbox_exec"
@@ -800,17 +821,20 @@ impl NativeTool for SandboxExecTool {
         // Centralized from coder/debugger/executor SKILL.md (#466). The gateway
         // enforces this for every `sandbox_exec` call, so it belongs with the
         // tool rather than copy-pasted per role.
-        vec![GuidanceBlock {
-            id: "sandbox.forbidden_commands",
-            when: GuidanceCondition::ToolPresent("sandbox_exec"),
-            priority: 10,
-            prose: "**Forbidden shell commands** (blocked by gateway security policy): destructive \
+        vec![
+            GuidanceBlock {
+                id: "sandbox.forbidden_commands",
+                when: GuidanceCondition::ToolPresent("sandbox_exec"),
+                priority: 10,
+                prose: "**Forbidden shell commands** (blocked by gateway security policy): destructive \
 file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shred`, `wipefs`, \
 `dd if=`/`dd of=/dev/…`, redirects to `/dev/…`); privilege escalation (`sudo`, `su`, `doas`, \
 `setuid`/`setgid`, `chmod +s`, `chown root`); and environment/process-secret disclosure (`env`, \
 `printenv`, `declare -x`, and reads of `/proc/self/environ`, `/proc/1/environ`, `/etc/environment`)."
-                .to_string(),
-        }]
+                    .to_string(),
+            },
+            exec_approval_continuation_block(),
+        ]
     }
 
     fn definition(&self) -> ToolDefinition {

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -796,10 +796,10 @@ pub(crate) fn exec_approval_continuation_block() -> crate::runtime::guidance::Gu
         ]),
         priority: 11,
         prose: "**Approval continuation.** If `sandbox_exec`/`artifact_exec` returns \
-`approval_required: true` with an `approval_ref`, do not invent or guess an id — return the exact \
-approval fields to your caller and stop. After the operator approves and you resume, retry the \
-**exact same** command with `approval_ref` set to the approved `request_id`, then continue your task; \
-do NOT `EndTurn` immediately after resumption."
+`approval_required: true` with a `request_id`, do not invent or guess ids — return that exact \
+`request_id` to your caller and stop. After the operator approves and you resume, retry the \
+**exact same** command with the `approval_ref` input set to the approved `request_id`, then continue \
+your task; do NOT `EndTurn` immediately after resumption."
             .to_string(),
     }
 }


### PR DESCRIPTION
## What

Follow-up #3 to #466. Migrates **Cluster D** (the `approval_required` → retry-with-`approval_ref` → don't-`EndTurn` protocol), duplicated in `coder` and `sealed_evaluator`, into a shared tool-contributed block.

Partially addresses #466.

## How

- **`exec_approval_continuation_block()`** in `sandbox.rs`, contributed by **both** `sandbox_exec` and `artifact_exec` (same `id` → deduped at compose; gated `Any[ToolPresent("sandbox_exec"), ToolPresent("artifact_exec")]`). Contributing from both means an `artifact_exec`-only agent (e.g. an evaluator) still gets it, and dedup ensures it shows once when both tools are present.
- Trimmed the duplicated prose from `coder` (the approval-retry line, the never-invent item, and the Remote Access Approval mechanics) and `sealed_evaluator` (resumption item 2), keeping role-specific framing (coder's `intent`-passing and artifact_build-before-end; sealed's resumption flow).

## Tests

Extended `test_execute_loop_includes_migrated_tool_doctrine`: a CodeExecution agent's prompt now also contains the "Approval continuation" block. Dedup-by-id is already covered in `runtime::guidance` tests.

## Remaining #466 clusters

unittest policy (coder/unit_test_runner), resumption/reuse_guards (broad). The role-nuanced ones (no-network, single-pass) remain on hold pending your call. Sequential to avoid SKILL.md conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)