### PR TITLE
fix(guidance): exclude promotion-gate agents from exec.approval_continuation (P-3.10)

### DIFF
--- a/autonoetic-gateway/src/runtime/guidance.rs
+++ b/autonoetic-gateway/src/runtime/guidance.rs
@@ -32,6 +32,8 @@ pub enum GuidanceCondition {
     All(Vec<GuidanceCondition>),
     /// Any sub-condition holds.
     Any(Vec<GuidanceCondition>),
+    /// The sub-condition does NOT hold (for exclusions).
+    Not(Box<GuidanceCondition>),
 }
 
 /// A unit of prompt prose with a declarative activation condition.
@@ -78,6 +80,7 @@ impl GuidanceCondition {
             GuidanceCondition::Role(role) => ctx.role == Some(*role),
             GuidanceCondition::All(conds) => conds.iter().all(|c| c.matches(ctx)),
             GuidanceCondition::Any(conds) => conds.iter().any(|c| c.matches(ctx)),
+            GuidanceCondition::Not(cond) => !cond.matches(ctx),
         }
     }
 }
@@ -280,5 +283,37 @@ mod tests {
         // any agent, even with no capabilities/tools.
         let out = compose_guidance(&builtin_blocks(), &GuidanceContext::default());
         assert!(out.contains("Don't fabricate a missing fact"), "got: {out:?}");
+    }
+
+    #[test]
+    fn not_negates() {
+        let caps = write_access();
+        let ctx = GuidanceContext { capabilities: &caps, ..Default::default() };
+        // write_access present → Not(write_access) is false → excluded.
+        let a = block(
+            "a",
+            GuidanceCondition::Not(Box::new(GuidanceCondition::Capability("write_access"))),
+            0,
+        );
+        assert_eq!(compose_guidance(&[a], &ctx), "");
+        // network_access absent → Not(network_access) is true → included.
+        let b = block(
+            "b",
+            GuidanceCondition::Not(Box::new(GuidanceCondition::Capability("network_access"))),
+            0,
+        );
+        assert_eq!(compose_guidance(&[b], &ctx), "b");
+    }
+
+    #[test]
+    fn approval_block_excluded_for_promotion_gate_roles() {
+        // P-3.10: promotion-gate agents can't get network approval, so the
+        // exec approval-continuation block must not fire for them.
+        let block = vec![crate::runtime::tools::sandbox::exec_approval_continuation_block()];
+        let tools = vec!["artifact_exec".to_string()];
+        let coder = GuidanceContext { active_tool_names: &tools, role: Some("coder"), ..Default::default() };
+        assert!(compose_guidance(&block, &coder).contains("Approval continuation"));
+        let utr = GuidanceContext { active_tool_names: &tools, role: Some("unit_test_runner"), ..Default::default() };
+        assert_eq!(compose_guidance(&block, &utr), "");
     }
 }

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -888,35 +888,26 @@ impl AgentExecutor {
     /// `active_tool_names` must be the FINAL advertised tool set (post
     /// MCP-merge/dedupe/cap), so `ToolPresent` gating matches what the model
     /// actually sees rather than the native-only candidate set.
-    /// The agent's configured model id, resolving a routing preset to its first
-    /// concrete model when `llm_config.model` is unset. Returns `"unknown"` when
-    /// nothing resolves. Shared by tracing/context-window sizing and guidance
-    /// (`model_family`) so both observe the same model.
+    /// The concrete model id for this spawn. Agents declare a **preset**
+    /// (`llm_preset`), not a pinned model — so the source of truth is the
+    /// resolved inference profile (preset → concrete `llm_config`), not
+    /// `manifest.llm_config` (normally `None`). Falls back to a legacy explicit
+    /// `manifest.llm_config.model`, then `"unknown"`. Shared by tracing/
+    /// context-window sizing and guidance (`model_family`).
     fn resolved_model_id(&self) -> String {
+        // Preferred: the resolved profile's concrete model (from the preset).
+        if let Some(profile) = self.resolved_inference.as_ref() {
+            let m = profile.llm_config.model.trim();
+            if !m.is_empty() && m != "unknown" {
+                return m.to_string();
+            }
+        }
+        // Legacy fallback: an explicit pinned model in the manifest.
         self.manifest
             .llm_config
             .as_ref()
-            .and_then(|c| {
-                // Explicit model wins; otherwise derive from the routing preset's
-                // first concrete model.
-                if !c.model.is_empty() && c.model != "unknown" {
-                    Some(c.model.clone())
-                } else {
-                    c.routing_preset.as_ref().and_then(|preset_name| {
-                        self.config
-                            .as_ref()
-                            .and_then(|cfg| cfg.llm_presets.get(preset_name))
-                            .and_then(|preset| preset.routing.as_ref())
-                            .and_then(|routing| routing.models.first())
-                            .and_then(|first_model_name| {
-                                self.config
-                                    .as_ref()
-                                    .and_then(|cfg| cfg.llm_presets.get(first_model_name))
-                                    .and_then(|fixed| fixed.model.clone())
-                            })
-                    })
-                }
-            })
+            .map(|c| c.model.clone())
+            .filter(|m| !m.is_empty() && m != "unknown")
             .unwrap_or_else(|| "unknown".to_string())
     }
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -888,6 +888,38 @@ impl AgentExecutor {
     /// `active_tool_names` must be the FINAL advertised tool set (post
     /// MCP-merge/dedupe/cap), so `ToolPresent` gating matches what the model
     /// actually sees rather than the native-only candidate set.
+    /// The agent's configured model id, resolving a routing preset to its first
+    /// concrete model when `llm_config.model` is unset. Returns `"unknown"` when
+    /// nothing resolves. Shared by tracing/context-window sizing and guidance
+    /// (`model_family`) so both observe the same model.
+    fn resolved_model_id(&self) -> String {
+        self.manifest
+            .llm_config
+            .as_ref()
+            .and_then(|c| {
+                // Explicit model wins; otherwise derive from the routing preset's
+                // first concrete model.
+                if !c.model.is_empty() && c.model != "unknown" {
+                    Some(c.model.clone())
+                } else {
+                    c.routing_preset.as_ref().and_then(|preset_name| {
+                        self.config
+                            .as_ref()
+                            .and_then(|cfg| cfg.llm_presets.get(preset_name))
+                            .and_then(|preset| preset.routing.as_ref())
+                            .and_then(|routing| routing.models.first())
+                            .and_then(|first_model_name| {
+                                self.config
+                                    .as_ref()
+                                    .and_then(|cfg| cfg.llm_presets.get(first_model_name))
+                                    .and_then(|fixed| fixed.model.clone())
+                            })
+                    })
+                }
+            })
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
     fn render_tool_guidance(
         &self,
         tier_filter: &crate::runtime::tools::ToolTierFilter,
@@ -895,13 +927,20 @@ impl AgentExecutor {
     ) -> String {
         let mut blocks = self.registry.collect_guidance_blocks(&self.manifest, tier_filter);
         blocks.extend(crate::runtime::guidance::builtin_blocks());
+        // Resolve the model id (preset-aware) so `ModelFamily` matches even for
+        // preset-configured agents whose `llm_config.model` is empty (#465/#479).
+        // `ModelFamily` substring-matches it (e.g. ["claude"] matches
+        // "claude-opus-4-8"); "unknown"/empty → None so family guidance just
+        // doesn't fire.
+        let model = self.resolved_model_id();
+        let model_family = match model.as_str() {
+            "" | "unknown" => None,
+            m => Some(m),
+        };
         let ctx = crate::runtime::guidance::GuidanceContext {
             capabilities: &self.manifest.capabilities,
             active_tool_names,
-            // The configured model id; `ModelFamily` substring-matches it
-            // (e.g. ["claude"] matches "claude-opus-4-8"). None when unset, so
-            // family-gated guidance simply doesn't fire (#465).
-            model_family: self.manifest.llm_config.as_ref().map(|c| c.model.as_str()),
+            model_family,
             role: crate::runtime::context::role_from_manifest(&self.manifest),
         };
         crate::runtime::guidance::compose_guidance(&blocks, &ctx)
@@ -1261,32 +1300,7 @@ impl AgentExecutor {
                 .unwrap_or_else(DisclosurePolicy::default),
         );
 
-        let model = self
-            .manifest
-            .llm_config
-            .as_ref()
-            .and_then(|c| {
-                // If the model is explicitly set, use it.
-                // Otherwise try to derive one from the routing preset's first model.
-                if !c.model.is_empty() && c.model != "unknown" {
-                    Some(c.model.clone())
-                } else {
-                    c.routing_preset.as_ref().and_then(|preset_name| {
-                        self.config
-                            .as_ref()
-                            .and_then(|cfg| cfg.llm_presets.get(preset_name))
-                            .and_then(|preset| preset.routing.as_ref())
-                            .and_then(|routing| routing.models.first())
-                            .and_then(|first_model_name| {
-                                self.config
-                                    .as_ref()
-                                    .and_then(|cfg| cfg.llm_presets.get(first_model_name))
-                                    .and_then(|fixed| fixed.model.clone())
-                            })
-                    })
-                }
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+        let model = self.resolved_model_id();
         let temperature = self
             .manifest
             .llm_config
@@ -3668,11 +3682,26 @@ mod tests {
         // WriteAccess ⇒ content_write block; CodeExecution ⇒ sandbox_exec
         // forbidden-commands + approval blocks; ReadAccess ⇒ workflow_state
         // resumption kernel (#466 migration from per-SKILL.md prose).
-        let manifest = manifest_with_capabilities(vec![
+        let mut manifest = manifest_with_capabilities(vec![
             Capability::WriteAccess { scopes: vec!["*".to_string()] },
             Capability::CodeExecution { patterns: vec![], commands: vec![] },
             Capability::ReadAccess { scopes: vec!["*".to_string()] },
         ]);
+        // Explicit Claude model → resolved_model_id → model_family, so the
+        // content_patch Claude edit-format hint fires (#465/#479).
+        manifest.llm_config = Some(autonoetic_types::agent::LlmConfig {
+            provider: "anthropic".to_string(),
+            model: "claude-opus-4-8".to_string(),
+            temperature: 0.0,
+            fallback_provider: None,
+            fallback_model: None,
+            chat_only: false,
+            context_window_tokens: None,
+            base_url: None,
+            api_key_env: None,
+            routing_preset: None,
+            thinking: None,
+        });
         let temp = tempdir().expect("tempdir should create");
         let captured = Arc::new(Mutex::new(None));
         let driver = CaptureSystemDriver { system_message: Arc::clone(&captured) };
@@ -3701,6 +3730,10 @@ mod tests {
         assert!(
             system.contains("On any wake-up"),
             "workflow_state resumption kernel missing"
+        );
+        assert!(
+            system.contains("prefer `mode=\"replace\"`"),
+            "Claude-family edit-format hint missing (model_family resolution)"
         );
     }
 

--- a/autonoetic-gateway/src/runtime/tools/content_patch.rs
+++ b/autonoetic-gateway/src/runtime/tools/content_patch.rs
@@ -173,9 +173,13 @@ impl NativeTool for ContentPatchTool {
     }
 
     fn guidance(&self) -> Vec<GuidanceBlock> {
-        // The general doctrine is family-agnostic; the format hints below are
-        // model-family-specific (#465), mirroring the Hermes finding that
-        // different model families drive different edit formats most reliably.
+        // The general doctrine is family-agnostic. The format hints (#465) take
+        // the Hermes *insight* — only gpt/codex reliably drive the multi-entry
+        // V4A diff; every other family drives `replace` better — but express it
+        // openly: `replace` is the DEFAULT (gated `Not(gpt/codex)`), so local
+        // models (qwen, minimax, nemotron, …) and unknown models all get it,
+        // with no model allowlist to maintain. Only gpt/codex are special-cased.
+        const V4A_FAMILIES: &[&str] = &["gpt", "codex"];
         let present = || {
             GuidanceCondition::All(vec![
                 GuidanceCondition::Capability("write_access"),
@@ -202,10 +206,11 @@ retrying — don't guess variations of the same snippet."
                     .to_string(),
             },
             GuidanceBlock {
-                id: "editing.content_patch.format.claude",
+                // Default for every family except gpt/codex (and for unknown models).
+                id: "editing.content_patch.format.replace",
                 when: GuidanceCondition::All(vec![
                     present(),
-                    GuidanceCondition::ModelFamily(&["claude", "sonnet", "opus", "haiku"]),
+                    GuidanceCondition::Not(Box::new(GuidanceCondition::ModelFamily(V4A_FAMILIES))),
                 ]),
                 priority: 11,
                 prose: "Edit format: prefer `mode=\"replace\"` — match a unique snippet and swap it. \
@@ -213,10 +218,10 @@ Reach for `mode=\"v4a\"` only when one edit genuinely spans several entries at o
                     .to_string(),
             },
             GuidanceBlock {
-                id: "editing.content_patch.format.gpt",
+                id: "editing.content_patch.format.v4a",
                 when: GuidanceCondition::All(vec![
                     present(),
-                    GuidanceCondition::ModelFamily(&["gpt", "codex"]),
+                    GuidanceCondition::ModelFamily(V4A_FAMILIES),
                 ]),
                 priority: 11,
                 prose: "Edit format: for edits spanning several entries prefer `mode=\"v4a\"` (the \
@@ -622,23 +627,31 @@ mod tests {
             role: None,
         };
 
-        // Claude → replace-first hint, not the v4a-first one.
+        // Claude → replace-first hint (it's not gpt/codex), not the v4a one.
         let claude = GuidanceContext { model_family: Some("claude-opus-4-8"), ..base.clone() };
         let out = compose_guidance(&blocks, &claude);
         assert!(out.contains("Editing existing content"));
         assert!(out.contains("prefer `mode=\"replace\"`"));
         assert!(!out.contains("most reliably"));
 
-        // GPT → v4a-for-multi-entry hint, not the replace-first one.
+        // GPT/codex → v4a-for-multi-entry hint, not the replace-first one.
         let gpt = GuidanceContext { model_family: Some("gpt-4o"), ..base.clone() };
         let out = compose_guidance(&blocks, &gpt);
         assert!(out.contains("most reliably"));
         assert!(!out.contains("Edit format: prefer `mode=\"replace\"`"));
 
-        // No model family → general doctrine only, no format hint.
+        // Local/other models (qwen, minimax, …) → replace is the default.
+        for m in ["qwen2.5-coder", "minimax/minimax-m2.7", "nemotron-4"] {
+            let ctx = GuidanceContext { model_family: Some(m), ..base.clone() };
+            let out = compose_guidance(&blocks, &ctx);
+            assert!(out.contains("prefer `mode=\"replace\"`"), "{m} should get replace hint");
+            assert!(!out.contains("most reliably"), "{m} should not get v4a hint");
+        }
+
+        // Unknown model → replace is still the safe default.
         let out = compose_guidance(&blocks, &base);
-        assert!(out.contains("Editing existing content"));
-        assert!(!out.contains("Edit format:"));
+        assert!(out.contains("prefer `mode=\"replace\"`"));
+        assert!(!out.contains("most reliably"));
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -790,9 +790,22 @@ pub(crate) fn exec_approval_continuation_block() -> crate::runtime::guidance::Gu
     use crate::runtime::guidance::{GuidanceBlock, GuidanceCondition};
     GuidanceBlock {
         id: "exec.approval_continuation",
-        when: GuidanceCondition::Any(vec![
-            GuidanceCondition::ToolPresent("sandbox_exec"),
-            GuidanceCondition::ToolPresent("artifact_exec"),
+        // Fires for exec-capable agents, but NOT promotion-gate agents: under
+        // P-3.10 their sandbox has network permanently denied, so "seek approval
+        // and retry" is wrong for them (artifact_exec returns
+        // `promotion_gate_network_denied`, not `approval_required`). Roles here
+        // mirror `promotion::manifest_may_record_promotion_verdicts` — keep in sync.
+        when: GuidanceCondition::All(vec![
+            GuidanceCondition::Any(vec![
+                GuidanceCondition::ToolPresent("sandbox_exec"),
+                GuidanceCondition::ToolPresent("artifact_exec"),
+            ]),
+            GuidanceCondition::Not(Box::new(GuidanceCondition::Any(vec![
+                GuidanceCondition::Role("sealed_evaluator"),
+                GuidanceCondition::Role("auditor"),
+                GuidanceCondition::Role("static_evaluator"),
+                GuidanceCondition::Role("unit_test_runner"),
+            ]))),
         ]),
         priority: 11,
         prose: "**Approval continuation.** If `sandbox_exec`/`artifact_exec` returns \


### PR DESCRIPTION
## What

Resolves the contradiction surfaced while reviewing #479: our `exec.approval_continuation` guidance block told **every** exec-capable agent to "seek operator approval and retry with `approval_ref`", but #479's **P-3.10** makes promotion-gate agents run with network *permanently denied* — `artifact_exec` returns `promotion_gate_network_denied`, not `approval_required`. So those agents (unit_test_runner / sealed_evaluator / auditor / static_evaluator) were getting our "seek approval" block **and** #479's "never seek approval" prose at the same time.

## How

- Add a general **`Not(Box<GuidanceCondition>)`** negation primitive to the guidance mechanism.
- Gate the block: `All[ Any[ToolPresent(sandbox_exec|artifact_exec)], Not[Any[Role(promotion-gate roles)]] ]`. The roles mirror `promotion::manifest_may_record_promotion_verdicts` (comment notes the coupling).

### Why role exclusion, not a capability
`Capability("evaluation")` looks tempting but **doesn't work**: `sealed_evaluator` and `unit_test_runner` declare `CodeExecution`, not `Evaluation` (verified). Role exclusion is the precise mirror of the P-3.10 agent set.

## Result

Promotion-gate agents no longer receive the (wrong-for-them) approval-continuation guidance — removing the contradiction so #479's per-agent prose no longer has to counter a block. Regular exec agents (coder/executor/debugger/specialized_builder) are unaffected.

## Tests

- `not_negates` — the new negation primitive.
- `approval_block_excluded_for_promotion_gate_roles` — present for `coder`, absent for `unit_test_runner`.
- Existing guidance (13) + migrated-doctrine compose tests green.

Follow-up still queued: make `model_family` preset-aware (#465 reads raw `llm_config.model`, empty for preset-configured agents — also surfaced by #479).

🤖 Generated with [Claude Code](https://claude.com/claude-code)