### PR TITLE
fix(gateway): timeline altitude categorization (exhaustive + documented)

### DIFF
--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -383,29 +383,111 @@ pub fn operator_message_event(
 }
 
 /// Base importance of a digest event type, before any role refinement.
+/// Base importance for a timeline event type. The effective altitude written
+/// to a row is `max(base_altitude(et), role_floor(role))` (see [`altitude_for`]),
+/// unless an emitter passes an explicit altitude that *raises* it further
+/// (e.g. `runtime.lock_drift` → `Error` when rejected).
+///
+/// # Altitude policy
+///
+/// The four altitudes (`Detail < Normal < Attention < Error`) partition events
+/// by what the operator needs to see:
+///
+/// - **Error** — failures and integrity breaches. Always visible; the operator
+///   must know these happened.
+/// - **Attention** — operator **gates**: the full lifecycle of a decision that
+///   suspends for, or records, operator input. Both the *request* (`*.pending`,
+///   `*.proposed`) and the *decision* (`*.approved`, `*.rejected`, `*.promoted`)
+///   share this altitude so each gate reads as a paired ask↔resolution.
+///   Abandonments (`*.cancelled`, `*.withdrawn`) are NOT decisions → Normal.
+/// - **Normal** — visible progress: agent/operator narrative, session
+///   boundaries, workbench creation (a milestone), audits, retries, and gate
+///   abandonments. The default floor.
+/// - **Detail** — hidable plumbing: turns, LLM rounds, reasoning, tool
+///   requests *and* successful tool completions, workflow bookkeeping,
+///   scheduled jobs, workbench reconcile/discard.
+///
+/// # Per-event rationale
+///
+/// | Event type | Altitude | Why |
+/// |---|---|---|
+/// | `turn.start` / `turn.end` | Detail | turn plumbing |
+/// | `llm.round` | Detail | per-round token accounting |
+/// | `agent.reasoning` | Detail | verbose "why"; surfaced on dial-down |
+/// | `tool.requested` | Detail | the request is plumbing; the agent's message carries intent |
+/// | `tool.completed` | Detail | success completion pairs with the request; **failures** (`ok:false`) are bumped to Attention at the emit site so they aren't hidden |
+/// | `workbench.created` | Normal | milestone — content becomes reviewable (NOT plumbing) |
+/// | `workbench.reconciled` / `workbench.discarded` | Detail | edit/discard mechanics around the real work |
+/// | `workflow.child_state` / `workflow.join_satisfied` / `workflow.signal` | Detail | workflow bookkeeping |
+/// | `scheduled_job.*` | Detail | cron plumbing |
+/// | `agent.message` | Normal | primary agent narrative — the thing to read |
+/// | `operator.message` | Normal | operator input — primary |
+/// | `session.start` / `session.end` | Normal | session boundaries a new agent joins/leaves |
+/// | `digest_annotate` | Normal | auditor/evaluator annotation — output worth seeing |
+/// | `llm.retry` | Normal | a retry is notable (transient trouble) but not a failure |
+/// | `plan.pending` / `plan.approved` | Attention | plan gate lifecycle (request + decision) |
+/// | `approval.pending` / `approval.approved` / `approval.rejected` | Attention | approval gate lifecycle |
+/// | `approval.cancelled` | Normal | abandonment, not a decision |
+/// | `escalation.pending` | Attention | escalation gate request |
+/// | `user.ask.pending` | Attention | conversational clarification gate |
+/// | `wiki.proposed` / `wiki.promoted` / `wiki.rejected` | Attention | wiki-contribution gate lifecycle |
+/// | `wiki.withdrawn` | Normal | abandonment, not a decision |
+/// | `divergence.intervention` | Attention | sentinel intervention (emit site raises to Error when critical) |
+/// | `runtime.lock_drift` | Attention | integrity event (emit site stores Error when rejected) |
+/// | `security.escape_threshold` | Attention | escape-probability threshold reached |
+/// | `llm.request_failed` / `llm.empty_response` | Error | LLM failures |
+/// | `guard.tripped` | Error | LoopGuard circuit breaker |
+/// | `session.emergency_stop` | Error | emergency stop fired |
+/// | `security.sandbox_escape` | Error | sandbox breach |
+/// | `tool.failed` | Error | reserved — no emitter today (failures use `tool.completed` with `ok:false`, bumped to Attention at the emit site). Kept so a future dedicated failure event lands at Error. |
+///
+/// This match is **exhaustive over every event type the gateway emits**; the
+/// `_ => Normal` arm is a safe fallback for forward-compat (a new event type
+/// defaults to visible progress until consciously classified here).
 pub fn base_altitude(event_type: &str) -> Altitude {
     match event_type {
-        // Mechanics / poll-ish / infra — hidden at the normal floor. Workbench
-        // lifecycle is plumbing around the real work (edits/artifacts), so it
-        // stays Detail and surfaces only when the operator dials down.
-        // Extended-thinking "why" is verbose; hidable by default, surfaced on dial-down.
-        "turn.start" | "turn.end" | "llm.round" | "tool.requested" | "agent.reasoning"
-        | "workbench.created" | "workbench.reconciled" | "workbench.discarded"
+        // ─── Error: failures and integrity breaches. ───
+        "llm.request_failed" | "llm.empty_response" | "guard.tripped"
+        | "session.emergency_stop" | "security.sandbox_escape"
+        | "tool.failed" => Altitude::Error,
+
+        // ─── Attention: operator gates — requests AND decisions. ───
+        // The full lifecycle of a gate shares one altitude so each ask reads
+        // paired with its resolution. Abandonments (cancelled/withdrawn) are
+        // NOT decisions → Normal below.
+        "plan.pending" | "plan.approved"
+        | "approval.pending" | "approval.approved" | "approval.rejected"
+        | "escalation.pending"
+        | "user.ask.pending"
+        | "wiki.proposed" | "wiki.promoted" | "wiki.rejected"
+        | "divergence.intervention"
+        | "runtime.lock_drift"
+        | "security.escape_threshold" => Altitude::Attention,
+
+        // ─── Normal: visible progress (the default floor). ───
+        // Agent/operator narrative, session boundaries, the workbench-CREATED
+        // milestone, audits, retries, and gate abandonments.
+        "agent.message" | "operator.message"
+        | "session.start" | "session.end"
+        | "workbench.created"
+        | "digest_annotate"
+        | "llm.retry"
+        | "approval.cancelled" | "wiki.withdrawn" => Altitude::Normal,
+
+        // ─── Detail: hidable plumbing. ───
+        // Turns, LLM rounds, reasoning, tool requests AND successful tool
+        // completions (failures are bumped to Attention at the emit site),
+        // workflow bookkeeping, scheduled jobs, workbench reconcile/discard.
+        "turn.start" | "turn.end" | "llm.round" | "agent.reasoning"
+        | "tool.requested" | "tool.completed"
+        | "workbench.reconciled" | "workbench.discarded"
         | "workflow.child_state" | "workflow.join_satisfied" | "workflow.signal"
         | "scheduled_job.triggered" | "scheduled_job.completed" | "scheduled_job.failed" => {
             Altitude::Detail
         }
-        "llm.request_failed" | "llm.empty_response" | "tool.failed" | "session.emergency_stop"
-        | "security.sandbox_escape" | "guard.tripped" => Altitude::Error,
-        // Gates awaiting the operator (conversational asks, RFC §3.5) and
-        // integrity events. `runtime.lock_drift` stores an explicit altitude
-        // (Error when rejected, Attention when overridden); this is just the
-        // safe floor for any NULL-altitude fallback.
-        "user.ask.pending" | "approval.pending" | "plan.pending" | "divergence.intervention"
-        | "runtime.lock_drift" | "escalation.pending" | "security.escape_threshold" => {
-            Altitude::Attention
-        }
-        // Everything else is normal progress.
+
+        // Unknown event type: Normal is the safe default (visible). New event
+        // types surface until consciously classified above.
         _ => Altitude::Normal,
     }
 }
@@ -724,6 +806,53 @@ mod tests {
             altitude_for("agent.reasoning", &SessionRole::Sentinel),
             Altitude::Attention
         );
+    }
+
+    #[test]
+    fn altitude_policy_gate_lifecycle_shares_attention() {
+        // A gate's request AND decision share Attention so each ask reads
+        // paired with its resolution. Abandonments (cancelled/withdrawn) are
+        // NOT decisions → Normal.
+        for approved in ["plan.approved", "approval.approved", "approval.rejected"] {
+            assert_eq!(base_altitude(approved), Altitude::Attention, "{approved}");
+        }
+        for pending in [
+            "plan.pending", "approval.pending", "escalation.pending",
+            "user.ask.pending", "wiki.proposed", "wiki.promoted", "wiki.rejected",
+        ] {
+            assert_eq!(base_altitude(pending), Altitude::Attention, "{pending}");
+        }
+        // Abandonments — visible, but not decision checkpoints.
+        assert_eq!(base_altitude("approval.cancelled"), Altitude::Normal);
+        assert_eq!(base_altitude("wiki.withdrawn"), Altitude::Normal);
+    }
+
+    #[test]
+    fn altitude_policy_tool_completion_is_detail_success() {
+        // tool.requested and tool.completed are a matched pair at Detail
+        // (success = plumbing). Failures are bumped to Attention at the emit
+        // site (see session_tracer), not here.
+        assert_eq!(base_altitude("tool.requested"), Altitude::Detail);
+        assert_eq!(base_altitude("tool.completed"), Altitude::Detail);
+    }
+
+    #[test]
+    fn altitude_policy_workbench_created_is_normal_milestone() {
+        // Creation is a milestone (content becomes reviewable); reconcile/
+        // discard remain plumbing.
+        assert_eq!(base_altitude("workbench.created"), Altitude::Normal);
+        assert_eq!(base_altitude("workbench.reconciled"), Altitude::Detail);
+        assert_eq!(base_altitude("workbench.discarded"), Altitude::Detail);
+    }
+
+    #[test]
+    fn altitude_policy_explicit_normal_progress() {
+        for et in [
+            "agent.message", "operator.message", "session.start", "session.end",
+            "digest_annotate", "llm.retry",
+        ] {
+            assert_eq!(base_altitude(et), Altitude::Normal, "{et}");
+        }
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -28,6 +28,12 @@ pub fn build_timeline_event(
     refs: TimelineRefs,
 ) -> LiveDigestEventRecord {
     let altitude = altitude.unwrap_or_else(|| altitude_for(event_type, role));
+    // NOTE: an explicit `altitude` arg is used AS-IS and can undercut the
+    // seat floor (`role_floor`). This is intentional for a few plumbing
+    // emitters (e.g. `workflow.signal` pins to Detail regardless of seat),
+    // but most callers should pass `None` and let `altitude_for` apply the
+    // floor. For a raise-only override, use the session_tracer's
+    // `append_live_digest_event_at(.., Some(alt))`, which takes `max`.
     LiveDigestEventRecord {
         event_id: uuid::Uuid::new_v4().to_string(),
         root_session_id,
@@ -384,9 +390,25 @@ pub fn operator_message_event(
 
 /// Base importance of a digest event type, before any role refinement.
 /// Base importance for a timeline event type. The effective altitude written
-/// to a row is `max(base_altitude(et), role_floor(role))` (see [`altitude_for`]),
-/// unless an emitter passes an explicit altitude that *raises* it further
-/// (e.g. `runtime.lock_drift` → `Error` when rejected).
+/// to a row is normally `max(base_altitude(et), role_floor(role))` (see
+/// [`altitude_for`]).
+///
+/// # Explicit altitude — two contracts
+///
+/// Emitters can pass an explicit altitude, but the contract depends on the
+/// helper used — they are NOT the same:
+///
+/// - **`build_timeline_event(.., Some(alt))`** uses the explicit value AS-IS
+///   (it REPLACES `altitude_for`, and can undercut `role_floor`). This is
+///   relied on by a few plumbing emitters that pin to `Detail` regardless of
+///   seat (e.g. `workflow.signal`). Callers that should not undercut the
+///   floor must pass `None`.
+/// - **`session_tracer::append_live_digest_event_at(.., Some(alt))`** is
+///   **raise-only**: it takes `max(altitude_for(et, role), alt)`, so a caller
+///   can never undercut the floor. Used by `tool.completed` to bump failures
+///   (`ok:false`) from `Detail` up to `Attention`.
+///
+/// Most emitters pass `None` and let `base_altitude` + the seat floor decide.
 ///
 /// # Altitude policy
 ///

--- a/autonoetic-gateway/src/runtime/session_tracer.rs
+++ b/autonoetic-gateway/src/runtime/session_tracer.rs
@@ -382,13 +382,31 @@ impl SessionTracer {
     }
 
     fn append_live_digest_event(&self, event_type: &str, payload: Option<serde_json::Value>) {
+        self.append_live_digest_event_at(event_type, payload, None)
+    }
+
+    /// Like [`append_live_digest_event`] but lets the caller *raise* the
+    /// altitude for this one event (e.g. a `tool.completed` whose result is
+    /// `ok:false` is bumped to `Attention` so failures aren't hidden at
+    /// `Detail`). The override only ever raises: `max(override, derived)` is
+    /// used, so a caller cannot accidentally lower an event below its policy
+    /// floor.
+    fn append_live_digest_event_at(
+        &self,
+        event_type: &str,
+        payload: Option<serde_json::Value>,
+        altitude_override: Option<autonoetic_types::session_timeline::Altitude>,
+    ) {
         let Some(store) = &self.gateway_store else {
             return;
         };
         // Session Room attribution (#363 P1): seat derived from the agent id,
         // principal = this autonoetic agent, altitude = max(base, role_floor).
         let role = crate::runtime::session_timeline::derive_role(&self.agent_id);
-        let altitude = crate::runtime::session_timeline::altitude_for(event_type, &role);
+        let mut altitude = crate::runtime::session_timeline::altitude_for(event_type, &role);
+        if let Some(override_alt) = altitude_override {
+            altitude = altitude.max(override_alt);
+        }
         let principal = autonoetic_types::principal::Principal::agent(self.agent_id.clone());
         let row = crate::scheduler::gateway_store::LiveDigestEventRecord {
             event_id: uuid::Uuid::new_v4().to_string(),
@@ -1042,7 +1060,21 @@ impl SessionTracer {
         if let Some(preview) = args_preview {
             timeline_payload["args_preview"] = serde_json::json!(preview);
         }
-        self.append_live_digest_event("tool.completed", Some(timeline_payload));
+        // `tool.completed` is Detail by default (success = plumbing). A result
+        // with `ok:false` is a failure the operator should see without dialing
+        // the floor down, so bump it to Attention. The override only raises.
+        let failed = parsed_result
+            .as_ref()
+            .and_then(|r| r.get("ok"))
+            .and_then(|v| v.as_bool())
+            .map(|ok| !ok)
+            .unwrap_or(false);
+        let alt_override = if failed {
+            Some(autonoetic_types::session_timeline::Altitude::Attention)
+        } else {
+            None
+        };
+        self.append_live_digest_event_at("tool.completed", Some(timeline_payload), alt_override);
         Ok(event_id)
     }
 
@@ -1398,6 +1430,60 @@ mod tests {
             payload.get("args_preview").and_then(|v| v.as_str()),
             Some("coder.default")
         );
+    }
+
+    #[test]
+    fn tool_completed_failure_is_bumped_to_attention() {
+        // tool.completed is Detail for success, but a result with ok:false is a
+        // failure the operator should see without dialing the floor down — so
+        // the emit site bumps it to Attention. Verify both halves.
+        use autonoetic_types::session_timeline::Altitude;
+        let temp = tempdir().unwrap();
+        let agents_dir = temp.path().join("agents");
+        let agent_dir = agents_dir.join("planner.default");
+        let gateway_dir = agents_dir.join(".gateway");
+        fs::create_dir_all(agent_dir.join("history")).unwrap();
+        fs::create_dir_all(&gateway_dir).unwrap();
+        let store = std::sync::Arc::new(
+            crate::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+        );
+        let mut tracer = SessionTracer::test_tracer_with_store(&agent_dir, store.clone());
+        tracer.set_turn_id("turn-000001");
+
+        // Success — Detail (folds as routine plumbing).
+        tracer
+            .log_tool_completed("resolve", r#"{"ok":true,"value":"answer"}"#)
+            .unwrap();
+        // Failure — bumped to Attention.
+        tracer
+            .log_tool_completed("sandbox_exec", r#"{"ok":false,"exit_code":1,"stderr":"boom"}"#)
+            .unwrap();
+
+        let result = store
+            .list_session_timeline("test-session", None, 10, None, None)
+            .unwrap();
+        let mut seen_success = false;
+        let mut seen_failure = false;
+        for e in &result.entries {
+            if e.event_type != "tool.completed" {
+                continue;
+            }
+            let payload: serde_json::Value =
+                serde_json::from_str(e.payload.as_deref().unwrap()).unwrap();
+            let ok = payload.get("result")
+                .and_then(|r| serde_json::from_str::<serde_json::Value>(r.as_str().unwrap_or("")).ok())
+                .and_then(|r| r.get("ok").and_then(|v| v.as_bool()))
+                .unwrap_or(true);
+            if ok {
+                assert_eq!(e.altitude, Altitude::Detail, "success should stay Detail");
+                seen_success = true;
+            } else {
+                assert_eq!(e.altitude, Altitude::Attention, "failure should bump to Attention");
+                seen_failure = true;
+            }
+        }
+        assert!(seen_success, "expected a successful tool.completed");
+        assert!(seen_failure, "expected a failed tool.completed");
     }
 
     #[test]

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -237,15 +237,20 @@ impl GatewayStore {
         decided_by: &str,
         ctx: Option<(Option<String>, String, String)>,
     ) {
-        use autonoetic_types::session_timeline::{Altitude, TimelineRefs};
+        use autonoetic_types::session_timeline::TimelineRefs;
 
         let Some((root, session, _agent)) = ctx else {
             return;
         };
-        let (event_type, altitude) = match status {
-            "approved" => ("approval.approved", Altitude::Normal),
-            "rejected" | "denied" => ("approval.rejected", Altitude::Attention),
-            "cancelled" => ("approval.cancelled", Altitude::Detail),
+        // The event type selects the gate-lifecycle arm; the altitude comes
+        // from `base_altitude` (the single source of truth for gate altitudes:
+        // approved/rejected = Attention, cancelled = Normal). Passing `None`
+        // lets `altitude_for` apply `max(base, role_floor)` so a Sentinel
+        // decider's resolution stays at least Attention.
+        let event_type = match status {
+            "approved" => "approval.approved",
+            "rejected" | "denied" => "approval.rejected",
+            "cancelled" => "approval.cancelled",
             _ => return,
         };
         // Author = the decider: Operator seat (human), the agent's seat (stripping
@@ -262,7 +267,7 @@ impl GatewayStore {
             &principal,
             &role,
             event_type,
-            Some(altitude),
+            None,
             Some(serde_json::json!({ "request_id": request_id, "decided_by": decided_by })),
             refs,
         );
@@ -1103,6 +1108,6 @@ mod decided_by_kind_tests {
 
         let mech_ev = tl.entries.iter().find(|e| e.event_type == "approval.cancelled").unwrap();
         assert_eq!(mech_ev.role, SessionRole::Runtime);
-        assert_eq!(mech_ev.altitude, Altitude::Detail); // hidable
+        assert_eq!(mech_ev.altitude, Altitude::Normal); // abandonment: visible, not a checkpoint
     }
 }


### PR DESCRIPTION
Closes #492. Fixes the **source-of-truth** altitude model that PR #491 (view-tier classifier) patches on top. The two compose.

## The three bugs + coverage gap

| # | Before | After | Why |
|---|--------|-------|-----|
| 1 | `tool.requested`=Detail, `tool.completed`=**Normal** (fallthrough) | both **Detail** (success) | a split matched pair — the 94-row clutter source |
| 2 | `*.pending`=Attention, `*.approved`/`wiki.proposed`=**Normal** | gate request AND decision = **Attention** | decision lifecycle reads paired; abandonments (`*.cancelled`/`*.withdrawn`) stay Normal |
| 3 | `workbench.created`=**Detail** | **Normal** | it's a milestone, not plumbing |
| 4 | ~14 event types → implicit `_ => Normal` fallthrough | **exhaustive** explicit list | every altitude is now a conscious decision |

## The failure-subtlety (important)

`tool.failed` is a **phantom** — no emitter exists; failures emit as `tool.completed` with `ok:false`. So naively setting `tool.completed`→Detail would **hide failures**. Fixed at the emit site: `session_tracer::append_live_digest_event_at(.., override)` bumps `ok:false` results to **Attention** (override only ever *raises*, never lowers). Verified by a dedicated test.

## Changes (3 files, gateway-only — no prompt/guidance)

- **`session_timeline.rs`** — `base_altitude` rewritten: exhaustive over all 40 emitted types + reserved phantom, with a full **per-event rationale table** in the doc comment (the \"document extensively\" deliverable).
- **`session_tracer.rs`** — new `append_live_digest_event_at` with a raise-only override; `tool.completed` failure detection (`ok:false` → Attention).
- **`approvals.rs`** — `emit_gate_resolution` passes `None` (single source of truth via `base_altitude`); removed the dual-source altitude override table.

## Verification

- `cargo build` (full workspace) — clean.
- `session_timeline` 27 passed · `session_tracer` 17 passed · `approvals` 3 passed (all in isolation; the full parallel suite has pre-existing interference unrelated to this change — `test_dispatch_ping` passes alone, fails in-batch, on `main` too).
- New tests: `altitude_policy_gate_lifecycle_shares_attention`, `altitude_policy_tool_completion_is_detail_success`, `altitude_policy_workbench_created_is_normal_milestone`, `altitude_policy_explicit_normal_progress`, `tool_completed_failure_is_bumped_to_attention`.

## Non-goals

- No TUI/view changes (#491).
- No prompt/guidance changes — altitude is a timeline-importance axis, not a prompt concern.