### PR TITLE
refactor(agents): orchestration coordination kernel as an agent_spawn block (#466 item D)

### DIFF
--- a/agents/evolution/agent-factory.default/SKILL.md
+++ b/agents/evolution/agent-factory.default/SKILL.md
@@ -102,12 +102,10 @@ Auto-detect: if `intended_capabilities` contains only `CredentialAccess`, `Netwo
 
 ## Tools for delegation
 
-**IMPORTANT**: To delegate to a sub-agent, always use `agent_spawn` (NOT `workflow.spawn` — that tool does not exist).
-- `agent_spawn` with `async=true` — enqueues a sub-agent and returns a `task_id`.
-- **Sequential step (one child, then the next) → end your turn.** Most of this pipeline is sequential: architect → coder → packager → install. After spawning the stage owner, reply with a short status line and stop. The gateway suspends you as `WaitingForChild` and **wakes you automatically** when that sub-agent reaches a terminal state or hits a gate (constitutional right Ri-0.14); its typed state is already in your turn-start context. Yielding is cheaper than blocking and costs exactly one resumption. So each sequential step is: spawn the stage owner → end turn → resume on wake → spawn the next stage.
-- **Parallel fan-out you must fully join (the promotion gates) → one `workflow_wait` join.** When you spawn several independent children at once and need all of them before proceeding (Step 4), call `workflow_wait(task_ids=[<all of them>], timeout_secs=300)` **once**. It blocks until the whole group is terminal and is cheaper than being woken once per child. This is a join, not polling.
-- `workflow_state` — on resume, the one call that gives mechanical `reuse_guards` truth (which stages already completed). Call it once per resume, never in a loop.
-- **Never** loop `workflow_wait` or spin `workflow_state` to discover progress — the wake-up (sequential) or the single join (parallel) already does that.
+**IMPORTANT**: To delegate to a sub-agent, always use `agent_spawn` (NOT `workflow.spawn` — that tool does not exist). Coordinate children per the shared `agent_spawn` guidance (yield on a sequential child; one `workflow_wait` join on a parallel fan-out; never poll). Mapped onto this pipeline:
+- **Sequential stages** (architect → coder → packager → install): spawn the stage owner with `async=true`, end your turn, resume on wake, then spawn the next stage.
+- **Parallel fan-out** (the Step 4 promotion gates): spawn the independent roles, then call `workflow_wait(task_ids=[<all of them>], timeout_secs=300)` once.
+- On resume, read `reuse_guards` from `workflow_state` (which stages already completed) — once per resume, never in a loop.
 
 Do not use write tools to produce the primary output of design, implementation, evaluation, audit, packaging, or installation stages. Spawn the stage owner instead. If that owner is unavailable or fails, report the failed stage rather than completing it yourself.
 

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -3677,6 +3677,7 @@ mod tests {
             Capability::WriteAccess { scopes: vec!["*".to_string()] },
             Capability::CodeExecution { patterns: vec![], commands: vec![] },
             Capability::ReadAccess { scopes: vec!["*".to_string()] },
+            Capability::AgentSpawn { max_children: 5, max_spawn_depth: 3 },
         ]);
         // Explicit Claude model → resolved_model_id → model_family, so the
         // content_patch Claude edit-format hint fires (#465/#479).
@@ -3725,6 +3726,10 @@ mod tests {
         assert!(
             system.contains("prefer `mode=\"replace\"`"),
             "Claude-family edit-format hint missing (model_family resolution)"
+        );
+        assert!(
+            system.contains("Coordinating children"),
+            "agent_spawn orchestration kernel missing"
         );
     }
 

--- a/autonoetic-gateway/src/runtime/tools/agent.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent.rs
@@ -130,6 +130,27 @@ impl NativeTool for AgentSpawnTool {
             .any(|cap| matches!(cap, Capability::AgentSpawn { .. }))
     }
 
+    fn guidance(&self) -> Vec<crate::runtime::guidance::GuidanceBlock> {
+        use crate::runtime::guidance::{GuidanceBlock, GuidanceCondition};
+        // The Ri-0.14 yield/join doctrine, uniform across every spawner (#466).
+        // The heavy orchestrators (planner, agent-factory) keep their detailed,
+        // role-specific coordination sections; this guarantees the light spawners
+        // (agent-adapter, evolution-steward, specialized_builder) get the rule too.
+        vec![GuidanceBlock {
+            id: "orchestration.coordinate_children",
+            when: GuidanceCondition::ToolPresent("agent_spawn"),
+            priority: 7,
+            prose: "**Coordinating children — yield, don't block or poll.** Spawn with \
+`async=true`. For a sequential/single child: reply with a short status and **end your turn** — the \
+gateway suspends you as `WaitingForChild` and wakes you automatically when the child reaches a \
+terminal state or a gate (Ri-0.14), with its typed state in your turn-start context. For a parallel \
+fan-out you must fully join: call `workflow_wait(task_ids=[…])` **once** (a join, not a poll). \
+**Never** loop `workflow_wait` or spin `workflow_state` to discover progress — the wake-up or the \
+single join already does that. Yielding is cheaper than blocking and costs one resumption."
+                .to_string(),
+        }]
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),


### PR DESCRIPTION
## What

Structural item **D**. The Ri-0.14 yield/join doctrine — *spawn `async` → end turn → gateway auto-wakes you (`WaitingForChild`); join a parallel fan-out with one `workflow_wait`; never poll `workflow_wait`/`workflow_state`* — was spelled out by `planner` and `agent-factory` but **entirely missing from the light spawners** (`agent-adapter`, `evolution-steward`, `specialized_builder` — 0 coverage, verified). Those agents spawn children and could block or poll incorrectly.

## How

- **`agent_spawn.guidance()`** contributes the coordination kernel, gated `ToolPresent("agent_spawn")` → every spawner gets it uniformly.
- **`agent-factory`**: trimmed its generic three-cases exposition (now the block's job) to a short pointer + its **pipeline-specific** mapping (architect→coder→packager→install; the Step-4 promotion-gate fan-out).
- **`planner` keeps its detailed "Coordinating With Children — Three Cases" section deliberately** — it's the lead orchestrator's role elaboration (runnable examples, the `timeout_secs=0` probe, resumption-cost reasoning), not boilerplate. This is base-block + role-elaboration, not duplication.

## Honest scope note

Unlike the ×25 output-contract line, the orchestrators' coordination sections are **rich and role-specific**, not clean duplication — so D's real value is *uniform coverage* (the additive kernel for the light spawners) plus a modest agent-factory trim, not a big line reduction. No doctrine-guard fingerprint here, because the kernel legitimately remains in planner's detailed section.

## Tests

The lifecycle compose test (now AgentSpawn-capable) asserts the orchestration kernel renders alongside the other migrated blocks. Green.

Independent of #482 (different files); both can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)