### PR TITLE
feat(tui): tiered timeline — squash routine rows, jump checkpoints

### DIFF
--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -1892,10 +1892,16 @@ pub enum RowSource {
     Run { start: usize, len: usize },
 }
 
-/// Fold consecutive `Detail` events into a single collapsed row so routine
-/// plumbing (turns, workbench bookkeeping, polls) doesn't flood the view when
-/// the floor is low. A lone Detail event renders normally — collapsing one is
-/// pointless. Higher altitudes always render individually. Coalescing is
+/// Fold consecutive **routine** events into a single collapsed row so plumbing
+/// (turns, LLM rounds, read-only tool calls, workflow bookkeeping) doesn't
+/// flood the view. Classification is by [`event_tier`], not raw altitude, so
+/// that routine `tool.completed` rows (which the gateway tags `Normal`) also
+/// fold — previously only `Detail`-altitude events collapsed, which left the
+/// asymmetric `tool.requested` (Detail, folded) vs `tool.completed` (Normal,
+/// individual) pair and produced dozens of completion rows.
+///
+/// A lone routine event renders normally — collapsing one is pointless.
+/// Checkpoint and Significant tiers always render individually. Coalescing is
 /// page-local; a run split across reads collapses per page.
 pub fn coalesce(entries: &[SessionTimelineEntry]) -> Vec<RenderedRow> {
     coalesce_indexed(entries).into_iter().map(|(r, _)| r).collect()
@@ -1907,7 +1913,7 @@ pub fn coalesce_indexed(entries: &[SessionTimelineEntry]) -> Vec<(RenderedRow, R
     let mut run_start: Option<usize> = None;
     let mut run_len: usize = 0;
     for (i, e) in entries.iter().enumerate() {
-        if e.altitude == Altitude::Detail {
+        if event_tier(e) == EventTier::Routine {
             if run_start.is_none() {
                 run_start = Some(i);
             }
@@ -1922,6 +1928,92 @@ pub fn coalesce_indexed(entries: &[SessionTimelineEntry]) -> Vec<(RenderedRow, R
     }
     flush_run(entries, &mut run_start, &mut run_len, &mut out);
     out
+}
+
+/// Visibility tier for a timeline event — drives squashing in the default
+/// (squashed) view. Pure-view classification; the gateway-assigned altitude
+/// remains the source of truth for glyph/color, and the floor filter still
+/// applies before coalescing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventTier {
+    /// Decisions, boundaries, and errors — plans, approvals, escalations,
+    /// operator messages, session starts. Always rendered individually; the
+    /// TUI elevates these with banner chrome and jump-to-checkpoint keys.
+    Checkpoint,
+    /// Agent output and state-changing actions — `agent.message`, audits, and
+    /// `tool.completed` for privileged/state-changing tools. Always rendered
+    /// individually so the operator sees what the session *produced*.
+    Significant,
+    /// Plumbing — turns, LLM rounds, reasoning, tool requests, read-only tool
+    /// completions, workflow bookkeeping. Folded into collapsed runs.
+    Routine,
+}
+
+/// `tool.completed` for these state-changing tools is Significant (shown
+/// individually); every other `tool.completed` is Routine (folded).
+const SIGNIFICANT_TOOL_NAMES: &[&str] = &[
+    "agent_spawn",
+    "content_write",
+    "content_patch",
+    "artifact_build",
+    "artifact_project",
+    "artifact_exec",
+    "sandbox_exec",
+    "promotion_record",
+    "agent_revision_create",
+    "agent_revision_create_from_intent",
+    "agent_revision_promote",
+    "agent_revision_rollback",
+    "skill_install",
+    "federation.escalate",
+];
+
+/// Classify a timeline event into a visibility tier. Used by the squashed
+/// view to decide what folds vs renders individually.
+pub fn event_tier(entry: &SessionTimelineEntry) -> EventTier {
+    match entry.event_type.as_str() {
+        "plan.pending" | "plan.approved" | "plan.rejected" | "plan.withdrawn"
+        | "approval.pending" | "approval.approved" | "approval.rejected"
+        | "approval.cancelled" | "approval.withdrawn"
+        | "escalation.pending" | "escalation.approved" | "escalation.rejected"
+        | "operator.message"
+        | "session.start" | "session.end"
+        | "workbench.created" | "workbench.reconciled" | "workbench.discarded"
+        | "runtime.lock_drift"
+        | "wiki.proposed" | "wiki.promoted" | "wiki.rejected" | "wiki.withdrawn" => {
+            EventTier::Checkpoint
+        }
+        "agent.message" | "digest_annotate" => EventTier::Significant,
+        "tool.completed" => tool_completed_tier(entry),
+        _ => EventTier::Routine,
+    }
+}
+
+/// `tool.completed` is Significant only for a state-changing tool; routine
+/// (folded) otherwise. Reads `tool_name` from the payload defensively.
+fn tool_completed_tier(entry: &SessionTimelineEntry) -> EventTier {
+    let Some(p) = entry.payload.as_deref() else {
+        return EventTier::Significant;
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(p) else {
+        return EventTier::Significant;
+    };
+    let tool = v
+        .get("tool_name")
+        .or_else(|| v.get("tool"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+    if SIGNIFICANT_TOOL_NAMES.contains(&tool) {
+        EventTier::Significant
+    } else {
+        EventTier::Routine
+    }
+}
+
+/// True when the event is a first-class checkpoint (see [`EventTier::Checkpoint`]).
+/// Convenience for the TUI to mark checkpoint rows for banner/jump handling.
+pub fn is_checkpoint(entry: &SessionTimelineEntry) -> bool {
+    event_tier(entry) == EventTier::Checkpoint
 }
 
 fn flush_run(
@@ -2558,7 +2650,7 @@ mod tests {
     }
 
     #[test]
-    fn coalesce_folds_detail_runs_but_keeps_higher_altitudes() {
+    fn coalesce_folds_routine_runs_but_keeps_checkpoints_and_significant() {
         let mk = |et: &str, alt: Altitude| {
             entry(
                 SessionRole::Planner,
@@ -2570,24 +2662,120 @@ mod tests {
         };
         let entries = vec![
             mk("turn.start", Altitude::Detail),
-            mk("workbench.created", Altitude::Detail),
+            mk("llm.round", Altitude::Detail),
             mk("turn.start", Altitude::Detail),
-            mk("approval.pending", Altitude::Attention), // breaks the run
-            mk("turn.end", Altitude::Detail),            // lone detail ⇒ normal line
+            mk("approval.pending", Altitude::Attention), // checkpoint — breaks the run
+            mk("turn.end", Altitude::Detail),            // lone routine ⇒ normal line
         ];
         let rows = coalesce(&entries);
-        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.len(), 3, "run + checkpoint + lone routine");
         match &rows[0] {
             RenderedRow::Collapsed { count, summary } => {
                 assert_eq!(*count, 3);
                 assert!(summary.contains("turn.start×2"));
+                assert!(summary.contains("llm.round"));
             }
             other => panic!("expected collapsed run, got {other:?}"),
         }
         assert!(matches!(&rows[1], RenderedRow::Line(spec) if spec.headline.contains("APPROVAL REQUIRED")));
-        // The trailing lone Detail event is a normal line, not collapsed.
+        // The trailing lone routine event is a normal line, not collapsed.
         assert!(matches!(&rows[2], RenderedRow::Line { .. }));
         assert!(row_text(&rows[0]).contains("⟨3 routine events"));
+    }
+
+    #[test]
+    fn coalesce_folds_routine_tool_completed_but_keeps_significant() {
+        // The clutter fix: a read-only tool.completed (e.g. workflow_wait)
+        // folds as Routine, while a state-changing tool.completed
+        // (e.g. agent_spawn) renders individually as Significant.
+        let mk_tool = |et: &str, tool: &str| {
+            entry(
+                SessionRole::Planner,
+                Principal::agent("planner.default"),
+                et,
+                Altitude::Normal,
+                serde_json::json!({ "tool_name": tool }),
+            )
+        };
+        let entries = vec![
+            mk_tool("tool.completed", "workflow_wait"), // routine
+            mk_tool("tool.completed", "workflow_wait"), // routine  (run of 2)
+            mk_tool("tool.completed", "agent_spawn"),   // significant — breaks run
+            mk_tool("tool.completed", "resolve"),       // routine (lone ⇒ individual)
+        ];
+        let rows = coalesce(&entries);
+        assert_eq!(rows.len(), 3, "run(2) + agent_spawn + lone resolve");
+        assert!(
+            matches!(&rows[0], RenderedRow::Collapsed { count: 2, .. }),
+            "two read-only completions should fold; got {:?}",
+            rows[0]
+        );
+        assert!(matches!(&rows[1], RenderedRow::Line { .. }));
+        assert!(matches!(&rows[2], RenderedRow::Line { .. }));
+    }
+
+    #[test]
+    fn event_tier_classification() {
+        let mk = |et: &str| {
+            entry(
+                SessionRole::Planner,
+                Principal::agent("planner.default"),
+                et,
+                Altitude::Normal,
+                serde_json::json!({}),
+            )
+        };
+        // Checkpoints
+        for et in [
+            "plan.pending", "plan.approved", "approval.pending", "approval.approved",
+            "escalation.pending", "operator.message", "session.start", "workbench.created",
+            "runtime.lock_drift",
+        ] {
+            assert_eq!(
+                event_tier(&mk(et)),
+                EventTier::Checkpoint,
+                "{et} should be a checkpoint"
+            );
+        }
+        // Significant
+        assert_eq!(event_tier(&mk("agent.message")), EventTier::Significant);
+        assert_eq!(event_tier(&mk("digest_annotate")), EventTier::Significant);
+        // Routine
+        for et in [
+            "turn.start", "turn.end", "llm.round", "agent.reasoning",
+            "tool.requested", "workflow.child_state", "workflow.join_satisfied",
+        ] {
+            assert_eq!(event_tier(&mk(et)), EventTier::Routine, "{et} should be routine");
+        }
+    }
+
+    #[test]
+    fn event_tier_tool_completed_splits_by_tool_name() {
+        let mk = |tool: &str| {
+            entry(
+                SessionRole::Planner,
+                Principal::agent("planner.default"),
+                "tool.completed",
+                Altitude::Normal,
+                serde_json::json!({ "tool_name": tool }),
+            )
+        };
+        // Significant tools
+        for tool in ["agent_spawn", "content_write", "artifact_build", "sandbox_exec"] {
+            assert_eq!(
+                event_tier(&mk(tool)),
+                EventTier::Significant,
+                "tool.completed({tool}) should be significant"
+            );
+        }
+        // Routine tools
+        for tool in ["resolve", "artifact_inspect", "workflow_wait", "agent_list"] {
+            assert_eq!(
+                event_tier(&mk(tool)),
+                EventTier::Routine,
+                "tool.completed({tool}) should be routine"
+            );
+        }
     }
 
     #[test]
@@ -2598,8 +2786,8 @@ mod tests {
         let entries = vec![
             mk("turn.start", Altitude::Detail),   // 0 ┐ run
             mk("turn.end", Altitude::Detail),     // 1 ┘
-            mk("approval.pending", Altitude::Attention), // 2 single
-            mk("turn.start", Altitude::Detail),   // 3 lone detail → single
+            mk("approval.pending", Altitude::Attention), // 2 single (checkpoint)
+            mk("turn.start", Altitude::Detail),   // 3 lone routine → single
         ];
         let rows = coalesce_indexed(&entries);
         assert_eq!(rows.len(), 3);

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -1913,7 +1913,13 @@ pub fn coalesce_indexed(entries: &[SessionTimelineEntry]) -> Vec<(RenderedRow, R
     let mut run_start: Option<usize> = None;
     let mut run_len: usize = 0;
     for (i, e) in entries.iter().enumerate() {
-        if event_tier(e) == EventTier::Routine {
+        // Defense-in-depth: only fold Routine-tier events that are ALSO below
+        // the Attention altitude. This preserves the original invariant that
+        // Attention/Error rows (gates, failures, interventions) NEVER collapse,
+        // even if a future event type is mis-classified as Routine by `event_tier`.
+        let foldable = event_tier(e) == EventTier::Routine
+            && e.altitude < Altitude::Attention;
+        if foldable {
             if run_start.is_none() {
                 run_start = Some(i);
             }
@@ -1970,22 +1976,43 @@ const SIGNIFICANT_TOOL_NAMES: &[&str] = &[
 
 /// Classify a timeline event into a visibility tier. Used by the squashed
 /// view to decide what folds vs renders individually.
+///
+/// The `_ => Significant` default is deliberately conservative: an unknown
+/// event type renders individually (never folds) until it is consciously
+/// classified here. Folding is opt-in for known plumbing only.
 pub fn event_tier(entry: &SessionTimelineEntry) -> EventTier {
     match entry.event_type.as_str() {
+        // ── Checkpoints: operator decisions, gates, boundaries. Jump targets. ──
         "plan.pending" | "plan.approved" | "plan.rejected" | "plan.withdrawn"
         | "approval.pending" | "approval.approved" | "approval.rejected"
         | "approval.cancelled" | "approval.withdrawn"
         | "escalation.pending" | "escalation.approved" | "escalation.rejected"
+        | "user.ask.pending"
         | "operator.message"
         | "session.start" | "session.end"
         | "workbench.created" | "workbench.reconciled" | "workbench.discarded"
         | "runtime.lock_drift"
+        | "divergence.intervention"
+        | "security.escape_threshold"
         | "wiki.proposed" | "wiki.promoted" | "wiki.rejected" | "wiki.withdrawn" => {
             EventTier::Checkpoint
         }
-        "agent.message" | "digest_annotate" => EventTier::Significant,
+        // ── Significant: agent output, audits, and failures. Never folded. ──
+        "agent.message" | "digest_annotate"
+        | "llm.request_failed" | "llm.empty_response" | "llm.retry"
+        | "tool.failed" | "guard.tripped"
+        | "session.emergency_stop" | "security.sandbox_escape" => EventTier::Significant,
         "tool.completed" => tool_completed_tier(entry),
-        _ => EventTier::Routine,
+        // ── Routine: known plumbing only. Folded into collapsed runs. ──
+        "turn.start" | "turn.end" | "llm.round" | "agent.reasoning"
+        | "tool.requested"
+        | "workflow.child_state" | "workflow.join_satisfied" | "workflow.signal"
+        | "workflow.started" | "workflow.completed"
+        | "scheduled_job.triggered" | "scheduled_job.completed" | "scheduled_job.failed" => {
+            EventTier::Routine
+        }
+        // Unknown event type: render individually (never fold) until classified.
+        _ => EventTier::Significant,
     }
 }
 
@@ -2729,7 +2756,8 @@ mod tests {
         for et in [
             "plan.pending", "plan.approved", "approval.pending", "approval.approved",
             "escalation.pending", "operator.message", "session.start", "workbench.created",
-            "runtime.lock_drift",
+            "runtime.lock_drift", "user.ask.pending", "divergence.intervention",
+            "security.escape_threshold",
         ] {
             assert_eq!(
                 event_tier(&mk(et)),
@@ -2737,16 +2765,70 @@ mod tests {
                 "{et} should be a checkpoint"
             );
         }
-        // Significant
-        assert_eq!(event_tier(&mk("agent.message")), EventTier::Significant);
-        assert_eq!(event_tier(&mk("digest_annotate")), EventTier::Significant);
-        // Routine
+        // Significant — agent output, audits, AND failures (never folded).
+        for et in [
+            "agent.message", "digest_annotate",
+            "llm.request_failed", "llm.empty_response", "guard.tripped",
+            "tool.failed", "session.emergency_stop", "security.sandbox_escape",
+        ] {
+            assert_eq!(
+                event_tier(&mk(et)),
+                EventTier::Significant,
+                "{et} should be significant (never folded)"
+            );
+        }
+        // Unknown event type defaults to Significant (never folded).
+        assert_eq!(
+            event_tier(&mk("some.future.event_type")),
+            EventTier::Significant,
+            "unknown event type must not default to Routine (would hide it)"
+        );
+        // Routine — known plumbing only.
         for et in [
             "turn.start", "turn.end", "llm.round", "agent.reasoning",
             "tool.requested", "workflow.child_state", "workflow.join_satisfied",
         ] {
             assert_eq!(event_tier(&mk(et)), EventTier::Routine, "{et} should be routine");
         }
+    }
+
+    #[test]
+    fn coalesce_never_folds_attention_or_error_rows() {
+        // Defense-in-depth: even if a high-importance event were mis-classified
+        // as Routine, the altitude guard in coalesce_indexed must keep it
+        // individual. Attention/Error rows never collapse into a run.
+        let mk_at = |et: &str, alt: Altitude| {
+            entry(
+                SessionRole::Planner,
+                Principal::agent("planner.default"),
+                et,
+                alt,
+                serde_json::json!({}),
+            )
+        };
+        let entries = vec![
+            mk_at("turn.start", Altitude::Detail),                 // routine, folds
+            mk_at("user.ask.pending", Altitude::Attention),        // checkpoint — never folds
+            mk_at("turn.end", Altitude::Detail),                   // routine, folds (lone ⇒ line)
+            mk_at("llm.request_failed", Altitude::Error),          // significant — never folds
+        ];
+        let rows = coalesce(&entries);
+        // No row may be a Collapsed run containing an Attention/Error event.
+        for r in &rows {
+            if let RenderedRow::Collapsed { summary, .. } = r {
+                // A collapsed run is allowed only for Detail/Routine events; assert
+                // it does not mention the high-importance types.
+                assert!(
+                    !summary.contains("user.ask.pending") && !summary.contains("llm.request_failed"),
+                    "high-importance event leaked into a collapsed run: {summary}"
+                );
+            }
+        }
+        // The Attention and Error rows must be present as individual lines.
+        assert!(
+            rows.iter().any(|r| matches!(r, RenderedRow::Line(s) if s.headline.contains("CLARIFICATION") || s.headline.contains("user.ask"))),
+            "user.ask.pending must render individually"
+        );
     }
 
     #[test]

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -483,6 +483,7 @@ fn build_info_panel(
     follow: bool,
     show_reasoning: bool,
     row_count: usize,
+    checkpoint_count: usize,
     gate: Option<&GateRef>,
     pending_plan_count: usize,
     status: Option<&str>,
@@ -514,6 +515,11 @@ fn build_info_panel(
         if follow { "●" } else { "○" },
     ));
     lines.push(format!("  Rows       {row_count}"));
+    if checkpoint_count > 0 {
+        lines.push(format!(
+            "  Checkpoints {checkpoint_count}  ([ / ] jump)"
+        ));
+    }
     lines.push(String::new());
     let mut active = Vec::new();
     if let Some(g) = gate {
@@ -1284,6 +1290,10 @@ pub fn run(
     let mut squash = true;
     let mut follow = true; // pin to newest
     let mut selected: usize = 0;
+    // View-row indices (into the squashed `rows` vec) that are first-class
+    // checkpoints (plan/approval/escalation/operator/session boundaries).
+    // Recomputed each frame after coalescing; the `[` / `]` keys jump across.
+    let mut checkpoint_rows: Vec<usize> = Vec::new();
     let mut detail: Option<DetailPane> = None;
     let mut detail_scroll: u16 = 0; // vertical scroll offset for detail pane
     let mut detail_h_scroll: u16 = 0; // horizontal scroll offset for detail pane
@@ -2033,6 +2043,34 @@ pub fn run(
                             detail = None;
                         }
                         KeyCode::Char('s') => squash = !squash,
+                        // [ / ]: jump to the previous / next first-class
+                        // checkpoint (plan, approval, escalation, operator
+                        // message, session start). Makes the decision narrative
+                        // scannable without scrolling past routine plumbing.
+                        KeyCode::Char('[') => {
+                            if detail.is_none() && !checkpoint_rows.is_empty() {
+                                follow = false;
+                                if let Some(&p) =
+                                    checkpoint_rows.iter().rev().find(|&&r| r < selected)
+                                {
+                                    selected = p;
+                                } else if let Some(&last) = checkpoint_rows.last() {
+                                    selected = last; // wrap to the end
+                                }
+                            }
+                        }
+                        KeyCode::Char(']') => {
+                            if detail.is_none() && !checkpoint_rows.is_empty() {
+                                follow = false;
+                                if let Some(&n) =
+                                    checkpoint_rows.iter().find(|&&r| r > selected)
+                                {
+                                    selected = n;
+                                } else if let Some(&first) = checkpoint_rows.first() {
+                                    selected = first; // wrap to the start
+                                }
+                            }
+                        }
                         // R: toggle the 💭 reasoning prefix on/off everywhere. Off
                         // hides the prefix; the reasoning row itself stays visible
                         // (it's a Detail-altitude event, so it's normally hidden
@@ -2505,6 +2543,20 @@ pub fn run(
         let pending_plan_count =
             unresolved_pending_plan_ids(&entries, &resolved, &acted).len();
 
+        // First-class checkpoint view-row indices — plan/approval/escalation/
+        // operator/session-start events that survived coalescing. Collapsed
+        // runs are never checkpoints (checkpoints always render individually).
+        checkpoint_rows = indexed
+            .iter()
+            .enumerate()
+            .filter_map(|(vi, (_, src))| match src {
+                RowSource::Single(i) => {
+                    visible.get(*i).filter(|e| render::is_checkpoint(e)).map(|_| vi)
+                }
+                _ => None,
+            })
+            .collect();
+
         let new_plan = if input.is_none() && compose.is_none() {
             newest_pending_plan_event(&visible, &indexed, &resolved, &acted)
         } else {
@@ -2631,6 +2683,7 @@ pub fn run(
                 follow,
                 show_reasoning,
                 row_count,
+                checkpoint_rows.len(),
                 gate.as_ref(),
                 pending_plan_count,
                 status.as_deref(),


### PR DESCRIPTION
Closes #490. Implements **Pillar A, slice 1** of [`docs/design/operator-legibility.md`](../blob/main/docs/design/operator-legibility.md).

## Why

Session `943eb58c` (554 events) was hard to follow because of an **altitude asymmetry**: `tool.requested` is `Detail` (collapses) but `tool.completed` is `Normal` (renders individually → **94 rows**). Plan/approval/escalation events were buried among them. With squash already on by default, the bulk of the clutter was routine `tool.completed` rows that escaped folding.

## What (pure view layer — no gateway / prompt / guidance / storage changes)

**`render.rs` — `EventTier` classifier + tier-based coalescing:**
- `coalesce_indexed` now folds by tier instead of raw altitude.
- **Checkpoint** — `plan.*`, `approval.*`, `escalation.*`, `operator.message`, `session.start/end`, `workbench.*`, `runtime.lock_drift` → always individual.
- **Significant** — `agent.message`, `digest_annotate`, and `tool.completed` for state-changing tools (`agent_spawn`, `content_write`, `artifact_build`, `sandbox_exec`, `promotion_record`, `agent_revision_*`, `skill_install`, …) → always individual.
- **Routine** — `turn.*`, `llm.round`, `agent.reasoning`, `tool.requested`, read-only `tool.completed`, `workflow.*` → folded into collapsed runs.

A lone routine event still renders individually (collapsing one is pointless). The gateway-assigned altitude remains the source of truth for glyph/color.

**`tui.rs` — checkpoint navigation:**
- `[` / `]` jump to the previous / next checkpoint row (wraps at the ends) so the decision narrative is scannable in seconds.
- Info panel surfaces the checkpoint count.

## Verification

- `cargo build` — clean (only pre-existing warnings).
- `cargo test --bin autonoetic room::` — **140 passed**, 0 failed (+3 new tier tests).
- New tests: `event_tier_classification`, `event_tier_tool_completed_splits_by_tool_name`, `coalesce_folds_routine_tool_completed_but_keeps_significant`. Existing coalesce tests updated for the new tier semantics (e.g. `workbench.created` is now correctly a Checkpoint, not foldable Detail).

## Non-goals (later slices)

- No checkpoint banner *divider lines* yet (the checkpoints already render with ◆ + yellow + bold chrome; dividers are a possible follow-up).
- Plan inherit-by-default + diff (Pillar B), approve-the-envelope (Pillar C), t=0 workbench (Pillar D) — separate PRs.

## Prompt-factorization note

Verified that the TUI (`autonoetic/src/cli/room/`) does **not** touch the gateway guidance/prompt-factorization system (`autonoetic-gateway/src/runtime/guidance.rs`). This slice is pure view code — no prompts, no guidance blocks, no gateway changes.