### PR TITLE
fix(guidance): orchestration block — make agent_spawn mandatory, forbid spawn-less 'delegated'

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent.rs
@@ -140,13 +140,15 @@ impl NativeTool for AgentSpawnTool {
             id: "orchestration.coordinate_children",
             when: GuidanceCondition::ToolPresent("agent_spawn"),
             priority: 7,
-            prose: "**Coordinating children — yield, don't block or poll.** Spawn with \
-`async=true`. For a sequential/single child: reply with a short status and **end your turn** — the \
-gateway suspends you as `WaitingForChild` and wakes you automatically when the child reaches a \
-terminal state or a gate (Ri-0.14), with its typed state in your turn-start context. For a parallel \
-fan-out you must fully join: call `workflow_wait(task_ids=[…])` **once** (a join, not a poll). \
-**Never** loop `workflow_wait` or spin `workflow_state` to discover progress — the wake-up or the \
-single join already does that. Yielding is cheaper than blocking and costs one resumption."
+            prose: "**Coordinating children — yield, don't block or poll.** Delegating means \
+**actually calling `agent_spawn`**: emitting a `delegated`/handoff status *without* a real \
+`agent_spawn` call in this turn does nothing — the workflow just ends and no child runs. So to \
+delegate: call `agent_spawn` with `async=true` **first**, then reply with a short status and end \
+your turn — the gateway suspends you as `WaitingForChild` and wakes you automatically when the child \
+reaches a terminal state or a gate (Ri-0.14), with its typed state in your turn-start context. For a \
+parallel fan-out you must fully join: call `workflow_wait(task_ids=[…])` **once** (a join, not a \
+poll). **Never** loop `workflow_wait` or spin `workflow_state` to discover progress — the wake-up or \
+the single join already does that."
                 .to_string(),
         }]
     }

--- a/autonoetic-gateway/src/runtime/tools/agent.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent.rs
@@ -141,7 +141,7 @@ impl NativeTool for AgentSpawnTool {
             when: GuidanceCondition::ToolPresent("agent_spawn"),
             priority: 7,
             prose: "**Coordinating children — yield, don't block or poll.** Delegating means \
-**actually calling `agent_spawn`**: emitting a `delegated`/handoff status *without* a real \
+**actually calling `agent_spawn`**: emitting a `delegated` status *without* a real \
 `agent_spawn` call in this turn does nothing — the workflow just ends and no child runs. So to \
 delegate: call `agent_spawn` with `async=true` **first**, then reply with a short status and end \
 your turn — the gateway suspends you as `WaitingForChild` and wakes you automatically when the child \


### PR DESCRIPTION
## The report

Planner replied `status:"delegated"` and **ended the turn without calling `agent_spawn`** — nothing was delegated (asked to "make it an agent" after a weather request).

## Diagnosis

- **Our planner `SKILL.md` trims did NOT cause this.** Verified by diff (`c3c0b429..main`): we only replaced the resumption Step 1/2/3 intro with a pointer (kept the reuse-guards table) and removed the redundant "raw JSON / no fences" output line. The **Decision Flow, agent-factory routing, and Coordinating-With-Children sections are intact.**
- **Likely contributor:** the orchestration guidance block added in #483 — *"reply with a short status and end your turn"* can be misread (especially by a weak routed model; the `smart` preset can route short requests to haiku) as license to *declare* `delegated` and yield, skipping the `agent_spawn` call.
- **No mechanical guard:** the gateway doesn't detect a spawn-less `delegated` status — it just ends the workflow.

## Fix (this PR)

Reword the `orchestration.coordinate_children` block to make the spawn **mandatory** and name the failure mode: *"Delegating means actually calling `agent_spawn`; emitting a `delegated`/handoff status without a real `agent_spawn` call in this turn does nothing — the workflow just ends. Spawn first, then reply + end turn."*

## Recommended follow-up (not in this PR)

A **gateway-side guard** (Separation of Powers): if an `AgentSpawn`-capable agent emits a terminal `delegated`/handoff status but spawned no child this turn/session, reject with a repair prompt rather than silently ending the workflow. That's the robust, prompt-independent fix; happy to do it next if you want.

Tests: lifecycle compose test (asserts the block renders) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)