### PR TITLE
refactor(agents): centralize clarification principle into a builtin guidance block (#466)

### DIFF
--- a/agents/specialists/architect.default/SKILL.md
+++ b/agents/specialists/architect.default/SKILL.md
@@ -135,4 +135,4 @@ Within the same root session, prefer names for collaboration. For agent-creation
 
 ## Clarification
 
-Request clarification when the goal is ambiguous, key constraints are missing, or requirements conflict. Otherwise use sensible defaults and document trade-offs.
+Your clarification triggers: an ambiguous goal, missing key constraints, or conflicting requirements. When you proceed on a default, document the trade-off.

--- a/agents/specialists/auditor.default/SKILL.md
+++ b/agents/specialists/auditor.default/SKILL.md
@@ -198,4 +198,4 @@ is the intent-only bundle agent-factory built.
 
 ## Clarification
 
-Request clarification when security policy, approval criteria, or scope are undefined. Otherwise apply standard security practices with conservative defaults.
+Your clarification triggers: undefined security policy, approval criteria, or scope. Otherwise apply standard security practices with conservative defaults.

--- a/agents/specialists/debugger.default/SKILL.md
+++ b/agents/specialists/debugger.default/SKILL.md
@@ -78,4 +78,4 @@ Return a single raw JSON object that matches `io.returns`. Do not wrap JSON in m
 
 ## Clarification
 
-Request clarification when you cannot reproduce the issue, when multiple root causes are possible, or when error context is missing. Otherwise start with logs, stack traces, and error messages.
+Your clarification triggers: you cannot reproduce the issue, multiple root causes are possible, or error context is missing. Otherwise start with logs, stack traces, and error messages.

--- a/agents/specialists/executor.default/SKILL.md
+++ b/agents/specialists/executor.default/SKILL.md
@@ -197,4 +197,4 @@ Return a single raw JSON object matching `io.returns`. Do not wrap JSON in markd
 
 ## Clarification
 
-Request clarification only when a missing parameter changes the command or script materially. Otherwise use sensible defaults and execute.
+Your clarification trigger: a missing parameter that materially changes the command or script. Otherwise default and execute.

--- a/autonoetic-gateway/src/runtime/guidance.rs
+++ b/autonoetic-gateway/src/runtime/guidance.rs
@@ -6,11 +6,10 @@
 //! ordered by priority, deduped by `id`, and rendered into one section of the
 //! system prompt (see `context::compose_system_instructions_full`).
 //!
-//! This module is the mechanism only. The block *content* (e.g. moving the
-//! editing doctrine out of `foundation_editing.md`) arrives in #464/#466, and
-//! model-family population of [`GuidanceContext`] in #465. Until then
-//! [`builtin_blocks`] is empty, so wiring it in is a no-op on the rendered
-//! prompt.
+//! Block *content* lives with whatever owns it: tools contribute blocks via
+//! `NativeTool::guidance()` (#464), model-family conditions are populated from
+//! the manifest (#465), and cross-cutting doctrine not owned by any tool lives
+//! in [`builtin_blocks`] (#466, e.g. the clarification principle).
 
 use autonoetic_types::capability::Capability;
 use std::collections::HashSet;
@@ -104,7 +103,9 @@ pub fn compose_guidance(blocks: &[GuidanceBlock], ctx: &GuidanceContext) -> Stri
     rendered.join("\n\n")
 }
 
-/// The built-in guidance blocks. Empty until #464/#466 migrate doctrine here.
+/// Cross-cutting guidance blocks not owned by any single tool (#466). Tool- and
+/// role-specific doctrine lives with its tool's `guidance()`; this is for
+/// genuinely universal doctrine (e.g. the clarification principle).
 pub fn builtin_blocks() -> Vec<GuidanceBlock> {
     vec![GuidanceBlock {
         // Universal clarification principle (#466 recurring-section migration).
@@ -117,8 +118,9 @@ pub fn builtin_blocks() -> Vec<GuidanceBlock> {
 caller or operator can supply — a missing required parameter, a genuinely ambiguous instruction, or \
 conflicting requirements — do not guess and do not spin discovery tools (`agent_list`, \
 `workflow_state`, repeated re-reads) to manufacture the answer. Return `clarification_needed` (or use \
-`user_ask` if you hold that tool) and end the turn. Otherwise proceed with a sensible, documented \
-default — a reasonable default or a clearly-better interpretation does not warrant a round-trip."
+`user_ask` if you hold that tool) and end the turn — the reply must still satisfy your declared \
+output schema (required fields, types). Otherwise proceed with a sensible, documented default — a \
+reasonable default or a clearly-better interpretation does not warrant a round-trip."
             .to_string(),
     }]
 }

--- a/autonoetic-gateway/src/runtime/guidance.rs
+++ b/autonoetic-gateway/src/runtime/guidance.rs
@@ -106,7 +106,21 @@ pub fn compose_guidance(blocks: &[GuidanceBlock], ctx: &GuidanceContext) -> Stri
 
 /// The built-in guidance blocks. Empty until #464/#466 migrate doctrine here.
 pub fn builtin_blocks() -> Vec<GuidanceBlock> {
-    Vec::new()
+    vec![GuidanceBlock {
+        // Universal clarification principle (#466 recurring-section migration).
+        // Each role keeps its own *triggers* (what counts as blocked); this is
+        // the shared "ask-or-default, don't fabricate" rule.
+        id: "clarification.ask_or_default",
+        when: GuidanceCondition::Always,
+        priority: 5,
+        prose: "**Don't fabricate a missing fact.** When you're blocked on something only the \
+caller or operator can supply — a missing required parameter, a genuinely ambiguous instruction, or \
+conflicting requirements — do not guess and do not spin discovery tools (`agent_list`, \
+`workflow_state`, repeated re-reads) to manufacture the answer. Return `clarification_needed` (or use \
+`user_ask` if you hold that tool) and end the turn. Otherwise proceed with a sensible, documented \
+default — a reasonable default or a clearly-better interpretation does not warrant a round-trip."
+            .to_string(),
+    }]
 }
 
 /// Stable discriminant string for a capability, matched by
@@ -256,5 +270,13 @@ mod tests {
         let ctx = GuidanceContext::default();
         let b = block("n", GuidanceCondition::Capability("network_access"), 0);
         assert_eq!(compose_guidance(&[b], &ctx), "");
+    }
+
+    #[test]
+    fn builtin_clarification_block_is_always_active() {
+        // The clarification principle (#466) is an Always builtin → renders for
+        // any agent, even with no capabilities/tools.
+        let out = compose_guidance(&builtin_blocks(), &GuidanceContext::default());
+        assert!(out.contains("Don't fabricate a missing fact"), "got: {out:?}");
     }
 }

--- a/autonoetic-gateway/tests/skill_doctrine_guard.rs
+++ b/autonoetic-gateway/tests/skill_doctrine_guard.rs
@@ -33,6 +33,10 @@ const MIGRATED_DOCTRINE_FINGERPRINTS: &[(&str, &str)] = &[
         "never restart from scratch",
         "resumption.workflow_state_first (workflow_state.guidance)",
     ),
+    (
+        "warrant a round-trip",
+        "clarification.ask_or_default (builtin block)",
+    ),
 ];
 
 fn agents_root() -> PathBuf {


### PR DESCRIPTION
## What

Recurring-section migration from the factorization roadmap: the **clarification** principle (×6 specialists). First use of an `Always` **builtin** guidance block.

## How

- **`builtin_blocks()`** now contributes `clarification.ask_or_default` (gated `Always`): *don't fabricate a missing fact — when blocked on something only the caller/operator can supply, don't guess and don't spin discovery tools (`agent_list`/`workflow_state`/re-reads) to manufacture it; return `clarification_needed` (or `user_ask` if held) and end the turn; otherwise proceed with a sensible, documented default.*
- This was the genuinely-universal, currently-scattered kernel. The **role-specific triggers stay** in each SKILL.md (auditor: security policy; debugger: can't-reproduce; architect: ambiguous goal; executor: param changes command; coder/researcher: their detailed when-to-request/proceed with role examples).
- Trimmed the repeated generic "request clarification… otherwise use sensible defaults" stem from the four one-liner sections, keeping each role's triggers and default behavior (e.g. debugger's "start with logs", auditor's "conservative security defaults").
- Registered the `warrant a round-trip` fingerprint in the #477 doctrine guard.

## Why a builtin (not a tool block)

Clarification isn't owned by one tool — `clarification_needed` is an output-contract behavior and `user_ask` is only held by some agents. `Always` gives uniform coverage (including agents that had no clarification section) and is universally-sound advice. The "don't spin discovery tools to manufacture a missing fact" half addresses a real failure mode.

## Tests

- `builtin_clarification_block_is_always_active` — renders with an empty context.
- Doctrine guard + lifecycle compose tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)