### PR TITLE
feat(plan): inherit approval on cosmetic amend; re-gate on envelope expansion

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -6,7 +6,7 @@ use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
 use autonoetic_types::plan_frame::{
-    PlanFrame, PlanFrameSummary, PlanRef, PlanStatus, PlanStep, StepOwner,
+    plan_envelope_diff, PlanFrame, PlanFrameSummary, PlanRef, PlanStatus, PlanStep, StepOwner,
     ValidationEntry, ValidationPolicy,
 };
 use serde::Deserialize;
@@ -670,7 +670,7 @@ impl NativeTool for PlanFrameAmendTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Amend an existing PlanFrame by creating a new immutable revision. The previous revision is preserved unchanged. If the plan was approved, the new revision requires re-approval.".to_string(),
+            description: "Amend an existing PlanFrame by creating a new immutable revision. The previous revision is preserved unchanged. If the prior revision was approved, the new revision INHERITS that approval unless the amendment expands the safety envelope (adds/removes a step, changes a step owner or agent, or weakens/removes a validation gate). Cosmetic changes (rewording objective/title, recording a progress reason) inherit automatically. Envelope-expanding changes re-open the operator gate. The response carries `diff_summary`, `inherited`, and `requires_regate` so the caller — and the operator — can see exactly what changed.".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -881,6 +881,30 @@ impl NativeTool for PlanFrameAmendTool {
 
         let now = now_rfc3339();
 
+        // Decide whether the amendment inherits the prior approval or
+        // re-opens the operator gate. An envelope expansion (new/removed step,
+        // owner/agent change, weakened/removed validation) re-gates; everything
+        // else (objective rewording, title, progress reason) inherits. This is
+        // a mechanical, gateway-computed classification — never LLM-judged —
+        // and is more faithful to the constitution: the operator consents to
+        // risky/irreversible change, not to progress bookkeeping.
+        let envelope_diff = plan_envelope_diff(&current, &{
+            // Build a transient child view to diff against, mirroring the
+            // field resolution below (args override parent).
+            let mut probe = current.clone();
+            if let Some(t) = &args.title {
+                probe.title = t.clone();
+            }
+            if let Some(o) = &args.objective {
+                probe.objective = o.clone();
+            }
+            probe.steps = steps.clone();
+            probe.validation_policy = validation_policy.clone();
+            probe
+        });
+        let inherit = current.status == PlanStatus::Approved
+            && envelope_diff.is_cosmetic_only();
+
         let new_revision = PlanFrame {
             plan_id: current.plan_id.clone(),
             version: new_version,
@@ -889,11 +913,19 @@ impl NativeTool for PlanFrameAmendTool {
             root_session_id: current.root_session_id.clone(),
             title: args.title.unwrap_or(current.title.clone()),
             objective: args.objective.unwrap_or(current.objective.clone()),
-            status: PlanStatus::AwaitingApproval,
+            status: if inherit {
+                PlanStatus::Approved
+            } else {
+                PlanStatus::AwaitingApproval
+            },
             steps,
             validation_policy,
-            approved_by: None,
-            approved_at: None,
+            approved_by: if inherit {
+                current.approved_by.clone()
+            } else {
+                None
+            },
+            approved_at: if inherit { Some(now.clone()) } else { None },
             created_by_agent_id: manifest.agent.id.clone(),
             reason: args.reason,
             created_at: now,
@@ -901,7 +933,11 @@ impl NativeTool for PlanFrameAmendTool {
 
         store.save_plan_frame(&new_revision)?;
 
-        // Canonical timeline: an amended revision re-opens the operator gate.
+        // Canonical timeline. An envelope-expanding amendment re-opens the
+        // operator gate (plan.pending with the diff so the operator sees what
+        // they are approving). A cosmetic amendment inherits and emits
+        // plan.approved with `inherited: true` + the (empty) diff so the
+        // checkpoint still surfaces and shows why the operator wasn't asked.
         {
             let root_session_id = new_revision.root_session_id.clone();
             let session_id = _session_id
@@ -916,25 +952,49 @@ impl NativeTool for PlanFrameAmendTool {
                 plan_id: Some(new_revision.plan_id.clone()),
                 ..Default::default()
             };
+            let (event_type, extra) = if inherit {
+                (
+                    "plan.approved",
+                    serde_json::json!({
+                        "inherited": true,
+                        "inherited_from": old_version,
+                        "diff_summary": envelope_diff.summary(),
+                    }),
+                )
+            } else {
+                (
+                    "plan.pending",
+                    serde_json::json!({
+                        "diff_summary": envelope_diff.summary(),
+                        "requires_regate": envelope_diff.requires_regate(),
+                    }),
+                )
+            };
+            let mut payload = serde_json::json!({
+                "plan_id": new_revision.plan_id,
+                "version": new_revision.version,
+                "parent_version": new_revision.parent_version,
+                "title": new_revision.title,
+                "reason": new_revision.reason,
+            });
+            if let serde_json::Value::Object(map) = extra {
+                for (k, v) in map {
+                    payload[k] = v;
+                }
+            }
             let event = crate::runtime::session_timeline::build_timeline_event(
                 root_session_id,
                 session_id,
                 _turn_id.map(str::to_string),
                 &principal,
                 &role,
-                "plan.pending",
+                event_type,
                 None,
-                Some(serde_json::json!({
-                    "plan_id": new_revision.plan_id,
-                    "version": new_revision.version,
-                    "parent_version": new_revision.parent_version,
-                    "title": new_revision.title,
-                    "reason": new_revision.reason,
-                })),
+                Some(payload),
                 refs,
             );
             if let Err(e) = store.create_live_digest_event(&event) {
-                tracing::debug!(target: "session_timeline", error = %e, "plan.pending timeline emit failed (amend)");
+                tracing::debug!(target: "session_timeline", error = %e, "plan timeline emit failed (amend)");
             }
         }
 
@@ -983,9 +1043,16 @@ impl NativeTool for PlanFrameAmendTool {
             "ok": true,
             "plan_id": current.plan_id,
             "version": new_version,
-            "status": "awaiting_approval",
+            "status": if inherit { "approved" } else { "awaiting_approval" },
             "parent_version": old_version,
-            "message": "Plan amended (new immutable revision). Operator re-approval is required.",
+            "inherited": inherit,
+            "diff_summary": envelope_diff.summary(),
+            "requires_regate": envelope_diff.requires_regate(),
+            "message": if inherit {
+                "Plan amended (no envelope change) — operator approval inherited from the prior revision."
+            } else {
+                "Plan amended (envelope changed) — operator re-approval is required."
+            },
         }))?)
     }
 

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -952,11 +952,15 @@ impl NativeTool for PlanFrameAmendTool {
                 plan_id: Some(new_revision.plan_id.clone()),
                 ..Default::default()
             };
+            // Both checkpoints carry the same triple (`inherited`,
+            // `requires_regate`, `diff_summary`) so the timeline schema is
+            // uniform and consumers don't have to infer a missing boolean.
             let (event_type, extra) = if inherit {
                 (
                     "plan.approved",
                     serde_json::json!({
                         "inherited": true,
+                        "requires_regate": envelope_diff.requires_regate(),
                         "inherited_from": old_version,
                         "diff_summary": envelope_diff.summary(),
                     }),
@@ -965,8 +969,9 @@ impl NativeTool for PlanFrameAmendTool {
                 (
                     "plan.pending",
                     serde_json::json!({
-                        "diff_summary": envelope_diff.summary(),
+                        "inherited": false,
                         "requires_regate": envelope_diff.requires_regate(),
+                        "diff_summary": envelope_diff.summary(),
                     }),
                 )
             };

--- a/autonoetic-gateway/tests/plan_frame_integration.rs
+++ b/autonoetic-gateway/tests/plan_frame_integration.rs
@@ -615,6 +615,160 @@ fn planframe_amend_preserves_original_revision() {
     assert_eq!(v2.reason.as_deref(), Some("Scope change"));
 }
 
+/// Propose → approve → amend with a cosmetic-only change (objective rewording
+/// + progress reason). The amendment must INHERIT the prior approval: status
+/// stays `approved`, `inherited == true`, and no `plan.pending` checkpoint is
+/// emitted (a `plan.approved` with `inherited: true` is emitted instead).
+#[test]
+fn planframe_amend_inherits_approval_on_cosmetic_change() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+    let session_id = "root-session-inherit/planner";
+
+    let propose = json!({
+        "title": "Weather Agent",
+        "objective": "Build a weather agent",
+        "steps": [{ "step_id": "s1", "title": "Implement" }]
+    });
+    let result = registry
+        .execute("planframe_propose", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&propose).unwrap(),
+            Some(session_id), Some("t1"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str().unwrap().to_string();
+
+    // Approve v1.
+    registry
+        .execute("planframe_approve", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id), Some("t2"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+
+    // Cosmetic amend: objective rewording + progress reason, same step set.
+    let amend = json!({
+        "plan_id": plan_id,
+        "objective": "Build a reusable weather agent (refined)",
+        "reason": "Steps s1 completed; clarifying objective for the record."
+    });
+    let result = registry
+        .execute("planframe_amend", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&amend).unwrap(),
+            Some(session_id), Some("t3"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["version"], 2, "new revision created");
+    assert_eq!(parsed["status"], "approved", "cosmetic amend inherits approval");
+    assert_eq!(parsed["inherited"], true);
+    assert_eq!(parsed["diff_summary"], "no envelope change");
+    assert_eq!(parsed["requires_regate"], false);
+
+    let latest = store.load_plan_frame(&plan_id).unwrap().unwrap();
+    assert_eq!(latest.status, PlanStatus::Approved);
+    assert_eq!(latest.parent_version, Some(1));
+    assert!(latest.approved_at.is_some(), "inherited approval re-stamped");
+
+    // The timeline must NOT carry a plan.pending for the inherited amend; it
+    // carries plan.approved with inherited:true instead.
+    let tl = store.list_session_timeline("root-session-inherit", None, 50, None, None).unwrap();
+    let v2_events: Vec<_> = tl.entries.iter().filter(|e| {
+        let p = e.payload.as_deref().unwrap_or("");
+        p.contains("\"version\":2")
+    }).collect();
+    assert!(!v2_events.is_empty(), "v2 should be on the timeline");
+    assert!(
+        v2_events.iter().all(|e| e.event_type != "plan.pending"),
+        "inherited amend must not emit plan.pending"
+    );
+    assert!(
+        v2_events.iter().any(|e| e.event_type == "plan.approved"),
+        "inherited amend should emit plan.approved"
+    );
+}
+
+/// Propose → approve → amend that ADDS a step (envelope expansion). The
+/// amendment must RE-OPEN the gate: status `awaiting_approval`, `inherited
+/// == false`, `requires_regate == true`, and the diff_summary calls out the
+/// added step so the operator sees what they are approving.
+#[test]
+fn planframe_amend_regates_on_envelope_expansion() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+    let session_id = "root-session-regate/planner";
+
+    let propose = json!({
+        "title": "Weather Agent",
+        "objective": "Build a weather agent",
+        "steps": [{ "step_id": "s1", "title": "Implement" }]
+    });
+    let result = registry
+        .execute("planframe_propose", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&propose).unwrap(),
+            Some(session_id), Some("t1"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str().unwrap().to_string();
+
+    registry
+        .execute("planframe_approve", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id), Some("t2"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+
+    // Envelope-expanding amend: add step s2.
+    let amend = json!({
+        "plan_id": plan_id,
+        "steps": [
+            { "step_id": "s1", "title": "Implement" },
+            { "step_id": "s2", "title": "Package" }
+        ],
+        "reason": "Added packaging step"
+    });
+    let result = registry
+        .execute("planframe_amend", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&amend).unwrap(),
+            Some(session_id), Some("t3"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["status"], "awaiting_approval", "envelope change re-gates");
+    assert_eq!(parsed["inherited"], false);
+    assert_eq!(parsed["requires_regate"], true);
+    assert!(
+        parsed["diff_summary"].as_str().unwrap().contains("+step s2"),
+        "diff_summary should call out the added step: {}",
+        parsed["diff_summary"]
+    );
+
+    let latest = store.load_plan_frame(&plan_id).unwrap().unwrap();
+    assert_eq!(latest.status, PlanStatus::AwaitingApproval);
+    assert!(latest.approved_at.is_none(), "re-gated revision is not approved");
+
+    // The timeline must carry plan.pending for the re-gated amend.
+    let tl = store.list_session_timeline("root-session-regate", None, 50, None, None).unwrap();
+    assert!(
+        tl.entries.iter().any(|e| e.event_type == "plan.pending"
+            && e.payload.as_deref().unwrap_or("").contains("\"version\":2")),
+        "envelope-expanding amend should emit plan.pending for v2"
+    );
+}
+
 #[test]
 fn planframe_history_returns_full_revision_chain() {
     let dir = tempdir().unwrap();

--- a/autonoetic-types/src/plan_frame.rs
+++ b/autonoetic-types/src/plan_frame.rs
@@ -346,6 +346,187 @@ pub struct PlanFramesApproveResult {
     pub plan: PlanFrame,
 }
 
+/// Structural diff of the safety-relevant **envelope** between two plan
+/// revisions. Used by `planframe_amend` to decide whether an amendment
+/// **inherits** the prior operator approval (no envelope change) or
+/// **re-opens the gate** (envelope expansion). This is a mechanical,
+/// gateway-computed classification — never delegated to the LLM.
+///
+/// The envelope is what could expand the capability/safety surface of the
+/// work: which steps exist, who owns them, which agent runs them, and the
+/// validation gates that bound the work. Rewording the objective/title or
+/// recording a progress `reason` is NOT an envelope change and inherits.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanEnvelopeDiff {
+    /// `step_id`s present in the new revision but not the parent. New work ⇒
+    /// re-gate (the operator didn't consent to it).
+    pub steps_added: Vec<String>,
+    /// `step_id`s removed. Removing work changes the shape the operator
+    /// approved ⇒ re-gate.
+    pub steps_removed: Vec<String>,
+    /// `(step_id, old_owner, new_owner)` — e.g. a step moving to `Operator`
+    /// or from `Agent` to `Shared`. Changes accountability ⇒ re-gate.
+    pub owners_changed: Vec<(String, StepOwner, StepOwner)>,
+    /// `(step_id, old_agent_id, new_agent_id)` — a different agent means a
+    /// different capability set ⇒ re-gate.
+    pub agents_changed: Vec<(String, Option<String>, Option<String>)>,
+    /// `validation_id`s removed. Less validation ⇒ riskier ⇒ re-gate.
+    pub validation_removed: Vec<String>,
+    /// `(validation_id, old_requirement, new_requirement)` where the new
+    /// requirement is weaker (Required → Advisory/Waived). Weakening a gate
+    /// ⇒ re-gate. Strengthening does NOT (more safety is fine).
+    pub validation_weakened: Vec<(String, ValidationRequirement, ValidationRequirement)>,
+}
+
+impl PlanEnvelopeDiff {
+    /// True when the amendment expands the safety/capability envelope and the
+    /// operator must re-approve. Conservative: any envelope touch ⇒ re-gate.
+    pub fn requires_regate(&self) -> bool {
+        !self.steps_added.is_empty()
+            || !self.steps_removed.is_empty()
+            || !self.owners_changed.is_empty()
+            || !self.agents_changed.is_empty()
+            || !self.validation_removed.is_empty()
+            || !self.validation_weakened.is_empty()
+    }
+
+    /// True when the only changes are cosmetic/progress (objective rewording,
+    /// title tweak, reason note). The approval is inherited in this case.
+    pub fn is_cosmetic_only(&self) -> bool {
+        !self.requires_regate()
+    }
+
+    /// Compact one-line human summary, e.g.
+    /// `+step s5  owner s3→operator  −validation v2`. Empty for cosmetic-only.
+    pub fn summary(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        if !self.steps_added.is_empty() {
+            parts.push(format!("+step {}", self.steps_added.join(",")));
+        }
+        if !self.steps_removed.is_empty() {
+            parts.push(format!("−step {}", self.steps_removed.join(",")));
+        }
+        for (sid, old, new) in &self.owners_changed {
+            parts.push(format!("owner {sid}:{}→{}", old.as_str(), new.as_str()));
+        }
+        for (sid, old, new) in &self.agents_changed {
+            parts.push(format!(
+                "agent {sid}:{}→{}",
+                old.as_deref().unwrap_or("—"),
+                new.as_deref().unwrap_or("—")
+            ));
+        }
+        if !self.validation_removed.is_empty() {
+            parts.push(format!("−validation {}", self.validation_removed.join(",")));
+        }
+        for (vid, old, new) in &self.validation_weakened {
+            parts.push(format!("weaken {vid}:{}→{}", old.as_str(), new.as_str()));
+        }
+        if parts.is_empty() {
+            "no envelope change".to_string()
+        } else {
+            parts.join("  ")
+        }
+    }
+}
+
+/// Compute the envelope diff between a parent revision and a proposed child.
+/// Both are immutable `PlanFrame`s, so this is a pure function. Step identity
+/// is by `step_id`; validation identity by `validation_id`.
+pub fn plan_envelope_diff(parent: &PlanFrame, child: &PlanFrame) -> PlanEnvelopeDiff {
+    let parent_steps: std::collections::HashMap<&str, &PlanStep> = parent
+        .steps
+        .iter()
+        .map(|s| (s.step_id.as_str(), s))
+        .collect();
+    let child_steps: std::collections::HashMap<&str, &PlanStep> = child
+        .steps
+        .iter()
+        .map(|s| (s.step_id.as_str(), s))
+        .collect();
+
+    let mut steps_added = Vec::new();
+    let mut steps_removed = Vec::new();
+    let mut owners_changed = Vec::new();
+    let mut agents_changed = Vec::new();
+
+    for sid in child_steps.keys() {
+        if !parent_steps.contains_key(sid) {
+            steps_added.push(sid.to_string());
+        }
+    }
+    for (sid, pstep) in &parent_steps {
+        match child_steps.get(sid) {
+            None => steps_removed.push(sid.to_string()),
+            Some(cstep) => {
+                if pstep.owner != cstep.owner {
+                    owners_changed.push((sid.to_string(), pstep.owner, cstep.owner));
+                }
+                if pstep.agent_id != cstep.agent_id {
+                    agents_changed.push((
+                        sid.to_string(),
+                        pstep.agent_id.clone(),
+                        cstep.agent_id.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    let parent_val: std::collections::HashMap<&str, &ValidationEntry> = parent
+        .validation_policy
+        .entries
+        .iter()
+        .map(|v| (v.validation_id.as_str(), v))
+        .collect();
+    let child_val: std::collections::HashMap<&str, &ValidationEntry> = child
+        .validation_policy
+        .entries
+        .iter()
+        .map(|v| (v.validation_id.as_str(), v))
+        .collect();
+
+    let mut validation_removed = Vec::new();
+    let mut validation_weakened = Vec::new();
+    for (vid, pve) in &parent_val {
+        match child_val.get(vid) {
+            None => validation_removed.push(vid.to_string()),
+            Some(cve) => {
+                if is_weaker(&cve.requirement, &pve.requirement) {
+                    validation_weakened.push((
+                        vid.to_string(),
+                        pve.requirement,
+                        cve.requirement,
+                    ));
+                }
+            }
+        }
+    }
+
+    PlanEnvelopeDiff {
+        steps_added,
+        steps_removed,
+        owners_changed,
+        agents_changed,
+        validation_removed,
+        validation_weakened,
+    }
+}
+
+/// True when `new` is a weaker validation requirement than `old`
+/// (Required > Advisory > Waived). Strengthening (Waived→Required) is NOT
+/// weaker, so it doesn't trigger re-gate.
+fn is_weaker(new: &ValidationRequirement, old: &ValidationRequirement) -> bool {
+    fn rank(r: &ValidationRequirement) -> u8 {
+        match r {
+            ValidationRequirement::Required => 2,
+            ValidationRequirement::Advisory => 1,
+            ValidationRequirement::Waived => 0,
+        }
+    }
+    rank(new) < rank(old)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -390,5 +571,126 @@ mod tests {
         assert!(hint.contains("researcher.default"));
         assert!(hint.contains("agent_spawn"));
         assert!(hint.contains("agent_list"));
+    }
+
+    fn plan_with(steps: Vec<PlanStep>, val: Vec<ValidationEntry>) -> PlanFrame {
+        PlanFrame {
+            plan_id: "p".into(),
+            version: 1,
+            parent_version: None,
+            workflow_id: "wf".into(),
+            root_session_id: "s".into(),
+            title: "T".into(),
+            objective: "O".into(),
+            status: PlanStatus::Approved,
+            steps,
+            validation_policy: ValidationPolicy { entries: val },
+            approved_by: None,
+            approved_at: None,
+            created_by_agent_id: "planner".into(),
+            reason: None,
+            created_at: "now".into(),
+        }
+    }
+
+    fn step(id: &str, owner: StepOwner, agent: Option<&str>) -> PlanStep {
+        PlanStep {
+            step_id: id.into(),
+            title: format!("step {id}"),
+            owner,
+            depends_on: vec![],
+            agent_id: agent.map(str::to_string),
+            notes: None,
+        }
+    }
+
+    fn vent(id: &str, req: ValidationRequirement) -> ValidationEntry {
+        ValidationEntry {
+            validation_id: id.into(),
+            title: format!("v {id}"),
+            class: ValidationClass::CorrectnessCheck,
+            requirement: req,
+        }
+    }
+
+    #[test]
+    fn diff_cosmetic_change_inherits() {
+        // Only the objective/title/reason changes — no envelope touch.
+        let parent = plan_with(vec![step("s1", StepOwner::Agent, None)], vec![]);
+        let mut child = parent.clone();
+        child.objective = "reworded objective".into();
+        child.title = "new title".into();
+        let diff = plan_envelope_diff(&parent, &child);
+        assert!(diff.is_cosmetic_only(), "cosmetic should inherit: {:?}", diff);
+        assert!(!diff.requires_regate());
+        assert_eq!(diff.summary(), "no envelope change");
+    }
+
+    #[test]
+    fn diff_added_step_requires_regate() {
+        let parent = plan_with(vec![step("s1", StepOwner::Agent, None)], vec![]);
+        let child = plan_with(
+            vec![step("s1", StepOwner::Agent, None), step("s2", StepOwner::Agent, None)],
+            vec![],
+        );
+        let diff = plan_envelope_diff(&parent, &child);
+        assert!(diff.requires_regate());
+        assert_eq!(diff.steps_added, vec!["s2".to_string()]);
+        assert!(diff.summary().contains("+step s2"));
+    }
+
+    #[test]
+    fn diff_owner_change_requires_regate() {
+        let parent = plan_with(vec![step("s1", StepOwner::Agent, None)], vec![]);
+        let child = plan_with(vec![step("s1", StepOwner::Operator, None)], vec![]);
+        let diff = plan_envelope_diff(&parent, &child);
+        assert!(diff.requires_regate());
+        assert_eq!(diff.owners_changed, vec![("s1".to_string(), StepOwner::Agent, StepOwner::Operator)]);
+    }
+
+    #[test]
+    fn diff_agent_change_requires_regate() {
+        let parent = plan_with(vec![step("s1", StepOwner::Agent, Some("coder.default"))], vec![]);
+        let child = plan_with(vec![step("s1", StepOwner::Agent, Some("researcher.default"))], vec![]);
+        let diff = plan_envelope_diff(&parent, &child);
+        assert!(diff.requires_regate());
+        assert_eq!(diff.agents_changed.len(), 1);
+    }
+
+    #[test]
+    fn diff_validation_weakening_requires_regate_but_strengthening_does_not() {
+        let parent = plan_with(vec![], vec![vent("v1", ValidationRequirement::Required)]);
+        // Strengthen: Required → (stays Required) — no change
+        let same = plan_with(vec![], vec![vent("v1", ValidationRequirement::Required)]);
+        assert!(plan_envelope_diff(&parent, &same).is_cosmetic_only());
+
+        // Weaken: Required → Advisory ⇒ re-gate
+        let weakened = plan_with(vec![], vec![vent("v1", ValidationRequirement::Advisory)]);
+        let d = plan_envelope_diff(&parent, &weakened);
+        assert!(d.requires_regate());
+        assert_eq!(d.validation_weakened.len(), 1);
+
+        // Strengthen: Advisory → Required does NOT re-gate (more safety).
+        let adv = plan_with(vec![], vec![vent("v1", ValidationRequirement::Advisory)]);
+        let strengthened = plan_with(vec![], vec![vent("v1", ValidationRequirement::Required)]);
+        assert!(plan_envelope_diff(&adv, &strengthened).is_cosmetic_only());
+    }
+
+    #[test]
+    fn diff_removed_step_and_validation_require_regate() {
+        let parent = plan_with(
+            vec![step("s1", StepOwner::Agent, None), step("s2", StepOwner::Agent, None)],
+            vec![ent("v1", ValidationRequirement::Required), ent("v2", ValidationRequirement::Required)],
+        );
+        let child = plan_with(vec![step("s1", StepOwner::Agent, None)], vec![ent("v1", ValidationRequirement::Required)]);
+        let d = plan_envelope_diff(&parent, &child);
+        assert!(d.requires_regate());
+        assert_eq!(d.steps_removed, vec!["s2".to_string()]);
+        assert_eq!(d.validation_removed, vec!["v2".to_string()]);
+    }
+
+    // helper alias used above
+    fn ent(id: &str, req: ValidationRequirement) -> ValidationEntry {
+        vent(id, req)
     }
 }

--- a/autonoetic-types/src/plan_frame.rs
+++ b/autonoetic-types/src/plan_frame.rs
@@ -397,7 +397,9 @@ impl PlanEnvelopeDiff {
     }
 
     /// Compact one-line human summary, e.g.
-    /// `+step s5  owner s3→operator  −validation v2`. Empty for cosmetic-only.
+    /// `+step s5  owner s3→operator  −validation v2`. Returns the literal
+    /// `"no envelope change"` for a cosmetic-only diff (callers display this
+    /// to explain why the operator was not asked to re-approve).
     pub fn summary(&self) -> String {
         let mut parts: Vec<String> = Vec::new();
         if !self.steps_added.is_empty() {
@@ -502,6 +504,16 @@ pub fn plan_envelope_diff(parent: &PlanFrame, child: &PlanFrame) -> PlanEnvelope
             }
         }
     }
+
+    // Sort every collected vector for deterministic output. The diff feeds an
+    // operator-facing `diff_summary` and a timeline payload, so it MUST be
+    // stable regardless of HashMap iteration order.
+    steps_added.sort();
+    steps_removed.sort();
+    owners_changed.sort_by(|a, b| a.0.cmp(&b.0));
+    agents_changed.sort_by(|a, b| a.0.cmp(&b.0));
+    validation_removed.sort();
+    validation_weakened.sort_by(|a, b| a.0.cmp(&b.0));
 
     PlanEnvelopeDiff {
         steps_added,
@@ -687,6 +699,50 @@ mod tests {
         assert!(d.requires_regate());
         assert_eq!(d.steps_removed, vec!["s2".to_string()]);
         assert_eq!(d.validation_removed, vec!["v2".to_string()]);
+    }
+
+    #[test]
+    fn diff_multi_item_output_is_deterministic() {
+        // With several added steps + removed steps + weakened validations, the
+        // collected vectors (and the operator-facing summary) MUST be sorted,
+        // not dependent on HashMap iteration order. Run a few times — a
+        // non-deterministic ordering would flake here against the asserted order.
+        let parent = plan_with(
+            vec![
+                step("s_alpha", StepOwner::Agent, None),
+                step("s_beta", StepOwner::Agent, None),
+                step("s_gamma", StepOwner::Agent, None),
+            ],
+            vec![
+                ent("v_one", ValidationRequirement::Required),
+                ent("v_two", ValidationRequirement::Required),
+            ],
+        );
+        let child = plan_with(
+            // s_beta + s_gamma removed; s_delta + s_epsilon added
+            vec![
+                step("s_alpha", StepOwner::Agent, None),
+                step("s_delta", StepOwner::Agent, None),
+                step("s_epsilon", StepOwner::Agent, None),
+            ],
+            // both weakened Required → Advisory
+            vec![
+                ent("v_one", ValidationRequirement::Advisory),
+                ent("v_two", ValidationRequirement::Advisory),
+            ],
+        );
+        for _ in 0..8 {
+            let d = plan_envelope_diff(&parent, &child);
+            // Sorted lexicographically — not insertion order.
+            assert_eq!(d.steps_added, vec!["s_delta".to_string(), "s_epsilon".to_string()]);
+            assert_eq!(d.steps_removed, vec!["s_beta".to_string(), "s_gamma".to_string()]);
+            assert_eq!(d.validation_weakened.iter().map(|(v, _, _)| v).collect::<Vec<_>>(),
+                vec![&"v_one".to_string(), &"v_two".to_string()]);
+            // Summary is stable too.
+            let s = d.summary();
+            assert!(s.contains("+step s_delta,s_epsilon"), "sorted added in summary: {s}");
+            assert!(s.contains("−step s_beta,s_gamma"), "sorted removed in summary: {s}");
+        }
     }
 
     // helper alias used above


### PR DESCRIPTION
Closes #494. Implements **Pillar B** of [`docs/design/operator-legibility.md`](../blob/main/docs/design/operator-legibility.md).

## Why

`planframe_amend` unconditionally re-opened the operator gate. In session `943eb58c` that meant **3 manual plan approvals** for one task — none changing the safety surface. Re-gating trivial amendments trains operators to rubber-stamp, which is the *actual* safety degradation. This makes the operator gate mean what it should: consent to **risky/irreversible** change, not progress bookkeeping.

## What

**Mechanical structural diff** (`plan_envelope_diff`, pure function over immutable revisions) decides inherit vs re-gate — never LLM-judged:

| Change | Result |
|---|---|
| objective/title rewording, progress `reason`, step title/notes | **inherits** (cosmetic) |
| new/removed step, owner change, `agent_id` change | **re-gates** (envelope) |
| validation gate removed, or requirement weakened (Required→Advisory/Waived) | **re-gates** |
| validation requirement **strengthened** | inherits (more safety is fine) |

The diff is the **object the operator reviews**: every amend response + timeline checkpoint carries `diff_summary`, `inherited`, `requires_regate` so the operator sees *exactly what changed* and *why they were (not) asked*. Cosmetic amend emits `plan.approved {inherited:true}` (no `plan.pending`); envelope amend emits `plan.pending {diff_summary}`.

## Files (3)

- **`autonoetic-types/src/plan_frame.rs`** — `PlanEnvelopeDiff` + `plan_envelope_diff()` + 6 diff tests.
- **`autonoetic-gateway/src/runtime/tools/plan_frame.rs`** — `planframe_amend` inherit/regate logic + timeline emit + updated tool description & response.
- **`autonoetic-gateway/tests/plan_frame_integration.rs`** — 2 new e2e tests (inherit-on-cosmetic, regate-on-envelope-expansion) incl. timeline-event assertions.

## Prompt-factorization note (your concern)

Verified `plan_frame.rs` registers **no `GuidanceBlock`s** — the amend tool owns no doctrine. The only prompt-visible change is the tool **schema description** string (updated to describe inherit semantics). No guidance blocks added/changed; the factorization system is untouched.

## Verification

- Full workspace `cargo build` — clean.
- `plan_frame` types: 8 passed (6 new). `plan_frame_integration`: 12 passed (2 new). Existing amend tests still pass (they amend unapproved plans or add steps → still re-gate).

## Composes with

- #491 (view-tier Checkpoint classifier — inherited `plan.approved` is already a Checkpoint)
- #493 (altitude — `plan.approved` = Attention, so inherited amends stay visible)

## Non-goals (later)

- Hard-blocking lateral agent action while a plan is pending (design doc §9.1) — reduces pending-plan frequency but doesn't yet enforce rail-staying.
- Plan-as-capability-grant (Pillar C).