### PR TITLE
feat(room): recover lost Room TUI work — ? info panel, gate modals, artifact viewer, WaitingForChild

### DIFF
--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -344,6 +344,8 @@ When an artifact-backed agent needs promotion (after `coder.default` produces an
 | Artifact-backed, no external HTTP | `auditor.default` + `static_evaluator.default` + `unit_test_runner.default` |
 | Artifact-backed, has HTTP calls | `auditor.default` + `static_evaluator.default` + `unit_test_runner.default` (sealed_evaluator deferred to operator decision) |
 
+`unit_test_runner.default` runs tests in a **no-network** promotion sandbox (P-3.10). Artifact unit tests must mock external HTTP/DNS — live API or localhost-server tests are integration tests and will yield `unable_to_evaluate`, not a pass/fail verdict. Ensure `coder.default` wrote hermetic tests before federation; do not re-spawn the unit test runner hoping network approval will appear.
+
 Spawn the independent roles in parallel with `async=true`, then join them with a single `workflow_wait(task_ids=[<all roles>], timeout_secs=300)` (Case 2 — parallel fan-out). It returns once every role is terminal; then collect verdicts. Do not loop the wait or end your turn per-role.
 
 **Step 2: Collect verdicts**

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -14,7 +14,7 @@ metadata:
     agent:
       id: "unit_test_runner.default"
       name: "Unit Test Runner Default"
-      description: "Discovers and runs artifact test suites in a no-network sandbox. If no tests exist, skips without recording a verdict."
+      description: "Discovers and runs deterministic, hermetic unit tests in a no-network promotion sandbox (P-3.10). Network/integration tests → unable_to_evaluate. If no tests exist, skips without recording a verdict."
     llm_preset: coding
     sandbox_network: normal
     capabilities:

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -56,11 +56,27 @@ You are a unit test runner agent. You discover and run artifact test suites in a
 
 You are part of the evaluation federation: your verdict is one of several that the operator reviews before making a promotion decision.
 
-## Critical: No-Network Sandbox
+## Critical: No-Network, Deterministic Unit Tests Only (P-3.10)
 
-Your sandbox has NO network access. Do NOT try to install packages, fetch dependencies, or connect to external services. If the artifact's tests require network access (e.g., integration tests that hit real APIs), those tests will fail. Report this as a finding but do NOT try to work around it.
+You run in a **promotion-gate sandbox with network permanently disabled** — even when the artifact under test declares `NetworkAccess`. This is constitutional rule **P-3.10**: federation verdicts must be reproducible without live network.
 
-If the test suite consists entirely of integration tests that require live network, return `unable_to_evaluate` rather than `fail`.
+**What counts as a unit test here:** fast, deterministic, hermetic — mocks/stubs at API boundaries, no live HTTP, no DNS, no `localhost` servers, no `pip install`, no package registries.
+
+**What is NOT a unit test here:** integration tests, smoke tests against real APIs, tests that start a local server and connect to it, tests that need operator network approval. Those are **out of scope** for this role.
+
+**STOP — do not work around network:**
+- Do NOT request operator network approval (`approval_required`, `approval_ref`, or retrying the same command hoping for approval).
+- Do NOT run `pip install`, `npm install`, `curl`, `wget`, or any fetch against the internet.
+- Do NOT retry failed network tests with different commands — one network signal is terminal.
+
+**When you detect network dependency** (any of):
+- `artifact_exec` returns `promotion_gate_network_denied: true` or `approval_required: true` because tests touch URLs/hosts
+- Test output contains `ECONNREFUSED`, `ConnectionError`, `Name or service not known`, `Network is unreachable`, `getaddrinfo failed`, `timeout` to external hosts, or HTTP 5xx from live services
+- Test source (from `artifact_inspect`) imports `requests`/`httpx`/`urllib` **and** calls them without mocks
+
+→ Return `status: "unable_to_evaluate"` immediately with a finding that tests require live network and cannot be evaluated in the sealed promotion sandbox. **Do not** return `status: "fail"` for environment/network blockers — that invites the planner to send you back in a loop.
+
+If the entire suite is network/integration-only, skip `promotion_record` and return `unable_to_evaluate` (same as “no tests”).
 
 ## Behavior
 
@@ -86,6 +102,7 @@ If the test suite consists entirely of integration tests that require live netwo
 
 These are stop conditions, not invitations to explore.
 
+- If `artifact_exec` returns `promotion_gate_network_denied` or `approval_required` for network patterns in the artifact's tests, stop immediately — return `unable_to_evaluate` (see above). **Never** wait for or seek operator approval.
 - If `artifact_exec` is rejected by CodeExecution policy, stop and report the policy mismatch. Do **not** retry with different command variants.
 - If test execution fails with `ModuleNotFoundError` / missing third-party dependency, first check whether the artifact has dependency layers (review `artifact_inspect` output for `layers` with a `mount_path`). If layers exist but imports still fail, the issue is a runtime PYTHONPATH wiring problem — not a packaging failure. In that case, record a `warning` finding describing the missing module and the layer mount paths, and set `status: "unable_to_evaluate"` rather than `fail`. If no layers exist and the artifact declares dependencies that were not packaged, that IS a packaging failure — record `status: "fail"`.
 - If `artifact_exec` fails because the artifact ref is missing, expired, or revoked, stop and report that exact issue. Do not retry with guessed artifact refs.
@@ -138,7 +155,7 @@ If you found NO tests, **do NOT call `promotion_record`**. The role is inapplica
 - **If some tests exist**: run all of them, report total/passed/failed
 - **If all tests pass**: `status = "pass"`, `evaluator_pass = true`
 - **If any test fails**: `status = "fail"`, `evaluator_pass = false`, include failure output in findings
-- **If tests require network**: return `status = "unable_to_evaluate"` with a finding describing the integration-test dependency (cannot be evaluated in sealed sandbox per P-3.10)
+- **If tests require network** (including `approval_required` / `promotion_gate_network_denied` from `artifact_exec`): return `status = "unable_to_evaluate"` with a finding describing the integration-test dependency (P-3.10). Do **not** call `promotion_record`.
 - **If imports fail and the artifact has dependency layers**: return `status: "unable_to_evaluate"` with a warning finding — the layers are mounted but may have a runtime wiring issue
 - **If imports fail and the artifact has NO dependency layers**: return `status: "fail"`, `evaluator_pass = false`, and state that the promoted artifact is not execution-ready for tests
 

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2057,7 +2057,7 @@ impl JsonRpcRouter {
             "artifact.list_files" => {
                 #[derive(Deserialize)]
                 struct ArtifactListParams {
-                    artifact_id: String,
+                    artifact_ref: String,
                 }
                 let params: ArtifactListParams = match serde_json::from_value(req.params) {
                     Ok(v) => v,
@@ -2080,7 +2080,38 @@ impl JsonRpcRouter {
                         );
                     }
                 };
-                match store.inspect(&params.artifact_id) {
+                let artifact_id = if params.artifact_ref.starts_with("art_") {
+                    params.artifact_ref.clone()
+                } else {
+                    let gw_store = match self.execution.gateway_store() {
+                        Some(s) => s,
+                        None => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                "Gateway store not available for ref resolution".to_string(),
+                            );
+                        }
+                    };
+                    match gw_store.resolve_artifact_ref_any_scope(&params.artifact_ref, "") {
+                        Ok(Some(rec)) => rec.artifact_id,
+                        Ok(None) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                format!("artifact ref '{}' not found or expired", params.artifact_ref),
+                            );
+                        }
+                        Err(e) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                format!("artifact ref resolution failed: {}", e),
+                            );
+                        }
+                    }
+                };
+                match store.inspect(&artifact_id) {
                     Ok(bundle) => {
                         let files: Vec<serde_json::Value> = bundle
                             .files
@@ -2097,6 +2128,7 @@ impl JsonRpcRouter {
                             req.id,
                             serde_json::json!({
                                 "artifact_id": bundle.artifact_id,
+                                "artifact_ref": params.artifact_ref,
                                 "kind": format!("{:?}", bundle.kind),
                                 "files": files,
                                 "created_at": bundle.created_at,
@@ -2114,7 +2146,7 @@ impl JsonRpcRouter {
             "artifact.read_file" => {
                 #[derive(Deserialize)]
                 struct ArtifactReadParams {
-                    artifact_id: String,
+                    artifact_ref: String,
                     file_name: String,
                 }
                 let params: ArtifactReadParams = match serde_json::from_value(req.params) {
@@ -2138,7 +2170,38 @@ impl JsonRpcRouter {
                         );
                     }
                 };
-                match store.inspect(&params.artifact_id) {
+                let artifact_id = if params.artifact_ref.starts_with("art_") {
+                    params.artifact_ref.clone()
+                } else {
+                    let gw_store = match self.execution.gateway_store() {
+                        Some(s) => s,
+                        None => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                "Gateway store not available for ref resolution".to_string(),
+                            );
+                        }
+                    };
+                    match gw_store.resolve_artifact_ref_any_scope(&params.artifact_ref, "") {
+                        Ok(Some(rec)) => rec.artifact_id,
+                        Ok(None) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                format!("artifact ref '{}' not found or expired", params.artifact_ref),
+                            );
+                        }
+                        Err(e) => {
+                            return JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                format!("artifact ref resolution failed: {}", e),
+                            );
+                        }
+                    }
+                };
+                match store.inspect(&artifact_id) {
                     Ok(bundle) => {
                         let file_entry = match bundle.files.iter().find(|f| f.name == params.file_name) {
                             Some(f) => f,
@@ -2148,7 +2211,7 @@ impl JsonRpcRouter {
                                     -32000,
                                     format!(
                                         "file '{}' not found in artifact '{}'",
-                                        params.file_name, params.artifact_id
+                                        params.file_name, artifact_id
                                     ),
                                 );
                             }
@@ -2157,7 +2220,7 @@ impl JsonRpcRouter {
                             Ok(content) => JsonRpcResponse::success(
                                 req.id,
                                 serde_json::json!({
-                                    "artifact_id": params.artifact_id,
+                                    "artifact_id": artifact_id,
                                     "file_name": params.file_name,
                                     "content": content,
                                 }),

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2460,28 +2460,66 @@ impl JsonRpcRouter {
                 };
                 match store.get_approval(params.request_id.trim()) {
                     Ok(Some(approval)) => {
+                        use autonoetic_types::background::ScheduledAction;
                         let mut added_capabilities = Vec::new();
                         let mut broadened_capabilities = Vec::new();
-                        if let autonoetic_types::background::ScheduledAction::RevisionPromote {
-                            added_capabilities: added,
-                            broadened_capabilities: broadened,
-                            ..
-                        } = &approval.action
-                        {
-                            added_capabilities = added.clone();
-                            broadened_capabilities = broadened.clone();
+                        let mut extra = serde_json::Map::new();
+                        match &approval.action {
+                            ScheduledAction::RevisionPromote {
+                                added_capabilities: added,
+                                broadened_capabilities: broadened,
+                                agent_id,
+                                revision_id,
+                                ..
+                            } => {
+                                added_capabilities = added.clone();
+                                broadened_capabilities = broadened.clone();
+                                extra.insert("agent_id".into(), serde_json::json!(agent_id));
+                                extra.insert("revision_id".into(), serde_json::json!(revision_id));
+                            }
+                            ScheduledAction::SessionEscalate {
+                                session_id,
+                                root_session_id,
+                                requested_by_agent_id,
+                                reason,
+                                context,
+                                urgency,
+                                suggested_actions,
+                                ..
+                            } => {
+                                extra.insert("reason".into(), serde_json::json!(reason));
+                                extra.insert("urgency".into(), serde_json::json!(urgency));
+                                extra.insert("session_id".into(), serde_json::json!(session_id));
+                                extra.insert("root_session_id".into(), serde_json::json!(root_session_id));
+                                extra.insert(
+                                    "requested_by_agent_id".into(),
+                                    serde_json::json!(requested_by_agent_id),
+                                );
+                                extra.insert("context".into(), serde_json::json!(context));
+                                extra.insert(
+                                    "suggested_actions".into(),
+                                    serde_json::json!(suggested_actions),
+                                );
+                            }
+                            _ => {}
                         }
-                        JsonRpcResponse::success(
-                            req.id,
-                            serde_json::json!({
-                                "request_id": approval.request_id,
-                                "status": approval.status.as_ref().map(|s| s.as_str()),
-                                "action": approval.action.kind(),
-                                "confirm_phrase": approval.confirm_phrase,
-                                "added_capabilities": added_capabilities,
-                                "broadened_capabilities": broadened_capabilities,
-                            }),
-                        )
+                        let mut body = serde_json::json!({
+                            "request_id": approval.request_id,
+                            "status": approval.status.as_ref().map(|s| s.as_str()),
+                            "action": approval.action.kind(),
+                            "approval_level": approval.approval_level.to_config(),
+                            "confirm_phrase": approval.confirm_phrase,
+                            "summary": approval.reason,
+                            "risk_summary": approval.risk_summary,
+                            "added_capabilities": added_capabilities,
+                            "broadened_capabilities": broadened_capabilities,
+                        });
+                        if let Some(obj) = body.as_object_mut() {
+                            for (k, v) in extra {
+                                obj.insert(k, v);
+                            }
+                        }
+                        JsonRpcResponse::success(req.id, body)
                     }
                     Ok(None) => JsonRpcResponse::error(
                         req.id,

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2054,6 +2054,129 @@ impl JsonRpcRouter {
                 )
             }
 
+            "artifact.list_files" => {
+                #[derive(Deserialize)]
+                struct ArtifactListParams {
+                    artifact_id: String,
+                }
+                let params: ArtifactListParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for artifact.list_files: {}", e),
+                        );
+                    }
+                };
+                let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
+                let store = match crate::artifact_store::ArtifactStore::new(&gateway_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("artifact store open failed: {}", e),
+                        );
+                    }
+                };
+                match store.inspect(&params.artifact_id) {
+                    Ok(bundle) => {
+                        let files: Vec<serde_json::Value> = bundle
+                            .files
+                            .iter()
+                            .map(|f| {
+                                serde_json::json!({
+                                    "name": f.name,
+                                    "handle": f.handle,
+                                    "alias": f.alias,
+                                })
+                            })
+                            .collect();
+                        JsonRpcResponse::success(
+                            req.id,
+                            serde_json::json!({
+                                "artifact_id": bundle.artifact_id,
+                                "kind": format!("{:?}", bundle.kind),
+                                "files": files,
+                                "created_at": bundle.created_at,
+                            }),
+                        )
+                    }
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("artifact.list_files failed: {}", e),
+                    ),
+                }
+            }
+
+            "artifact.read_file" => {
+                #[derive(Deserialize)]
+                struct ArtifactReadParams {
+                    artifact_id: String,
+                    file_name: String,
+                }
+                let params: ArtifactReadParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for artifact.read_file: {}", e),
+                        );
+                    }
+                };
+                let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
+                let store = match crate::artifact_store::ArtifactStore::new(&gateway_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("artifact store open failed: {}", e),
+                        );
+                    }
+                };
+                match store.inspect(&params.artifact_id) {
+                    Ok(bundle) => {
+                        let file_entry = match bundle.files.iter().find(|f| f.name == params.file_name) {
+                            Some(f) => f,
+                            None => {
+                                return JsonRpcResponse::error(
+                                    req.id,
+                                    -32000,
+                                    format!(
+                                        "file '{}' not found in artifact '{}'",
+                                        params.file_name, params.artifact_id
+                                    ),
+                                );
+                            }
+                        };
+                        match store.content_store().read_string(&file_entry.handle) {
+                            Ok(content) => JsonRpcResponse::success(
+                                req.id,
+                                serde_json::json!({
+                                    "artifact_id": params.artifact_id,
+                                    "file_name": params.file_name,
+                                    "content": content,
+                                }),
+                            ),
+                            Err(e) => JsonRpcResponse::error(
+                                req.id,
+                                -32000,
+                                format!("artifact.read_file failed: {}", e),
+                            ),
+                        }
+                    }
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("artifact.read_file failed: {}", e),
+                    ),
+                }
+            }
+
             "gate.get_messages" => {
                 #[derive(Deserialize)]
                 struct GetMessagesParams {
@@ -2173,6 +2296,10 @@ impl JsonRpcRouter {
                     #[serde(default)]
                     secrets: Option<Vec<(String, String)>>,
                     approver_level: Option<String>,
+                    #[serde(default)]
+                    confirm_phrase: Option<String>,
+                    #[serde(default)]
+                    acknowledged_capabilities: Vec<String>,
                 }
 
                 let params: ApproveParams = match serde_json::from_value(req.params) {
@@ -2207,7 +2334,7 @@ impl JsonRpcRouter {
                     _ => autonoetic_types::background::ApprovalLevel::Operator,
                 });
 
-                match crate::scheduler::approve_request(
+                match crate::scheduler::approve_request_with_options(
                     config.as_ref(),
                     store.as_deref(),
                     params.request_id.trim(),
@@ -2216,6 +2343,11 @@ impl JsonRpcRouter {
                     params.secrets,
                     level.as_ref(),
                     Some(hooks.as_ref()),
+                    crate::scheduler::ApproveOptions {
+                        acknowledged_capabilities: params.acknowledged_capabilities,
+                        confirm_phrase: params.confirm_phrase,
+                        ..Default::default()
+                    },
                 ) {
                     Ok(decision) => {
                         self.transition_async_to_processing(
@@ -2234,6 +2366,69 @@ impl JsonRpcRouter {
                         req.id,
                         -32000,
                         format!("Approval failed: {}", e),
+                    ),
+                }
+            }
+
+            "approvals.inspect" => {
+                #[derive(Deserialize)]
+                struct InspectParams {
+                    request_id: String,
+                }
+                let params: InspectParams = match serde_json::from_value(req.params) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for approvals.inspect: {}", e),
+                        );
+                    }
+                };
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "GatewayStore not available",
+                        );
+                    }
+                };
+                match store.get_approval(params.request_id.trim()) {
+                    Ok(Some(approval)) => {
+                        let mut added_capabilities = Vec::new();
+                        let mut broadened_capabilities = Vec::new();
+                        if let autonoetic_types::background::ScheduledAction::RevisionPromote {
+                            added_capabilities: added,
+                            broadened_capabilities: broadened,
+                            ..
+                        } = &approval.action
+                        {
+                            added_capabilities = added.clone();
+                            broadened_capabilities = broadened.clone();
+                        }
+                        JsonRpcResponse::success(
+                            req.id,
+                            serde_json::json!({
+                                "request_id": approval.request_id,
+                                "status": approval.status.as_ref().map(|s| s.as_str()),
+                                "action": approval.action.kind(),
+                                "confirm_phrase": approval.confirm_phrase,
+                                "added_capabilities": added_capabilities,
+                                "broadened_capabilities": broadened_capabilities,
+                            }),
+                        )
+                    }
+                    Ok(None) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("Approval not found: {}", params.request_id.trim()),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("approvals.inspect failed: {}", e),
                     ),
                 }
             }

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2058,6 +2058,8 @@ impl JsonRpcRouter {
                 #[derive(Deserialize)]
                 struct ArtifactListParams {
                     artifact_ref: String,
+                    #[serde(default)]
+                    session_id: String,
                 }
                 let params: ArtifactListParams = match serde_json::from_value(req.params) {
                     Ok(v) => v,
@@ -2093,7 +2095,7 @@ impl JsonRpcRouter {
                             );
                         }
                     };
-                    match gw_store.resolve_artifact_ref_any_scope(&params.artifact_ref, "") {
+                    match gw_store.resolve_artifact_ref_any_scope(&params.artifact_ref, &params.session_id) {
                         Ok(Some(rec)) => rec.artifact_id,
                         Ok(None) => {
                             return JsonRpcResponse::error(
@@ -2148,6 +2150,8 @@ impl JsonRpcRouter {
                 struct ArtifactReadParams {
                     artifact_ref: String,
                     file_name: String,
+                    #[serde(default)]
+                    session_id: String,
                 }
                 let params: ArtifactReadParams = match serde_json::from_value(req.params) {
                     Ok(v) => v,
@@ -2183,7 +2187,7 @@ impl JsonRpcRouter {
                             );
                         }
                     };
-                    match gw_store.resolve_artifact_ref_any_scope(&params.artifact_ref, "") {
+                    match gw_store.resolve_artifact_ref_any_scope(&params.artifact_ref, &params.session_id) {
                         Ok(Some(rec)) => rec.artifact_id,
                         Ok(None) => {
                             return JsonRpcResponse::error(

--- a/autonoetic-gateway/src/runtime/continuation.rs
+++ b/autonoetic-gateway/src/runtime/continuation.rs
@@ -675,6 +675,55 @@ pub fn execute_approved_action(
             )
         }
 
+        ScheduledAction::RevisionPromote {
+            agent_id,
+            revision_id,
+            ..
+        } => {
+            let mut args = if let Some(pending) = pending_tool_call {
+                if pending.tool_name == "agent_revision_promote" {
+                    match serde_json::from_str::<serde_json::Value>(&pending.arguments) {
+                        Ok(serde_json::Value::Object(map)) => map,
+                        _ => serde_json::Map::new(),
+                    }
+                } else {
+                    serde_json::Map::new()
+                }
+            } else {
+                serde_json::Map::new()
+            };
+            if !args.contains_key("agent_id") {
+                args.insert("agent_id".to_string(), serde_json::json!(agent_id));
+            }
+            if !args.contains_key("revision_id") {
+                args.insert("revision_id".to_string(), serde_json::json!(revision_id));
+            }
+            args.insert(
+                "approval_ref".to_string(),
+                serde_json::json!(decision.request_id),
+            );
+            tracing::info!(
+                target: "continuation",
+                request_id = %decision.request_id,
+                agent_id = %agent_id,
+                revision_id = %revision_id,
+                "Executing approved agent_revision_promote action"
+            );
+            registry.execute(
+                "agent_revision_promote",
+                manifest,
+                &policy,
+                agent_dir,
+                gateway_dir,
+                &serde_json::Value::Object(args).to_string(),
+                session_id,
+                None,
+                Some(config),
+                gateway_store,
+                None,
+            )
+        }
+
         other => {
             anyhow::bail!(
                 "execute_approved_action: unsupported ScheduledAction variant {:?}",

--- a/autonoetic-gateway/src/runtime/human_gate.rs
+++ b/autonoetic-gateway/src/runtime/human_gate.rs
@@ -851,47 +851,6 @@ impl GateService {
 
         self.store.create_approval(&mut approval_req)?;
 
-        // Surface the gate on the canonical timeline as an `attention` ask
-        // addressed to the operator (#363 P1, RFC §3.5).
-        let role = crate::runtime::session_timeline::derive_role(&approval_req.agent_id);
-        let principal = autonoetic_types::principal::Principal::agent(approval_req.agent_id.clone());
-        let refs = autonoetic_types::session_timeline::TimelineRefs {
-            approval_request_id: Some(request_id.clone()),
-            ..Default::default()
-        };
-        let mut payload = serde_json::json!({
-            "request_id": request_id,
-            "approval_level": approval_req.approval_level.to_config(),
-            "action": action.kind(),
-        });
-        if let ScheduledAction::WikiProposal { page_id, title, content_sha256, tags, .. } = action {
-            if let Some(obj) = payload.as_object_mut() {
-                obj.insert("page_id".into(), serde_json::json!(page_id));
-                obj.insert("title".into(), serde_json::json!(title));
-                if let Some(sha) = content_sha256 {
-                    obj.insert("content_sha256".into(), serde_json::json!(sha));
-                }
-                obj.insert("tags".into(), serde_json::json!(tags));
-            }
-        }
-        let event = crate::runtime::session_timeline::build_timeline_event(
-            approval_req
-                .root_session_id
-                .clone()
-                .unwrap_or_else(|| approval_req.session_id.clone()),
-            approval_req.session_id.clone(),
-            req.turn_id.map(str::to_string),
-            &principal,
-            &role,
-            "approval.pending",
-            None,
-            Some(payload),
-            refs,
-        );
-        if let Err(e) = self.store.create_live_digest_event(&event) {
-            tracing::debug!(target: "session_timeline", error = %e, "approval.pending timeline emit failed");
-        }
-
         Ok(request_id)
     }
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1265,8 +1265,28 @@ impl AgentExecutor {
             .manifest
             .llm_config
             .as_ref()
-            .map(|c| c.model.clone())
-            .unwrap_or_else(|| "gpt-4o".to_string());
+            .and_then(|c| {
+                // If the model is explicitly set, use it.
+                // Otherwise try to derive one from the routing preset's first model.
+                if !c.model.is_empty() && c.model != "unknown" {
+                    Some(c.model.clone())
+                } else {
+                    c.routing_preset.as_ref().and_then(|preset_name| {
+                        self.config
+                            .as_ref()
+                            .and_then(|cfg| cfg.llm_presets.get(preset_name))
+                            .and_then(|preset| preset.routing.as_ref())
+                            .and_then(|routing| routing.models.first())
+                            .and_then(|first_model_name| {
+                                self.config
+                                    .as_ref()
+                                    .and_then(|cfg| cfg.llm_presets.get(first_model_name))
+                                    .and_then(|fixed| fixed.model.clone())
+                            })
+                    })
+                }
+            })
+            .unwrap_or_else(|| "unknown".to_string());
         let temperature = self
             .manifest
             .llm_config

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -158,6 +158,11 @@ pub fn emit_approval_pending_timeline_event(
             );
         }
     }
+    if let Some(phrase) = approval.confirm_phrase.as_ref().filter(|p| !p.is_empty()) {
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("confirm_phrase".into(), serde_json::Value::String(phrase.clone()));
+        }
+    }
     let event = build_timeline_event(
         root,
         approval.session_id.clone(),

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -78,12 +78,22 @@ pub fn approval_timeline_extra_from_action(
             "host_patterns": detected_hosts,
         })),
         ScheduledAction::SessionEscalate {
+            session_id,
+            root_session_id,
+            requested_by_agent_id,
             reason,
+            context,
             urgency,
+            suggested_actions,
             ..
         } => Some(serde_json::json!({
             "reason": reason,
             "urgency": urgency,
+            "session_id": session_id,
+            "root_session_id": root_session_id,
+            "requested_by_agent_id": requested_by_agent_id,
+            "context": context,
+            "suggested_actions": suggested_actions,
         })),
         ScheduledAction::RevisionPromote {
             agent_id,

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -50,6 +50,193 @@ pub fn build_timeline_event(
     }
 }
 
+/// Optional structured fields for an `approval.pending` timeline payload, derived
+/// from the persisted `ScheduledAction`.
+pub fn approval_timeline_extra_from_action(
+    action: &autonoetic_types::background::ScheduledAction,
+) -> Option<serde_json::Value> {
+    use autonoetic_types::background::ScheduledAction;
+    match action {
+        ScheduledAction::WikiProposal {
+            page_id,
+            title,
+            content_sha256,
+            tags,
+            ..
+        } => Some(serde_json::json!({
+            "page_id": page_id,
+            "title": title,
+            "content_sha256": content_sha256,
+            "tags": tags,
+        })),
+        ScheduledAction::SandboxExec {
+            command,
+            detected_hosts,
+            ..
+        } => Some(serde_json::json!({
+            "command": command,
+            "host_patterns": detected_hosts,
+        })),
+        ScheduledAction::SessionEscalate {
+            reason,
+            urgency,
+            ..
+        } => Some(serde_json::json!({
+            "reason": reason,
+            "urgency": urgency,
+        })),
+        ScheduledAction::RevisionPromote {
+            agent_id,
+            revision_id,
+            added_capabilities,
+            broadened_capabilities,
+            ..
+        } => Some(serde_json::json!({
+            "agent_id": agent_id,
+            "revision_id": revision_id,
+            "added_capabilities": added_capabilities,
+            "broadened_capabilities": broadened_capabilities,
+        })),
+        ScheduledAction::ProfileShare {
+            user_id,
+            scope,
+            ..
+        } => Some(serde_json::json!({
+            "user_id": user_id,
+            "scope": scope,
+        })),
+        ScheduledAction::SessionContinue {
+            max_turns,
+            turn_counter,
+            ..
+        } => Some(serde_json::json!({
+            "max_turns": max_turns,
+            "turn_counter": turn_counter,
+        })),
+        _ => None,
+    }
+}
+
+/// Emit `approval.pending` on the canonical timeline after persisting an approval row.
+///
+/// The Room TUI resolves gates from timeline events, not from the `approvals`
+/// table alone (#363). `GatewayStore::create_approval` invokes this automatically.
+pub fn emit_approval_pending_timeline_event(
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    approval: &autonoetic_types::background::ApprovalRequest,
+    turn_id: Option<&str>,
+) {
+    let action_label = approval.action.kind();
+    let extra_payload = approval_timeline_extra_from_action(&approval.action);
+    let root = approval
+        .root_session_id
+        .clone()
+        .unwrap_or_else(|| approval.session_id.clone());
+    let role = derive_role(&approval.agent_id);
+    let principal = autonoetic_types::principal::Principal::agent(approval.agent_id.clone());
+    let refs = TimelineRefs {
+        approval_request_id: Some(approval.request_id.clone()),
+        ..Default::default()
+    };
+    let mut payload = serde_json::json!({
+        "request_id": approval.request_id,
+        "approval_level": approval.approval_level.to_config(),
+        "action": action_label,
+    });
+    if let Some(extra) = extra_payload {
+        if let (Some(obj), Some(extra_obj)) = (payload.as_object_mut(), extra.as_object()) {
+            for (k, v) in extra_obj {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    if let Some(reason) = approval.reason.as_ref().filter(|r| !r.is_empty()) {
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert(
+                "summary".into(),
+                serde_json::Value::String(crate::log_redaction::redact_text_for_logs(reason)),
+            );
+        }
+    }
+    let event = build_timeline_event(
+        root,
+        approval.session_id.clone(),
+        turn_id.map(str::to_string),
+        &principal,
+        &role,
+        "approval.pending",
+        None,
+        Some(payload),
+        refs,
+    );
+    if let Err(e) = store.create_live_digest_event(&event) {
+        tracing::debug!(
+            target: "session_timeline",
+            error = %e,
+            request_id = %approval.request_id,
+            "approval.pending timeline emit failed"
+        );
+    }
+}
+
+/// Emit `user.ask.pending` on the canonical timeline after persisting an interaction.
+///
+/// `GatewayStore::create_user_interaction` invokes this automatically so every
+/// clarification path is visible in the Room TUI (#363).
+pub fn emit_user_ask_pending_timeline_event(
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    interaction: &autonoetic_types::background::UserInteraction,
+) {
+    let root = if interaction.root_session_id.is_empty() {
+        crate::runtime::content_store::root_session_id(&interaction.session_id).to_string()
+    } else {
+        interaction.root_session_id.clone()
+    };
+    let role = derive_role(&interaction.agent_id);
+    let principal = autonoetic_types::principal::Principal::agent(interaction.agent_id.clone());
+    let refs = TimelineRefs {
+        interaction_id: Some(interaction.interaction_id.clone()),
+        ..Default::default()
+    };
+    let options_for_event: Vec<serde_json::Value> = interaction
+        .options
+        .iter()
+        .map(|o| {
+            serde_json::json!({
+                "id": o.id,
+                "label": o.label,
+            })
+        })
+        .collect();
+    let payload = serde_json::json!({
+        "interaction_id": interaction.interaction_id,
+        "question": crate::log_redaction::redact_text_for_logs(&interaction.question),
+        "kind": interaction.kind.as_str(),
+        "options_count": interaction.options.len(),
+        "options": options_for_event,
+        "allow_freeform": interaction.allow_freeform,
+    });
+    let event = build_timeline_event(
+        root,
+        interaction.session_id.clone(),
+        Some(interaction.turn_id.clone()).filter(|t| !t.is_empty() && t != "unknown"),
+        &principal,
+        &role,
+        "user.ask.pending",
+        None,
+        Some(payload),
+        refs,
+    );
+    if let Err(e) = store.create_live_digest_event(&event) {
+        tracing::debug!(
+            target: "session_timeline",
+            error = %e,
+            interaction_id = %interaction.interaction_id,
+            "user.ask.pending timeline emit failed"
+        );
+    }
+}
+
 /// Build the `operator.message` timeline event for an operator-originated chat
 /// message into a session (#405) — so channels show both sides of the
 /// conversation, not just agent replies. Attribution: a human chat (no
@@ -391,6 +578,95 @@ mod tests {
         assert_eq!(
             altitude_for("turn.start", &SessionRole::Planner),
             Altitude::Detail
+        );
+    }
+
+    #[test]
+    fn create_approval_emits_approval_pending_timeline_event() {
+        use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
+
+        let temp = tempfile::tempdir().unwrap();
+        let store = crate::scheduler::gateway_store::GatewayStore::open(temp.path()).unwrap();
+        let mut approval = ApprovalRequest {
+            request_id: "apr-test01".to_string(),
+            agent_id: "unit_test_runner.default".to_string(),
+            session_id: "root/unit_test_runner-abc".to_string(),
+            root_session_id: Some("root".to_string()),
+            workflow_id: None,
+            task_id: None,
+            action: ScheduledAction::SandboxExec {
+                command: "python3 test.py".to_string(),
+                dependencies: None,
+                requires_approval: true,
+                evidence_ref: None,
+                detected_hosts: None,
+            },
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            reason: Some("run tests".to_string()),
+            evidence_ref: None,
+            decision_reason: None,
+            approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+            code_excerpts: None,
+            risk_summary: None,
+        };
+        store.create_approval(&mut approval).unwrap();
+        let page = store
+            .list_session_timeline("root", None, 10, None, None)
+            .unwrap();
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(page.entries[0].event_type, "approval.pending");
+        assert_eq!(
+            page.entries[0].refs.approval_request_id.as_deref(),
+            Some("apr-test01")
+        );
+    }
+
+    #[test]
+    fn create_user_interaction_emits_user_ask_pending_timeline_event() {
+        use autonoetic_types::background::{
+            UserInteraction, UserInteractionKind, UserInteractionStatus,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let store = crate::scheduler::gateway_store::GatewayStore::open(temp.path()).unwrap();
+        let interaction = UserInteraction {
+            interaction_id: "ui-test01".to_string(),
+            session_id: "root/planner-abc".to_string(),
+            root_session_id: "root".to_string(),
+            workflow_id: None,
+            task_id: None,
+            agent_id: "planner.default".to_string(),
+            turn_id: "turn-000002".to_string(),
+            kind: UserInteractionKind::Clarification,
+            question: "Which API should I use?".to_string(),
+            context: None,
+            options: vec![],
+            allow_freeform: true,
+            status: UserInteractionStatus::Pending,
+            answer_option_id: None,
+            answer_text: None,
+            answered_by: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            answered_at: None,
+            expires_at: None,
+            checkpoint_turn_id: Some("turn-000002".to_string()),
+        };
+        store.create_user_interaction(&interaction).unwrap();
+        let page = store
+            .list_session_timeline("root", None, 10, None, None)
+            .unwrap();
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(page.entries[0].event_type, "user.ask.pending");
+        assert_eq!(
+            page.entries[0].refs.interaction_id.as_deref(),
+            Some("ui-test01")
         );
     }
 

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -900,8 +900,9 @@ impl SessionTracer {
             "result_sha256": sha256_hex(result),
             "result_preview": redact_text_for_logs(&truncate_for_log(result, TOOL_RESULT_PREVIEW_MAX_CHARS))
         });
-        if let Some(args_preview) = arguments.and_then(|a| extract_tool_args_preview(tool_name, a)) {
-            completed_payload["args_preview"] = serde_json::json!(args_preview);
+        let args_preview = arguments.and_then(|a| extract_tool_args_preview(tool_name, a));
+        if let Some(ref preview) = args_preview {
+            completed_payload["args_preview"] = serde_json::json!(preview);
         }
         if let Some(enforced_rules) = parsed_result
             .as_ref()
@@ -1022,13 +1023,16 @@ impl SessionTracer {
                 }
             }
         }
-        self.append_live_digest_event(
-            "tool.completed",
-            Some(serde_json::json!({
-                "tool_name": tool_name,
-                "result": crate::log_redaction::redact_text_for_logs(result)
-            })),
-        );
+        // Room TUI reads the canonical timeline — carry the same args_preview the
+        // causal row stores so list rows can show artifact_ref / name / agent_id.
+        let mut timeline_payload = serde_json::json!({
+            "tool_name": tool_name,
+            "result": crate::log_redaction::redact_text_for_logs(result),
+        });
+        if let Some(preview) = args_preview {
+            timeline_payload["args_preview"] = serde_json::json!(preview);
+        }
+        self.append_live_digest_event("tool.completed", Some(timeline_payload));
         Ok(event_id)
     }
 
@@ -1345,6 +1349,69 @@ mod tests {
         assert!(!should_force_tool_result_evidence(
             r#"{"ok":true,"exit_code":0,"stdout":"all good"}"#
         ));
+    }
+
+    #[test]
+    fn tool_completed_timeline_includes_args_preview() {
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let agent_dir = agents_dir.join("planner.default");
+        let gateway_dir = agents_dir.join(".gateway");
+        fs::create_dir_all(agent_dir.join("history")).unwrap();
+        fs::create_dir_all(&gateway_dir).unwrap();
+        let store = std::sync::Arc::new(
+            crate::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+        );
+        let mut tracer = SessionTracer::test_tracer_with_store(&agent_dir, store.clone());
+        tracer.set_turn_id("turn-000001");
+
+        tracer
+            .log_tool_completed_with_approval(
+                "agent_spawn",
+                r#"{"accepted":true,"agent_id":"coder.default"}"#,
+                Some(r#"{"agent_id":"coder.default","message":"implement feature"}"#),
+                None,
+            )
+            .unwrap();
+
+        let result = store
+            .list_session_timeline("test-session", None, 10, None, None)
+            .unwrap();
+        let completed = result
+            .entries
+            .iter()
+            .find(|e| e.event_type == "tool.completed")
+            .expect("tool.completed on timeline");
+        let payload: serde_json::Value =
+            serde_json::from_str(completed.payload.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            payload.get("args_preview").and_then(|v| v.as_str()),
+            Some("coder.default")
+        );
+    }
+
+    #[test]
+    fn extract_tool_args_preview_for_known_tools() {
+        assert_eq!(
+            extract_tool_args_preview(
+                "content_write",
+                r#"{"name":"skills/weather/SKILL.md","content":"..."}"#
+            )
+            .as_deref(),
+            Some("skills/weather/SKILL.md")
+        );
+        assert_eq!(
+            extract_tool_args_preview(
+                "agent_spawn",
+                r#"{"agent_id":"researcher.default","message":"find APIs"}"#
+            )
+            .as_deref(),
+            Some("researcher.default")
+        );
+        assert_eq!(
+            extract_tool_args_preview("spawn", r#"{"agent_id":"coder.default"}"#),
+            None
+        );
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -900,7 +900,17 @@ impl SessionTracer {
             "result_sha256": sha256_hex(result),
             "result_preview": redact_text_for_logs(&truncate_for_log(result, TOOL_RESULT_PREVIEW_MAX_CHARS))
         });
-        let args_preview = arguments.and_then(|a| extract_tool_args_preview(tool_name, a));
+        let args_preview = arguments.and_then(|a| extract_tool_args_preview(tool_name, a))
+            .or_else(|| {
+                if tool_name == "artifact_build" {
+                    parsed_result.as_ref()
+                        .and_then(|r| r.get("artifact_ref"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
+            });
         if let Some(ref preview) = args_preview {
             completed_payload["args_preview"] = serde_json::json!(preview);
         }

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -883,13 +883,14 @@ impl SessionTracer {
     }
 
     pub fn log_tool_completed(&mut self, tool_name: &str, result: &str) -> anyhow::Result<String> {
-        self.log_tool_completed_with_approval(tool_name, result, None)
+        self.log_tool_completed_with_approval(tool_name, result, None, None)
     }
 
     pub fn log_tool_completed_with_approval(
         &mut self,
         tool_name: &str,
         result: &str,
+        arguments: Option<&str>,
         approval_ref: Option<&str>,
     ) -> anyhow::Result<String> {
         let parsed_result = serde_json::from_str::<serde_json::Value>(result).ok();
@@ -899,6 +900,9 @@ impl SessionTracer {
             "result_sha256": sha256_hex(result),
             "result_preview": redact_text_for_logs(&truncate_for_log(result, TOOL_RESULT_PREVIEW_MAX_CHARS))
         });
+        if let Some(args_preview) = arguments.and_then(|a| extract_tool_args_preview(tool_name, a)) {
+            completed_payload["args_preview"] = serde_json::json!(args_preview);
+        }
         if let Some(enforced_rules) = parsed_result
             .as_ref()
             .and_then(|v| v.get("enforced_rules"))
@@ -1145,6 +1149,26 @@ fn cap_chars(value: &str, max: usize) -> String {
     }
     let truncated: String = value.chars().take(max - 1).collect();
     format!("{truncated}…")
+}
+
+/// Extract a short preview of the key argument for known tools.
+/// Returned string is the argument value, which is small (artifact ref, file name,
+/// agent id) and does not need truncation.
+fn extract_tool_args_preview(tool_name: &str, arguments: &str) -> Option<String> {
+    let args: serde_json::Value = serde_json::from_str(arguments).ok()?;
+    let preview = match tool_name {
+        "artifact_inspect" => args.get("artifact_ref").and_then(|v| v.as_str()),
+        "content_write" => args.get("name").and_then(|v| v.as_str()),
+        "agent_spawn" => args.get("agent_id").and_then(|v| v.as_str()),
+        _ => return None,
+    };
+    preview.map(|s| {
+        if s.len() > 80 {
+            format!("{}…", &s[..79])
+        } else {
+            s.to_string()
+        }
+    })
 }
 
 fn sanitize_token(value: &str) -> String {

--- a/autonoetic-gateway/src/runtime/tool_call_processor.rs
+++ b/autonoetic-gateway/src/runtime/tool_call_processor.rs
@@ -167,14 +167,15 @@ impl<'a> ToolCallProcessor<'a> {
                     continue;
                 }
             };
-            tracer.log_tool_requested(&tc.name, &tc.arguments, intent.as_deref())?;
+            let canonical_tool = Self::canonical_tool_name(&tc.name);
+            tracer.log_tool_requested(canonical_tool, &tc.arguments, intent.as_deref())?;
 
             // Execute tool call, handling errors appropriately
             let result = match self.execute_tool_call(tc, agent_dir, gateway_dir).await {
                 Ok(res) => {
                     let res = normalize_tool_result_json(&res);
                     let event_id = tracer.log_tool_completed_with_approval(
-                        &tc.name,
+                        canonical_tool,
                         &res,
                         Some(&tc.arguments),
                         approval_ref.as_deref(),
@@ -210,7 +211,7 @@ impl<'a> ToolCallProcessor<'a> {
                         ));
                     }
                     let event_id = tracer.log_tool_completed_with_approval(
-                        &tc.name,
+                        canonical_tool,
                         &error_json,
                         Some(&tc.arguments),
                         approval_ref.as_deref(),

--- a/autonoetic-gateway/src/runtime/tool_call_processor.rs
+++ b/autonoetic-gateway/src/runtime/tool_call_processor.rs
@@ -176,6 +176,7 @@ impl<'a> ToolCallProcessor<'a> {
                     let event_id = tracer.log_tool_completed_with_approval(
                         &tc.name,
                         &res,
+                        Some(&tc.arguments),
                         approval_ref.as_deref(),
                     )?;
                     self.record_execution_trace(
@@ -211,6 +212,7 @@ impl<'a> ToolCallProcessor<'a> {
                     let event_id = tracer.log_tool_completed_with_approval(
                         &tc.name,
                         &error_json,
+                        Some(&tc.arguments),
                         approval_ref.as_deref(),
                     )?;
                     self.record_execution_trace(

--- a/autonoetic-gateway/src/runtime/tools/agent.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent.rs
@@ -368,6 +368,25 @@ impl NativeTool for AgentSpawnTool {
             Some(source_agent_id.as_str()),
         )?;
         let workflow_id = workflow.workflow_id.clone();
+
+        if let Some(gate) = crate::scheduler::workflow_approval_gate_active(
+            gw_config,
+            gateway_store.as_deref(),
+            &workflow_id,
+        )? {
+            let approval_ids = if gate.pending_approval_request_ids.is_empty() {
+                "see awaiting task(s)".to_string()
+            } else {
+                gate.pending_approval_request_ids.join(", ")
+            };
+            return Err(anyhow::anyhow!(
+                "Cannot delegate (agent.spawn): workflow {} has task(s) awaiting operator approval. Awaiting task id(s): {}. Pending approval request id(s): {}. Resolve with `autonoetic gateway approvals approve|reject <id> --config <path>` before spawning new tasks.",
+                gate.workflow_id,
+                gate.awaiting_task_ids.join(", "),
+                approval_ids,
+            ));
+        }
+
         let task_id = crate::scheduler::new_task_id();
         let target_agent_id = args.agent_id.clone();
 

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2314,39 +2314,6 @@ impl NativeTool for AgentRevisionPromoteTool {
                     guard.disarm();
                 }
 
-                // Emit approval.pending on the canonical timeline so the Room TUI
-                // can surface the gate (same pattern as human_gate.rs #363).
-                if let Some(root) = &root_sid {
-                    let role = crate::runtime::session_timeline::derive_role(&manifest.agent.id);
-                    let principal = autonoetic_types::principal::Principal::agent(manifest.agent.id.clone());
-                    let refs = autonoetic_types::session_timeline::TimelineRefs {
-                        approval_request_id: Some(request_id.clone()),
-                        ..Default::default()
-                    };
-                    let event = crate::runtime::session_timeline::build_timeline_event(
-                        root.clone(),
-                        session_id.unwrap_or("").to_string(),
-                        turn_id.map(str::to_string),
-                        &principal,
-                        &role,
-                        "approval.pending",
-                        None,
-                        Some(serde_json::json!({
-                            "request_id": request_id,
-                            "approval_level": approval_level.to_config(),
-                            "action": "revision_promote",
-                            "agent_id": args.agent_id,
-                            "revision_id": args.revision_id,
-                            "added_capabilities": added_capabilities,
-                            "broadened_capabilities": broadened_capabilities,
-                        })),
-                        refs,
-                    );
-                    if let Err(e) = gateway_store.create_live_digest_event(&event) {
-                        tracing::debug!(target: "session_timeline", error = %e, "approval.pending timeline emit failed for revision promote");
-                    }
-                }
-
                 return Ok(serde_json::json!({
                     "ok": false,
                     "error_type": "permission",

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -224,7 +224,7 @@ impl NativeTool for ArtifactExecTool {
         gateway_dir: Option<&Path>,
         arguments_json: &str,
         session_id: Option<&str>,
-        turn_id: Option<&str>,
+        _turn_id: Option<&str>,
         config: Option<&autonoetic_types::config::GatewayConfig>,
         gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
         run_context: Option<&NativeToolRunContext>,

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -224,7 +224,7 @@ impl NativeTool for ArtifactExecTool {
         gateway_dir: Option<&Path>,
         arguments_json: &str,
         session_id: Option<&str>,
-        _turn_id: Option<&str>,
+        turn_id: Option<&str>,
         config: Option<&autonoetic_types::config::GatewayConfig>,
         gateway_store: Option<std::sync::Arc<crate::scheduler::gateway_store::GatewayStore>>,
         run_context: Option<&NativeToolRunContext>,

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -9,8 +9,8 @@ use crate::runtime::remote_access::{
     NetworkCoverage, RemoteAccessAnalyzer,
 };
 use crate::runtime::tools::{
-    build_approval_details, load_session_content_mounts, CredentialEnvMapping, NativeTool,
-    NativeToolRegistry,
+    build_approval_details, load_session_content_mounts, promotion::manifest_may_record_promotion_verdicts,
+    CredentialEnvMapping, NativeTool, NativeToolRegistry,
 };
 use crate::sandbox::{SandboxDriverKind, SandboxMount, SandboxRunner};
 use autonoetic_types::agent::AgentManifest;
@@ -433,6 +433,18 @@ impl NativeTool for ArtifactExecTool {
         }
 
         if remote_analysis.requires_approval && !approval_validated_for_command {
+            if manifest_may_record_promotion_verdicts(manifest) {
+                return Ok(serde_json::json!({
+                    "ok": false,
+                    "exit_code": null,
+                    "stdout": "",
+                    "stderr": "Promotion-gate execution (P-3.10): artifact test run requires network access. Unit tests must be deterministic without live network.",
+                    "promotion_gate_network_denied": true,
+                    "recommendation": "unable_to_evaluate",
+                    "detected_patterns": remote_analysis.detected_patterns,
+                })
+                .to_string());
+            }
             let detected_patterns = remote_analysis.detected_patterns.clone();
             let concrete_targets = normalize_targets(&detected_patterns);
             let coverage = classify_network_coverage(&detected_patterns, concrete_targets.clone());
@@ -850,9 +862,12 @@ impl NativeTool for ArtifactExecTool {
             }
         }
 
-        let mut overrides =
-            crate::sandbox::BwrapIsolationOverrides::from_capabilities(&manifest.capabilities);
-        if approval_validated_for_command {
+        let mut overrides = if manifest_may_record_promotion_verdicts(manifest) {
+            crate::sandbox::BwrapIsolationOverrides::promotion_gate_overrides()
+        } else {
+            crate::sandbox::BwrapIsolationOverrides::from_capabilities(&manifest.capabilities)
+        };
+        if approval_validated_for_command && !manifest_may_record_promotion_verdicts(manifest) {
             overrides.share_net = true;
         }
 

--- a/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
@@ -107,7 +107,7 @@ impl NativeTool for ArtifactPrepareTool {
         gateway_dir: Option<&Path>,
         arguments_json: &str,
         session_id: Option<&str>,
-        _turn_id: Option<&str>,
+        turn_id: Option<&str>,
         config: Option<&autonoetic_types::config::GatewayConfig>,
         gateway_store: Option<Arc<GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,

--- a/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
@@ -107,7 +107,7 @@ impl NativeTool for ArtifactPrepareTool {
         gateway_dir: Option<&Path>,
         arguments_json: &str,
         session_id: Option<&str>,
-        turn_id: Option<&str>,
+        _turn_id: Option<&str>,
         config: Option<&autonoetic_types::config::GatewayConfig>,
         gateway_store: Option<Arc<GatewayStore>>,
         _run_context: Option<&NativeToolRunContext>,

--- a/autonoetic-gateway/src/runtime/tools/user_interaction.rs
+++ b/autonoetic-gateway/src/runtime/tools/user_interaction.rs
@@ -176,16 +176,19 @@ impl NativeTool for UserAskTool {
                 }
             }
 
+            let pending_approvals = store
+                .get_pending_approvals_for_root(&root_session_id)
+                .unwrap_or_default();
             let pending_interactions = store
                 .get_pending_interactions_for_root_session(&root_session_id)
                 .unwrap_or_default();
-            if !pending_interactions.is_empty() {
+            if !pending_approvals.is_empty() || !pending_interactions.is_empty() {
                 return Ok(serde_json::json!({
                     "ok": false,
                     "error_type": "conflict",
-                    "message": "user.ask is not available while interactions are pending. Resolve pending interactions before retrying.",
-                    "repair_hint": "Resolve or wait for pending interactions, then retry user.ask.",
-                    "error": "user.ask is not available while interactions are pending. Resolve pending interactions before retrying."
+                    "message": "user.ask is not available while gates are pending (approvals, interactions, or escalations). Resolve pending gates before retrying.",
+                    "repair_hint": "Resolve or wait for pending gates, then retry user.ask.",
+                    "error": "user.ask is not available while gates are pending. Resolve pending gates before retrying."
                 }).to_string());
             }
         }
@@ -221,18 +224,6 @@ impl NativeTool for UserAskTool {
                     .join("; "),
             )
         };
-        let options_count = options.len();
-        // Embed the pre-digested choices (id + label) in the timeline event so
-        // every channel can render one-tap options inline without an extra
-        // round-trip — the room is store-free and reads only the timeline (#393).
-        // Labels only (not `value`, which may be sensitive); freeform-allowed
-        // travels too so a channel knows whether to offer a text fallback.
-        let options_for_event: Vec<serde_json::Value> = options
-            .iter()
-            .map(|o| serde_json::json!({ "id": o.id, "label": o.label }))
-            .collect();
-        let allow_freeform_for_event = args.allow_freeform;
-
         let store = match gateway_store {
             Some(ref s) => s.clone(),
             None => {
@@ -306,47 +297,6 @@ impl NativeTool for UserAskTool {
                             );
                         }
                     }
-                    let ask_role =
-                        crate::runtime::session_timeline::derive_role(&_manifest.agent.id);
-                    let ask_altitude = crate::runtime::session_timeline::altitude_for(
-                        "user.ask.pending",
-                        &ask_role,
-                    );
-                    let ask_principal = autonoetic_types::principal::Principal::agent(
-                        _manifest.agent.id.clone(),
-                    );
-                    let ask_refs = autonoetic_types::session_timeline::TimelineRefs {
-                        interaction_id: Some(gate_id.clone()),
-                        ..Default::default()
-                    };
-                    let _ = store.create_live_digest_event(
-                        &crate::scheduler::gateway_store::LiveDigestEventRecord {
-                            event_id: uuid::Uuid::new_v4().to_string(),
-                            root_session_id: ctx.root_session_id.clone(),
-                            source_session_id: ctx.session_id.clone(),
-                            turn_id: turn_id.map(|s| s.to_string()),
-                            source_agent_id: Some(_manifest.agent.id.clone()),
-                            source_node_id: std::env::var("AUTONOETIC_NODE_ID")
-                                .unwrap_or_else(|_| "gateway".to_string()),
-                            event_type: "user.ask.pending".to_string(),
-                            payload: Some(
-                                serde_json::json!({
-                                    "interaction_id": gate_id,
-                                    "question": crate::log_redaction::redact_text_for_logs(&question_for_side_effects),
-                                    "options_count": options_count,
-                                    "options": options_for_event,
-                                    "allow_freeform": allow_freeform_for_event,
-                                })
-                                .to_string(),
-                            ),
-                            created_at: chrono::Utc::now().to_rfc3339(),
-                            principal_kind: Some(ask_principal.kind_to_storage()),
-                            principal_id: Some(ask_principal.id.clone()),
-                            role: Some(ask_role.to_storage()),
-                            altitude: Some(ask_altitude.as_str().to_string()),
-                            refs_json: serde_json::to_string(&ask_refs).ok(),
-                        },
-                    );
                 }
                 Ok(response_json)
             }

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -782,6 +782,8 @@ pub async fn reap_orphaned_sessions(
                 if is_terminal {
                     continue;
                 }
+                let was_awaiting_approval =
+                    task.status == autonoetic_types::workflow::TaskRunStatus::AwaitingApproval;
                 task.status = autonoetic_types::workflow::TaskRunStatus::Cancelled;
                 task.updated_at = now_rfc.clone();
                 task.result_summary = Some(
@@ -793,6 +795,19 @@ pub async fn reap_orphaned_sessions(
                     Some(store.as_ref()),
                     &task,
                 );
+                if was_awaiting_approval {
+                    let _ = crate::scheduler::approval::cancel_pending_approval_for_workflow_task(
+                        Some(store.as_ref()),
+                        &task.task_id,
+                        "gateway",
+                        "orphan_child_reaper",
+                    );
+                    let _ = crate::scheduler::workflow_store::sync_workflow_blocked_approval_status(
+                        &config,
+                        Some(store.as_ref()),
+                        &task.workflow_id,
+                    );
+                }
                 crate::scheduler::workflow_store::dequeue_task(
                     &config,
                     Some(store.as_ref()),

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -816,6 +816,7 @@ fn resume_session_after_approval(
             | autonoetic_types::background::ScheduledAction::WebFetch { .. }
             | autonoetic_types::background::ScheduledAction::WebCall { .. }
             | autonoetic_types::background::ScheduledAction::WebSearch { .. }
+            | autonoetic_types::background::ScheduledAction::RevisionPromote { .. }
     );
 
     if !is_supported_action {
@@ -948,6 +949,23 @@ fn resume_session_after_approval(
                 ),
                 ApprovalStatus::Cancelled => format!(
                     "approval_cancelled:web:{}:cancelled",
+                    decision.request_id
+                ),
+            };
+            (decision.agent_id.clone(), msg)
+        }
+        autonoetic_types::background::ScheduledAction::RevisionPromote { .. } => {
+            let msg = match decision.status {
+                ApprovalStatus::Approved => format!(
+                    "approval_resumed:revision_promote:{}:approved",
+                    decision.request_id
+                ),
+                ApprovalStatus::Rejected => format!(
+                    "approval_rejected:revision_promote:{}:rejected",
+                    decision.request_id
+                ),
+                ApprovalStatus::Cancelled => format!(
+                    "approval_cancelled:revision_promote:{}:cancelled",
                     decision.request_id
                 ),
             };
@@ -2046,6 +2064,53 @@ mod tests {
         assert!(
             pending.is_empty(),
             "workflow-bound approvals should continue through workflow re-queue only"
+        );
+    }
+
+    #[test]
+    fn revision_promote_approval_signal_prompts_agent_retry() {
+        let dir = tempdir().unwrap();
+        let agents_dir = dir.path().join("agents");
+        let gateway_dir = agents_dir.join(".gateway");
+        std::fs::create_dir_all(&gateway_dir).unwrap();
+        let cfg = GatewayConfig {
+            agents_dir,
+            ..Default::default()
+        };
+        let store = std::sync::Arc::new(
+            crate::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+        );
+
+        let decision = ApprovalDecision {
+            request_id: "apr-promote01".to_string(),
+            agent_id: "specialized_builder.default".to_string(),
+            session_id: "session-88f313bd/specialized_builder.default-c671e74b".to_string(),
+            action: ScheduledAction::RevisionPromote {
+                agent_id: "weather-lookup".to_string(),
+                revision_id: "ar-weather01".to_string(),
+                outgoing_revision_id: String::new(),
+                added_capabilities: vec!["NetworkAccess".to_string()],
+                broadened_capabilities: vec![],
+                payload: None,
+            },
+            status: ApprovalStatus::Approved,
+            decided_at: chrono::Utc::now().to_rfc3339(),
+            decided_by: "operator".to_string(),
+            reason: None,
+            workflow_id: None,
+            task_id: None,
+            root_session_id: Some("session-88f313bd".to_string()),
+            approval_level: ApprovalLevel::Operator,
+        };
+
+        super::resume_session_after_approval(&cfg, Some(store.as_ref()), &decision, None).unwrap();
+
+        let pending = store.list_pending_notifications().unwrap();
+        assert!(!pending.is_empty(), "should have created a notification");
+        let payload = &pending[0].payload;
+        assert_eq!(
+            payload.get("message").and_then(|v| v.as_str()),
+            Some("approval_resumed:revision_promote:apr-promote01:approved")
         );
     }
 

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -655,6 +655,44 @@ pub fn cancel_request(
     Ok(decision)
 }
 
+/// Withdraw a still-pending approval bound to a workflow task (e.g. task cancelled).
+pub fn cancel_pending_approval_for_workflow_task(
+    gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
+    task_id: &str,
+    cancelled_by: &str,
+    reason: &str,
+) -> anyhow::Result<Option<String>> {
+    let Some(store) = gateway_store else {
+        return Ok(None);
+    };
+    let Some(request_id) = store.get_pending_approval_request_id_for_task(task_id)? else {
+        return Ok(None);
+    };
+    let cancelled_at = chrono::Utc::now().to_rfc3339();
+    match store.cancel_approval(&request_id, cancelled_by, &cancelled_at) {
+        Ok(()) => {
+            tracing::info!(
+                target: "approval",
+                request_id = %request_id,
+                task_id = %task_id,
+                reason = %reason,
+                "Cancelled pending approval for workflow task"
+            );
+            Ok(Some(request_id))
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "approval",
+                request_id = %request_id,
+                task_id = %task_id,
+                error = %error,
+                "Failed to cancel pending approval for workflow task"
+            );
+            Ok(None)
+        }
+    }
+}
+
 fn cancel_approval_request(
     config: &GatewayConfig,
     gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -70,6 +70,10 @@ impl GatewayStore {
                 risk_summary_json,
             ],
         )?;
+        // Release the conn lock before timeline emit — create_live_digest_event
+        // re-locks the same Mutex and would deadlock otherwise.
+        drop(conn);
+        crate::runtime::session_timeline::emit_approval_pending_timeline_event(self, request, None);
         Ok(())
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -417,6 +417,17 @@ impl GatewayStore {
         .map_err(Into::into)
     }
 
+    pub fn get_pending_approval_request_id_for_task(&self, task_id: &str) -> Result<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT request_id FROM approvals WHERE task_id = ?1 AND status = 'pending' ORDER BY created_at DESC LIMIT 1",
+            params![task_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
     pub fn insert_session_grant(
         &self,
         root_session_id: &str,

--- a/autonoetic-gateway/src/scheduler/gateway_store/user_interactions.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/user_interactions.rs
@@ -44,6 +44,9 @@ impl GatewayStore {
                 interaction.checkpoint_turn_id,
             ],
         )?;
+        // Release the conn lock before timeline emit (same deadlock pattern as approvals).
+        drop(conn);
+        crate::runtime::session_timeline::emit_user_ask_pending_timeline_event(self, interaction);
         Ok(())
     }
 

--- a/autonoetic-gateway/src/scheduler/workflow_store.rs
+++ b/autonoetic-gateway/src/scheduler/workflow_store.rs
@@ -822,6 +822,89 @@ pub fn list_task_runs_for_workflow(
     Ok(out)
 }
 
+/// Active workflow approval gate: any task in `AwaitingApproval` or workflow `BlockedApproval`.
+#[derive(Debug, Clone)]
+pub struct WorkflowApprovalGate {
+    pub workflow_id: String,
+    pub awaiting_task_ids: Vec<String>,
+    pub pending_approval_request_ids: Vec<String>,
+}
+
+pub fn workflow_approval_gate_active(
+    config: &GatewayConfig,
+    store: Option<&GatewayStore>,
+    workflow_id: &str,
+) -> anyhow::Result<Option<WorkflowApprovalGate>> {
+    let Some(wf) = load_workflow_run(config, store, workflow_id)? else {
+        return Ok(None);
+    };
+    let tasks = list_task_runs_for_workflow(config, store, workflow_id)?;
+    let awaiting_task_ids: Vec<String> = tasks
+        .iter()
+        .filter(|task| task.status == TaskRunStatus::AwaitingApproval)
+        .map(|task| task.task_id.clone())
+        .collect();
+    let gate_active =
+        wf.status == WorkflowRunStatus::BlockedApproval || !awaiting_task_ids.is_empty();
+    if !gate_active {
+        return Ok(None);
+    }
+
+    let mut pending_approval_request_ids = Vec::new();
+    if let Some(store) = store {
+        for task_id in &awaiting_task_ids {
+            if let Ok(Some(request_id)) = store.get_pending_approval_request_id_for_task(task_id)
+            {
+                pending_approval_request_ids.push(request_id);
+            }
+        }
+    }
+
+    Ok(Some(WorkflowApprovalGate {
+        workflow_id: workflow_id.to_string(),
+        awaiting_task_ids,
+        pending_approval_request_ids,
+    }))
+}
+
+/// Keep `WorkflowRunStatus::BlockedApproval` aligned with task-level `AwaitingApproval` rows.
+pub fn sync_workflow_blocked_approval_status(
+    config: &GatewayConfig,
+    store: Option<&GatewayStore>,
+    workflow_id: &str,
+) -> anyhow::Result<()> {
+    let Some(mut wf) = load_workflow_run(config, store, workflow_id)? else {
+        return Ok(());
+    };
+    if matches!(
+        wf.status,
+        WorkflowRunStatus::EmergencyStopping
+            | WorkflowRunStatus::EmergencyStopped
+            | WorkflowRunStatus::Completed
+            | WorkflowRunStatus::Failed
+            | WorkflowRunStatus::Cancelled
+    ) {
+        return Ok(());
+    }
+
+    let tasks = list_task_runs_for_workflow(config, store, workflow_id)?;
+    let any_awaiting = tasks
+        .iter()
+        .any(|task| task.status == TaskRunStatus::AwaitingApproval);
+    if any_awaiting {
+        if wf.status != WorkflowRunStatus::BlockedApproval {
+            wf.status = WorkflowRunStatus::BlockedApproval;
+            wf.updated_at = now_rfc3339();
+            save_workflow_run(config, store, &wf)?;
+        }
+    } else if wf.status == WorkflowRunStatus::BlockedApproval {
+        wf.status = WorkflowRunStatus::WaitingChildren;
+        wf.updated_at = now_rfc3339();
+        save_workflow_run(config, store, &wf)?;
+    }
+    Ok(())
+}
+
 /// Update task status (and optional result summary) and append a completion-style event.
 pub fn update_task_run_status(
     config: &GatewayConfig,
@@ -835,6 +918,8 @@ pub fn update_task_run_status(
 ) -> anyhow::Result<()> {
     let mut task = load_task_run(config, store, workflow_id, task_id)?
         .ok_or_else(|| anyhow::anyhow!("task '{}' not in workflow '{}'", task_id, workflow_id))?;
+
+    let previous_status = task.status;
 
     // Store previous status for implicit artifact creation
     let was_succeeded = task.status == TaskRunStatus::Succeeded;
@@ -857,6 +942,23 @@ pub fn update_task_run_status(
         task.side_effect_state = failure.side_effect_state;
     }
     save_task_run(config, store, &task)?;
+
+    if status == TaskRunStatus::Cancelled && previous_status == TaskRunStatus::AwaitingApproval {
+        let cancel_reason = result_summary
+            .as_deref()
+            .unwrap_or("workflow_task_cancelled");
+        let _ = crate::scheduler::approval::cancel_pending_approval_for_workflow_task(
+            store,
+            task_id,
+            "gateway",
+            cancel_reason,
+        );
+    }
+    if previous_status == TaskRunStatus::AwaitingApproval
+        || status == TaskRunStatus::AwaitingApproval
+    {
+        let _ = sync_workflow_blocked_approval_status(config, store, workflow_id);
+    }
 
     // Create implicit artifact when task succeeds (transition to Succeeded)
     if is_now_succeeded && !was_succeeded {

--- a/autonoetic-gateway/tests/timeline_causal_coverage_guard.rs
+++ b/autonoetic-gateway/tests/timeline_causal_coverage_guard.rs
@@ -17,6 +17,8 @@ const TIMELINE_COVERAGE: &[(&str, Altitude)] = &[
     ("security.escape_threshold", Altitude::Attention),
     ("escalation.pending", Altitude::Attention),
     ("approval.pending", Altitude::Attention),
+    ("user.ask.pending", Altitude::Attention),
+    ("plan.pending", Altitude::Attention),
     ("divergence.intervention", Altitude::Attention),
     ("runtime.lock_drift", Altitude::Attention),
     ("guard.tripped", Altitude::Error),

--- a/autonoetic-gateway/tests/workflow_approval_spawn_gate_integration.rs
+++ b/autonoetic-gateway/tests/workflow_approval_spawn_gate_integration.rs
@@ -1,0 +1,278 @@
+use std::sync::Arc;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_gateway::scheduler::workflow_store;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::background::{ApprovalLevel, ApprovalRequest, ScheduledAction};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::workflow::{TaskRun, TaskRunStatus, WorkflowRunStatus};
+use tempfile::tempdir;
+
+fn planner_manifest() -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: "planner.default".to_string(),
+            name: "planner.default".to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: vec![Capability::AgentSpawn {
+            max_children: 4,
+            max_spawn_depth: 2,
+        }],
+        llm_overrides: None,
+        llm_preset: None,
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+#[test]
+fn agent_spawn_blocked_while_workflow_task_awaiting_approval() -> anyhow::Result<()> {
+    let temp = tempdir()?;
+    let agents_dir = temp.path().join("agents");
+    let planner_dir = agents_dir.join("planner.default");
+    let child_dir = agents_dir.join("coder.default");
+    std::fs::create_dir_all(&planner_dir)?;
+    std::fs::create_dir_all(&child_dir)?;
+
+    let config = GatewayConfig {
+        agents_dir: agents_dir.clone(),
+        ..GatewayConfig::default()
+    };
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let root_session_id = "session-spawn-gate";
+    let task_id = "task-awaiting-approval";
+
+    let mut workflow = workflow_store::ensure_workflow_for_root_session(
+        &config,
+        Some(store.as_ref()),
+        root_session_id,
+        Some("planner.default"),
+    )?;
+    let workflow_id = workflow.workflow_id.clone();
+    workflow.status = WorkflowRunStatus::BlockedApproval;
+    workflow.join_task_ids = vec![task_id.to_string()];
+    workflow.active_task_ids = vec![task_id.to_string()];
+    workflow.updated_at = chrono::Utc::now().to_rfc3339();
+    workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
+
+    let task = TaskRun {
+        task_id: task_id.to_string(),
+        workflow_id: workflow_id.to_string(),
+        agent_id: "unit_test_runner.default".to_string(),
+        session_id: format!("{root_session_id}/unit_test_runner.default-abc"),
+        parent_session_id: root_session_id.to_string(),
+        status: TaskRunStatus::AwaitingApproval,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        source_agent_id: Some("planner.default".to_string()),
+        result_summary: Some("awaiting approval apr-gate01".to_string()),
+        join_group: None,
+        message: Some("Run unit tests".to_string()),
+        metadata: None,
+        retry_count: 0,
+        last_failure_class: None,
+        retry_policy: None,
+        side_effect_state: None,
+        dedupe_key: None,
+    };
+    workflow_store::save_task_run(&config, Some(store.as_ref()), &task)?;
+
+    let mut approval = ApprovalRequest {
+        request_id: "apr-gate01".to_string(),
+        agent_id: "unit_test_runner.default".to_string(),
+        session_id: task.session_id.clone(),
+        action: ScheduledAction::SandboxExec {
+            command: "python3 /tmp/test_main.py".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        },
+        created_at: chrono::Utc::now().to_rfc3339(),
+        reason: Some("unit test exec".to_string()),
+        evidence_ref: None,
+        root_session_id: Some(root_session_id.to_string()),
+        workflow_id: Some(workflow_id.to_string()),
+        task_id: Some(task_id.to_string()),
+        status: None,
+        decided_at: None,
+        decided_by: None,
+        decision_reason: None,
+        approval_level: ApprovalLevel::Operator,
+        similar_to_request_id: None,
+        similarity_score: None,
+        min_dwell_ms: None,
+        confirm_phrase: None,
+        code_excerpts: None,
+        risk_summary: None,
+    };
+    store.create_approval(&mut approval)?;
+
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let runtime = tokio::runtime::Runtime::new()?;
+    let _guard = runtime.enter();
+
+    let spawn_args = serde_json::json!({
+        "agent_id": "coder.default",
+        "message": "Build another federation batch",
+        "async": true
+    });
+    let err = registry
+        .execute(
+            "agent_spawn",
+            &manifest,
+            &policy,
+            &planner_dir,
+            Some(&gateway_dir),
+            &serde_json::to_string(&spawn_args)?,
+            Some(root_session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .expect_err("spawn should be blocked while approval gate is active");
+    let msg = err.to_string();
+    assert!(msg.contains("awaiting operator approval"), "{msg}");
+    assert!(msg.contains(task_id), "{msg}");
+    assert!(msg.contains("apr-gate01"), "{msg}");
+
+    Ok(())
+}
+
+#[test]
+fn cancelling_awaiting_approval_task_withdraws_pending_approval() -> anyhow::Result<()> {
+    let temp = tempdir()?;
+    let agents_dir = temp.path().join("agents");
+    std::fs::create_dir_all(agents_dir.join("planner.default"))?;
+
+    let config = GatewayConfig {
+        agents_dir: agents_dir.clone(),
+        ..GatewayConfig::default()
+    };
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let store = Arc::new(GatewayStore::open(&gateway_dir)?);
+
+    let task_id = "task-cancel-me";
+    let root_session_id = "session-cancel-approval";
+
+    let mut workflow = workflow_store::ensure_workflow_for_root_session(
+        &config,
+        Some(store.as_ref()),
+        root_session_id,
+        Some("planner.default"),
+    )?;
+    let workflow_id = workflow.workflow_id.clone();
+    workflow.status = WorkflowRunStatus::BlockedApproval;
+    workflow.join_task_ids = vec![task_id.to_string()];
+    workflow.active_task_ids = vec![task_id.to_string()];
+    workflow.updated_at = chrono::Utc::now().to_rfc3339();
+    workflow_store::save_workflow_run(&config, Some(store.as_ref()), &workflow)?;
+
+    let child_session = format!("{root_session_id}/unit_test_runner.default-cancel");
+    let task = TaskRun {
+        task_id: task_id.to_string(),
+        workflow_id: workflow_id.to_string(),
+        agent_id: "unit_test_runner.default".to_string(),
+        session_id: child_session.clone(),
+        parent_session_id: root_session_id.to_string(),
+        status: TaskRunStatus::AwaitingApproval,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        source_agent_id: Some("planner.default".to_string()),
+        result_summary: Some("awaiting approval".to_string()),
+        join_group: None,
+        message: Some("Run tests".to_string()),
+        metadata: None,
+        retry_count: 0,
+        last_failure_class: None,
+        retry_policy: None,
+        side_effect_state: None,
+        dedupe_key: None,
+    };
+    workflow_store::save_task_run(&config, Some(store.as_ref()), &task)?;
+
+    let mut approval = ApprovalRequest {
+        request_id: "apr-cancel-me".to_string(),
+        agent_id: "unit_test_runner.default".to_string(),
+        session_id: child_session,
+        action: ScheduledAction::SandboxExec {
+            command: "python3 /tmp/test_main.py".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        },
+        created_at: chrono::Utc::now().to_rfc3339(),
+        reason: None,
+        evidence_ref: None,
+        root_session_id: Some(root_session_id.to_string()),
+        workflow_id: Some(workflow_id.to_string()),
+        task_id: Some(task_id.to_string()),
+        status: None,
+        decided_at: None,
+        decided_by: None,
+        decision_reason: None,
+        approval_level: ApprovalLevel::Operator,
+        similar_to_request_id: None,
+        similarity_score: None,
+        min_dwell_ms: None,
+        confirm_phrase: None,
+        code_excerpts: None,
+        risk_summary: None,
+    };
+    store.create_approval(&mut approval)?;
+
+    workflow_store::update_task_run_status(
+        &config,
+        Some(store.as_ref()),
+        &workflow_id,
+        task_id,
+        TaskRunStatus::Cancelled,
+        Some("Cancelled after approval timeout".to_string()),
+        None,
+        None,
+    )?;
+
+    let decided = store.get_approval("apr-cancel-me")?.expect("approval row");
+    assert_eq!(
+        decided.status.map(|s| s.as_str().to_string()),
+        Some("cancelled".to_string())
+    );
+
+    let wf = workflow_store::load_workflow_run(&config, Some(store.as_ref()), &workflow_id)?
+        .expect("workflow");
+    assert_ne!(wf.status, WorkflowRunStatus::BlockedApproval);
+
+    Ok(())
+}

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -7367,9 +7367,11 @@ async fn run_loop<B: ratatui::backend::Backend>(
                                             autonoetic_types::background::ApprovalLevel::Operator;
                                         let mut options =
                                             autonoetic_gateway::scheduler::ApproveOptions::default();
+                                        let mut reason: Option<String> = None;
                                         if let Ok(Some(ref approval)) = store.get_approval(&apr_id) {
                                             if let Some(ref phrase) = approval.confirm_phrase {
                                                 options.confirm_phrase = Some(phrase.clone());
+                                                reason = Some(phrase.clone());
                                             }
                                             if let autonoetic_types::background::ScheduledAction::RevisionPromote {
                                                 added_capabilities,
@@ -7389,7 +7391,7 @@ async fn run_loop<B: ratatui::backend::Backend>(
                                             Some(store),
                                             &apr_id,
                                             "chat-tui",
-                                            None,
+                                            reason,
                                             None,
                                             Some(&approver_level),
                                             None,
@@ -7533,9 +7535,11 @@ async fn run_loop<B: ratatui::backend::Backend>(
                                                 autonoetic_types::background::ApprovalLevel::Operator;
                                             let mut options =
                                                 autonoetic_gateway::scheduler::ApproveOptions::default();
+                                            let mut reason: Option<String> = None;
                                             if let Ok(Some(ref approval)) = store.get_approval(&apr_id) {
                                                 if let Some(ref phrase) = approval.confirm_phrase {
                                                     options.confirm_phrase = Some(phrase.clone());
+                                                    reason = Some(phrase.clone());
                                                 }
                                                 if let autonoetic_types::background::ScheduledAction::RevisionPromote {
                                                     added_capabilities,
@@ -7555,7 +7559,7 @@ async fn run_loop<B: ratatui::backend::Backend>(
                                                 Some(store),
                                                 &apr_id,
                                                 "chat-tui",
-                                                None,
+                                                reason,
                                                 None,
                                                 Some(&approver_level),
                                                 None,

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -662,6 +662,35 @@ fn payload_field_str(p: &serde_json::Value, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Wrap plain text to `max_width` display cells (Unicode-aware).
+pub fn wrap_display_lines(text: &str, max_width: usize) -> Vec<String> {
+    let width = max_width.max(1);
+    let mut lines: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut current_w = 0usize;
+    for word in text.split_whitespace() {
+        let word_w = unicode_width::UnicodeWidthStr::width(word);
+        let extra = if current.is_empty() { word_w } else { word_w + 1 };
+        if current_w + extra > width && !current.is_empty() {
+            lines.push(std::mem::take(&mut current));
+            current_w = 0;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+            current_w += 1;
+        }
+        current.push_str(word);
+        current_w += word_w;
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
 /// High-visibility approval gate card (`approval.pending`).
 fn approval_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) {
     let p = parse_entry_payload(entry);
@@ -671,10 +700,50 @@ fn approval_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) 
         .unwrap_or_default();
     let action = field("action").unwrap_or_else(|| "approval".into());
     let level = field("approval_level");
-    let headline = format!("⏸ APPROVAL REQUIRED — {}", one_line(&action, 72));
+    let headline = if action == "revision_promote" {
+        let agent = field("agent_id").unwrap_or_else(|| "agent".into());
+        format!("⏸ PROMOTION APPROVAL — {agent}")
+    } else {
+        format!("⏸ APPROVAL REQUIRED — {}", one_line(&action, 72))
+    };
     let mut lines = vec![format!("  request: {request_id}")];
     if let Some(lvl) = level {
         lines.push(format!("  level: {lvl}"));
+    }
+    if action == "revision_promote" {
+        if let Some(agent) = field("agent_id") {
+            lines.push(format!("  agent: {agent}"));
+        }
+        if let Some(rev) = field("revision_id") {
+            lines.push(format!("  revision: {}", one_line(&rev, 120)));
+        }
+        if let Some(summary) = field("summary") {
+            lines.push("  about:".to_string());
+            for line in wrap_display_lines(&summary, 76) {
+                lines.push(format!("    {line}"));
+            }
+        }
+        for (label, key) in [
+            ("added capabilities", "added_capabilities"),
+            ("broadened capabilities", "broadened_capabilities"),
+        ] {
+            if let Some(values) = p
+                .as_ref()
+                .and_then(|v| v.get(key))
+                .and_then(|v| v.as_array())
+            {
+                let joined: Vec<_> = values
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .collect();
+                if !joined.is_empty() {
+                    lines.push(format!("  {label}:"));
+                    for cap in joined {
+                        lines.push(format!("    · {cap}"));
+                    }
+                }
+            }
+        }
     }
     if let Some(cmd) = field("command") {
         lines.push(format!("  command: {}", one_line(&cmd, 140)));
@@ -695,11 +764,10 @@ fn approval_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) 
     if let Some(risk) = field("risk_summary") {
         lines.push(format!("  risk: {}", one_line(&risk, 120)));
     }
-    if let Some(phrase) = field("confirm_phrase") {
-        lines.push(format!("  confirm phrase: {}", one_line(&phrase, 120)));
-        lines.push("  ↳ y then type confirm phrase · n reject".to_string());
+    if field("confirm_phrase").is_some() {
+        lines.push("  ↳ y approve (confirm phrase shown below) · n reject · Esc peek timeline".to_string());
     } else {
-        lines.push("  ↳ y approve · n reject".to_string());
+        lines.push("  ↳ y approve · n reject · Esc peek timeline".to_string());
     }
     (headline, Some(lines.join("\n")))
 }
@@ -2989,6 +3057,35 @@ mod tests {
         let ask_detail = ask_spec.detail.expect("ask card body");
         assert!(ask_detail.contains("[1] Postgres"));
         assert!(ask_detail.contains("Enter/i/r"));
+    }
+
+    #[test]
+    fn render_spec_revision_promote_approval_shows_agent_context() {
+        let appr = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "approval.pending",
+            Altitude::Attention,
+            serde_json::json!({
+                "request_id": "apr-promo",
+                "action": "revision_promote",
+                "approval_level": "elevated",
+                "agent_id": "weather-lookup",
+                "revision_id": "rev_sha256:abc123",
+                "summary": "Promote after federation pass",
+                "added_capabilities": ["NetworkAccess(hosts=[api.open-meteo.com])"],
+                "confirm_phrase": "promote weather-lookup rev_sha256:abc123",
+            }),
+        );
+        let spec = render_spec(&appr);
+        assert!(spec.headline.contains("PROMOTION APPROVAL"));
+        assert!(spec.headline.contains("weather-lookup"));
+        let detail = spec.detail.expect("promotion detail");
+        assert!(detail.contains("weather-lookup"));
+        assert!(detail.contains("rev_sha256"));
+        assert!(detail.contains("federation pass"));
+        assert!(detail.contains("NetworkAccess"));
+        assert!(detail.contains("Esc peek timeline"));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -851,18 +851,95 @@ fn plan_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) {
     (headline, Some(lines.join("\n")))
 }
 
-/// High-visibility escalation gate card (`escalation.pending`).
+/// High-visibility session-escalate gate card (`approval.pending` + session_escalate).
+fn session_escalate_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) {
+    let p = parse_entry_payload(entry);
+    let field = |key: &str| p.as_ref().and_then(|v| payload_field_str(v, key));
+    let request_id = field("request_id")
+        .or_else(|| entry.refs.approval_request_id.clone())
+        .unwrap_or_default();
+    let reason_field = field("reason");
+    let summary_field = field("summary");
+    let reason = reason_field
+        .clone()
+        .or_else(|| summary_field.clone())
+        .unwrap_or_else(|| "agent needs human guidance".into());
+    let headline = format!("⏸ SESSION ESCALATION — {}", one_line(&reason, 88));
+    let mut lines = vec![format!("  request: {request_id}")];
+    lines.push("  reason:".to_string());
+    for line in wrap_display_lines(&reason, 76) {
+        lines.push(format!("    {line}"));
+    }
+    if let Some(agent) = field("requested_by_agent_id") {
+        lines.push(format!("  requested by: {agent}"));
+    }
+    if let Some(u) = field("urgency") {
+        lines.push(format!("  urgency: {u}"));
+    }
+    if let Some(sid) = field("session_id") {
+        lines.push(format!("  session: {sid}"));
+    }
+    if let Some(ctx) = field("context").filter(|c| !c.is_empty()) {
+        lines.push("  context:".to_string());
+        for line in wrap_display_lines(&ctx, 76) {
+            lines.push(format!("    {line}"));
+        }
+    }
+    if let Some(summary) = summary_field.filter(|s| {
+        !s.is_empty() && reason_field.as_ref().map(String::as_str) != Some(s.as_str())
+    }) {
+        lines.push("  summary:".to_string());
+        for line in wrap_display_lines(&summary, 76) {
+            lines.push(format!("    {line}"));
+        }
+    }
+    if let Some(actions) = p
+        .as_ref()
+        .and_then(|v| v.get("suggested_actions"))
+        .and_then(|v| v.as_array())
+    {
+        let joined: Vec<_> = actions
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        if !joined.is_empty() {
+            lines.push(format!("  suggested: {}", joined.join(" · ")));
+        }
+    }
+    lines.push("  ↳ y approve (resume with your guidance) · n reject · Esc peek timeline".to_string());
+    (headline, Some(lines.join("\n")))
+}
+
+/// High-visibility federation/promotion escalation gate card (`escalation.pending`).
 fn escalation_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) {
     let p = parse_entry_payload(entry);
     let field = |key: &str| p.as_ref().and_then(|v| payload_field_str(v, key));
     let synthesis = field("synthesis").unwrap_or_else(|| "operator decision requested".into());
-    let rev = field("revision_id");
-    let headline = format!("⏸ ESCALATION — {}", one_line(&synthesis, 88));
+    let headline = format!("⏸ PROMOTION ESCALATION — {}", one_line(&synthesis, 88));
     let mut lines = Vec::new();
-    if let Some(r) = rev.filter(|r| !r.is_empty()) {
-        lines.push(format!("  revision: {r}"));
+    if let Some(id) = field("escalation_id") {
+        lines.push(format!("  escalation: {id}"));
     }
-    lines.push("  ↳ review in detail pane · resolve via gateway approvals".to_string());
+    if let Some(req) = entry.refs.approval_request_id.clone().or(field("request_id")) {
+        lines.push(format!("  approval: {req}"));
+    }
+    if let Some(agent) = field("agent_id") {
+        lines.push(format!("  agent: {agent}"));
+    }
+    if let Some(rev) = field("revision_id").filter(|r| !r.is_empty()) {
+        lines.push(format!("  revision: {}", one_line(&rev, 120)));
+    }
+    if let Some(kind) = field("escalation_type") {
+        lines.push(format!("  type: {kind}"));
+    }
+    if let Some(artifact) = entry.refs.artifact_id.clone() {
+        lines.push(format!("  artifact: {artifact}"));
+    }
+    lines.push("  synthesis:".to_string());
+    for line in wrap_display_lines(&synthesis, 76) {
+        lines.push(format!("    {line}"));
+    }
+    lines.push("  ↳ y approve · n reject · Esc peek timeline".to_string());
     (headline, Some(lines.join("\n")))
 }
 
@@ -1556,15 +1633,15 @@ pub fn render_spec(entry: &SessionTimelineEntry) -> RowSpec {
             }
         }
         "approval.pending" => {
-            let is_wiki = entry
+            let action = entry
                 .payload
                 .as_deref()
                 .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
-                .is_some_and(|v| v.get("action").and_then(|a| a.as_str()) == Some("wiki_propose"));
-            if is_wiki {
-                wiki_proposal_gate_card(entry)
-            } else {
-                approval_gate_card(entry)
+                .and_then(|v| v.get("action").and_then(|a| a.as_str()).map(str::to_string));
+            match action.as_deref() {
+                Some("wiki_propose") => wiki_proposal_gate_card(entry),
+                Some("session_escalate") => session_escalate_gate_card(entry),
+                _ => approval_gate_card(entry),
             }
         }
         "user.ask.pending" => interaction_gate_card(entry),
@@ -3057,6 +3134,33 @@ mod tests {
         let ask_detail = ask_spec.detail.expect("ask card body");
         assert!(ask_detail.contains("[1] Postgres"));
         assert!(ask_detail.contains("Enter/i/r"));
+    }
+
+    #[test]
+    fn render_spec_session_escalate_approval_shows_guidance_context() {
+        let appr = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "approval.pending",
+            Altitude::Attention,
+            serde_json::json!({
+                "request_id": "esc-abc123",
+                "action": "session_escalate",
+                "approval_level": "operator",
+                "requested_by_agent_id": "planner.default",
+                "urgency": "normal",
+                "reason": "Unit tests require live network and cannot be evaluated",
+                "context": "Federation blocked on environment.",
+                "suggested_actions": ["accept without dynamic evidence", "retry with mocks"],
+            }),
+        );
+        let spec = render_spec(&appr);
+        assert!(spec.headline.contains("SESSION ESCALATION"));
+        let detail = spec.detail.expect("session escalate detail");
+        assert!(detail.contains("planner.default"));
+        assert!(detail.contains("live network"));
+        assert!(detail.contains("Federation blocked"));
+        assert!(detail.contains("retry with mocks"));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -994,6 +994,33 @@ fn extract_tool_summary(p: Option<&serde_json::Value>) -> Option<String> {
     None
 }
 
+/// Extract the key argument from a `tool.requested` or `tool.completed` payload.
+/// For `tool.requested` the `arguments` field is a JSON string; for `tool.completed`
+/// there is an `args_preview` field written by the tracer.
+fn extract_tool_key_param(p: &Option<serde_json::Value>, tool_name: &str) -> Option<String> {
+    let v = p.as_ref()?;
+    // tool.completed may have a pre-extracted args_preview
+    if let Some(preview) = v.get("args_preview").and_then(|x| x.as_str()) {
+        return Some(preview.to_string());
+    }
+    // tool.requested has arguments as a JSON string
+    let args_str = v.get("arguments")?.as_str()?;
+    let args: serde_json::Value = serde_json::from_str(args_str).ok()?;
+    let key = match tool_name {
+        "artifact_inspect" => args.get("artifact_ref").and_then(|x| x.as_str()),
+        "content_write" => args.get("name").and_then(|x| x.as_str()),
+        "agent_spawn" => args.get("agent_id").and_then(|x| x.as_str()),
+        _ => return None,
+    };
+    key.map(|s| {
+        if s.len() > 80 {
+            format!("{}…", &s[..79])
+        } else {
+            s.to_string()
+        }
+    })
+}
+
 /// Human summary of an event, from its type + payload. Keeps the most useful
 /// field per known event type; falls back to the bare event type.
 pub fn summarize(entry: &SessionTimelineEntry) -> String {
@@ -1072,9 +1099,24 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
             one_line(&field("question").unwrap_or_default(), 200),
         ),
         // Payload key is `tool_name`; keep `tool` as a fallback for older rows.
-        // Show just the result summary — status is conveyed by altitude color.
+        // Show the result summary — status is conveyed by altitude color.
+        // For tool.completed, also include the key argument (args_preview) when
+        // available so the row tells you what artifact/file/agent was involved.
+        "tool.requested" => {
+            let tool_name = field("tool_name").unwrap_or_default();
+            match extract_tool_key_param(&p, &tool_name) {
+                Some(kp) => format!("{tool_name} → {kp}"),
+                None => format!("{tool_name} requested"),
+            }
+        }
         "tool.completed" => {
             let summary = extract_tool_summary(p.as_ref());
+            let tool_name = field("tool_name")
+                .or_else(|| field("tool"))
+                .unwrap_or_else(|| "completed".into());
+            let key_suffix = extract_tool_key_param(&p, &tool_name)
+                .map(|kp| format!(" ({kp})"))
+                .unwrap_or_default();
             match summary {
                 Some(s) => {
                     let plain = if super::markdown::looks_like_markdown(&s) {
@@ -1082,11 +1124,10 @@ pub fn summarize(entry: &SessionTimelineEntry) -> String {
                     } else {
                         s
                     };
-                    one_line(&plain, 160)
+                    let base = one_line(&plain, 160);
+                    format!("{base}{key_suffix}")
                 }
-                None => format!("tool {}", field("tool_name")
-                    .or_else(|| field("tool"))
-                    .unwrap_or_else(|| "completed".into())),
+                None => format!("tool {tool_name}{key_suffix}"),
             }
         }
         // A promotion/governance escalation awaiting the operator's decision (#413).
@@ -1244,13 +1285,29 @@ fn detail_preview(entry: &SessionTimelineEntry) -> Option<String> {
     };
 
     match entry.event_type.as_str() {
+        // Tool requested: show the key argument (artifact_ref, name, agent_id)
+        // from the arguments JSON.
+        "tool.requested" => {
+            let tool = s("tool_name").or_else(|| s("tool"));
+            match tool.as_deref() {
+                Some(name) => extract_tool_key_param(&p, name).map(|kp| cap_preview(&kp, 80)),
+                None => None,
+            }
+        }
         // Tool calls: a one-line hint at the args or the result preview.
         "tool.completed" => {
             let tool = s("tool_name").or_else(|| s("tool"));
             // For sandbox_exec-like tools, surface the result.stdout (or first
-            // 80 chars of any string result). For content_write, surface path.
+            // 80 chars of any string result). For content_write, surface path
+            // or args_preview. For artifact_inspect/agent_spawn, show the key
+            // argument from args_preview (extracted by the tracer).
             match tool.as_deref() {
-                Some("content_write") => s("path").map(|p| cap_preview(&p, 80)),
+                Some("content_write") => s("args_preview")
+                    .or_else(|| s("name")).or_else(|| s("path"))
+                    .map(|p| cap_preview(&p, 80)),
+                Some("artifact_inspect") => s("args_preview")
+                    .or_else(|| s("artifact_ref"))
+                    .map(|p| cap_preview(&p, 80)),
                 Some("sandbox_exec") | Some("artifact_exec") => p
                     .as_ref()
                     .and_then(|v| v.get("result"))
@@ -1261,7 +1318,9 @@ fn detail_preview(entry: &SessionTimelineEntry) -> Option<String> {
                         // The result may be a JSON string (not an object).
                         s("result").map(|r| cap_preview(&r, 80))
                     }),
-                Some("agent_spawn") => s("message").map(|m| cap_preview(&m, 80)),
+                Some("agent_spawn") => s("args_preview")
+                    .or_else(|| s("message"))
+                    .map(|m| cap_preview(&m, 80)),
                 Some("workflow_wait") | Some("workflow_state") => p
                     .as_ref()
                     .and_then(|v| v.get("task_ids"))

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -695,7 +695,12 @@ fn approval_gate_card(entry: &SessionTimelineEntry) -> (String, Option<String>) 
     if let Some(risk) = field("risk_summary") {
         lines.push(format!("  risk: {}", one_line(&risk, 120)));
     }
-    lines.push("  ↳ y approve · n reject".to_string());
+    if let Some(phrase) = field("confirm_phrase") {
+        lines.push(format!("  confirm phrase: {}", one_line(&phrase, 120)));
+        lines.push("  ↳ y then type confirm phrase · n reject".to_string());
+    } else {
+        lines.push("  ↳ y approve · n reject".to_string());
+    }
     (headline, Some(lines.join("\n")))
 }
 

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -3205,6 +3205,46 @@ mod tests {
     }
 
     #[test]
+    fn render_spec_tool_completed_shows_args_preview_from_timeline_payload() {
+        let spawn = entry(
+            SessionRole::Planner,
+            Principal::agent("planner.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({
+                "tool_name": "agent_spawn",
+                "result": r#"{"accepted":true}"#,
+                "args_preview": "coder.default"
+            }),
+        );
+        let spawn_spec = render_spec(&spawn);
+        assert!(
+            spawn_spec.headline.contains("coder.default"),
+            "headline: {}",
+            spawn_spec.headline
+        );
+        assert_eq!(spawn_spec.detail.as_deref(), Some("coder.default"));
+
+        let write = entry(
+            SessionRole::Specialist { kind: "coder".into() },
+            Principal::agent("coder.default"),
+            "tool.completed",
+            Altitude::Normal,
+            serde_json::json!({
+                "tool_name": "content_write",
+                "result": r#"{"ok":true}"#,
+                "args_preview": "skills/weather/SKILL.md"
+            }),
+        );
+        let write_spec = render_spec(&write);
+        assert!(write_spec.headline.contains("skills/weather/SKILL.md"));
+        assert_eq!(
+            write_spec.detail.as_deref(),
+            Some("skills/weather/SKILL.md")
+        );
+    }
+
+    #[test]
     fn agent_spawn_agent_id_from_completed_result_json() {
         let e = entry(
             SessionRole::Planner,

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -618,6 +618,57 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
         .split(popup_layout[1])[1]
 }
 
+struct ArtifactFileEntry {
+    name: String,
+    alias: String,
+}
+
+struct ArtifactViewer {
+    artifact_id: String,
+    kind: String,
+    files: Vec<ArtifactFileEntry>,
+    selected: usize,
+    scroll: u16,
+}
+
+struct ArtifactFileView {
+    artifact_id: String,
+    file_name: String,
+    content: String,
+    scroll: u16,
+}
+
+/// Extract artifact_id from a timeline entry, if it has one.
+fn artifact_id_for_entry(entry: &SessionTimelineEntry) -> Option<String> {
+    if let Some(ref aid) = entry.refs.artifact_id {
+        return Some(aid.clone());
+    }
+    if entry.event_type == "tool.completed" {
+        if let Some(ref payload) = entry.payload {
+            if let Ok(p) = serde_json::from_str::<serde_json::Value>(payload) {
+                if p.get("tool_name").and_then(|v| v.as_str())
+                    .map(|n| n.starts_with("artifact"))
+                    .unwrap_or(false)
+                {
+                    if let Some(result_str) = p.get("result").and_then(|v| v.as_str()) {
+                        if let Ok(result) = serde_json::from_str::<serde_json::Value>(result_str) {
+                            if let Some(ref aid) = result.get("artifact_id").and_then(|v| v.as_str()) {
+                                return Some(aid.to_string());
+                            }
+                        }
+                    }
+                    if let Some(ref aid) = p.get("args_preview").and_then(|v| v.as_str()) {
+                        if aid.starts_with("ar.") || aid.starts_with("art_") {
+                            return Some(aid.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 /// An in-flight operator decision — captures an optional motivation (approvals,
 /// §3.5) or the answer (interactions) before committing. `GateRef`, `GateKind`,
 /// and `GateAction` are the channel-neutral primitives, shared from
@@ -634,30 +685,140 @@ struct GateInput {
     /// Rejections always require motivation (§O). Approvals may require it for
     /// elevated/external actions — the gateway enforces that on submit.
     motivation_required: bool,
+    /// R++4: destructive approval classes require typing this phrase exactly
+    /// (case-insensitive) instead of optional motivation.
+    required_confirm_phrase: Option<String>,
+    /// R++2: `revision_promote` approvals — auto-filled from the timeline payload.
+    acknowledged_capabilities: Vec<String>,
 }
 
-fn gate_commit_validation_error(gi: &GateInput) -> Option<&'static str> {
+fn approval_entry_for_id<'a>(
+    entries: &'a [SessionTimelineEntry],
+    request_id: &str,
+) -> Option<&'a SessionTimelineEntry> {
+    entries.iter().find(|entry| approval_id_for(entry).as_deref() == Some(request_id))
+}
+
+fn approval_gate_requirements_from_entry(
+    entry: &SessionTimelineEntry,
+) -> (Option<String>, Vec<String>) {
+    let confirm_phrase = payload_field_str(entry, "confirm_phrase");
+    let mut acknowledged_capabilities = Vec::new();
+    if let Some(payload) = entry
+        .payload
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+    {
+        for key in ["added_capabilities", "broadened_capabilities"] {
+            if let Some(values) = payload.get(key).and_then(|v| v.as_array()) {
+                for value in values {
+                    if let Some(cap) = value.as_str() {
+                        acknowledged_capabilities.push(cap.to_string());
+                    }
+                }
+            }
+        }
+    }
+    acknowledged_capabilities.sort();
+    acknowledged_capabilities.dedup();
+    (confirm_phrase, acknowledged_capabilities)
+}
+
+fn approval_gate_requirements(
+    client: &RoomClient,
+    entries: &[SessionTimelineEntry],
+    request_id: &str,
+) -> (Option<String>, Vec<String>) {
+    if let Some(entry) = approval_entry_for_id(entries, request_id) {
+        let (mut confirm_phrase, mut acknowledged_capabilities) =
+            approval_gate_requirements_from_entry(entry);
+        if confirm_phrase.is_none() || acknowledged_capabilities.is_empty() {
+            if let Ok(value) = rpc(
+                client,
+                "approvals.inspect",
+                serde_json::json!({ "request_id": request_id }),
+            ) {
+                if confirm_phrase.is_none() {
+                    confirm_phrase = value
+                        .get("confirm_phrase")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                }
+                if acknowledged_capabilities.is_empty() {
+                    for key in ["added_capabilities", "broadened_capabilities"] {
+                        if let Some(values) = value.get(key).and_then(|v| v.as_array()) {
+                            for cap in values {
+                                if let Some(name) = cap.as_str() {
+                                    acknowledged_capabilities.push(name.to_string());
+                                }
+                            }
+                        }
+                    }
+                    acknowledged_capabilities.sort();
+                    acknowledged_capabilities.dedup();
+                }
+            }
+        }
+        return (confirm_phrase, acknowledged_capabilities);
+    }
+    (None, Vec::new())
+}
+
+fn approval_gate_input(
+    client: &RoomClient,
+    action: GateAction,
+    id: String,
+    entries: &[SessionTimelineEntry],
+    motivation_required: bool,
+) -> GateInput {
+    let (required_confirm_phrase, acknowledged_capabilities) =
+        approval_gate_requirements(client, entries, &id);
+    GateInput {
+        action,
+        id,
+        buffer: String::new(),
+        options: Vec::new(),
+        allow_freeform: true,
+        motivation_required,
+        required_confirm_phrase,
+        acknowledged_capabilities,
+    }
+}
+
+fn gate_commit_validation_error(gi: &GateInput) -> Option<String> {
+    if matches!(gi.action, GateAction::Approve) {
+        if let Some(ref required) = gi.required_confirm_phrase {
+            if !gi.buffer.trim().eq_ignore_ascii_case(required) {
+                return Some(format!(
+                    "✗ type confirm phrase exactly: '{required}'"
+                ));
+            }
+            return None;
+        }
+    }
     if matches!(gi.action, GateAction::Approve | GateAction::Reject)
         && gi.motivation_required
         && gi.buffer.trim().is_empty()
     {
-        Some("✗ motivation required — type a reason and press Enter")
+        Some("✗ motivation required — type a reason and press Enter".to_string())
     } else {
         None
     }
 }
 
-fn gate_input_label(gi: &GateInput) -> &'static str {
+fn gate_input_label(gi: &GateInput) -> String {
     match gi.action {
-        GateAction::Answer => "ANSWER",
+        GateAction::Answer => "ANSWER".to_string(),
         GateAction::Approve => {
-            if gi.motivation_required {
-                "APPROVE — motivation (required)"
+            if gi.required_confirm_phrase.is_some() {
+                "APPROVE — confirm phrase (required)".to_string()
+            } else if gi.motivation_required {
+                "APPROVE — motivation (required)".to_string()
             } else {
-                "APPROVE — motivation (optional)"
+                "APPROVE — motivation (optional)".to_string()
             }
         }
-        GateAction::Reject => "REJECT — motivation (required)",
+        GateAction::Reject => "REJECT — motivation (required)".to_string(),
     }
 }
 
@@ -1000,6 +1161,8 @@ pub fn run(
     let mut spinner_frame: usize = 0;
     let mut info_panel_open = false;
     let mut info_scroll: u16 = 0;
+    let mut artifact_viewer: Option<ArtifactViewer> = None;
+    let mut artifact_file_view: Option<ArtifactFileView> = None;
     let mut quit_armed_until: Option<Instant> = None;
     let mut last_mouse_click: Option<(Instant, usize, u16, u16)> = None;
     let mut last_announced_plan_event: Option<String> = None;
@@ -1378,7 +1541,11 @@ pub fn run(
                     }
                     match key.code {
                         KeyCode::Esc => {
-                            if info_panel_open {
+                            if artifact_file_view.is_some() {
+                                artifact_file_view = None;
+                            } else if artifact_viewer.is_some() {
+                                artifact_viewer = None;
+                            } else if info_panel_open {
                                 info_panel_open = false;
                                 info_scroll = 0;
                             } else if detail.is_some() {
@@ -1479,18 +1646,17 @@ pub fn run(
                                 view_gate.as_ref().filter(|g| matches!(g.kind, GateKind::Approval | GateKind::WikiProposal | GateKind::Escalation))
                             {
                                 clear_detail(&mut detail, &mut detail_scroll, &mut detail_h_scroll);
-                                input = Some(GateInput {
-                                    action: if key.code == KeyCode::Char('y') {
+                                input = Some(approval_gate_input(
+                                    client,
+                                    if key.code == KeyCode::Char('y') {
                                         GateAction::Approve
                                     } else {
                                         GateAction::Reject
                                     },
-                                    id: g.id.clone(),
-                                    buffer: String::new(),
-                                    options: Vec::new(),
-                                    allow_freeform: true,
-                                    motivation_required: key.code == KeyCode::Char('n'),
-                                });
+                                    g.id.clone(),
+                                    &entries,
+                                    key.code == KeyCode::Char('n'),
+                                ));
                                 status = None;
                                 continue;
                             }
@@ -1510,6 +1676,8 @@ pub fn run(
                                     options,
                                     allow_freeform,
                                     motivation_required: false,
+                                    required_confirm_phrase: None,
+                                    acknowledged_capabilities: Vec::new(),
                                 });
                                 status = None;
                             }
@@ -1561,6 +1729,8 @@ pub fn run(
                                     options,
                                     allow_freeform,
                                     motivation_required: false,
+                                    required_confirm_phrase: None,
+                                    acknowledged_capabilities: Vec::new(),
                                 });
                                 status = None;
                             } else {
@@ -1646,6 +1816,8 @@ pub fn run(
                                     options,
                                     allow_freeform,
                                     motivation_required: false,
+                                    required_confirm_phrase: None,
+                                    acknowledged_capabilities: Vec::new(),
                                 });
                                 status = None;
                             } else {
@@ -1659,6 +1831,8 @@ pub fn run(
                         KeyCode::Char('/') | KeyCode::Char(':') => {
                             detail = None;
                             info_panel_open = false;
+                            artifact_viewer = None;
+                            artifact_file_view = None;
                             slash = Some(String::new());
                             status = None;
                         }
@@ -1672,8 +1846,90 @@ pub fn run(
                                 status = Some("info: j/k scroll · Esc close".to_string());
                             }
                         }
+                        KeyCode::Char('o') => {
+                            if artifact_file_view.is_some() {
+                            } else if let Some(ref viewer) = artifact_viewer {
+                                if let Some(file) = viewer.files.get(viewer.selected) {
+                                    let result = rpc(
+                                        client,
+                                        "artifact.read_file",
+                                        serde_json::json!({
+                                            "artifact_id": viewer.artifact_id,
+                                            "file_name": file.name,
+                                        }),
+                                    );
+                                    match result {
+                                        Ok(v) => {
+                                            if let Some(content) = v.get("content").and_then(|c| c.as_str()) {
+                                                artifact_file_view = Some(ArtifactFileView {
+                                                    artifact_id: viewer.artifact_id.clone(),
+                                                    file_name: file.name.clone(),
+                                                    content: content.to_string(),
+                                                    scroll: 0,
+                                                });
+                                            } else {
+                                                status = Some("artifact.read_file: no content field".to_string());
+                                            }
+                                        }
+                                        Err(e) => status = Some(format!("artifact read failed: {e}")),
+                                    }
+                                }
+                            } else if let Some((_, src)) = view_indexed.get(selected) {
+                                let idx = match src {
+                                    RowSource::Single(i) => *i,
+                                    RowSource::Run { start, .. } => *start,
+                                };
+                                if let Some(entry) = view_visible.get(idx) {
+                                    if let Some(artifact_id) = artifact_id_for_entry(entry) {
+                                        let result = rpc(
+                                            client,
+                                            "artifact.list_files",
+                                            serde_json::json!({
+                                                "artifact_id": artifact_id,
+                                            }),
+                                        );
+                                        match result {
+                                            Ok(v) => {
+                                                let files: Vec<ArtifactFileEntry> = v.get("files")
+                                                    .and_then(|f| f.as_array())
+                                                    .map(|arr| {
+                                                        arr.iter().filter_map(|item| {
+                                                            Some(ArtifactFileEntry {
+                                                                name: item.get("name")?.as_str()?.to_string(),
+                                                                alias: item.get("alias").and_then(|a| a.as_str()).unwrap_or("").to_string(),
+                                                            })
+                                                        }).collect()
+                                                    })
+                                                    .unwrap_or_default();
+                                                if files.is_empty() {
+                                                    status = Some("artifact has no files".to_string());
+                                                } else {
+                                                    let kind = v.get("kind").and_then(|k| k.as_str()).unwrap_or("unknown").to_string();
+                                                    artifact_viewer = Some(ArtifactViewer {
+                                                        artifact_id,
+                                                        kind,
+                                                        files,
+                                                        selected: 0,
+                                                        scroll: 0,
+                                                    });
+                                                    status = Some("artifact: Enter to view · Esc close".to_string());
+                                                }
+                                            }
+                                            Err(e) => status = Some(format!("artifact list failed: {e}")),
+                                        }
+                                    } else {
+                                        status = Some("no artifact on this row".to_string());
+                                    }
+                                }
+                            }
+                        }
                         KeyCode::Down | KeyCode::Char('j') => {
-                            if info_panel_open {
+                            if artifact_file_view.is_some() {
+                                artifact_file_view.as_mut().unwrap().scroll = artifact_file_view.as_ref().unwrap().scroll.saturating_add(1);
+                            } else if artifact_viewer.is_some() {
+                                let viewer = artifact_viewer.as_mut().unwrap();
+                                viewer.selected = (viewer.selected + 1).min(viewer.files.len().saturating_sub(1));
+                            } else if info_panel_open {
                                 info_scroll = info_scroll.saturating_add(1);
                             } else if detail.is_some() {
                                 detail_scroll = detail_scroll.saturating_add(1);
@@ -1684,7 +1940,12 @@ pub fn run(
                             }
                         }
                         KeyCode::Up | KeyCode::Char('k') => {
-                            if info_panel_open {
+                            if artifact_file_view.is_some() {
+                                artifact_file_view.as_mut().unwrap().scroll = artifact_file_view.as_ref().unwrap().scroll.saturating_sub(1);
+                            } else if artifact_viewer.is_some() {
+                                let viewer = artifact_viewer.as_mut().unwrap();
+                                viewer.selected = viewer.selected.saturating_sub(1);
+                            } else if info_panel_open {
                                 info_scroll = info_scroll.saturating_sub(1);
                             } else if detail.is_some() {
                                 detail_scroll = detail_scroll.saturating_sub(1);
@@ -2071,6 +2332,8 @@ pub fn run(
                 info_panel.as_ref(),
                 info_scroll,
                 gate_count,
+                artifact_viewer.as_ref(),
+                artifact_file_view.as_ref(),
             )
         })?;
 
@@ -2342,16 +2605,31 @@ fn answer_params(gi: &GateInput, chosen: Option<&GateOption>) -> Result<serde_js
 /// failure, leaving the gate offerable so the operator can retry.
 fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>) -> Result<String, String> {
     let text = gi.buffer.trim();
-    let reason = (!text.is_empty()).then(|| text.to_string());
+    let reason = if gi.required_confirm_phrase.is_some() {
+        None
+    } else {
+        (!text.is_empty()).then(|| text.to_string())
+    };
     let (result, verb) = match gi.action {
-        GateAction::Approve => (
-            rpc(
-                client,
-                "approvals.approve",
-                serde_json::json!({ "request_id": gi.id, "decided_by": "operator", "reason": reason }),
-            ),
-            "approved",
-        ),
+        GateAction::Approve => {
+            let mut params = serde_json::json!({
+                "request_id": gi.id,
+                "decided_by": "operator",
+            });
+            if let Some(r) = reason {
+                params["reason"] = serde_json::json!(r);
+            }
+            if gi.required_confirm_phrase.is_some() && !text.is_empty() {
+                params["confirm_phrase"] = serde_json::json!(text);
+            }
+            if !gi.acknowledged_capabilities.is_empty() {
+                params["acknowledged_capabilities"] = serde_json::json!(gi.acknowledged_capabilities);
+            }
+            (
+                rpc(client, "approvals.approve", params),
+                "approved",
+            )
+        }
         GateAction::Reject => (
             rpc(
                 client,
@@ -3532,6 +3810,8 @@ fn draw(
     info_panel: Option<&InfoPanel>,
     info_scroll: u16,
     gate_count: usize,
+    artifact_viewer: Option<&ArtifactViewer>,
+    artifact_file_view: Option<&ArtifactFileView>,
 ) {
     let compose_open = compose.is_some() && detail.is_none();
     let chunks = if compose_open {
@@ -3616,6 +3896,74 @@ fn draw(
                         .borders(Borders::ALL)
                         .title(" Session Info [?/Esc close] ")
                         .border_style(Style::default().fg(Color::Cyan))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    }
+
+    // Artifact file content overlay (level 2 of artifact viewer).
+    if let Some(ref view) = artifact_file_view {
+        let area = centered_rect(80, 85, f.area());
+        let lines: Vec<Line> = view
+            .content
+            .lines()
+            .map(|l| Line::from(Span::styled(l.to_string(), Style::default().bg(Color::Black))))
+            .collect();
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
+        let scroll = view.scroll.min(max_scroll);
+        let title = format!(
+            " {} {} → {} [Esc back] ",
+            view.artifact_id, view.file_name, lines.len()
+        );
+        f.render_widget(
+            Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(title)
+                        .border_style(Style::default().fg(Color::Green))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    } else if let Some(ref viewer) = artifact_viewer {
+        // Artifact file list overlay (level 1).
+        let area = centered_rect(60, 60, f.area());
+        let lines: Vec<Line> = viewer
+            .files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let marker = if i == viewer.selected { " > " } else { "   " };
+                let style = if i == viewer.selected {
+                    Style::default().fg(Color::Yellow).bg(Color::Black)
+                } else {
+                    Style::default().bg(Color::Black)
+                };
+                Line::from(Span::styled(
+                    format!("{}{}", marker, f.name),
+                    style,
+                ))
+            })
+            .collect();
+        let title = format!(
+            " {} [{}] {} files [Enter/Esc] ",
+            viewer.artifact_id, viewer.kind, viewer.files.len()
+        );
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
+        let scroll = viewer.scroll.min(max_scroll);
+        f.render_widget(
+            Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(title)
+                        .border_style(Style::default().fg(Color::Green))
                         .style(Style::default().bg(Color::Black)),
                 )
                 .scroll((scroll, 0)),
@@ -4169,6 +4517,24 @@ mod tests {
     }
 
     #[test]
+    fn gate_commit_validation_requires_confirm_phrase_for_promotion() {
+        let gi = GateInput {
+            action: GateAction::Approve,
+            id: "apr-promote".into(),
+            buffer: "agreed".into(),
+            options: Vec::new(),
+            allow_freeform: true,
+            motivation_required: false,
+            required_confirm_phrase: Some("promote weather-lookup rev_sha256:abc".into()),
+            acknowledged_capabilities: vec!["NetworkAccess".into()],
+        };
+        assert!(gate_commit_validation_error(&gi).is_some());
+        let mut ok = gi;
+        ok.buffer = "promote weather-lookup rev_sha256:abc".into();
+        assert!(gate_commit_validation_error(&ok).is_none());
+    }
+
+    #[test]
     fn gate_commit_validation_requires_motivation_for_reject() {
         let gi = GateInput {
             action: GateAction::Reject,
@@ -4177,6 +4543,8 @@ mod tests {
             options: Vec::new(),
             allow_freeform: true,
             motivation_required: true,
+            required_confirm_phrase: None,
+            acknowledged_capabilities: Vec::new(),
         };
         assert!(gate_commit_validation_error(&gi).is_some());
         let mut ok = gi;
@@ -4196,6 +4564,8 @@ mod tests {
             options: Vec::new(),
             allow_freeform: true,
             motivation_required: false,
+            required_confirm_phrase: None,
+            acknowledged_capabilities: Vec::new(),
         };
         let err = resolve_gate(&client, &gi, None).unwrap_err();
         assert!(err.contains("empty"), "expected empty-answer rejection, got: {err}");
@@ -4214,6 +4584,8 @@ mod tests {
             options,
             allow_freeform,
             motivation_required: false,
+            required_confirm_phrase: None,
+            acknowledged_capabilities: Vec::new(),
         };
 
         // A typed number selects the matching option — even when free-text is

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -697,6 +697,9 @@ struct GateInput {
 struct GateModal {
     gate: GateRef,
     scroll: u16,
+    /// When true, the timeline stays interactive; a compact banner reminds the
+    /// operator that a gate is still open (`g` reopens the full modal).
+    peek_timeline: bool,
 }
 
 fn gate_modal_kind(gate: &GateRef) -> bool {
@@ -1590,10 +1593,59 @@ pub fn run(
                         continue;
                     }
 
-                    // Blocking gate modal — capture y/n/Enter before timeline nav.
+                    // Gate modal — full overlay blocks nav; peek mode leaves timeline usable.
                     if let Some(modal) = gate_modal.as_ref() {
-                        if input.is_none() {
+                        if modal.peek_timeline {
                             match key.code {
+                                KeyCode::Char('g') | KeyCode::Enter => {
+                                    if let Some(m) = gate_modal.as_mut() {
+                                        m.peek_timeline = false;
+                                    }
+                                    continue;
+                                }
+                                KeyCode::Char('y') | KeyCode::Char('n')
+                                    if input.is_none()
+                                        && matches!(
+                                            modal.gate.kind,
+                                            GateKind::Approval
+                                                | GateKind::WikiProposal
+                                                | GateKind::Escalation
+                                        ) =>
+                                {
+                                    let gate_id = modal.gate.id.clone();
+                                    let approve = key.code == KeyCode::Char('y');
+                                    if let Some(m) = gate_modal.as_mut() {
+                                        m.peek_timeline = false;
+                                    }
+                                    input = Some(approval_gate_input(
+                                        client,
+                                        if approve {
+                                            GateAction::Approve
+                                        } else {
+                                            GateAction::Reject
+                                        },
+                                        gate_id,
+                                        &entries,
+                                        !approve,
+                                    ));
+                                    status = None;
+                                    continue;
+                                }
+                                _ => {}
+                            }
+                        } else if input.is_none() {
+                            match key.code {
+                                KeyCode::Esc => {
+                                    if let Some(m) = gate_modal.as_mut() {
+                                        m.peek_timeline = true;
+                                        m.scroll = 0;
+                                    }
+                                    status = Some(
+                                        "approval peeking — browse timeline · g resolve · y/n act"
+                                            .to_string(),
+                                    );
+                                    continue;
+                                }
                                 KeyCode::Char('y') | KeyCode::Char('n')
                                     if matches!(
                                         modal.gate.kind,
@@ -1665,6 +1717,9 @@ pub fn run(
                                     continue;
                                 }
                             }
+                        } else {
+                            // Input mode inside the modal — block timeline navigation.
+                            continue;
                         }
                     }
 
@@ -2412,6 +2467,7 @@ pub fn run(
                     gate_modal = Some(GateModal {
                         gate: gate_ref,
                         scroll: 0,
+                        peek_timeline: false,
                     });
                 }
             }
@@ -4062,103 +4118,6 @@ fn draw(
         }
     }
 
-    // Info panel overlay (? key) — shows session stats, toggles, active gates.
-    if let Some(panel) = info_panel {
-        let area = centered_rect(60, 70, f.area());
-        f.render_widget(Clear, area);
-        let inner_height = area.height.saturating_sub(2) as usize;
-        let total_lines = panel.lines.len();
-        let max_scroll = total_lines.saturating_sub(inner_height) as u16;
-        let scroll = info_scroll.min(max_scroll);
-        let text: Vec<Line> = panel
-            .lines
-            .iter()
-            .map(|l| Line::from(Span::styled(l.clone(), Style::default().bg(Color::Black))))
-            .collect();
-        f.render_widget(
-            Paragraph::new(text)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(" Session Info [?/Esc close] ")
-                        .border_style(Style::default().fg(Color::Cyan))
-                        .style(Style::default().bg(Color::Black)),
-                )
-                .scroll((scroll, 0)),
-            area,
-        );
-    }
-
-    // Artifact file content overlay (level 2 of artifact viewer).
-    if let Some(ref view) = artifact_file_view {
-        let area = centered_rect(80, 85, f.area());
-        f.render_widget(Clear, area);
-        let lines: Vec<Line> = view
-            .content
-            .lines()
-            .map(|l| Line::from(Span::styled(l.to_string(), Style::default().bg(Color::Black))))
-            .collect();
-        let inner_height = area.height.saturating_sub(2) as usize;
-        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
-        let scroll = view.scroll.min(max_scroll);
-        let title = format!(
-            " {} {} → {} [Esc back] ",
-            view.artifact_id, view.file_name, lines.len()
-        );
-        f.render_widget(
-            Paragraph::new(lines)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(title)
-                        .border_style(Style::default().fg(Color::Green))
-                        .style(Style::default().bg(Color::Black)),
-                )
-                .scroll((scroll, 0)),
-            area,
-        );
-    } else if let Some(ref viewer) = artifact_viewer {
-        // Artifact file list overlay (level 1).
-        let area = centered_rect(60, 60, f.area());
-        f.render_widget(Clear, area);
-        let lines: Vec<Line> = viewer
-            .files
-            .iter()
-            .enumerate()
-            .map(|(i, f)| {
-                let marker = if i == viewer.selected { " > " } else { "   " };
-                let style = if i == viewer.selected {
-                    Style::default().fg(Color::Yellow).bg(Color::Black)
-                } else {
-                    Style::default().bg(Color::Black)
-                };
-                Line::from(Span::styled(
-                    format!("{}{}", marker, f.name),
-                    style,
-                ))
-            })
-            .collect();
-        let title = format!(
-            " {} [{}] {} files [Enter/Esc] ",
-            viewer.artifact_id, viewer.kind, viewer.files.len()
-        );
-        let inner_height = area.height.saturating_sub(2) as usize;
-        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
-        let scroll = viewer.scroll.min(max_scroll);
-        f.render_widget(
-            Paragraph::new(lines)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(title)
-                        .border_style(Style::default().fg(Color::Green))
-                        .style(Style::default().bg(Color::Black)),
-                )
-                .scroll((scroll, 0)),
-            area,
-        );
-    }
-
     // The terminal width caps each line. Reserve 2 cells for the actor rail
     // and 3 cells for the altitude glyph + space, leaving the rest for the
     // label + headline + detail.
@@ -4350,9 +4309,244 @@ fn draw(
     };
     f.render_widget(footer, chunks[footer_idx]);
 
+    // Overlays render last (on top of everything) so they are never painted over.
+    if let Some(panel) = info_panel {
+        let area = centered_rect(60, 70, f.area());
+        f.render_widget(Clear, area);
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let total_lines = panel.lines.len();
+        let max_scroll = total_lines.saturating_sub(inner_height) as u16;
+        let scroll = info_scroll.min(max_scroll);
+        let text: Vec<Line> = panel
+            .lines
+            .iter()
+            .map(|l| Line::from(Span::styled(l.clone(), Style::default().bg(Color::Black))))
+            .collect();
+        f.render_widget(
+            Paragraph::new(text)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Session Info [?/Esc close] ")
+                        .border_style(Style::default().fg(Color::Cyan))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    }
+
+    if let Some(ref view) = artifact_file_view {
+        let area = centered_rect(80, 85, f.area());
+        f.render_widget(Clear, area);
+        let lines: Vec<Line> = view
+            .content
+            .lines()
+            .map(|l| Line::from(Span::styled(l.to_string(), Style::default().bg(Color::Black))))
+            .collect();
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
+        let scroll = view.scroll.min(max_scroll);
+        let title = format!(
+            " {} {} → {} [Esc back] ",
+            view.artifact_id, view.file_name, lines.len()
+        );
+        f.render_widget(
+            Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(title)
+                        .border_style(Style::default().fg(Color::Green))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    } else if let Some(ref viewer) = artifact_viewer {
+        let area = centered_rect(60, 60, f.area());
+        f.render_widget(Clear, area);
+        let lines: Vec<Line> = viewer
+            .files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let marker = if i == viewer.selected { " > " } else { "   " };
+                let style = if i == viewer.selected {
+                    Style::default().fg(Color::Yellow).bg(Color::Black)
+                } else {
+                    Style::default().bg(Color::Black)
+                };
+                Line::from(Span::styled(
+                    format!("{}{}", marker, f.name),
+                    style,
+                ))
+            })
+            .collect();
+        let title = format!(
+            " {} [{}] {} files [Enter/Esc] ",
+            viewer.artifact_id, viewer.kind, viewer.files.len()
+        );
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
+        let scroll = viewer.scroll.min(max_scroll);
+        f.render_widget(
+            Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(title)
+                        .border_style(Style::default().fg(Color::Green))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    }
+
     if let Some(modal) = gate_modal {
         draw_gate_modal(f, modal, gate_modal_entry, input, status);
     }
+}
+
+fn gate_modal_title(modal: &GateModal, entry: Option<&SessionTimelineEntry>) -> String {
+    if let Some(entry) = entry {
+        if payload_field_str(entry, "action").as_deref() == Some("revision_promote") {
+            let agent = payload_field_str(entry, "agent_id").unwrap_or_else(|| "agent".into());
+            return format!(" ⚠ PROMOTE AGENT — {agent} ");
+        }
+    }
+    match modal.gate.kind {
+        GateKind::Approval => " ⚠ APPROVAL REQUIRED ".to_string(),
+        GateKind::WikiProposal => " ⚠ WIKI PROPOSAL ".to_string(),
+        GateKind::Escalation => " ⚠ ESCALATION ".to_string(),
+        GateKind::Interaction => " ❓ QUESTION PENDING ".to_string(),
+        GateKind::Plan => " ⚠ ACTION REQUIRED ".to_string(),
+    }
+}
+
+fn gate_modal_peek_summary(modal: &GateModal, entry: Option<&SessionTimelineEntry>) -> String {
+    if let Some(entry) = entry {
+        let spec = render::render_spec(entry);
+        return render::one_line(&spec.headline, 72);
+    }
+    format!("Gate {}", modal.gate.id)
+}
+
+fn gate_modal_input_panel_lines(
+    gi: &GateInput,
+    width: usize,
+    status: Option<&str>,
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let wrap_w = width.saturating_sub(2).max(20);
+
+    if let Some(ref phrase) = gi.required_confirm_phrase {
+        lines.push(Line::from(Span::styled(
+            "Type this phrase exactly to approve:",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for line in render::wrap_display_lines(phrase, wrap_w) {
+            lines.push(Line::from(Span::styled(
+                line,
+                Style::default().fg(Color::Green),
+            )));
+        }
+        lines.push(Line::raw(""));
+    } else if matches!(gi.action, GateAction::Reject) {
+        lines.push(Line::from(Span::styled(
+            "Rejection reason (required):",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+    } else if gi.motivation_required {
+        lines.push(Line::from(Span::styled(
+            "Approval motivation (required):",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    let input_label = if gi.required_confirm_phrase.is_some() {
+        "Your input".to_string()
+    } else {
+        gate_input_label(gi).trim_end_matches(':').to_string()
+    };
+    lines.push(Line::from(vec![
+        Span::styled(format!("{input_label}: "), Style::default().fg(Color::Cyan)),
+        Span::styled(format!("{}▏", gi.buffer), Style::default().fg(Color::White)),
+    ]));
+
+    if let Some(err) = status.filter(|s| s.starts_with('✗')) {
+        lines.push(Line::from(Span::styled(
+            err.to_string(),
+            Style::default().fg(Color::Red),
+        )));
+    }
+
+    let choices = gi
+        .options
+        .iter()
+        .enumerate()
+        .map(|(i, o)| format!("[{}] {}", i + 1, render::one_line(&o.label, 28)))
+        .collect::<Vec<_>>()
+        .join(" · ");
+    let hint = if gi.options.is_empty() {
+        "Enter submit · Esc back · Esc×2 peek timeline".to_string()
+    } else if gi.allow_freeform {
+        format!("{choices}   Enter submit · Esc back")
+    } else {
+        format!("{choices}   number choose · Esc back")
+    };
+    lines.push(Line::from(Span::styled(
+        hint,
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines
+}
+
+fn gate_modal_input_panel_height(gi: &GateInput, width: u16, status: Option<&str>) -> u16 {
+    let lines = gate_modal_input_panel_lines(gi, width as usize, status);
+    lines.len().max(3) as u16 + 1
+}
+
+fn draw_gate_modal_peek_banner(
+    f: &mut Frame,
+    modal: &GateModal,
+    entry: Option<&SessionTimelineEntry>,
+) {
+    let full = f.area();
+    let banner_h = 3u16.min(full.height);
+    let area = Rect {
+        x: full.x,
+        y: full.y,
+        width: full.width,
+        height: banner_h,
+    };
+    f.render_widget(Clear, area);
+    let summary = gate_modal_peek_summary(modal, entry);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" ⚠ OPERATOR ACTION PENDING ")
+        .border_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))
+        .style(Style::default().bg(Color::Black));
+    let inner = block.inner(area);
+    let text = vec![
+        Line::from(Span::styled(
+            summary,
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(Span::styled(
+            format!("id: {}  ·  g or Enter resolve  ·  y approve  ·  n reject", modal.gate.id),
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+    f.render_widget(block, area);
+    f.render_widget(Paragraph::new(text), inner);
 }
 
 fn draw_gate_modal(
@@ -4362,26 +4556,26 @@ fn draw_gate_modal(
     input: Option<&GateInput>,
     status: Option<&str>,
 ) {
+    if modal.peek_timeline {
+        draw_gate_modal_peek_banner(f, modal, entry);
+        return;
+    }
+
     let full = f.area();
+    f.render_widget(Clear, full);
     f.render_widget(
         Paragraph::new("").style(Style::default().bg(Color::Rgb(20, 20, 20))),
         full,
     );
 
-    let area = centered_rect(78, 72, full);
+    let area = centered_rect(82, 78, full);
     f.render_widget(Clear, area);
 
-    let title = match modal.gate.kind {
-        GateKind::Approval => " ⚠ APPROVAL REQUIRED ",
-        GateKind::WikiProposal => " ⚠ WIKI PROPOSAL ",
-        GateKind::Escalation => " ⚠ ESCALATION ",
-        GateKind::Interaction => " ❓ QUESTION PENDING ",
-        GateKind::Plan => " ⚠ ACTION REQUIRED ",
-    };
     let border_color = match modal.gate.kind {
         GateKind::Interaction => Color::Cyan,
         _ => Color::Yellow,
     };
+    let title = gate_modal_title(modal, entry);
 
     let mut content_lines: Vec<Line<'static>> = Vec::new();
     if let Some(entry) = entry {
@@ -4401,31 +4595,28 @@ fn draw_gate_modal(
         content_lines.push(Line::from(format!("Gate id: {}", modal.gate.id)));
     }
 
-    let action_hint = if input.is_some() {
-        String::new()
-    } else {
-        match modal.gate.kind {
-            GateKind::Approval | GateKind::WikiProposal | GateKind::Escalation => {
-                "y approve · n reject · j/k scroll".to_string()
-            }
-            GateKind::Interaction => "Enter/r answer · j/k scroll".to_string(),
-            GateKind::Plan => String::new(),
-        }
-    };
-
     let block = Block::default()
         .borders(Borders::ALL)
         .title(title)
         .border_style(Style::default().fg(border_color).add_modifier(Modifier::BOLD))
         .style(Style::default().bg(Color::Black));
     let inner = block.inner(area);
-    let footer_h = if input.is_some() || !action_hint.is_empty() {
-        2u16
+    let inner_width = inner.width;
+
+    let preview_phrase = input
+        .is_none()
+        .then(|| entry.and_then(|e| payload_field_str(e, "confirm_phrase")))
+        .flatten();
+    let footer_h = if let Some(gi) = input {
+        gate_modal_input_panel_height(gi, inner_width, status)
+    } else if preview_phrase.is_some() {
+        4 + render::wrap_display_lines(preview_phrase.as_deref().unwrap_or(""), inner_width as usize - 2)
+            .len() as u16
     } else {
-        0
+        2
     };
     let chunks = Layout::vertical([
-        Constraint::Min(4),
+        Constraint::Min(6),
         Constraint::Length(footer_h),
     ])
     .split(inner);
@@ -4441,35 +4632,43 @@ fn draw_gate_modal(
     );
 
     if let Some(gi) = input {
-        let label = gate_input_label(gi);
-        let err = status
-            .filter(|s| s.starts_with('✗'))
-            .map(|s| format!("  {s}"))
-            .unwrap_or_default();
-        let choices = gi
-            .options
-            .iter()
-            .enumerate()
-            .map(|(i, o)| format!("[{}] {}", i + 1, render::one_line(&o.label, 28)))
-            .collect::<Vec<_>>()
-            .join(" · ");
-        let hint = if gi.options.is_empty() {
-            "[Enter submit · Esc back]".to_string()
-        } else if gi.allow_freeform {
-            format!("{choices}   [number · or type reply · Esc back]")
-        } else {
-            format!("{choices}   [number choose · Esc back]")
+        let panel_lines = gate_modal_input_panel_lines(gi, inner_width as usize, status);
+        let panel_block = Block::default()
+            .borders(Borders::TOP)
+            .border_style(Style::default().fg(Color::DarkGray))
+            .style(Style::default().bg(Color::Black));
+        let panel_inner = panel_block.inner(chunks[1]);
+        f.render_widget(panel_block, chunks[1]);
+        f.render_widget(Paragraph::new(panel_lines), panel_inner);
+    } else {
+        let mut footer_lines: Vec<Line<'static>> = Vec::new();
+        if let Some(ref phrase) = preview_phrase {
+            footer_lines.push(Line::from(Span::styled(
+                "Confirm phrase (shown now — type after y):",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            for line in render::wrap_display_lines(phrase, inner_width as usize - 2) {
+                footer_lines.push(Line::from(Span::styled(
+                    line,
+                    Style::default().fg(Color::Green),
+                )));
+            }
+            footer_lines.push(Line::raw(""));
+        }
+        let action_hint = match modal.gate.kind {
+            GateKind::Approval | GateKind::WikiProposal | GateKind::Escalation => {
+                "y approve · n reject · j/k scroll details · Esc peek timeline"
+            }
+            GateKind::Interaction => "Enter/r answer · j/k scroll · Esc peek timeline",
+            GateKind::Plan => "",
         };
-        f.render_widget(
-            Paragraph::new(format!("{label}: {}▏{err}   {hint}", gi.buffer))
-                .style(Style::default().fg(Color::Cyan)),
-            chunks[1],
-        );
-    } else if !action_hint.is_empty() {
-        f.render_widget(
-            Paragraph::new(action_hint).style(Style::default().fg(Color::DarkGray)),
-            chunks[1],
-        );
+        footer_lines.push(Line::from(Span::styled(
+            action_hint,
+            Style::default().fg(Color::DarkGray),
+        )));
+        f.render_widget(Paragraph::new(footer_lines), chunks[1]);
     }
 }
 

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -625,6 +625,7 @@ struct ArtifactFileEntry {
 
 struct ArtifactViewer {
     artifact_id: String,
+    artifact_ref: String,
     kind: String,
     files: Vec<ArtifactFileEntry>,
     selected: usize,
@@ -638,28 +639,30 @@ struct ArtifactFileView {
     scroll: u16,
 }
 
-/// Extract artifact_id from a timeline entry, if it has one.
-fn artifact_id_for_entry(entry: &SessionTimelineEntry) -> Option<String> {
+/// Extract artifact_ref from a timeline entry, if it has one.
+/// Returns an `ar.*` or `art_*` ref that the gateway can resolve.
+fn artifact_ref_for_entry(entry: &SessionTimelineEntry) -> Option<String> {
     if let Some(ref aid) = entry.refs.artifact_id {
         return Some(aid.clone());
     }
     if entry.event_type == "tool.completed" {
         if let Some(ref payload) = entry.payload {
             if let Ok(p) = serde_json::from_str::<serde_json::Value>(payload) {
-                if p.get("tool_name").and_then(|v| v.as_str())
-                    .map(|n| n.starts_with("artifact"))
-                    .unwrap_or(false)
-                {
+                let tool_name = p.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+                if tool_name.starts_with("artifact") {
                     if let Some(result_str) = p.get("result").and_then(|v| v.as_str()) {
                         if let Ok(result) = serde_json::from_str::<serde_json::Value>(result_str) {
-                            if let Some(ref aid) = result.get("artifact_id").and_then(|v| v.as_str()) {
+                            if let Some(aref) = result.get("artifact_ref").and_then(|v| v.as_str()) {
+                                return Some(aref.to_string());
+                            }
+                            if let Some(aid) = result.get("artifact_id").and_then(|v| v.as_str()) {
                                 return Some(aid.to_string());
                             }
                         }
                     }
-                    if let Some(ref aid) = p.get("args_preview").and_then(|v| v.as_str()) {
-                        if aid.starts_with("ar.") || aid.starts_with("art_") {
-                            return Some(aid.to_string());
+                    if let Some(preview) = p.get("args_preview").and_then(|v| v.as_str()) {
+                        if preview.starts_with("ar.") || preview.starts_with("art_") {
+                            return Some(preview.to_string());
                         }
                     }
                 }
@@ -2047,7 +2050,7 @@ pub fn run(
                                         client,
                                         "artifact.read_file",
                                         serde_json::json!({
-                                            "artifact_id": viewer.artifact_id,
+                                            "artifact_ref": viewer.artifact_ref,
                                             "file_name": file.name,
                                         }),
                                     );
@@ -2073,16 +2076,17 @@ pub fn run(
                                     RowSource::Run { start, .. } => *start,
                                 };
                                 if let Some(entry) = view_visible.get(idx) {
-                                    if let Some(artifact_id) = artifact_id_for_entry(entry) {
+                                    if let Some(artifact_ref) = artifact_ref_for_entry(entry) {
                                         let result = rpc(
                                             client,
                                             "artifact.list_files",
                                             serde_json::json!({
-                                                "artifact_id": artifact_id,
+                                                "artifact_ref": artifact_ref,
                                             }),
                                         );
                                         match result {
                                             Ok(v) => {
+                                                let resolved_id = v.get("artifact_id").and_then(|i| i.as_str()).unwrap_or(&artifact_ref).to_string();
                                                 let files: Vec<ArtifactFileEntry> = v.get("files")
                                                     .and_then(|f| f.as_array())
                                                     .map(|arr| {
@@ -2099,7 +2103,8 @@ pub fn run(
                                                 } else {
                                                     let kind = v.get("kind").and_then(|k| k.as_str()).unwrap_or("unknown").to_string();
                                                     artifact_viewer = Some(ArtifactViewer {
-                                                        artifact_id,
+                                                        artifact_id: resolved_id,
+                                                        artifact_ref,
                                                         kind,
                                                         files,
                                                         selected: 0,
@@ -2842,33 +2847,37 @@ fn answer_params(gi: &GateInput, chosen: Option<&GateOption>) -> Result<serde_js
 /// Returns `Ok(msg)` only when the gateway accepted the decision (the caller
 /// uses this to mark the gate acted); `Err(msg)` on validation or transport
 /// failure, leaving the gate offerable so the operator can retry.
+fn approval_approve_params(gi: &GateInput) -> serde_json::Value {
+    let text = gi.buffer.trim();
+    let mut params = serde_json::json!({
+        "request_id": gi.id,
+        "decided_by": "operator",
+    });
+    // §O: destructive / elevated approvals need a non-empty motivation on the
+    // `reason` field. For R++4 confirm-phrase gates the typed phrase satisfies
+    // both obligations — do not send confirm_phrase without reason.
+    if gi.required_confirm_phrase.is_some() {
+        if !text.is_empty() {
+            params["confirm_phrase"] = serde_json::json!(text);
+            params["reason"] = serde_json::json!(text);
+        }
+    } else if !text.is_empty() {
+        params["reason"] = serde_json::json!(text);
+    }
+    if !gi.acknowledged_capabilities.is_empty() {
+        params["acknowledged_capabilities"] = serde_json::json!(gi.acknowledged_capabilities);
+    }
+    params
+}
+
 fn resolve_gate(client: &RoomClient, gi: &GateInput, chosen: Option<&GateOption>) -> Result<String, String> {
     let text = gi.buffer.trim();
-    let reason = if gi.required_confirm_phrase.is_some() {
-        None
-    } else {
-        (!text.is_empty()).then(|| text.to_string())
-    };
+    let reason = (!text.is_empty()).then(|| text.to_string());
     let (result, verb) = match gi.action {
-        GateAction::Approve => {
-            let mut params = serde_json::json!({
-                "request_id": gi.id,
-                "decided_by": "operator",
-            });
-            if let Some(r) = reason {
-                params["reason"] = serde_json::json!(r);
-            }
-            if gi.required_confirm_phrase.is_some() && !text.is_empty() {
-                params["confirm_phrase"] = serde_json::json!(text);
-            }
-            if !gi.acknowledged_capabilities.is_empty() {
-                params["acknowledged_capabilities"] = serde_json::json!(gi.acknowledged_capabilities);
-            }
-            (
-                rpc(client, "approvals.approve", params),
-                "approved",
-            )
-        }
+        GateAction::Approve => (
+            rpc(client, "approvals.approve", approval_approve_params(gi)),
+            "approved",
+        ),
         GateAction::Reject => (
             rpc(
                 client,
@@ -4272,11 +4281,11 @@ fn draw(
             _ => None,
         });
         let footer_w = chunks[footer_idx].width as usize;
-        let nav = "q quit · j↓ k↑ · Enter detail · ? info";
+        let nav = "q quit · j↓ k↑ · Enter detail · o artifact · ? info";
         let nav_display = if footer_w < 50 {
-            "j↓ k↑ · ?"
+            "j↓ k↑ · o · ?"
         } else if footer_w < 70 {
-            "q quit · j↓ k↑ · Enter · ?"
+            "q quit · j↓ k↑ · o · ?"
         } else {
             nav
         };
@@ -4443,7 +4452,7 @@ fn gate_modal_input_panel_lines(
 
     if let Some(ref phrase) = gi.required_confirm_phrase {
         lines.push(Line::from(Span::styled(
-            "Type this phrase exactly to approve:",
+            "Type this phrase exactly (also records your §O motivation):",
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
@@ -5042,6 +5051,35 @@ mod tests {
             kind: GateKind::Plan,
             id: "plan-1".into(),
         }));
+    }
+
+    #[test]
+    fn approval_approve_params_sends_phrase_as_reason_for_section_o() {
+        let gi = GateInput {
+            action: GateAction::Approve,
+            id: "apr-1".into(),
+            buffer: "promote weather-lookup rev_sha256:abc".into(),
+            options: Vec::new(),
+            allow_freeform: true,
+            motivation_required: false,
+            required_confirm_phrase: Some("promote weather-lookup rev_sha256:abc".into()),
+            acknowledged_capabilities: vec!["NetworkAccess".into()],
+        };
+        let params = approval_approve_params(&gi);
+        assert_eq!(
+            params.get("confirm_phrase").and_then(|v| v.as_str()),
+            Some("promote weather-lookup rev_sha256:abc")
+        );
+        assert_eq!(
+            params.get("reason").and_then(|v| v.as_str()),
+            Some("promote weather-lookup rev_sha256:abc")
+        );
+        assert_eq!(
+            params.get("acknowledged_capabilities")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(1)
+        );
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -704,6 +704,8 @@ struct GateModal {
     /// When true, the timeline stays interactive; a compact banner reminds the
     /// operator that a gate is still open (`g` reopens the full modal).
     peek_timeline: bool,
+    /// Fallback detail from `approvals.inspect` when the timeline row is sparse.
+    inspect_lines: Vec<String>,
 }
 
 fn gate_modal_kind(gate: &GateRef) -> bool {
@@ -730,6 +732,87 @@ fn newest_blocking_gate_event(
     None
 }
 
+fn gate_inspect_detail_lines(value: &serde_json::Value) -> Vec<String> {
+    let field = |key: &str| {
+        value
+            .get(key)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    let mut lines = Vec::new();
+    if let Some(action) = field("action") {
+        lines.push(format!("  action: {action}"));
+    }
+    if let Some(level) = field("approval_level") {
+        lines.push(format!("  level: {level}"));
+    }
+    match field("action").as_deref() {
+        Some("session_escalate") => {
+            if let Some(agent) = field("requested_by_agent_id") {
+                lines.push(format!("  requested by: {agent}"));
+            }
+            if let Some(u) = field("urgency") {
+                lines.push(format!("  urgency: {u}"));
+            }
+            if let Some(reason) = field("reason").or_else(|| field("summary")) {
+                lines.push("  reason:".to_string());
+                for line in render::wrap_display_lines(&reason, 76) {
+                    lines.push(format!("    {line}"));
+                }
+            }
+            if let Some(ctx) = field("context") {
+                lines.push("  context:".to_string());
+                for line in render::wrap_display_lines(&ctx, 76) {
+                    lines.push(format!("    {line}"));
+                }
+            }
+            if let Some(actions) = value.get("suggested_actions").and_then(|v| v.as_array()) {
+                let joined: Vec<_> = actions.iter().filter_map(|v| v.as_str()).collect();
+                if !joined.is_empty() {
+                    lines.push(format!("  suggested: {}", joined.join(" · ")));
+                }
+            }
+        }
+        Some("revision_promote") => {
+            if let Some(agent) = field("agent_id") {
+                lines.push(format!("  agent: {agent}"));
+            }
+            if let Some(rev) = field("revision_id") {
+                lines.push(format!("  revision: {}", render::one_line(&rev, 120)));
+            }
+            if let Some(summary) = field("summary") {
+                lines.push("  about:".to_string());
+                for line in render::wrap_display_lines(&summary, 76) {
+                    lines.push(format!("    {line}"));
+                }
+            }
+        }
+        _ => {
+            if let Some(summary) = field("summary") {
+                lines.push("  about:".to_string());
+                for line in render::wrap_display_lines(&summary, 76) {
+                    lines.push(format!("    {line}"));
+                }
+            }
+            if let Some(risk) = field("risk_summary") {
+                lines.push(format!("  risk: {}", render::one_line(&risk, 120)));
+            }
+        }
+    }
+    lines
+}
+
+fn fetch_gate_inspect_detail(client: &RoomClient, request_id: &str) -> Vec<String> {
+    rpc(
+        client,
+        "approvals.inspect",
+        serde_json::json!({ "request_id": request_id }),
+    )
+    .map(|v| gate_inspect_detail_lines(&v))
+    .unwrap_or_default()
+}
+
 fn gate_entry_for_ref<'a>(
     entries: &'a [SessionTimelineEntry],
     gate: &GateRef,
@@ -740,8 +823,10 @@ fn gate_entry_for_ref<'a>(
                 && approval_id_for(e).as_deref() == Some(gate.id.as_str())
         }
         GateKind::Escalation => {
-            e.event_type == "escalation.pending"
-                && e.refs.approval_request_id.as_deref() == Some(gate.id.as_str())
+            (e.event_type == "escalation.pending"
+                && e.refs.approval_request_id.as_deref() == Some(gate.id.as_str()))
+                || (e.event_type == "approval.pending"
+                    && approval_id_for(e).as_deref() == Some(gate.id.as_str()))
         }
         GateKind::Interaction => {
             e.event_type == "user.ask.pending"
@@ -2474,10 +2559,12 @@ pub fn run(
                     info_panel_open = false;
                     artifact_viewer = None;
                     artifact_file_view = None;
+                    let inspect_lines = fetch_gate_inspect_detail(client, &gate_ref.id);
                     gate_modal = Some(GateModal {
                         gate: gate_ref,
                         scroll: 0,
                         peek_timeline: false,
+                        inspect_lines,
                     });
                 }
             }
@@ -2751,11 +2838,13 @@ fn gate_for_entry(
     match e.event_type.as_str() {
         "approval.pending" => {
             let id = approval_id_for(e)?;
-            let is_wiki = payload_field_str(e, "action").as_deref() == Some("wiki_propose");
-            (!resolved.contains(&id) && !acted.contains(&id)).then_some(GateRef {
-                kind: if is_wiki { GateKind::WikiProposal } else { GateKind::Approval },
-                id,
-            })
+            let action = payload_field_str(e, "action");
+            let kind = match action.as_deref() {
+                Some("wiki_propose") => GateKind::WikiProposal,
+                Some("session_escalate") => GateKind::Escalation,
+                _ => GateKind::Approval,
+            };
+            (!resolved.contains(&id) && !acted.contains(&id)).then_some(GateRef { kind, id })
         }
         "plan.pending" => {
             let id = plan_id_for(e)?;
@@ -4425,9 +4514,29 @@ fn draw(
 
 fn gate_modal_title(modal: &GateModal, entry: Option<&SessionTimelineEntry>) -> String {
     if let Some(entry) = entry {
-        if payload_field_str(entry, "action").as_deref() == Some("revision_promote") {
-            let agent = payload_field_str(entry, "agent_id").unwrap_or_else(|| "agent".into());
-            return format!(" ⚠ PROMOTE AGENT — {agent} ");
+        match payload_field_str(entry, "action").as_deref() {
+            Some("revision_promote") => {
+                let agent = payload_field_str(entry, "agent_id").unwrap_or_else(|| "agent".into());
+                return format!(" ⚠ PROMOTE AGENT — {agent} ");
+            }
+            Some("session_escalate") => {
+                let reason = payload_field_str(entry, "reason")
+                    .or_else(|| payload_field_str(entry, "summary"))
+                    .unwrap_or_else(|| "needs guidance".into());
+                return format!(
+                    " ⚠ SESSION ESCALATION — {} ",
+                    render::one_line(&reason, 48)
+                );
+            }
+            _ => {}
+        }
+        if entry.event_type == "escalation.pending" {
+            let synthesis = payload_field_str(entry, "synthesis")
+                .unwrap_or_else(|| "operator decision".into());
+            return format!(
+                " ⚠ PROMOTION ESCALATION — {} ",
+                render::one_line(&synthesis, 48)
+            );
         }
     }
     match modal.gate.kind {
@@ -4570,6 +4679,7 @@ fn draw_gate_modal(
     input: Option<&GateInput>,
     status: Option<&str>,
 ) {
+    let inspect_lines = &modal.inspect_lines;
     if modal.peek_timeline {
         draw_gate_modal_peek_banner(f, modal, entry);
         return;
@@ -4607,6 +4717,25 @@ fn draw_gate_modal(
         }
     } else {
         content_lines.push(Line::from(format!("Gate id: {}", modal.gate.id)));
+    }
+    if content_lines.len() <= 2 && !inspect_lines.is_empty() {
+        content_lines.push(Line::from(Span::styled(
+            "From approval record:",
+            Style::default().fg(Color::DarkGray),
+        )));
+        for line in inspect_lines {
+            content_lines.push(Line::from(line.clone()));
+        }
+    } else if !inspect_lines.is_empty()
+        && entry.is_some_and(|e| {
+            payload_field_str(e, "reason").is_none()
+                && payload_field_str(e, "synthesis").is_none()
+                && payload_field_str(e, "summary").is_none()
+        })
+    {
+        for line in inspect_lines {
+            content_lines.push(Line::from(line.clone()));
+        }
     }
 
     let block = Block::default()

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -2138,6 +2138,7 @@ pub fn run(
                                         serde_json::json!({
                                             "artifact_ref": viewer.artifact_ref,
                                             "file_name": file.name,
+                                            "session_id": root_session_id.clone(),
                                         }),
                                     );
                                     match result {
@@ -2168,6 +2169,7 @@ pub fn run(
                                             "artifact.list_files",
                                             serde_json::json!({
                                                 "artifact_ref": artifact_ref,
+                                                "session_id": root_session_id.clone(),
                                             }),
                                         );
                                         match result {
@@ -2196,7 +2198,7 @@ pub fn run(
                                                         selected: 0,
                                                         scroll: 0,
                                                     });
-                                                    status = Some("artifact: Enter to view · Esc close".to_string());
+                                                    status = Some("artifact: o to view · Esc close".to_string());
                                                 }
                                             }
                                             Err(e) => status = Some(format!("artifact list failed: {e}")),
@@ -4398,15 +4400,15 @@ fn draw(
         if total <= footer_w && !right.is_empty() {
             let pad1 = (footer_w - total) / 3;
             let pad2 = footer_w - nav_w - center_w - right_w - pad1;
-            Paragraph::new(format!(" {nav}{}{center}{}{right}", " ".repeat(pad1), " ".repeat(pad2)))
+            Paragraph::new(format!(" {nav_display}{}{center}{}{right}", " ".repeat(pad1), " ".repeat(pad2)))
                 .style(Style::default().fg(Color::DarkGray))
         } else if total <= footer_w {
             let pad = footer_w - nav_w - center_w;
-            Paragraph::new(format!(" {nav}{}{center}", " ".repeat(pad)))
+            Paragraph::new(format!(" {nav_display}{}{center}", " ".repeat(pad)))
                 .style(Style::default().fg(Color::DarkGray))
         } else {
             let right_part = if right.is_empty() { String::new() } else { format!("  {right}") };
-            Paragraph::new(format!(" {nav}{right_part}"))
+            Paragraph::new(format!(" {nav_display}{right_part}"))
                 .style(Style::default().fg(Color::DarkGray))
         }
     };
@@ -4487,12 +4489,15 @@ fn draw(
             })
             .collect();
         let title = format!(
-            " {} [{}] {} files [Enter/Esc] ",
+            " {} [{}] {} files [o/Esc] ",
             viewer.artifact_id, viewer.kind, viewer.files.len()
         );
         let inner_height = area.height.saturating_sub(2) as usize;
-        let max_scroll = lines.len().saturating_sub(inner_height) as u16;
-        let scroll = viewer.scroll.min(max_scroll);
+        let max_scroll = lines.len().saturating_sub(inner_height);
+        let scroll = viewer
+            .selected
+            .saturating_sub(inner_height / 2)
+            .min(max_scroll) as u16;
         f.render_widget(
             Paragraph::new(lines)
                 .block(

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -21,7 +21,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 use unicode_width::UnicodeWidthStr;
 use std::collections::{HashMap, HashSet};
@@ -692,6 +692,58 @@ struct GateInput {
     acknowledged_capabilities: Vec<String>,
 }
 
+/// Blocking popup for operator gates — auto-opens when a new approval, question,
+/// or escalation appears so the operator does not have to hunt the timeline.
+struct GateModal {
+    gate: GateRef,
+    scroll: u16,
+}
+
+fn gate_modal_kind(gate: &GateRef) -> bool {
+    matches!(
+        gate.kind,
+        GateKind::Approval | GateKind::WikiProposal | GateKind::Escalation | GateKind::Interaction
+    )
+}
+
+/// Newest unresolved operator gate that should block the session (plans use the
+/// plan-review pane instead).
+fn newest_blocking_gate_event(
+    entries: &[SessionTimelineEntry],
+    resolved: &HashSet<String>,
+    acted: &HashSet<String>,
+) -> Option<(GateRef, String)> {
+    for e in entries.iter().rev() {
+        if let Some(gate) = gate_for_entry(e, resolved, acted) {
+            if gate_modal_kind(&gate) {
+                return Some((gate, e.event_id.clone()));
+            }
+        }
+    }
+    None
+}
+
+fn gate_entry_for_ref<'a>(
+    entries: &'a [SessionTimelineEntry],
+    gate: &GateRef,
+) -> Option<&'a SessionTimelineEntry> {
+    entries.iter().rev().find(|e| match gate.kind {
+        GateKind::Approval | GateKind::WikiProposal => {
+            e.event_type == "approval.pending"
+                && approval_id_for(e).as_deref() == Some(gate.id.as_str())
+        }
+        GateKind::Escalation => {
+            e.event_type == "escalation.pending"
+                && e.refs.approval_request_id.as_deref() == Some(gate.id.as_str())
+        }
+        GateKind::Interaction => {
+            e.event_type == "user.ask.pending"
+                && interaction_id_for(e).as_deref() == Some(gate.id.as_str())
+        }
+        GateKind::Plan => false,
+    })
+}
+
 fn approval_entry_for_id<'a>(
     entries: &'a [SessionTimelineEntry],
     request_id: &str,
@@ -1166,6 +1218,8 @@ pub fn run(
     let mut quit_armed_until: Option<Instant> = None;
     let mut last_mouse_click: Option<(Instant, usize, u16, u16)> = None;
     let mut last_announced_plan_event: Option<String> = None;
+    let mut last_announced_gate_event: Option<String> = None;
+    let mut gate_modal: Option<GateModal> = None;
     let mut last_session_status_poll = Instant::now();
     let mut last_timeline_poll = Instant::now();
     let mut force_timeline_refresh = true;
@@ -1507,6 +1561,12 @@ pub fn run(
                                 match resolve_gate(client, &gi, chosen.as_ref()) {
                                     Ok(msg) => {
                                         acted.insert(gi.id.clone());
+                                        if gate_modal
+                                            .as_ref()
+                                            .is_some_and(|m| m.gate.id == gi.id)
+                                        {
+                                            gate_modal = None;
+                                        }
                                         status = Some(msg);
                                         follow = true;
                                         force_timeline_refresh = true;
@@ -1528,6 +1588,84 @@ pub fn run(
                             _ => {}
                         }
                         continue;
+                    }
+
+                    // Blocking gate modal — capture y/n/Enter before timeline nav.
+                    if let Some(modal) = gate_modal.as_ref() {
+                        if input.is_none() {
+                            match key.code {
+                                KeyCode::Char('y') | KeyCode::Char('n')
+                                    if matches!(
+                                        modal.gate.kind,
+                                        GateKind::Approval
+                                            | GateKind::WikiProposal
+                                            | GateKind::Escalation
+                                    ) =>
+                                {
+                                    input = Some(approval_gate_input(
+                                        client,
+                                        if key.code == KeyCode::Char('y') {
+                                            GateAction::Approve
+                                        } else {
+                                            GateAction::Reject
+                                        },
+                                        modal.gate.id.clone(),
+                                        &entries,
+                                        key.code == KeyCode::Char('n'),
+                                    ));
+                                    status = None;
+                                    continue;
+                                }
+                                KeyCode::Char('r') | KeyCode::Enter
+                                    if modal.gate.kind == GateKind::Interaction =>
+                                {
+                                    let (options, allow_freeform) =
+                                        interaction_choices(&entries, &modal.gate.id);
+                                    input = Some(GateInput {
+                                        action: GateAction::Answer,
+                                        id: modal.gate.id.clone(),
+                                        buffer: String::new(),
+                                        options,
+                                        allow_freeform,
+                                        motivation_required: false,
+                                        required_confirm_phrase: None,
+                                        acknowledged_capabilities: Vec::new(),
+                                    });
+                                    status = None;
+                                    continue;
+                                }
+                                KeyCode::Char('j') | KeyCode::Down => {
+                                    if let Some(m) = gate_modal.as_mut() {
+                                        m.scroll = m.scroll.saturating_add(1);
+                                    }
+                                    continue;
+                                }
+                                KeyCode::Char('k') | KeyCode::Up => {
+                                    if let Some(m) = gate_modal.as_mut() {
+                                        m.scroll = m.scroll.saturating_sub(1);
+                                    }
+                                    continue;
+                                }
+                                KeyCode::Char('q') => {
+                                    if quit_armed(&quit_armed_until) {
+                                        break 'room;
+                                    }
+                                    arm_quit(&mut quit_armed_until, &mut status);
+                                    continue;
+                                }
+                                _ => {
+                                    let ctrl_c = key.code == KeyCode::Char('c')
+                                        && key.modifiers.contains(KeyModifiers::CONTROL);
+                                    if ctrl_c {
+                                        if quit_armed(&quit_armed_until) {
+                                            break 'room;
+                                        }
+                                        arm_quit(&mut quit_armed_until, &mut status);
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
                     }
 
                     let ctrl_c = key.code == KeyCode::Char('c')
@@ -2245,6 +2383,47 @@ pub fn run(
             selected = selected.min(rows.len().saturating_sub(1));
         }
 
+        if input.is_none() && compose.is_none() && slash.is_none() {
+            if let Some((gate_ref, event_id)) =
+                newest_blocking_gate_event(&entries, &resolved, &acted)
+            {
+                let needs_open = gate_modal
+                    .as_ref()
+                    .map(|m| m.gate.id != gate_ref.id)
+                    .unwrap_or(true);
+                if needs_open && last_announced_gate_event.as_deref() != Some(event_id.as_str())
+                {
+                    last_announced_gate_event = Some(event_id);
+                    if let Some(row_idx) = newest_gate_row_index(
+                        &visible,
+                        &indexed,
+                        &entries,
+                        &resolved,
+                        &acted,
+                        &gate_ref,
+                    ) {
+                        selected = row_idx;
+                        follow = false;
+                    }
+                    detail = None;
+                    info_panel_open = false;
+                    artifact_viewer = None;
+                    artifact_file_view = None;
+                    gate_modal = Some(GateModal {
+                        gate: gate_ref,
+                        scroll: 0,
+                    });
+                }
+            }
+        }
+        if let Some(modal) = &gate_modal {
+            let still_active = find_active_gate(&entries, &resolved, &acted)
+                .is_some_and(|g| g.id == modal.gate.id);
+            if !still_active {
+                gate_modal = None;
+            }
+        }
+
         let gate = active_gate(&entries, &visible, indexed.get(selected), &resolved, &acted);
 
         spinner_frame = (spinner_frame + 1) % SPINNER_FRAMES.len();
@@ -2334,6 +2513,10 @@ pub fn run(
                 gate_count,
                 artifact_viewer.as_ref(),
                 artifact_file_view.as_ref(),
+                gate_modal.as_ref(),
+                gate_modal
+                    .as_ref()
+                    .and_then(|m| gate_entry_for_ref(&entries, &m.gate)),
             )
         })?;
 
@@ -3812,6 +3995,8 @@ fn draw(
     gate_count: usize,
     artifact_viewer: Option<&ArtifactViewer>,
     artifact_file_view: Option<&ArtifactFileView>,
+    gate_modal: Option<&GateModal>,
+    gate_modal_entry: Option<&SessionTimelineEntry>,
 ) {
     let compose_open = compose.is_some() && detail.is_none();
     let chunks = if compose_open {
@@ -3880,6 +4065,7 @@ fn draw(
     // Info panel overlay (? key) — shows session stats, toggles, active gates.
     if let Some(panel) = info_panel {
         let area = centered_rect(60, 70, f.area());
+        f.render_widget(Clear, area);
         let inner_height = area.height.saturating_sub(2) as usize;
         let total_lines = panel.lines.len();
         let max_scroll = total_lines.saturating_sub(inner_height) as u16;
@@ -3906,6 +4092,7 @@ fn draw(
     // Artifact file content overlay (level 2 of artifact viewer).
     if let Some(ref view) = artifact_file_view {
         let area = centered_rect(80, 85, f.area());
+        f.render_widget(Clear, area);
         let lines: Vec<Line> = view
             .content
             .lines()
@@ -3933,6 +4120,7 @@ fn draw(
     } else if let Some(ref viewer) = artifact_viewer {
         // Artifact file list overlay (level 1).
         let area = centered_rect(60, 60, f.area());
+        f.render_widget(Clear, area);
         let lines: Vec<Line> = viewer
             .files
             .iter()
@@ -4161,6 +4349,128 @@ fn draw(
         }
     };
     f.render_widget(footer, chunks[footer_idx]);
+
+    if let Some(modal) = gate_modal {
+        draw_gate_modal(f, modal, gate_modal_entry, input, status);
+    }
+}
+
+fn draw_gate_modal(
+    f: &mut Frame,
+    modal: &GateModal,
+    entry: Option<&SessionTimelineEntry>,
+    input: Option<&GateInput>,
+    status: Option<&str>,
+) {
+    let full = f.area();
+    f.render_widget(
+        Paragraph::new("").style(Style::default().bg(Color::Rgb(20, 20, 20))),
+        full,
+    );
+
+    let area = centered_rect(78, 72, full);
+    f.render_widget(Clear, area);
+
+    let title = match modal.gate.kind {
+        GateKind::Approval => " ⚠ APPROVAL REQUIRED ",
+        GateKind::WikiProposal => " ⚠ WIKI PROPOSAL ",
+        GateKind::Escalation => " ⚠ ESCALATION ",
+        GateKind::Interaction => " ❓ QUESTION PENDING ",
+        GateKind::Plan => " ⚠ ACTION REQUIRED ",
+    };
+    let border_color = match modal.gate.kind {
+        GateKind::Interaction => Color::Cyan,
+        _ => Color::Yellow,
+    };
+
+    let mut content_lines: Vec<Line<'static>> = Vec::new();
+    if let Some(entry) = entry {
+        let spec = render::render_spec(entry);
+        content_lines.push(Line::from(Span::styled(
+            spec.headline,
+            Style::default()
+                .fg(border_color)
+                .add_modifier(Modifier::BOLD),
+        )));
+        if let Some(detail) = spec.detail {
+            for line in detail.lines() {
+                content_lines.push(Line::from(line.to_string()));
+            }
+        }
+    } else {
+        content_lines.push(Line::from(format!("Gate id: {}", modal.gate.id)));
+    }
+
+    let action_hint = if input.is_some() {
+        String::new()
+    } else {
+        match modal.gate.kind {
+            GateKind::Approval | GateKind::WikiProposal | GateKind::Escalation => {
+                "y approve · n reject · j/k scroll".to_string()
+            }
+            GateKind::Interaction => "Enter/r answer · j/k scroll".to_string(),
+            GateKind::Plan => String::new(),
+        }
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(border_color).add_modifier(Modifier::BOLD))
+        .style(Style::default().bg(Color::Black));
+    let inner = block.inner(area);
+    let footer_h = if input.is_some() || !action_hint.is_empty() {
+        2u16
+    } else {
+        0
+    };
+    let chunks = Layout::vertical([
+        Constraint::Min(4),
+        Constraint::Length(footer_h),
+    ])
+    .split(inner);
+
+    let inner_height = chunks[0].height as usize;
+    let max_scroll = content_lines.len().saturating_sub(inner_height) as u16;
+    let scroll = modal.scroll.min(max_scroll);
+
+    f.render_widget(block, area);
+    f.render_widget(
+        Paragraph::new(content_lines).scroll((scroll, 0)),
+        chunks[0],
+    );
+
+    if let Some(gi) = input {
+        let label = gate_input_label(gi);
+        let err = status
+            .filter(|s| s.starts_with('✗'))
+            .map(|s| format!("  {s}"))
+            .unwrap_or_default();
+        let choices = gi
+            .options
+            .iter()
+            .enumerate()
+            .map(|(i, o)| format!("[{}] {}", i + 1, render::one_line(&o.label, 28)))
+            .collect::<Vec<_>>()
+            .join(" · ");
+        let hint = if gi.options.is_empty() {
+            "[Enter submit · Esc back]".to_string()
+        } else if gi.allow_freeform {
+            format!("{choices}   [number · or type reply · Esc back]")
+        } else {
+            format!("{choices}   [number choose · Esc back]")
+        };
+        f.render_widget(
+            Paragraph::new(format!("{label}: {}▏{err}   {hint}", gi.buffer))
+                .style(Style::default().fg(Color::Cyan)),
+            chunks[1],
+        );
+    } else if !action_hint.is_empty() {
+        f.render_widget(
+            Paragraph::new(action_hint).style(Style::default().fg(Color::DarkGray)),
+            chunks[1],
+        );
+    }
 }
 
 /// Render the compose editor with wrapped lines and an inverted cursor cell.
@@ -4514,6 +4824,25 @@ mod tests {
         assert_eq!(g.id, "int-1");
         let active = active_gate(&entries, &entries, Some(&later_row), &empty, &empty).unwrap();
         assert_eq!(active.id, "int-1");
+    }
+
+    #[test]
+    fn newest_blocking_gate_event_prefers_latest_approval_over_older_ask() {
+        let mut approval = gate_entry("approval.pending");
+        approval.event_id = "ev-appr".into();
+        approval.refs.approval_request_id = Some("apr-new".into());
+        let mut ask = gate_entry("user.ask.pending");
+        ask.event_id = "ev-ask".into();
+        let entries = vec![ask, gate_entry("tool.completed"), approval];
+        let empty = HashSet::new();
+        let (gate, event_id) = newest_blocking_gate_event(&entries, &empty, &empty).unwrap();
+        assert_eq!(gate.kind, GateKind::Approval);
+        assert_eq!(gate.id, "apr-new");
+        assert_eq!(event_id, "ev-appr");
+        assert!(!gate_modal_kind(&GateRef {
+            kind: GateKind::Plan,
+            id: "plan-1".into(),
+        }));
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -3604,13 +3604,20 @@ fn draw(
         let total_lines = panel.lines.len();
         let max_scroll = total_lines.saturating_sub(inner_height) as u16;
         let scroll = info_scroll.min(max_scroll);
-        let text: Vec<Line> = panel.lines.iter().map(|l| Line::from(l.clone())).collect();
+        let text: Vec<Line> = panel
+            .lines
+            .iter()
+            .map(|l| Line::from(Span::styled(l.clone(), Style::default().bg(Color::Black))))
+            .collect();
         f.render_widget(
             Paragraph::new(text)
-                .block(Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Session Info [?/Esc close] ")
-                    .border_style(Style::default().fg(Color::Cyan)))
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Session Info [?/Esc close] ")
+                        .border_style(Style::default().fg(Color::Cyan))
+                        .style(Style::default().bg(Color::Black)),
+                )
                 .scroll((scroll, 0)),
             area,
         );

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -463,6 +463,161 @@ fn clear_detail(
     *h_scroll = 0;
 }
 
+struct InfoPanel {
+    lines: Vec<String>,
+}
+
+impl InfoPanel {
+    fn new(lines: Vec<String>) -> Self {
+        Self { lines }
+    }
+}
+
+fn build_info_panel(
+    root: &str,
+    channel_kind: &str,
+    stats: &SessionStats,
+    floor: Altitude,
+    squash: bool,
+    follow: bool,
+    show_reasoning: bool,
+    row_count: usize,
+    gate: Option<&GateRef>,
+    pending_plan_count: usize,
+    status: Option<&str>,
+    selected_spawn_agent: Option<&str>,
+) -> InfoPanel {
+    let mut lines = Vec::new();
+    let short_id = if root.len() > 32 {
+        format!("{}…{}", &root[..12], &root[root.len()-8..])
+    } else {
+        root.to_string()
+    };
+    lines.push(format!("  Session    {short_id}"));
+    lines.push(format!("  Channel    {channel_kind}"));
+    lines.push(String::new());
+    if stats.llm_calls > 0 {
+        let model_tag = if stats.models.len() == 1 {
+            stats.models[0].clone()
+        } else {
+            format!("{} models", stats.models.len())
+        };
+        lines.push(format!("  Model      {model_tag}  ({} calls)", stats.llm_calls));
+        lines.push(format!("  Tokens     in {}   out {}", format_tokens(stats.total_input), format_tokens(stats.total_output)));
+    }
+    lines.push(String::new());
+    lines.push(format!("  Toggles    floor:{}  squash:{}  reasoning:{}  follow:{}",
+        floor.as_str(),
+        if squash { "on" } else { "off" },
+        if show_reasoning { "on" } else { "off" },
+        if follow { "●" } else { "○" },
+    ));
+    lines.push(format!("  Rows       {row_count}"));
+    lines.push(String::new());
+    let mut active = Vec::new();
+    if let Some(g) = gate {
+        active.push(format!("  ⏸  gate: {} ({:?})", g.id, g.kind));
+    }
+    if pending_plan_count > 0 {
+        active.push(format!("  ⚠  {pending_plan_count} plan(s) pending"));
+    }
+    if let Some(agent) = selected_spawn_agent {
+        active.push(format!("  ↳  agent_spawn → {agent}"));
+    }
+    if active.is_empty() {
+        lines.push("  Active     —".to_string());
+    } else {
+        lines.push("  Active".to_string());
+        for a in active {
+            lines.push(a);
+        }
+    }
+    if let Some(s) = status {
+        lines.push(String::new());
+        lines.push(format!("  Status     {s}"));
+    }
+    InfoPanel::new(lines)
+}
+
+fn truncate_id(id: &str, max: usize) -> String {
+    if id.len() <= max {
+        id.to_string()
+    } else {
+        format!("{}…{}", &id[..max / 2], &id[id.len() - (max - max / 2 - 1)..])
+    }
+}
+
+fn build_header(
+    root: &str,
+    channel_kind: &str,
+    stats: &SessionStats,
+    gate_count: usize,
+    follow: bool,
+    width: u16,
+) -> String {
+    let left = format!(" Session Room [{}] — {}", channel_kind, truncate_id(root, 28));
+    let mut right_parts = Vec::new();
+    if stats.llm_calls > 0 {
+        right_parts.push(format!("{}→{} ●{}", format_tokens(stats.total_input), format_tokens(stats.total_output), stats.llm_calls));
+    }
+    if gate_count > 0 {
+        right_parts.push(format!("⚠{gate_count}"));
+    }
+    if follow {
+        right_parts.push("[following]".to_string());
+    }
+    let right = right_parts.join("  ");
+    let left_w = left.width();
+    let right_w = right.width();
+    let avail = width as usize;
+    if left_w + right_w + 2 >= avail {
+        format!("{left} {right}")
+    } else {
+        let pad = avail - left_w - right_w;
+        format!("{}{}{}", left, " ".repeat(pad), right)
+    }
+}
+
+/// Count pending gates from the rendered rows: approval, plan, interaction, escalation.
+fn count_active_gates(entries: &[SessionTimelineEntry], resolved: &HashSet<String>) -> usize {
+    entries.iter().filter(|e| {
+        matches!(e.event_type.as_str(),
+            "approval.pending" | "plan.pending" | "user.ask.pending" | "escalation.pending"
+        ) && !resolved.contains(approval_or_interaction_id(e).as_deref().unwrap_or(&e.event_id))
+    }).count()
+}
+
+fn approval_or_interaction_id(e: &SessionTimelineEntry) -> Option<String> {
+    if e.event_type == "user.ask.pending" {
+        e.payload.as_deref()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+            .and_then(|v| v.get("interaction_id").and_then(|x| x.as_str()).map(String::from))
+    } else {
+        e.payload.as_deref()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+            .and_then(|v| v.get("request_id").and_then(|x| x.as_str()).map(String::from))
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}
+
 /// An in-flight operator decision — captures an optional motivation (approvals,
 /// §3.5) or the answer (interactions) before committing. `GateRef`, `GateKind`,
 /// and `GateAction` are the channel-neutral primitives, shared from
@@ -843,6 +998,8 @@ pub fn run(
     // Display toggles + spinner state for the in-flight row indicator.
     let mut show_reasoning = true;
     let mut spinner_frame: usize = 0;
+    let mut info_panel_open = false;
+    let mut info_scroll: u16 = 0;
     let mut quit_armed_until: Option<Instant> = None;
     let mut last_mouse_click: Option<(Instant, usize, u16, u16)> = None;
     let mut last_announced_plan_event: Option<String> = None;
@@ -1221,7 +1378,10 @@ pub fn run(
                     }
                     match key.code {
                         KeyCode::Esc => {
-                            if detail.is_some() {
+                            if info_panel_open {
+                                info_panel_open = false;
+                                info_scroll = 0;
+                            } else if detail.is_some() {
                                 detail = None;
                                 detail_scroll = 0;
                                 detail_h_scroll = 0;
@@ -1496,13 +1656,26 @@ pub fn run(
                         }
                         // /: slash-command mode (vim/Discord convention). `:`
                         // and `?` are accepted aliases for muscle memory.
-                        KeyCode::Char('/') | KeyCode::Char(':') | KeyCode::Char('?') => {
+                        KeyCode::Char('/') | KeyCode::Char(':') => {
                             detail = None;
+                            info_panel_open = false;
                             slash = Some(String::new());
                             status = None;
                         }
+                        KeyCode::Char('?') => {
+                            if info_panel_open {
+                                info_panel_open = false;
+                                info_scroll = 0;
+                            } else {
+                                info_panel_open = true;
+                                info_scroll = 0;
+                                status = Some("info: j/k scroll · Esc close".to_string());
+                            }
+                        }
                         KeyCode::Down | KeyCode::Char('j') => {
-                            if detail.is_some() {
+                            if info_panel_open {
+                                info_scroll = info_scroll.saturating_add(1);
+                            } else if detail.is_some() {
                                 detail_scroll = detail_scroll.saturating_add(1);
                             } else {
                                 follow = false;
@@ -1511,7 +1684,9 @@ pub fn run(
                             }
                         }
                         KeyCode::Up | KeyCode::Char('k') => {
-                            if detail.is_some() {
+                            if info_panel_open {
+                                info_scroll = info_scroll.saturating_sub(1);
+                            } else if detail.is_some() {
                                 detail_scroll = detail_scroll.saturating_sub(1);
                             } else {
                                 follow = false;
@@ -1850,6 +2025,25 @@ pub fn run(
         } else {
             compute_viewport_offset(safe_selected, list_height, &row_heights)
         };
+        let gate_count = count_active_gates(&entries, &resolved);
+        let info_panel = if info_panel_open {
+            Some(build_info_panel(
+                root_session_id,
+                TuiChannel.kind(),
+                &session_stats,
+                floor,
+                squash,
+                follow,
+                show_reasoning,
+                row_count,
+                gate.as_ref(),
+                pending_plan_count,
+                status.as_deref(),
+                selected_spawn_agent.as_deref(),
+            ))
+        } else {
+            None
+        };
 
         terminal.draw(|f| {
             draw(
@@ -1874,6 +2068,9 @@ pub fn run(
                 &session_stats,
                 pending_plan_count,
                 selected_spawn_agent.as_deref(),
+                info_panel.as_ref(),
+                info_scroll,
+                gate_count,
             )
         })?;
 
@@ -3332,6 +3529,9 @@ fn draw(
     stats: &SessionStats,
     pending_plan_count: usize,
     selected_spawn_agent: Option<&str>,
+    info_panel: Option<&InfoPanel>,
+    info_scroll: u16,
+    gate_count: usize,
 ) {
     let compose_open = compose.is_some() && detail.is_none();
     let chunks = if compose_open {
@@ -3353,40 +3553,7 @@ fn draw(
     let footer_idx = if compose_open { 3 } else { 2 };
     let list_idx = 1usize;
 
-    let stats_tag = if stats.llm_calls > 0 {
-        let models_tag = if stats.models.len() == 1 {
-            stats.models[0].clone()
-        } else {
-            format!("{} models", stats.models.len())
-        };
-        format!(
-            "   in:{} out:{} calls:{} [{}]",
-            format_tokens(stats.total_input),
-            format_tokens(stats.total_output),
-            stats.llm_calls,
-            models_tag,
-        )
-    } else {
-        String::new()
-    };
-    let plan_chip = if pending_plan_count > 0 {
-        format!("   ⚠ {pending_plan_count} plan(s) pending")
-    } else {
-        String::new()
-    };
-    let spawn_chip = selected_spawn_agent
-        .map(|id| format!("   ↳ agent_spawn → {id}"))
-        .unwrap_or_default();
-    let header = format!(
-        " Session Room [{}] — {root}   floor: {}   squash: {}   reasoning: {}   {} rows{spawn_chip}{plan_chip}{stats_tag}{}{}",
-        TuiChannel.kind(),
-        floor.as_str(),
-        if squash { "on" } else { "off" },
-        if show_reasoning { "on" } else { "off" },
-        rows.len(),
-        if follow { "   (following)" } else { "" },
-        status.map(|s| format!("   {s}")).unwrap_or_default(),
-    );
+    let header = build_header(root, TuiChannel.kind(), stats, gate_count, follow, chunks[0].width);
     f.render_widget(
         Paragraph::new(header).style(Style::default().add_modifier(Modifier::BOLD)),
         chunks[0],
@@ -3428,6 +3595,25 @@ fn draw(
             );
             return;
         }
+    }
+
+    // Info panel overlay (? key) — shows session stats, toggles, active gates.
+    if let Some(panel) = info_panel {
+        let area = centered_rect(60, 70, f.area());
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let total_lines = panel.lines.len();
+        let max_scroll = total_lines.saturating_sub(inner_height) as u16;
+        let scroll = info_scroll.min(max_scroll);
+        let text: Vec<Line> = panel.lines.iter().map(|l| Line::from(l.clone())).collect();
+        f.render_widget(
+            Paragraph::new(text)
+                .block(Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Session Info [?/Esc close] ")
+                    .border_style(Style::default().fg(Color::Cyan)))
+                .scroll((scroll, 0)),
+            area,
+        );
     }
 
     // The terminal width caps each line. Reserve 2 cells for the actor rail
@@ -3578,18 +3764,46 @@ fn draw(
         Paragraph::new(format!(" {label}: {}▏{err}   {hint}", gi.buffer))
             .style(Style::default().fg(Color::Cyan))
     } else {
-        // The gate affordance hint is the channel's concern (#393) — route it
-        // through the channel so a Discord/WhatsApp bridge can render its own.
         let gate_hint = gate.map(|g| TuiChannel.gate_prompt(g)).unwrap_or_default();
-        let follow_indicator = if follow { " ● following" } else { " ○ paused" };
         let turn_hint = rows.get(safe_selected).and_then(|r| match r {
-            RenderedRow::Line(s) => s.turn_index.map(|n| format!(" · turn {n}")),
+            RenderedRow::Line(s) => s.turn_index.map(|n| format!("turn {n}")),
             _ => None,
-        }).unwrap_or_default();
-        Paragraph::new(format!(
-            " q quit (2×) · j/k scroll · PgUp/PgDn page · f/Space follow{follow_indicator}{turn_hint} · g/G top/bottom · a altitude · s squash · R reasoning · i message · / cmd · Enter/p plan review{gate_hint}"
-        ))
-        .style(Style::default().fg(Color::DarkGray))
+        });
+        let footer_w = chunks[footer_idx].width as usize;
+        let nav = "q quit · j↓ k↑ · Enter detail · ? info";
+        let nav_display = if footer_w < 50 {
+            "j↓ k↑ · ?"
+        } else if footer_w < 70 {
+            "q quit · j↓ k↑ · Enter · ?"
+        } else {
+            nav
+        };
+        let center = turn_hint.unwrap_or_else(|| "—".to_string());
+        let right = if info_panel.is_some() {
+            "info: j/k scroll · Esc close".to_string()
+        } else if !gate_hint.is_empty() {
+            gate_hint
+        } else {
+            String::new()
+        };
+        let nav_w = nav_display.width();
+        let center_w = center.width();
+        let right_w = right.width();
+        let total = nav_w + center_w + right_w + 4;
+        if total <= footer_w && !right.is_empty() {
+            let pad1 = (footer_w - total) / 3;
+            let pad2 = footer_w - nav_w - center_w - right_w - pad1;
+            Paragraph::new(format!(" {nav}{}{center}{}{right}", " ".repeat(pad1), " ".repeat(pad2)))
+                .style(Style::default().fg(Color::DarkGray))
+        } else if total <= footer_w {
+            let pad = footer_w - nav_w - center_w;
+            Paragraph::new(format!(" {nav}{}{center}", " ".repeat(pad)))
+                .style(Style::default().fg(Color::DarkGray))
+        } else {
+            let right_part = if right.is_empty() { String::new() } else { format!("  {right}") };
+            Paragraph::new(format!(" {nav}{right_part}"))
+                .style(Style::default().fg(Color::DarkGray))
+        }
     };
     f.render_widget(footer, chunks[footer_idx]);
 }

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -10,7 +10,8 @@ use super::channel::{Channel, GateAction, GateKind, GateOption, GateRef, TuiChan
 use super::client::RoomClient;
 use super::render::{self, ActorKind, RenderedRow, RowSource, RowSpec, RowTone};
 use super::slash::SlashCommand;
-use autonoetic_types::session_timeline::{Altitude, SessionTimelineEntry, SessionTimelineListResult};
+use autonoetic_types::principal::Principal;
+use autonoetic_types::session_timeline::{Altitude, SessionRole, SessionTimelineEntry, SessionTimelineListResult};
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste,
@@ -2116,7 +2117,11 @@ pub fn run(
                                             Err(e) => status = Some(format!("artifact list failed: {e}")),
                                         }
                                     } else {
-                                        status = Some("no artifact on this row".to_string());
+                                        let tool_name = entry.payload.as_ref()
+                                            .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                                            .and_then(|v| v.get("tool_name").and_then(|t| t.as_str()).map(String::from))
+                                            .unwrap_or_default();
+                                        status = Some(format!("no artifact on this row (type={} tool={})", entry.event_type, tool_name));
                                     }
                                 }
                             }
@@ -5566,5 +5571,87 @@ mod tests {
         disarm_quit(&mut armed, &mut status);
         assert!(armed.is_none());
         assert!(status.is_none());
+    }
+
+    #[test]
+    fn artifact_ref_for_entry_extracts_from_tool_completed() {
+        let result_json = serde_json::json!({
+            "ok": true,
+            "artifact_ref": "ar.abc12345",
+            "artifact_canonical_digest": "sha256:def456",
+            "kind": "binary",
+            "files": [{"name": "main.py", "alias": "main.py"}],
+            "message": "Created new artifact"
+        });
+        let result_str = serde_json::to_string(&result_json).unwrap();
+        let payload = serde_json::json!({
+            "tool_name": "artifact_build",
+            "result": result_str,
+        });
+        let entry = SessionTimelineEntry {
+            event_id: "ev1".into(),
+            root_session_id: "root".into(),
+            source_session_id: "src".into(),
+            turn_id: None,
+            principal: Principal::agent("test"),
+            role: SessionRole::Specialist { kind: "coder".into() },
+            event_type: "tool.completed".into(),
+            altitude: Altitude::Normal,
+            occurred_at: "2026-01-01T00:00:00Z".into(),
+            payload: Some(serde_json::to_string(&payload).unwrap()),
+            refs: Default::default(),
+        };
+        assert_eq!(
+            artifact_ref_for_entry(&entry),
+            Some("ar.abc12345".to_string())
+        );
+    }
+
+    #[test]
+    fn artifact_ref_for_entry_returns_none_for_non_artifact() {
+        let payload = serde_json::json!({
+            "tool_name": "sandbox_exec",
+            "result": "{\"ok\":true}",
+        });
+        let entry = SessionTimelineEntry {
+            event_id: "ev1".into(),
+            root_session_id: "root".into(),
+            source_session_id: "src".into(),
+            turn_id: None,
+            principal: Principal::agent("test"),
+            role: SessionRole::Specialist { kind: "coder".into() },
+            event_type: "tool.completed".into(),
+            altitude: Altitude::Normal,
+            occurred_at: "2026-01-01T00:00:00Z".into(),
+            payload: Some(serde_json::to_string(&payload).unwrap()),
+            refs: Default::default(),
+        };
+        assert_eq!(artifact_ref_for_entry(&entry), None);
+    }
+
+    #[test]
+    fn artifact_ref_for_entry_extracts_from_args_preview() {
+        let payload = serde_json::json!({
+            "tool_name": "artifact_build",
+            "result": "{}",
+            "args_preview": "ar.xyz99999",
+        });
+        let entry = SessionTimelineEntry {
+            event_id: "ev1".into(),
+            root_session_id: "root".into(),
+            source_session_id: "src".into(),
+            turn_id: None,
+            principal: Principal::agent("test"),
+            role: SessionRole::Specialist { kind: "coder".into() },
+            event_type: "tool.completed".into(),
+            altitude: Altitude::Normal,
+            occurred_at: "2026-01-01T00:00:00Z".into(),
+            payload: Some(serde_json::to_string(&payload).unwrap()),
+            refs: Default::default(),
+        };
+        assert_eq!(
+            artifact_ref_for_entry(&entry),
+            Some("ar.xyz99999".to_string())
+        );
     }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,1704 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Autonoetic Web Dashboard</title>
+  <!-- Tailwind CSS CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Google Fonts: Inter & Outfit -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'sans-serif'],
+            display: ['Outfit', 'sans-serif'],
+            mono: ['JetBrains Mono', 'monospace'],
+          },
+          colors: {
+            darkBg: '#0b0f19',
+            cardBg: '#111827',
+            borderBg: '#1f2937',
+            accentViolet: '#8b5cf6',
+            accentIndigo: '#6366f1',
+            accentAmber: '#f59e0b',
+            accentRed: '#ef4444',
+            accentGreen: '#10b981',
+          }
+        }
+      }
+    }
+  </script>
+
+  <style>
+    /* Premium glassmorphism & gradients */
+    body {
+      background: radial-gradient(circle at top right, rgba(99, 102, 241, 0.08), transparent 40%),
+                  radial-gradient(circle at bottom left, rgba(139, 92, 246, 0.05), transparent 40%),
+                  #0b0f19;
+      color: #f3f4f6;
+    }
+    
+    .glass-panel {
+      background: rgba(17, 24, 39, 0.75);
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    
+    .glow-violet {
+      box-shadow: 0 0 20px rgba(139, 92, 246, 0.15);
+    }
+    
+    .glow-indigo {
+      box-shadow: 0 0 25px rgba(99, 102, 241, 0.2);
+    }
+
+    /* Scrollbar Styling */
+    ::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+    ::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.02);
+    }
+    ::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+    }
+    ::-webkit-scrollbar-thumb:hover {
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    /* Micro-animations */
+    @keyframes pulse-glow {
+      0%, 100% { transform: scale(1); opacity: 0.8; box-shadow: 0 0 10px rgba(99, 102, 241, 0.4); }
+      50% { transform: scale(1.15); opacity: 1; box-shadow: 0 0 20px rgba(99, 102, 241, 0.8); }
+    }
+    .status-pulse {
+      animation: pulse-glow 2s infinite ease-in-out;
+    }
+
+    /* Diff line highlighting */
+    .diff-added { background-color: rgba(16, 185, 129, 0.15); color: #34d399; }
+    .diff-removed { background-color: rgba(239, 68, 68, 0.15); color: #f87171; }
+  </style>
+</head>
+<body class="font-sans min-h-screen flex flex-col antialiased">
+
+  <!-- Header Bar -->
+  <header class="glass-panel sticky top-0 z-40 px-6 py-4 flex items-center justify-between border-b border-gray-800 shadow-md">
+    <div class="flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-gradient-to-tr from-accentIndigo to-accentViolet flex items-center justify-center shadow-lg glow-indigo">
+        <span class="font-display font-extrabold text-lg text-white">A</span>
+      </div>
+      <div>
+        <h1 class="font-display font-bold text-lg text-white leading-tight">Autonoetic</h1>
+        <p class="text-xs text-gray-400">Principled Agentic Cockpit</p>
+      </div>
+    </div>
+
+    <!-- Connection Setup -->
+    <div class="flex items-center gap-4 text-sm">
+      <div class="flex flex-col">
+        <label class="text-[10px] text-gray-400 font-semibold uppercase tracking-wider">Root Session ID</label>
+        <input id="session-input" type="text" placeholder="session-abc123" class="bg-gray-900 border border-gray-800 rounded px-2.5 py-1 text-white text-xs w-48 focus:outline-none focus:border-accentIndigo transition-colors">
+      </div>
+      
+      <div class="flex flex-col">
+        <label class="text-[10px] text-gray-400 font-semibold uppercase tracking-wider">Shared Secret</label>
+        <input id="secret-input" type="password" placeholder="••••••••" class="bg-gray-900 border border-gray-800 rounded px-2.5 py-1 text-white text-xs w-36 focus:outline-none focus:border-accentIndigo transition-colors">
+      </div>
+
+      <div class="flex flex-col">
+        <label class="text-[10px] text-gray-400 font-semibold uppercase tracking-wider">Gateway Port</label>
+        <input id="port-input" type="text" value="4100" class="bg-gray-900 border border-gray-800 rounded px-2.5 py-1 text-white text-xs w-16 text-center focus:outline-none focus:border-accentIndigo transition-colors">
+      </div>
+
+      <button id="connect-btn" onclick="toggleConnection()" class="bg-accentIndigo hover:bg-opacity-90 active:scale-95 text-white font-medium text-xs px-4 py-2 rounded shadow transition-all duration-150 mt-4">
+        Connect
+      </button>
+
+      <div class="flex items-center gap-1.5 mt-4 ml-2">
+        <div id="status-indicator" class="w-2.5 h-2.5 rounded-full bg-gray-500"></div>
+        <span id="status-text" class="text-xs text-gray-400 font-medium">Disconnected</span>
+      </div>
+    </div>
+  </header>
+
+  <!-- Dashboard Grid -->
+  <main class="flex-1 flex overflow-hidden">
+    
+    <!-- Left Panel: Chat & Timeline -->
+    <section class="w-1/2 flex flex-col border-r border-gray-800 relative bg-darkBg">
+      <!-- Controls / Filter bar -->
+      <div class="flex items-center justify-between px-6 py-3 border-b border-gray-800 bg-gray-950 bg-opacity-40">
+        <h2 class="font-display font-semibold text-sm text-gray-300">Narrative Timeline</h2>
+        <div class="flex items-center gap-3">
+          <label class="text-xs text-gray-400">Altitude:</label>
+          <select id="altitude-filter" onchange="changeAltitudeFilter()" class="bg-gray-900 border border-gray-800 text-xs rounded px-2 py-0.5 text-gray-300 focus:outline-none">
+            <option value="detail">Detail (All)</option>
+            <option value="normal" selected>Normal (Milestones)</option>
+            <option value="attention">Attention (Gates)</option>
+            <option value="error">Error</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Timeline Stream -->
+      <div id="timeline-stream" class="flex-1 overflow-y-auto p-6 space-y-4">
+        <div class="text-center text-gray-500 text-sm mt-10">
+          Enter connection credentials and click Connect to load the session stream.
+        </div>
+      </div>
+
+      <!-- Composer Box -->
+      <div class="p-4 border-t border-gray-800 bg-gray-950 bg-opacity-40">
+        <div class="flex items-center gap-2">
+          <textarea id="composer-input" placeholder="Type a message to steer the session..." rows="1" class="flex-1 bg-gray-900 border border-gray-850 rounded px-4 py-2.5 text-sm text-white placeholder-gray-500 resize-none focus:outline-none focus:border-accentIndigo transition-colors max-h-24"></textarea>
+          <button id="send-btn" onclick="sendMessage()" disabled class="bg-accentIndigo disabled:bg-gray-800 disabled:text-gray-600 hover:bg-opacity-95 text-white p-2.5 rounded-lg shadow transition-all duration-150 flex items-center justify-center">
+            <!-- Send Icon (Lucide Send) -->
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-send-horizontal"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Right Panel: Plan, Hierarchy & Metadata sidebars -->
+    <section class="w-1/2 flex">
+      
+      <!-- Middle Pane: PlanFrame & Active Workbenches -->
+      <div class="w-1/2 border-r border-gray-800 flex flex-col bg-gray-950 bg-opacity-20">
+        <!-- PlanFrame Panel -->
+        <div class="flex-1 flex flex-col overflow-hidden">
+          <div class="px-6 py-3 border-b border-gray-800 bg-gray-950 bg-opacity-40 flex items-center justify-between">
+            <h2 class="font-display font-semibold text-sm text-gray-300 flex items-center gap-1.5">
+              <span>📋</span> Active PlanFrame
+            </h2>
+            <span id="plan-version-badge" class="bg-gray-800 text-[10px] text-gray-400 font-semibold px-2 py-0.5 rounded-full hidden">v1</span>
+          </div>
+          <div id="plan-steps" class="flex-1 overflow-y-auto p-6 space-y-3 text-sm">
+            <div class="text-center text-gray-500 text-xs py-8">No plan loaded yet.</div>
+          </div>
+        </div>
+
+        <!-- Workbenches Panel -->
+        <div class="h-1/3 border-t border-gray-800 flex flex-col overflow-hidden bg-gray-950 bg-opacity-40">
+          <div class="px-6 py-2 border-b border-gray-800 bg-gray-950 bg-opacity-60">
+            <h2 class="font-display font-semibold text-xs text-gray-400 tracking-wider uppercase">Active Workbenches</h2>
+          </div>
+          <div id="workbench-list" class="flex-1 overflow-y-auto p-4 space-y-2">
+            <div class="text-center text-gray-500 text-xs py-4">No active workbenches.</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right Pane: Agent Spawn Tree & Stats -->
+      <div class="w-1/2 flex flex-col bg-gray-950 bg-opacity-30">
+        
+        <!-- Agent spawn hierarchy graph -->
+        <div class="flex-1 flex flex-col overflow-hidden border-b border-gray-800">
+          <div class="px-6 py-3 border-b border-gray-800 bg-gray-950 bg-opacity-40">
+            <h2 class="font-display font-semibold text-sm text-gray-300 flex items-center gap-1.5">
+              <span>🌲</span> Agent Hierarchy
+            </h2>
+          </div>
+          <div class="flex-1 p-6 overflow-auto relative" id="agent-tree-container">
+            <svg id="agent-tree-svg" class="w-full h-full min-h-[250px]"></svg>
+            <div id="agent-tree-fallback" class="absolute inset-0 flex items-center justify-center text-gray-500 text-xs">
+              Waiting to parse timeline events...
+            </div>
+          </div>
+        </div>
+
+        <!-- Stats / Budget HUD -->
+        <div class="p-6 space-y-4 bg-gray-950 bg-opacity-60">
+          <h2 class="font-display font-semibold text-xs text-gray-400 tracking-wider uppercase border-b border-gray-800 pb-2">Session HUD</h2>
+          
+          <div class="grid grid-cols-2 gap-4 text-xs">
+            <div class="bg-gray-900 border border-gray-800 p-2.5 rounded shadow-inner">
+              <span class="text-[10px] text-gray-500 font-semibold block uppercase">LLM Calls</span>
+              <span id="hud-llm-calls" class="font-mono text-base font-bold text-accentIndigo">0</span>
+            </div>
+            
+            <div class="bg-gray-900 border border-gray-800 p-2.5 rounded shadow-inner">
+              <span class="text-[10px] text-gray-500 font-semibold block uppercase">Active Grants</span>
+              <span id="hud-grants-count" class="font-mono text-base font-bold text-accentViolet">0</span>
+            </div>
+          </div>
+
+          <!-- Token consumption -->
+          <div class="space-y-2 text-xs">
+            <div class="flex items-center justify-between text-[10px] text-gray-400 font-semibold uppercase">
+              <span>Token Consumption</span>
+              <span id="hud-tokens-total">0</span>
+            </div>
+            <div class="w-full bg-gray-900 h-2 rounded border border-gray-800 overflow-hidden">
+              <div id="token-bar-in" class="bg-accentIndigo h-full inline-block" style="width: 0%;"></div>
+              <div id="token-bar-out" class="bg-accentViolet h-full inline-block" style="width: 0%;"></div>
+            </div>
+            <div class="flex justify-between text-[9px] text-gray-500 font-mono">
+              <span id="hud-tokens-in">in: 0</span>
+              <span id="hud-tokens-out">out: 0</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+    </section>
+
+  </main>
+
+  <!-- Interactive Gate Modal (Suspension Popup) -->
+  <div id="gate-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 backdrop-blur-sm hidden">
+    <div class="w-[600px] max-w-full glass-panel glow-violet rounded-xl border border-gray-800 p-6 flex flex-col space-y-4">
+      <div class="flex items-center justify-between border-b border-gray-800 pb-3">
+        <h3 id="modal-title" class="font-display font-bold text-base text-accentAmber flex items-center gap-2">
+          <span>⏸</span> Gate Suspension
+        </h3>
+        <span id="modal-gate-id" class="text-xs font-mono text-gray-500">apr-xxxx</span>
+      </div>
+      
+      <div id="modal-body" class="text-sm text-gray-300 space-y-3 overflow-y-auto max-h-[300px]">
+        <!-- Filled dynamically -->
+      </div>
+
+      <!-- Motivation / Reply input panel -->
+      <div id="modal-action-panel" class="pt-3 border-t border-gray-800 flex flex-col space-y-3">
+        <label id="modal-input-label" class="text-xs text-gray-400 font-semibold uppercase tracking-wide">Motivation</label>
+        
+        <!-- Text/Motivation box -->
+        <input id="modal-text-input" type="text" placeholder="Explain your decision rationale..." class="bg-gray-950 border border-gray-850 rounded px-3.5 py-2 text-sm text-white focus:outline-none focus:border-accentIndigo transition-colors">
+        
+        <!-- Multi choice options list -->
+        <div id="modal-choices" class="flex flex-col gap-2 hidden"></div>
+
+        <div class="flex justify-end gap-3 pt-2">
+          <button id="modal-cancel-btn" onclick="closeGateModal()" class="border border-gray-800 hover:bg-gray-900 active:scale-95 text-gray-400 font-medium text-xs px-4 py-2 rounded transition-all duration-150">
+            Peek Timeline
+          </button>
+          
+          <button id="modal-reject-btn" onclick="submitGateAction(false)" class="bg-accentRed hover:bg-opacity-90 active:scale-95 text-white font-medium text-xs px-4 py-2 rounded shadow transition-all duration-150 hidden">
+            Reject
+          </button>
+
+          <button id="modal-submit-btn" onclick="submitGateAction(true)" class="bg-accentIndigo hover:bg-opacity-90 active:scale-95 text-white font-medium text-xs px-4 py-2 rounded shadow transition-all duration-150">
+            Submit
+          </button>
+        </div>
+    </div>
+  </div>
+
+  <!-- Event Detail Modal -->
+  <div id="event-detail-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 backdrop-blur-sm hidden">
+    <div class="w-[700px] max-w-[95%] h-[70%] glass-panel glow-indigo rounded-xl border border-gray-800 p-6 flex flex-col space-y-4">
+      <div class="flex items-center justify-between border-b border-gray-800 pb-3">
+        <h3 id="event-detail-title" class="font-display font-bold text-base text-white flex items-center gap-2">
+          <span>ℹ️</span> Event Details
+        </h3>
+        <button onclick="closeEventDetailModal()" class="text-gray-500 hover:text-white transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        </button>
+      </div>
+      
+      <div id="event-detail-content" class="flex-1 overflow-auto space-y-4">
+        <!-- Filled dynamically -->
+      </div>
+    </div>
+  </div>
+
+  <!-- JS Logic -->
+  <script>
+    let sseSource = null;
+    let sseActivitySource = null;
+    let isConnected = false;
+    let eventList = [];
+    let activityList = [];
+    let pendingGates = new Map();
+    let closedGates = new Set();
+    let currentModalGateId = null;
+    let currentModalGateType = null;
+    let activeGrants = new Set();
+
+    async function fetchWithTimeout(resource, options = {}) {
+      const { timeout = 8000 } = options;
+      const controller = new AbortController();
+      const id = setTimeout(() => controller.abort(), timeout);
+      try {
+        const response = await fetch(resource, {
+          ...options,
+          signal: controller.signal
+        });
+        clearTimeout(id);
+        return response;
+      } catch (e) {
+        clearTimeout(id);
+        throw e;
+      }
+    }
+    
+    // Config defaults
+    document.getElementById('session-input').value = localStorage.getItem('auto_sid') || '';
+    document.getElementById('secret-input').value = localStorage.getItem('auto_secret') || '';
+    document.getElementById('port-input').value = window.location.port || localStorage.getItem('auto_port') || '4100';
+
+    function toggleConnection() {
+      if (isConnected) {
+        disconnect();
+      } else {
+        connect();
+      }
+    }
+
+    function connect() {
+      const sid = document.getElementById('session-input').value.trim();
+      const secret = document.getElementById('secret-input').value.trim();
+      const port = document.getElementById('port-input').value.trim();
+
+      if (!sid || !secret) {
+        alert("Please enter both Root Session ID and Shared Secret.");
+        return;
+      }
+
+      localStorage.setItem('auto_sid', sid);
+      localStorage.setItem('auto_secret', secret);
+      localStorage.setItem('auto_port', port);
+
+      const statusIndicator = document.getElementById('status-indicator');
+      const statusText = document.getElementById('status-text');
+      const connectBtn = document.getElementById('connect-btn');
+
+      statusIndicator.className = 'w-2.5 h-2.5 rounded-full status-pulse bg-accentIndigo';
+      statusText.innerText = 'Connecting...';
+      connectBtn.innerText = 'Cancel';
+      
+      const baseURL = `http://127.0.0.1:${port}`;
+
+      // Reset list states and UI elements to clean loading slate
+      eventList = [];
+      activityList = [];
+      pendingGates.clear();
+      closedGates.clear();
+      activeGrants.clear();
+      document.getElementById('timeline-stream').innerHTML = '<div class="text-center text-gray-500 text-sm mt-10">Loading timeline history...</div>';
+      document.getElementById('plan-steps').innerHTML = '<div class="text-center text-gray-500 text-xs py-8">Loading active plan...</div>';
+      document.getElementById('plan-version-badge').classList.add('hidden');
+      document.getElementById('workbench-list').innerHTML = '<div class="text-center text-gray-500 text-xs py-4">No active workbenches.</div>';
+      document.getElementById('agent-tree-svg').innerHTML = '';
+      document.getElementById('agent-tree-fallback').style.display = 'flex';
+      updateHUD();
+
+      // Load all snapshot history first, then start streaming updates
+      loadInitialSessionData(baseURL, sid, secret);
+    }
+
+    async function loadInitialSessionData(baseURL, sid, secret) {
+      const statusIndicator = document.getElementById('status-indicator');
+      const statusText = document.getElementById('status-text');
+      const connectBtn = document.getElementById('connect-btn');
+
+      // 1. Fetch entire timeline history page-by-page
+      await fetchTimelineHistory(baseURL, sid, secret);
+
+      // 2. Fetch planframes checklist
+      await fetchPlanFrame(baseURL, sid, secret);
+
+      // 3. Fetch initial operator activity history page-by-page
+      await fetchActivityHistory(baseURL, sid, secret);
+
+      // Verify if still in connecting state
+      if (statusText.innerText !== 'Connecting...') return;
+
+      isConnected = true;
+      statusIndicator.className = 'w-2.5 h-2.5 rounded-full bg-accentGreen';
+      statusText.innerText = 'Connected';
+      connectBtn.innerText = 'Disconnect';
+      document.getElementById('send-btn').disabled = false;
+
+      // 4. Determine timeline stream offset (only fetch events after our snapshot)
+      let lastEventId = null;
+      if (eventList.length > 0) {
+        lastEventId = eventList[eventList.length - 1].event_id;
+      }
+
+      let timelineURL = `${baseURL}/api/session/timeline/stream/${sid}?token=${encodeURIComponent(secret)}&min_altitude=detail`;
+      if (lastEventId) {
+        timelineURL += `&after=${encodeURIComponent(lastEventId)}`;
+      }
+      sseSource = new EventSource(timelineURL);
+      
+      sseSource.addEventListener('session.timeline', (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data && data.entries) {
+            handleTimelineBatch(data.entries);
+          }
+        } catch(e) {
+          console.error("Failed to parse timeline SSE event", e);
+        }
+      });
+
+      sseSource.addEventListener('error', (err) => {
+        console.error("Timeline SSE source error", err);
+        disconnect();
+      });
+
+      // 5. Determine operator activity stream offset
+      let lastActivityId = null;
+      if (activityList.length > 0) {
+        lastActivityId = activityList[activityList.length - 1].activity_id;
+      }
+
+      let activityURL = `${baseURL}/api/operator/activity/stream/${sid}?token=${encodeURIComponent(secret)}`;
+      if (lastActivityId) {
+        activityURL += `&after=${encodeURIComponent(lastActivityId)}`;
+      }
+      sseActivitySource = new EventSource(activityURL);
+      
+      sseActivitySource.addEventListener('operator.activity', (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data && data.activities) {
+            handleActivityBatch(data.activities);
+          }
+        } catch(e) {
+          console.error("Failed to parse activity SSE event", e);
+        }
+      });
+
+      sseActivitySource.addEventListener('error', (err) => {
+        console.warn("Activity SSE source error (ignoring for fallback)", err);
+      });
+    }
+
+    function disconnect() {
+      if (sseSource) {
+        sseSource.close();
+        sseSource = null;
+      }
+      if (sseActivitySource) {
+        sseActivitySource.close();
+        sseActivitySource = null;
+      }
+      isConnected = false;
+      document.getElementById('status-indicator').className = 'w-2.5 h-2.5 rounded-full bg-gray-500';
+      document.getElementById('status-text').innerText = 'Disconnected';
+      document.getElementById('connect-btn').innerText = 'Connect';
+      document.getElementById('send-btn').disabled = true;
+      document.getElementById('timeline-stream').innerHTML = '<div class="text-center text-gray-500 text-sm mt-10">Disconnected. Re-enter credentials to stream.</div>';
+      document.getElementById('plan-steps').innerHTML = '<div class="text-center text-gray-500 text-xs py-8">No plan loaded yet.</div>';
+      document.getElementById('plan-version-badge').classList.add('hidden');
+      document.getElementById('workbench-list').innerHTML = '<div class="text-center text-gray-500 text-xs py-4">No active workbenches.</div>';
+      document.getElementById('agent-tree-svg').innerHTML = '';
+      document.getElementById('agent-tree-fallback').style.display = 'flex';
+      
+      eventList = [];
+      activityList = [];
+      pendingGates.clear();
+      closedGates.clear();
+      activeGrants.clear();
+      updateHUD();
+    }
+
+    async function fetchTimelineHistory(baseURL, sid, secret) {
+      let lastCursor = null;
+      let hasMore = true;
+      const seenCursors = new Set();
+      console.log("Starting timeline history fetch for root session:", sid);
+      try {
+        while (hasMore) {
+          if (lastCursor && seenCursors.has(lastCursor)) {
+            console.warn("Detected circular timeline cursor:", lastCursor);
+            break;
+          }
+          if (lastCursor) seenCursors.add(lastCursor);
+          
+          const resp = await fetchWithTimeout(`${baseURL}/api/jsonrpc`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${secret}`
+            },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: `bootstrap-tl-${lastCursor || 'start'}`,
+              method: 'session.timeline.list',
+              params: {
+                root_session_id: sid,
+                min_altitude: 'detail',
+                limit: 150,
+                after_event_id: lastCursor || undefined
+              }
+            })
+          });
+          const json = await resp.json();
+          if (json && json.result) {
+            const result = json.result;
+            console.log("Fetched timeline history page, entries count:", result.entries ? result.entries.length : 0, "has_more:", result.has_more, "next_cursor:", result.next_cursor);
+            if (result.entries && result.entries.length > 0) {
+              handleTimelineBatch(result.entries);
+            }
+            lastCursor = result.next_cursor;
+            hasMore = result.has_more && result.entries && result.entries.length > 0;
+          } else {
+            console.warn("Invalid jsonrpc result for timeline list:", json);
+            hasMore = false;
+          }
+        }
+      } catch(e) {
+        console.error("Failed to bootstrap snapshot timeline", e);
+      }
+    }
+
+    async function fetchActivityHistory(baseURL, sid, secret) {
+      let lastCursor = null;
+      let hasMore = true;
+      const seenCursors = new Set();
+      console.log("Starting activity history fetch for root session:", sid);
+      try {
+        while (hasMore) {
+          if (lastCursor && seenCursors.has(lastCursor)) {
+            console.warn("Detected circular activity cursor:", lastCursor);
+            break;
+          }
+          if (lastCursor) seenCursors.add(lastCursor);
+
+          const resp = await fetchWithTimeout(`${baseURL}/api/jsonrpc`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${secret}`
+            },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: `bootstrap-act-${lastCursor || 'start'}`,
+              method: 'operator.activity.list',
+              params: {
+                root_session_id: sid,
+                limit: 150,
+                after_activity_id: lastCursor || undefined
+              }
+            })
+          });
+          const json = await resp.json();
+          if (json && json.result) {
+            const result = json.result;
+            console.log("Fetched activity history page, activities count:", result.activities ? result.activities.length : 0, "has_more:", result.has_more, "next_cursor:", result.next_cursor);
+            if (result.activities && result.activities.length > 0) {
+              handleActivityBatch(result.activities);
+            }
+            lastCursor = result.next_cursor;
+            hasMore = result.has_more && result.activities && result.activities.length > 0;
+          } else {
+            console.warn("Invalid jsonrpc result for activity list:", json);
+            hasMore = false;
+          }
+        }
+      } catch(e) {
+        console.error("Failed to bootstrap snapshot activities", e);
+      }
+    }
+
+    async function fetchTimelineSnapshot(baseURL, sid, secret) {
+      let lastEventId = eventList.length > 0 ? eventList[eventList.length - 1].event_id : null;
+      console.log("Refreshing timeline snapshot, starting after event ID:", lastEventId);
+      try {
+        const resp = await fetchWithTimeout(`${baseURL}/api/jsonrpc`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${secret}`
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'refresh-tl',
+            method: 'session.timeline.list',
+            params: {
+              root_session_id: sid,
+              min_altitude: 'detail',
+              limit: 100,
+              after_event_id: lastEventId || undefined
+            }
+          })
+        });
+        const json = await resp.json();
+        if (json && json.result && json.result.entries) {
+          console.log("Timeline snapshot refreshed, new entries fetched:", json.result.entries.length);
+          handleTimelineBatch(json.result.entries);
+        }
+      } catch(e) {
+        console.error("Failed to refresh timeline snapshot", e);
+      }
+    }
+
+    async function fetchPlanFrame(baseURL, sid, secret) {
+      console.log("Fetching active PlanFrame for root session:", sid);
+      try {
+        const resp = await fetchWithTimeout(`${baseURL}/api/jsonrpc`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${secret}`
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'bootstrap-plan',
+            method: 'planframes.get_active',
+            params: { root_session_id: sid }
+          })
+        });
+        const json = await resp.json();
+        if (json && json.result && json.result.plan) {
+          const activePlan = json.result.plan;
+          console.log("PlanFrame fetched successfully, version:", activePlan.version);
+          renderPlanFrame(activePlan);
+        } else {
+          console.log("No active plan found.");
+          document.getElementById('plan-steps').innerHTML = '<div class="text-center text-gray-500 text-xs py-8">No active plan configured.</div>';
+          document.getElementById('plan-version-badge').classList.add('hidden');
+        }
+      } catch(e) {
+        console.error("Failed to load planframes", e);
+      }
+    }
+
+
+    function renderPlanFrame(plan) {
+      const planStepsDiv = document.getElementById('plan-steps');
+      const badge = document.getElementById('plan-version-badge');
+      
+      if (!plan || !plan.steps || plan.steps.length === 0) {
+        planStepsDiv.innerHTML = '<div class="text-center text-gray-500 text-xs py-8">No plan steps configured.</div>';
+        badge.classList.add('hidden');
+        return;
+      }
+
+      badge.innerText = `v${plan.version || 1}`;
+      badge.classList.remove('hidden');
+
+      planStepsDiv.innerHTML = '';
+      plan.steps.forEach((step, idx) => {
+        let statusIcon = '⏳';
+        let statusStyle = 'text-gray-500';
+        let bgStyle = 'bg-gray-900 bg-opacity-25';
+
+        if (step.status === 'Completed' || step.status === 'success') {
+          statusIcon = '✅';
+          statusStyle = 'text-accentGreen';
+        } else if (step.status === 'Active' || step.status === 'running') {
+          statusIcon = '⚙️';
+          statusStyle = 'text-accentIndigo font-semibold';
+          bgStyle = 'border border-accentIndigo/30 bg-accentIndigo/5 glow-indigo';
+        }
+
+        const stepCard = document.createElement('div');
+        stepCard.className = `p-3 rounded-lg border border-gray-800 ${bgStyle} flex items-start justify-between gap-3`;
+        stepCard.innerHTML = `
+          <div class="flex-1">
+            <span class="text-xs text-gray-500 font-mono block">Step ${idx + 1} · ${step.owner || 'Planner'}</span>
+            <span class="text-sm text-gray-100 font-medium block">${step.title || 'Untitled Step'}</span>
+          </div>
+          <span class="text-sm ${statusStyle}">${statusIcon}</span>
+        `;
+        planStepsDiv.appendChild(stepCard);
+      });
+    }
+
+    function handleTimelineBatch(entries) {
+      // Avoid rendering exact duplicates
+      const fresh = entries.filter(e => !eventList.some(x => x.event_id === e.event_id));
+      if (fresh.length === 0) return;
+
+      eventList = [...eventList, ...fresh].sort((a, b) => new Date(a.occurred_at) - new Date(b.occurred_at));
+      detectGates();
+      renderTimeline();
+      updateAgentTree();
+
+      // Refresh active plan steps when plan is proposed or approved
+      const hasPlanUpdate = fresh.some(e => e.event_type === 'plan.pending' || e.event_type === 'plan.approved');
+      if (hasPlanUpdate && isConnected) {
+        const sid = document.getElementById('session-input').value.trim();
+        const secret = document.getElementById('secret-input').value.trim();
+        const port = document.getElementById('port-input').value.trim();
+        const baseURL = `http://127.0.0.1:${port}`;
+        fetchPlanFrame(baseURL, sid, secret);
+      }
+    }
+
+    function handleActivityBatch(activities) {
+      const fresh = activities.filter(a => !activityList.some(x => x.activity_id === a.activity_id));
+      if (fresh.length === 0) return;
+
+      activityList = [...activityList, ...fresh];
+      updateHUD();
+    }
+
+    function changeAltitudeFilter() {
+      renderTimeline();
+    }
+
+    function renderTimeline() {
+      const streamDiv = document.getElementById('timeline-stream');
+      const altitudeFilter = document.getElementById('altitude-filter').value;
+      
+      const filtered = eventList.filter(e => {
+        const alt = (e.altitude || '').toLowerCase();
+        if (altitudeFilter === 'error') return alt === 'error';
+        if (altitudeFilter === 'attention') return alt === 'attention' || alt === 'error';
+        if (altitudeFilter === 'normal') return alt !== 'detail';
+        return true; // All details
+      });
+
+      if (filtered.length === 0) {
+        streamDiv.innerHTML = '<div class="text-center text-gray-500 text-sm mt-10">No events matched the altitude filter.</div>';
+        return;
+      }
+
+      streamDiv.innerHTML = '';
+      filtered.forEach(e => {
+        const item = document.createElement('div');
+        item.className = 'flex gap-4 p-3.5 rounded-xl border border-gray-800/40 bg-gray-900 bg-opacity-30 hover:bg-opacity-40 hover:border-gray-800 transition-all duration-100 cursor-pointer';
+        item.onclick = (event) => {
+          if (event.target.closest('button')) return;
+          showEventDetails(e.event_id);
+        };
+
+        // 1. Altitude/Icon column
+        const altLower = (e.altitude || '').toLowerCase();
+        let altColor = 'text-gray-500';
+        let altGlyph = '·';
+        if (altLower === 'error') { altColor = 'text-accentRed'; altGlyph = '✗'; }
+        else if (altLower === 'attention') { altColor = 'text-accentAmber'; altGlyph = '⚠'; }
+        else if (altLower === 'normal') { altColor = 'text-accentIndigo'; altGlyph = '▸'; }
+
+        // 2. Formatting Actor labels
+        let actorLabel = 'System';
+        let avatarStyle = 'from-gray-700 to-gray-800';
+        let roleBadge = '';
+        
+        const roleObj = e.role || {};
+        const roleType = typeof roleObj === 'string' ? roleObj : (roleObj.role || 'system');
+        
+        if (e.principal && e.principal.kind === 'Human') {
+          actorLabel = '🧑 Operator';
+          avatarStyle = 'from-accentGreen to-emerald-600';
+        } else if (roleType === 'planner') {
+          actorLabel = '🤖 Planner';
+          avatarStyle = 'from-accentViolet to-fuchsia-600';
+        } else if (roleType === 'sentinel') {
+          actorLabel = '🛡️ Sentinel';
+          avatarStyle = 'from-accentAmber to-yellow-600';
+        } else if (roleType === 'specialist') {
+          const kind = roleObj.kind || 'specialist';
+          const kindCap = kind.charAt(0).toUpperCase() + kind.slice(1);
+          actorLabel = `👾 ${kindCap}`;
+          avatarStyle = 'from-accentIndigo to-sky-600';
+        } else if (roleType === 'operator') {
+          actorLabel = '🧑 Operator';
+          avatarStyle = 'from-accentGreen to-emerald-600';
+        } else if (roleType === 'curator') {
+          actorLabel = '📚 Curator';
+          avatarStyle = 'from-teal-600 to-emerald-700';
+        } else if (roleType === 'auditor') {
+          actorLabel = '🔍 Auditor';
+          avatarStyle = 'from-accentRed to-rose-700';
+        } else if (roleType === 'runtime') {
+          actorLabel = '💻 Runtime';
+          avatarStyle = 'from-slate-600 to-slate-700';
+        } else {
+          actorLabel = roleType.charAt(0).toUpperCase() + roleType.slice(1);
+        }
+
+        // Summary details parsing
+        let summary = extractSummary(e);
+        let payload = null;
+        try {
+          if (e.payload) payload = JSON.parse(e.payload);
+        } catch(err) {}
+
+        let cardContent = '';
+        if (payload) {
+          if (e.event_type === 'content_write' || payload.tool_name === 'content_write') {
+            const fileName = payload.name || payload.sandbox_path || 'file';
+            cardContent = `
+              <div class="mt-2 text-xs bg-gray-950 bg-opacity-50 p-2.5 rounded-lg border border-gray-850 flex items-center justify-between">
+                <span class="font-mono text-gray-300">📄 ${fileName}</span>
+                <button onclick="inspectFile('${fileName}', '${e.session_id}')" class="text-accentIndigo hover:underline font-semibold font-mono text-[10px] uppercase">Inspect</button>
+              </div>
+            `;
+          } else if (e.event_type === 'approval.pending') {
+            const aprId = payload.request_id || e.event_id;
+            const isClosed = closedGates.has(aprId);
+            cardContent = `
+              <div class="mt-2.5 p-3 rounded-lg border border-accentAmber/30 bg-accentAmber/5 flex flex-col space-y-2">
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-accentAmber font-semibold tracking-wide uppercase">Gate Approval Required</span>
+                  <span class="text-[10px] font-mono text-gray-500">${aprId}</span>
+                </div>
+                <p class="text-xs text-gray-400 font-mono">${payload.command || payload.summary || 'Operation checks failed'}</p>
+                <div class="flex justify-end gap-2 pt-1.5">
+                  ${isClosed ? 
+                    `<span class="text-[10px] text-emerald-500 font-semibold tracking-wider uppercase border border-emerald-500 border-opacity-35 px-2 py-0.5 rounded bg-emerald-500 bg-opacity-5">✓ Resolved</span>` :
+                    `<button onclick="openGateModalById('${aprId}')" class="bg-accentAmber hover:bg-opacity-90 active:scale-95 text-gray-950 font-bold text-[10px] px-3.5 py-1.5 rounded uppercase">Resolve Gate</button>`
+                  }
+                </div>
+              </div>
+            `;
+          } else if (e.event_type === 'user.ask.pending') {
+            const askId = payload.interaction_id || e.event_id;
+            const isClosed = closedGates.has(askId);
+            cardContent = `
+              <div class="mt-2.5 p-3 rounded-lg border border-accentIndigo/30 bg-accentIndigo/5 flex flex-col space-y-2">
+                <div class="flex items-center justify-between">
+                  <span class="text-xs text-accentIndigo font-semibold tracking-wide uppercase">Clarification Request</span>
+                  <span class="text-[10px] font-mono text-gray-500">${askId}</span>
+                </div>
+                <p class="text-xs text-gray-300 font-medium">${payload.question || 'Agent requested feedback.'}</p>
+                <div class="flex justify-end gap-2 pt-1.5">
+                  ${isClosed ?
+                    `<span class="text-[10px] text-emerald-500 font-semibold tracking-wider uppercase border border-emerald-500 border-opacity-35 px-2 py-0.5 rounded bg-emerald-500 bg-opacity-5">✓ Answered</span>` :
+                    `<button onclick="openGateModalById('${askId}')" class="bg-accentIndigo hover:bg-opacity-90 active:scale-95 text-white font-bold text-[10px] px-3.5 py-1.5 rounded uppercase">Provide Answer</button>`
+                  }
+                </div>
+              </div>
+            `;
+          }
+        }
+
+        // Highlight operator messages
+        let messageStyle = 'text-gray-300';
+        if (e.event_type === 'operator.message') {
+          messageStyle = 'text-white font-medium';
+        }
+
+        item.innerHTML = `
+          <div class="w-8 h-8 rounded-full bg-gradient-to-tr ${avatarStyle} flex items-center justify-center font-display font-bold text-xs shadow text-white shrink-0 mt-0.5">
+            ${actorLabel.charAt(0)}
+          </div>
+          <div class="flex-1 space-y-0.5">
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-gray-400 font-bold font-display">${actorLabel}</span>
+              <span class="text-[10px] text-gray-600 font-mono">${formatTime(e.occurred_at)}</span>
+            </div>
+            <p class="text-sm ${messageStyle} leading-relaxed">${summary}</p>
+            ${cardContent}
+          </div>
+        `;
+        
+        streamDiv.appendChild(item);
+      });
+
+      // Keep timeline auto-scrolled to bottom
+      streamDiv.scrollTop = streamDiv.scrollHeight;
+    }
+
+    function formatTime(isoString) {
+      if (!isoString) return '';
+      const date = new Date(isoString);
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    }
+
+    function sendMessage() {
+      const input = document.getElementById('composer-input');
+      const text = input.value.trim();
+      if (!text) return;
+
+      const sid = document.getElementById('session-input').value.trim();
+      const secret = document.getElementById('secret-input').value.trim();
+      const port = document.getElementById('port-input').value.trim();
+      const baseURL = `http://127.0.0.1:${port}`;
+
+      input.value = '';
+      input.disabled = true;
+
+      fetchWithTimeout(`${baseURL}/api/event/ingest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${secret}`
+        },
+        body: JSON.stringify({
+          event_type: 'chat',
+          message: text,
+          session_id: sid,
+          async_mode: true
+        })
+      })
+      .then(res => res.json())
+      .then(data => {
+        input.disabled = false;
+        input.focus();
+      })
+      .catch(e => {
+        console.error("Failed to send message", e);
+        alert("Failed to send message: " + e.message);
+        input.disabled = false;
+      });
+    }
+
+    // Capture enter key in composer
+    document.getElementById('composer-input').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    });
+
+    function detectGates() {
+      // Scan timeline entries to find pending approvals or user requests
+      closedGates.clear();
+      eventList.forEach(e => {
+        if (['approval.resolved', 'approval.approved', 'approval.rejected', 'approval.cancelled', 'interaction.resolved'].includes(e.event_type)) {
+          try {
+            const p = JSON.parse(e.payload);
+            const id = p.request_id || p.interaction_id;
+            if (id) closedGates.add(id);
+          } catch(err) {}
+        }
+      });
+
+      let newestPending = null;
+      eventList.forEach(e => {
+        if (e.event_type === 'approval.pending' || e.event_type === 'user.ask.pending') {
+          try {
+            const p = JSON.parse(e.payload);
+            const id = p.request_id || p.interaction_id;
+            if (id && !closedGates.has(id)) {
+              pendingGates.set(id, { entry: e, payload: p, type: e.event_type });
+              newestPending = id;
+            }
+          } catch(err) {}
+        }
+      });
+
+      // Auto-open modal if there is a pending gate that we haven't resolved yet
+      if (newestPending && newestPending !== currentModalGateId && document.getElementById('gate-modal').classList.contains('hidden')) {
+        openGateModalById(newestPending);
+      }
+    }
+
+    function openGateModalById(gateId) {
+      const gate = pendingGates.get(gateId);
+      if (!gate) return;
+
+      currentModalGateId = gateId;
+      currentModalGateType = gate.type;
+      
+      const modal = document.getElementById('gate-modal');
+      const title = document.getElementById('modal-title');
+      const mId = document.getElementById('modal-gate-id');
+      const body = document.getElementById('modal-body');
+      
+      const textInput = document.getElementById('modal-text-input');
+      const choicesDiv = document.getElementById('modal-choices');
+      const submitBtn = document.getElementById('modal-submit-btn');
+      const rejectBtn = document.getElementById('modal-reject-btn');
+      const label = document.getElementById('modal-input-label');
+
+      mId.innerText = gateId;
+      textInput.value = '';
+      choicesDiv.innerHTML = '';
+      choicesDiv.classList.add('hidden');
+      textInput.classList.remove('hidden');
+      rejectBtn.classList.add('hidden');
+      
+      if (gate.type === 'approval.pending') {
+        title.innerText = '⏸ Gate Approval Needed';
+        title.className = 'font-display font-bold text-base text-accentAmber flex items-center gap-2';
+        label.innerText = 'Motivation (Why are you approving?)';
+        rejectBtn.classList.remove('hidden');
+        
+        let confirmPhraseHTML = '';
+        if (gate.payload.confirm_phrase) {
+          confirmPhraseHTML = `
+            <div class="bg-accentRed/10 border border-accentRed/30 p-3 rounded-lg text-xs">
+              <span class="text-accentRed font-semibold block uppercase tracking-wide">Tamper Confirmation Required</span>
+              <p class="text-gray-400 mt-1">To approve this high-risk sandbox execution, you MUST type the phrase below exactly into the motivation box:</p>
+              <p class="font-mono text-accentRed font-bold mt-1 text-sm bg-gray-950 p-2.5 rounded border border-gray-900 select-all">${gate.payload.confirm_phrase}</p>
+            </div>
+          `;
+        }
+
+        body.innerHTML = `
+          <div class="space-y-3">
+            <div class="flex justify-between items-center bg-gray-950 p-3 rounded-lg border border-gray-900 text-xs">
+              <span class="text-gray-400">Action:</span>
+              <span class="font-mono text-white font-semibold">${gate.payload.action || 'Unknown tool'}</span>
+            </div>
+            
+            ${gate.payload.command ? `
+              <div>
+                <span class="text-xs text-gray-500 font-semibold block mb-1">Command to Execute:</span>
+                <div class="font-mono text-xs bg-gray-950 p-3 rounded-lg border border-gray-900 text-gray-300 overflow-x-auto leading-relaxed">${gate.payload.command}</div>
+              </div>
+            ` : ''}
+
+            ${gate.payload.host_patterns ? `
+              <div>
+                <span class="text-xs text-gray-500 font-semibold block mb-1">Target Host Permissions:</span>
+                <div class="flex flex-wrap gap-1.5">
+                  ${gate.payload.host_patterns.map(h => `<span class="bg-gray-800 text-gray-300 font-mono text-[10px] px-2 py-0.5 rounded border border-gray-700">${h}</span>`).join('')}
+                </div>
+              </div>
+            ` : ''}
+
+            ${gate.payload.risk_summary ? `
+              <div class="bg-gray-900 border border-gray-800/80 p-3.5 rounded-lg text-xs">
+                <span class="text-xs font-semibold text-accentAmber block">Safety Risk Assessment:</span>
+                <p class="text-gray-400 mt-1 leading-relaxed">${gate.payload.risk_summary}</p>
+              </div>
+            ` : ''}
+
+            ${confirmPhraseHTML}
+          </div>
+        `;
+      } else {
+        title.innerText = '❓ Clarification Input';
+        title.className = 'font-display font-bold text-base text-accentIndigo flex items-center gap-2';
+        label.innerText = 'Your Answer';
+
+        body.innerHTML = `
+          <div class="space-y-3">
+            <p class="text-sm text-gray-200 font-medium leading-relaxed">${gate.payload.question}</p>
+          </div>
+        `;
+
+        if (gate.payload.options && gate.payload.options.length > 0) {
+          choicesDiv.classList.remove('hidden');
+          if (!gate.payload.allow_freeform) {
+            textInput.classList.add('hidden');
+          }
+          
+          gate.payload.options.forEach((opt, index) => {
+            const card = document.createElement('div');
+            card.className = 'flex items-center gap-3 p-3 rounded-lg border border-gray-850 bg-gray-900/30 hover:bg-gray-900 hover:border-gray-800 cursor-pointer text-xs';
+            card.onclick = () => submitInteractionChoice(gateId, opt.id || String(index + 1));
+            card.innerHTML = `
+              <span class="w-5 h-5 rounded-full bg-accentIndigo/10 text-accentIndigo flex items-center justify-center font-bold text-[10px]">${index + 1}</span>
+              <span class="text-gray-300 font-medium">${opt.label}</span>
+            `;
+            choicesDiv.appendChild(card);
+          });
+        }
+      }
+
+      modal.classList.remove('hidden');
+    }
+
+    function closeGateModal() {
+      document.getElementById('gate-modal').classList.add('hidden');
+      currentModalGateId = null;
+    }
+
+    async function submitGateAction(isApprove) {
+      const input = document.getElementById('modal-text-input').value.trim();
+      const sid = document.getElementById('session-input').value.trim();
+      const secret = document.getElementById('secret-input').value.trim();
+      const port = document.getElementById('port-input').value.trim();
+      const baseURL = `http://127.0.0.1:${port}`;
+
+      if (currentModalGateType === 'approval.pending') {
+        const gate = pendingGates.get(currentModalGateId);
+        // Enforce confirm phrase check on client side for immediate feedback
+        if (isApprove && gate && gate.payload && gate.payload.confirm_phrase && input.toLowerCase() !== gate.payload.confirm_phrase.toLowerCase()) {
+          alert(`Approval requires typing the confirmation phrase exactly: "${gate.payload.confirm_phrase}"`);
+          return;
+        }
+
+        const method = isApprove ? 'approvals.approve' : 'approvals.reject';
+        let params = {};
+        if (isApprove) {
+          let acknowledged_capabilities = [];
+          if (gate && gate.payload) {
+            if (gate.payload.added_capabilities) {
+              acknowledged_capabilities = acknowledged_capabilities.concat(gate.payload.added_capabilities);
+            }
+            if (gate.payload.broadened_capabilities) {
+              acknowledged_capabilities = acknowledged_capabilities.concat(gate.payload.broadened_capabilities);
+            }
+          }
+          params = {
+            request_id: currentModalGateId,
+            decided_by: "operator",
+            reason: input || undefined,
+            confirm_phrase: (gate && gate.payload && gate.payload.confirm_phrase) || undefined,
+            acknowledged_capabilities: Array.from(new Set(acknowledged_capabilities))
+          };
+        } else {
+          params = {
+            request_id: currentModalGateId,
+            decided_by: "operator",
+            reason: input || undefined
+          };
+        }
+
+        try {
+          const resp = await fetchWithTimeout(`${baseURL}/api/jsonrpc`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${secret}`
+            },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: 'gate-approve',
+              method: method,
+              params: params
+            })
+          });
+          const json = await resp.json();
+          if (json.error) {
+            alert(`Error: ${json.error.message}`);
+          } else {
+            closeGateModal();
+            fetchTimelineSnapshot(baseURL, sid, secret);
+          }
+        } catch(e) {
+          alert(`Connection failed: ${e.message}`);
+        }
+      } else {
+        // Submit user reply as interaction answer
+        if (!input) {
+          alert("Please type a reply.");
+          return;
+        }
+        submitInteractionChoice(currentModalGateId, input);
+      }
+    }
+
+    async function submitInteractionChoice(gateId, answerText) {
+      const sid = document.getElementById('session-input').value.trim();
+      const secret = document.getElementById('secret-input').value.trim();
+      const port = document.getElementById('port-input').value.trim();
+      const baseURL = `http://127.0.0.1:${port}`;
+
+      try {
+         const resp = await fetchWithTimeout(`${baseURL}/api/jsonrpc`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${secret}`
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'gate-answer',
+            method: 'interaction.resolve_and_answer',
+            params: {
+              interaction_id: gateId,
+              answer: answerText
+            }
+          })
+        });
+        const json = await resp.json();
+        if (json.error) {
+          alert(`Error: ${json.error.message}`);
+        } else {
+          closeGateModal();
+          fetchTimelineSnapshot(baseURL, sid, secret);
+        }
+      } catch(e) {
+        alert(`Connection failed: ${e.message}`);
+      }
+    }
+
+    // Dynamic Tree Visualization Builder
+    function updateAgentTree() {
+      const fallback = document.getElementById('agent-tree-fallback');
+      const svg = document.getElementById('agent-tree-svg');
+      
+      const rootSessionId = document.getElementById('session-input').value.trim();
+      const agents = new Map(); // id -> { name, parent, status }
+      const sessionNames = new Map(); // id -> name
+      
+      // Seed root session name
+      sessionNames.set(rootSessionId, 'Planner');
+
+      // 1. Scan roles to associate session IDs with agent types
+      eventList.forEach(e => {
+        const sessId = e.source_session_id;
+        if (!sessId) return;
+
+        let roleLabel = null;
+        const roleObj = e.role || {};
+        const roleType = typeof roleObj === 'string' ? roleObj : (roleObj.role || 'system');
+        
+        if (roleType === 'planner') {
+          roleLabel = 'Planner';
+        } else if (roleType === 'sentinel') {
+          roleLabel = 'Sentinel';
+        } else if (roleType === 'specialist') {
+          const kind = roleObj.kind || 'specialist';
+          roleLabel = kind.charAt(0).toUpperCase() + kind.slice(1);
+        } else if (roleType === 'curator') {
+          roleLabel = 'Curator';
+        } else if (roleType === 'auditor') {
+          roleLabel = 'Auditor';
+        } else if (roleType === 'runtime') {
+          roleLabel = 'Runtime';
+        }
+
+        if (roleLabel && !sessionNames.has(sessId)) {
+          sessionNames.set(sessId, roleLabel);
+        }
+      });
+
+      // Seed Planner root node
+      agents.set(rootSessionId, { id: rootSessionId, name: 'Planner', parent: null, status: 'running' });
+
+      // 2. Parse active agent nodes and hierarchies
+      eventList.forEach(e => {
+        let payload = null;
+        try {
+          if (e.payload) payload = JSON.parse(e.payload);
+        } catch(err) {}
+
+        const currentSessionId = e.source_session_id || rootSessionId;
+
+        if (payload) {
+          // Detect agent_spawn
+          if (payload.tool_name === 'agent_spawn' || e.event_type === 'agent_spawn') {
+            let argsObj = {};
+            if (typeof payload.arguments === 'string') {
+              try { argsObj = JSON.parse(payload.arguments); } catch(err) {}
+            } else if (payload.arguments) {
+              argsObj = payload.arguments;
+            }
+
+            let resObj = {};
+            if (typeof payload.result === 'string') {
+              try { resObj = JSON.parse(payload.result); } catch(err) {}
+            } else if (payload.result) {
+              resObj = payload.result;
+            }
+
+            const childId = payload.child_session_id || resObj.session_id || resObj.child_session_id;
+            let agentId = payload.agent_id || argsObj.agent_id || payload.args_preview || 'Specialist';
+            
+            // Clean suffix
+            agentId = agentId.replace('.default', '');
+            agentId = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+
+            if (childId) {
+              // Ensure parent exists
+              if (!agents.has(currentSessionId)) {
+                const pName = sessionNames.get(currentSessionId) || 'Agent';
+                agents.set(currentSessionId, { id: currentSessionId, name: pName, parent: null, status: 'idle' });
+              }
+              // Register child session label
+              if (!sessionNames.has(childId)) {
+                sessionNames.set(childId, agentId);
+              }
+              // Add child node
+              agents.set(childId, {
+                id: childId,
+                name: agentId,
+                parent: currentSessionId,
+                status: 'running'
+              });
+            }
+          }
+
+          // Detect turn ends to settle status
+          if (e.event_type === 'turn.end') {
+            const node = agents.get(currentSessionId);
+            if (node) node.status = 'idle';
+          }
+        }
+
+        // Adjust node statuses based on gate status
+        if (e.event_type === 'approval.pending' || e.event_type === 'user.ask.pending') {
+          try {
+            const p = JSON.parse(e.payload);
+            const id = p.request_id || p.interaction_id;
+            if (id && !closedGates.has(id)) {
+              const node = agents.get(currentSessionId);
+              if (node) node.status = 'gated';
+            }
+          } catch(err) {}
+        }
+      });
+
+      if (agents.size <= 1) {
+        svg.innerHTML = '';
+        fallback.style.display = 'flex';
+        return;
+      }
+      
+      fallback.style.display = 'none';
+      svg.innerHTML = '';
+
+      // Build hierarchical coordinates
+      const nodes = Array.from(agents.values());
+      const roots = nodes.filter(n => !n.parent || !agents.has(n.parent));
+      
+      // Basic layout coords
+      let levelHeights = [40, 120, 200, 280];
+      const visitedNodes = new Set();
+
+      // Assign position coordinates recursively
+      function layoutNode(node, depth, xStart, xRange) {
+        if (visitedNodes.has(node.id)) return;
+        visitedNodes.add(node.id);
+
+        node.y = levelHeights[depth] || 300;
+        node.x = xStart + xRange / 2;
+
+        const children = nodes.filter(n => n.parent === node.id);
+        if (children.length > 0) {
+          const subWidth = xRange / children.length;
+          children.forEach((child, i) => {
+            layoutNode(child, depth + 1, xStart + i * subWidth, subWidth);
+          });
+        }
+      }
+
+      roots.forEach((root, i) => {
+        layoutNode(root, 0, 0, svg.clientWidth || 300);
+      });
+
+      // Draw SVG lines first (so they compile behind text boxes)
+      nodes.forEach(node => {
+        if (node.parent && agents.has(node.parent)) {
+          const parent = agents.get(node.parent);
+          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          line.setAttribute('x1', parent.x);
+          line.setAttribute('y1', parent.y);
+          line.setAttribute('x2', node.x);
+          line.setAttribute('y2', node.y);
+          line.setAttribute('stroke', '#1f2937');
+          line.setAttribute('stroke-width', '2');
+          line.setAttribute('stroke-dasharray', '4 2');
+          svg.appendChild(line);
+        }
+      });
+
+      // Draw nodes
+      nodes.forEach(node => {
+        // Node color base
+        let strokeColor = '#4b5563';
+        let pulseStyle = '';
+
+        if (node.status === 'running') {
+          strokeColor = '#6366f1';
+          pulseStyle = 'stroke-width: 2.5; stroke-dasharray: 4 2; animation: spin 10s linear infinite;';
+        } else if (node.status === 'gated') {
+          strokeColor = '#f59e0b';
+        } else if (node.status === 'idle') {
+          strokeColor = '#10b981';
+        }
+
+        const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        group.setAttribute('transform', `translate(${node.x},${node.y})`);
+        group.style.cursor = 'pointer';
+
+        // Outer glow
+        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        circle.setAttribute('r', '18');
+        circle.setAttribute('fill', '#111827');
+        circle.setAttribute('stroke', strokeColor);
+        circle.setAttribute('stroke-width', '2');
+        circle.style = pulseStyle;
+        group.appendChild(circle);
+
+        // Name text
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('y', '32');
+        text.setAttribute('text-anchor', 'middle');
+        text.setAttribute('fill', '#9ca3af');
+        text.setAttribute('font-size', '10px');
+        text.setAttribute('font-weight', '600');
+        text.textContent = node.name.replace('.default', '');
+        group.appendChild(text);
+
+        // Status badge indicator
+        const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        dot.setAttribute('cx', '12');
+        dot.setAttribute('cy', '-12');
+        dot.setAttribute('r', '4');
+        dot.setAttribute('fill', node.status === 'running' ? '#6366f1' : (node.status === 'gated' ? '#f59e0b' : '#10b981'));
+        group.appendChild(dot);
+
+        svg.appendChild(group);
+      });
+    }
+
+    // Extract a human-readable summary from an event, since the API has no
+    // dedicated summary field — it's derived from event_type + payload.
+    function extractSummary(e) {
+      let payload = null;
+      try { if (e.payload) payload = JSON.parse(e.payload); } catch(err) {}
+
+      const type = e.event_type || '';
+
+      // Agent lifecycle
+      if (type === 'session.start') return payload?.goal || 'Session started';
+      if (type === 'session.end') return 'Session ended';
+      if (type === 'turn.start') return `Turn ${payload?.turn_number || ''} started`;
+      if (type === 'turn.end') return `Turn completed`;
+
+      // Operator messages
+      if (type === 'operator.message') return payload?.message || payload?.text || 'Operator message';
+
+      // LLM rounds
+      if (type === 'llm.round') {
+        const inp = payload?.input_tokens || 0;
+        const out = payload?.output_tokens || 0;
+        return `LLM round (${inp} in / ${out} out tokens)`;
+      }
+
+      // Tool calls
+      if (type === 'tool.call' || type === 'tool.result') {
+        const tool = payload?.tool_name || payload?.name || '';
+        return `${type === 'tool.call' ? 'Called' : 'Result from'} ${tool}`;
+      }
+
+      // Content writes
+      if (type === 'content_write') {
+        return `Wrote file: ${payload?.name || payload?.sandbox_path || 'unknown'}`;
+      }
+
+      // Approvals
+      if (type === 'approval.pending') return payload?.command || payload?.summary || 'Approval required';
+      if (type === 'approval.approved') return 'Approval granted';
+      if (type === 'approval.rejected') return 'Approval rejected';
+
+      // User interactions
+      if (type === 'user.ask.pending') return payload?.question || 'Agent requested feedback';
+      if (type === 'user.ask.resolved') return 'Interaction resolved';
+
+      // Plans
+      if (type === 'plan.pending') return payload?.title || 'Plan proposed';
+      if (type === 'plan.approved') return 'Plan approved';
+
+      // Promotions
+      if (type === 'promotion.pending') return payload?.title || 'Promotion pending';
+      if (type === 'promotion.approved') return 'Promotion approved';
+      if (type === 'promotion.rejected') return 'Promotion rejected';
+
+      // Delegate / escalate
+      if (type === 'delegate.start') return `Delegated to ${payload?.agent_id || 'specialist'}`;
+      if (type === 'delegate.end') return 'Delegate completed';
+
+      // Fallback: humanize event_type
+      return type.replace(/\./g, ' ').replace(/_/g, ' ');
+    }
+
+    function showEventDetails(eventId) {
+      const e = eventList.find(x => x.event_id === eventId);
+      if (!e) return;
+
+      let payloadObj = null;
+      try {
+        if (e.payload) payloadObj = JSON.parse(e.payload);
+      } catch(err) {}
+
+      // Extract principal info from nested object
+      const principalId = e.principal?.id || 'System';
+      const principalKind = e.principal?.kind || 'internal';
+      const altLower = (e.altitude || '').toLowerCase();
+      const altColorClass = altLower === 'error' ? 'text-accentRed' : (altLower === 'attention' ? 'text-accentAmber' : 'text-accentIndigo');
+
+      // Extract role info
+      const roleObj = e.role || {};
+      const roleType = typeof roleObj === 'string' ? roleObj : (roleObj.role || 'system');
+      const roleKind = roleObj.kind || roleObj.surface || '';
+      const roleLabel = roleKind ? `${roleType} (${roleKind})` : roleType;
+
+      document.getElementById('event-detail-title').innerHTML = `<span>ℹ️</span> Event Detail: <span class="font-mono text-accentIndigo">${e.event_type}</span>`;
+      
+      const content = document.getElementById('event-detail-content');
+      content.innerHTML = `
+        <div class="grid grid-cols-2 gap-4 text-xs">
+          <div class="bg-gray-900 border border-gray-850 p-3 rounded-lg">
+            <span class="text-[10px] text-gray-500 font-semibold block uppercase">Event Type</span>
+            <span class="font-mono text-gray-200 font-bold">${e.event_type}</span>
+          </div>
+          <div class="bg-gray-900 border border-gray-850 p-3 rounded-lg">
+            <span class="text-[10px] text-gray-500 font-semibold block uppercase">Occurred At</span>
+            <span class="font-mono text-gray-200">${formatTime(e.occurred_at)}</span>
+          </div>
+          <div class="bg-gray-900 border border-gray-850 p-3 rounded-lg">
+            <span class="text-[10px] text-gray-500 font-semibold block uppercase">Actor / Principal</span>
+            <span class="font-mono text-gray-200">${principalId} <span class="text-gray-500">(${principalKind})</span></span>
+          </div>
+          <div class="bg-gray-900 border border-gray-850 p-3 rounded-lg">
+            <span class="text-[10px] text-gray-500 font-semibold block uppercase">Altitude</span>
+            <span class="font-mono text-gray-200 font-bold ${altColorClass}">${e.altitude || 'normal'}</span>
+          </div>
+          <div class="bg-gray-900 border border-gray-850 p-3 rounded-lg">
+            <span class="text-[10px] text-gray-500 font-semibold block uppercase">Role / Seat</span>
+            <span class="font-mono text-gray-200">${roleLabel}</span>
+          </div>
+          <div class="bg-gray-900 border border-gray-850 p-3 rounded-lg">
+            <span class="text-[10px] text-gray-500 font-semibold block uppercase">Session</span>
+            <span class="font-mono text-gray-200 text-[10px]">${e.source_session_id || e.root_session_id || '—'}</span>
+          </div>
+        </div>
+
+        <div>
+          <span class="text-xs text-gray-500 font-semibold block mb-1">Summary:</span>
+          <div class="text-sm bg-gray-900 p-3.5 rounded-lg border border-gray-850 text-gray-250 leading-relaxed">${extractSummary(e)}</div>
+        </div>
+
+        ${payloadObj ? `
+          <div>
+            <span class="text-xs text-gray-500 font-semibold block mb-1">Structured Payload:</span>
+            <pre class="text-xs bg-gray-950 p-4 rounded-lg border border-gray-900 text-gray-350 overflow-x-auto leading-relaxed font-mono max-h-[300px]">${JSON.stringify(payloadObj, null, 2)}</pre>
+          </div>
+        ` : ''}
+
+        ${e.refs && Object.keys(e.refs).length > 0 ? `
+          <div>
+            <span class="text-xs text-gray-500 font-semibold block mb-1">References:</span>
+            <pre class="text-xs bg-gray-950 p-3 rounded-lg border border-gray-900 text-gray-400 overflow-x-auto font-mono">${JSON.stringify(e.refs, null, 2)}</pre>
+          </div>
+        ` : ''}
+
+        ${e.turn_id ? `
+          <div>
+            <span class="text-xs text-gray-500 font-semibold block mb-1">Turn ID:</span>
+            <span class="text-xs font-mono text-gray-400">${e.turn_id}</span>
+          </div>
+        ` : ''}
+      `;
+
+      document.getElementById('event-detail-modal').classList.remove('hidden');
+    }
+
+    function closeEventDetailModal() {
+      document.getElementById('event-detail-modal').classList.add('hidden');
+    }
+
+    // Dynamic HUD stats updating
+    function updateHUD() {
+      let llmCalls = 0;
+      let totalTokens = 0;
+      let inputTokens = 0;
+      let outputTokens = 0;
+      activeGrants.clear();
+
+      eventList.forEach(e => {
+        let payload = null;
+        try { if (e.payload) payload = JSON.parse(e.payload); } catch(err) {}
+
+        if (payload) {
+          // Tally active hosts from approval alerts
+          if (payload.host_patterns) {
+            payload.host_patterns.forEach(h => activeGrants.add(h));
+          }
+        }
+      });
+
+      // Scan operator activities for aggregate metrics
+      activityList.forEach(act => {
+        // Optional parse variables if needed
+      });
+
+      // Extract details from timeline stats
+      eventList.forEach(e => {
+        if (e.event_type === 'llm.round') {
+          llmCalls++;
+          try {
+            const p = JSON.parse(e.payload);
+            if (p.input_tokens) inputTokens += p.input_tokens;
+            if (p.output_tokens) outputTokens += p.output_tokens;
+          } catch(err) {}
+        }
+      });
+
+      totalTokens = inputTokens + outputTokens;
+
+      document.getElementById('hud-llm-calls').innerText = llmCalls;
+      document.getElementById('hud-grants-count').innerText = activeGrants.size;
+      document.getElementById('hud-tokens-total').innerText = totalTokens.toLocaleString();
+      document.getElementById('hud-tokens-in').innerText = `in: ${inputTokens.toLocaleString()}`;
+      document.getElementById('hud-tokens-out').innerText = `out: ${outputTokens.toLocaleString()}`;
+
+      // Calculate progress bars
+      if (totalTokens > 0) {
+        const inPct = (inputTokens / totalTokens) * 100;
+        const outPct = (outputTokens / totalTokens) * 100;
+        document.getElementById('token-bar-in').style.width = `${inPct}%`;
+        document.getElementById('token-bar-out').style.width = `${outPct}%`;
+      } else {
+        document.getElementById('token-bar-in').style.width = `0%`;
+        document.getElementById('token-bar-out').style.width = `0%`;
+      }
+    }
+
+    // Inspect files via base64 content loads
+    async function inspectFile(fileName, sessionId) {
+      const secret = document.getElementById('secret-input').value.trim();
+      const port = document.getElementById('port-input').value.trim();
+      const baseURL = `http://127.0.0.1:${port}`;
+
+      try {
+        const resp = await fetchWithTimeout(`${baseURL}/api/content/read`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${secret}`
+          },
+          body: JSON.stringify({
+            session_id: sessionId,
+            name_or_handle: fileName
+          })
+        });
+        const json = await resp.json();
+        if (json.content) {
+          // Decode content
+          const codeText = atob(json.content);
+          openDiffModal(fileName, codeText);
+        } else {
+          alert(`File content not found: ${json.error || 'Unknown error'}`);
+        }
+      } catch(e) {
+        alert(`Failed to load file contents: ${e.message}`);
+      }
+    }
+
+    function openDiffModal(fileName, codeText) {
+      const modal = document.getElementById('diff-modal');
+      document.getElementById('diff-title').innerHTML = `<span>📄</span> ${fileName}`;
+      
+      const contentDiv = document.getElementById('diff-content');
+      contentDiv.innerHTML = '';
+      
+      // Formatted file lines
+      codeText.split('\n').forEach((line, index) => {
+        const lineEl = document.createElement('div');
+        lineEl.className = 'hover:bg-gray-900/50 px-2 py-0.5 rounded flex';
+        
+        let highlightClass = '';
+        if (line.startsWith('+')) {
+          highlightClass = 'diff-added';
+        } else if (line.startsWith('-')) {
+          highlightClass = 'diff-removed';
+        }
+
+        lineEl.innerHTML = `
+          <span class="w-10 text-gray-650 text-[10px] select-none text-right pr-4 shrink-0 font-mono">${index + 1}</span>
+          <span class="flex-1 font-mono whitespace-pre ${highlightClass}">${escapeHTML(line)}</span>
+        `;
+        contentDiv.appendChild(lineEl);
+      });
+
+      modal.classList.remove('hidden');
+    }
+
+    function closeDiffModal() {
+      document.getElementById('diff-modal').classList.add('hidden');
+    }
+
+    function escapeHTML(str) {
+      return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Recovers 14 commits of Room TUI + gateway work that were developed locally but never pushed to origin. They were lost during a `git reset --hard origin/main` to fix divergent branches, but recovered cleanly from the reflog and rebased onto current main.

## What this includes

### Room TUI features
- **`?` info panel** — clean header/footer redesign with token consumption, altitude status, and keybindings help (D+E redesign)
- **Gate modals** — escalation and promotion gate overlays with solid backgrounds and proper z-ordering
- **Artifact viewer** — `o` to browse files, Enter to read content, Esc to close; resolves `ar.*` refs from tool results
- **Timeline enrichment** — key tool params (artifact_ref, name, agent_id) shown in timeline rows
- **Gate timeline events** centralized in GatewayStore so Room TUI shows all pending gates

### Gateway runtime
- **WaitingForChild** fix — sessions with active child work no longer close as completed (Ri-0.14)
- **Approval spawn gate** — blocks `agent_spawn` and `user.ask` while workflow has tasks awaiting operator approval
- **RevisionPromote resume** — auto-resumes sessions after approval resolution
- **Centralized timeline events** — `approval.pending` and `user.ask.pending` emitted from the store layer instead of scattered manual emits
- **Approvals.inspect** enriched with gate context (escalation messages, plan summaries)

### Tests
- `workflow_approval_spawn_gate_integration.rs` — approval-gate spawn blocking + withdrawal on task cancel
- Timeline coverage guard extended for `user.ask.pending` and `plan.pending`

## Build
Clean build. No new test failures beyond pre-existing ones.