### PR TITLE
refactor(agents): migrate resumption kernel into guidance block; close #466

### DIFF
--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -140,11 +140,9 @@ These agents are the system's vocabulary. Know them by name. They are **agent ID
 
 ## Resumption & Reuse Guards
 
-On every wake-up after interruption (approval, timeout, join, hibernation):
-
-**Step 1:** Call `workflow_state` immediately.
-**Step 2:** Read `resume_hint` and `reuse_guards`. They are mechanical truth.
-**Step 3:** Continue from where the workflow left off. Never restart from scratch.
+On every wake-up, follow the shared resumption rule (call `workflow_state` first;
+`reuse_guards`/`resume_hint` are mechanical truth; never restart). The
+planner-specific hard guards:
 
 **Hard Reuse Guards:**
 

--- a/agents/specialists/coder.default/SKILL.md
+++ b/agents/specialists/coder.default/SKILL.md
@@ -59,12 +59,11 @@ You are a coding agent. Produce tested, minimal, and auditable code and artifact
 
 ## Resumption
 
-When you wake up after any interruption (approval, timeout, hibernation):
+On wake-up, follow the shared resumption rule (call `workflow_state` first; never restart). Coder-specific:
 
-1. Call `workflow_state` to get structured facts about what was completed.
-2. Check `reuse_guards` — if `has_coder_artifact` is true, your work is done; return the artifact_ref.
-3. If you were mid-task (e.g., wrote files but didn't build artifact), continue from where you left off.
-4. **Never EndTurn immediately after resumption** — if building an agent script, you MUST call `artifact_build` and return the `artifact_ref` before ending.
+- If `reuse_guards.has_coder_artifact` is true, your work is done — return the `artifact_ref`.
+- If you were mid-task (wrote files but didn't build the artifact), continue from there.
+- **Never `EndTurn` immediately after resumption** — if building an agent script, you MUST call `artifact_build` and return the `artifact_ref` before ending.
 
 ## CRITICAL: No Network Access — Your Sandbox Has NO Network
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3645,11 +3645,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_loop_includes_migrated_tool_doctrine() {
-        // WriteAccess ⇒ content_write protocol block; CodeExecution ⇒ sandbox_exec
-        // forbidden-commands block (#466 migration from per-SKILL.md prose).
+        // WriteAccess ⇒ content_write block; CodeExecution ⇒ sandbox_exec
+        // forbidden-commands + approval blocks; ReadAccess ⇒ workflow_state
+        // resumption kernel (#466 migration from per-SKILL.md prose).
         let manifest = manifest_with_capabilities(vec![
             Capability::WriteAccess { scopes: vec!["*".to_string()] },
             Capability::CodeExecution { patterns: vec![], commands: vec![] },
+            Capability::ReadAccess { scopes: vec!["*".to_string()] },
         ]);
         let temp = tempdir().expect("tempdir should create");
         let captured = Arc::new(Mutex::new(None));
@@ -3675,6 +3677,10 @@ mod tests {
         assert!(
             system.contains("Approval continuation"),
             "exec approval-continuation block missing"
+        );
+        assert!(
+            system.contains("On any wake-up"),
+            "workflow_state resumption kernel missing"
         );
     }
 

--- a/autonoetic-gateway/src/runtime/tools/workflow.rs
+++ b/autonoetic-gateway/src/runtime/tools/workflow.rs
@@ -686,6 +686,23 @@ impl NativeTool for WorkflowStateTool {
             .any(|cap| matches!(cap, Capability::ReadAccess { .. }))
     }
 
+    fn guidance(&self) -> Vec<crate::runtime::guidance::GuidanceBlock> {
+        use crate::runtime::guidance::{GuidanceBlock, GuidanceCondition};
+        // Shared resumption kernel (#466), centralized from
+        // planner/coder/sealed_evaluator/packager SKILL.md. Each role keeps its
+        // own reuse-guard specifics; this is the universal principle.
+        vec![GuidanceBlock {
+            id: "resumption.workflow_state_first",
+            when: GuidanceCondition::ToolPresent("workflow_state"),
+            priority: 8,
+            prose: "**On any wake-up** (approval resolved, child join, timeout, hibernation), call \
+`workflow_state` FIRST and treat its `reuse_guards`/`resume_hint` as mechanical truth: continue from \
+where the workflow left off — never restart from scratch or re-spawn work a guard says is already \
+done. Read child outputs from `named_outputs` (don't guess content names)."
+                .to_string(),
+        }]
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),


### PR DESCRIPTION
## What

Final cut of #466 (**Cluster H kernel**) — and closes the issue.

**Closes #466.**

## How

- **`workflow_state.guidance()`** — the universal resumption principle: "on any wake-up (approval/join/timeout/hibernation) call `workflow_state` first, treat `reuse_guards`/`resume_hint` as mechanical truth, continue — never restart — and read child outputs from `named_outputs`." Gated `ToolPresent("workflow_state")`.
- Trimmed the generic Step 1/2/3 intro from the planner's "Resumption & Reuse Guards" section; its role-specific **Hard Reuse Guards** table stays.

## Why #466 is complete here (not all audit clusters migrated)

The genuinely-**duplicated** doctrine is now centralized across this PR series:

| Cluster | PR |
|---|---|
| forbidden-commands, content_write | #471 |
| promotion_record protocol | #473 |
| approval-continuation | #474 |
| resumption kernel | this PR |

The remaining audit clusters are **role-divergent, not duplicated**, and are intentionally left per-agent:
- **unittest policy** — coder says "never add pytest", unit_test_runner says "use pytest if vendored". Opposite guidance; only "stdlib default" is shared.
- **no-network sandbox**, **single-pass discovery** — each role frames the same boundary differently (developer UX vs capability boundary vs fixture-proxy; loop-guard avoidance per role).

Centralizing those would flatten meaningful nuance, so they stay. (As a bonus, this series surfaced and fixed three latent prose inaccuracies vs the real enforcement — forbidden-commands, promotion_record required fields, approval field names.)

## Tests

Extended `test_execute_loop_includes_migrated_tool_doctrine`: a ReadAccess agent's prompt now also contains the resumption kernel. All guidance/foundation suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)