### PR TITLE
feat(room): t=0 content tree pane — realtime draft visibility

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2244,6 +2244,136 @@ impl JsonRpcRouter {
                 }
             }
 
+            "content.list" => {
+                // List every content-store entry (name → handle) for a session.
+                // Mirrors `artifact.list_files` but over the live content store,
+                // so the operator can see what the session is producing in
+                // realtime — before any artifact is built (Pillar D, t=0
+                // visibility). Drafts are content-addressed blobs under mutable
+                // names; immutability is untouched.
+                #[derive(Deserialize)]
+                struct ContentListParams {
+                    session_id: String,
+                }
+                let params: ContentListParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for content.list: {}", e),
+                        );
+                    }
+                };
+                let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
+                let store = match crate::runtime::content_store::ContentStore::new(&gateway_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("content store open failed: {}", e),
+                        );
+                    }
+                };
+                let names_handles = match store.list_names_with_handles(&params.session_id) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("content.list failed: {}", e),
+                        );
+                    }
+                };
+                let visibility_map = store
+                    .load_manifest(&params.session_id)
+                    .map(|m| m.visibility)
+                    .unwrap_or_default();
+                let files: Vec<serde_json::Value> = names_handles
+                    .into_iter()
+                    .map(|(name, handle)| {
+                        let alias = crate::runtime::content_store::ContentStore::get_short_alias(&handle);
+                        let visibility = visibility_map
+                            .get(&handle)
+                            .map(|v| match v {
+                                crate::runtime::content_store::ContentVisibility::Private => "private",
+                                crate::runtime::content_store::ContentVisibility::Session => "session",
+                                crate::runtime::content_store::ContentVisibility::Global => "global",
+                            })
+                            .unwrap_or("session");
+                        serde_json::json!({
+                            "name": name,
+                            "handle": handle,
+                            "alias": alias,
+                            "visibility": visibility,
+                        })
+                    })
+                    .collect();
+                JsonRpcResponse::success(
+                    req.id,
+                    serde_json::json!({
+                        "session_id": params.session_id,
+                        "files": files,
+                    }),
+                )
+            }
+
+            "content.read" => {
+                // Read a content-store entry's bytes by name or handle. Mirrors
+                // `artifact.read_file` but over the live content store.
+                #[derive(Deserialize)]
+                struct ContentReadParams {
+                    session_id: String,
+                    name: String,
+                }
+                let params: ContentReadParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for content.read: {}", e),
+                        );
+                    }
+                };
+                let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
+                let store = match crate::runtime::content_store::ContentStore::new(&gateway_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("content store open failed: {}", e),
+                        );
+                    }
+                };
+                match store.read_by_name_or_handle(&params.session_id, &params.name) {
+                    Ok(bytes) => {
+                        let handle = store
+                            .resolve_name_or_handle_to_handle(&params.session_id, &params.name)
+                            .unwrap_or_default();
+                        // Lossy UTF-8: the viewer is text-oriented (markdown);
+                        // binary blobs surface a replacement-char placeholder.
+                        let content = String::from_utf8_lossy(&bytes).into_owned();
+                        JsonRpcResponse::success(
+                            req.id,
+                            serde_json::json!({
+                                "name": params.name,
+                                "handle": handle,
+                                "bytes": bytes.len(),
+                                "content": content,
+                            }),
+                        )
+                    }
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("content.read failed: {}", e),
+                    ),
+                }
+            }
+
             "gate.get_messages" => {
                 #[derive(Deserialize)]
                 struct GetMessagesParams {

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2286,9 +2286,23 @@ impl JsonRpcRouter {
                         );
                     }
                 };
+                // Cross-session visibility: a handle can be registered under
+                // a child session but declared global. We need the LOCAL
+                // manifest (per-session visibility for this session_id) AND
+                // a probe of the GLOBAL manifest (where global entries are
+                // registered under the sentinel "__global__" session).
+                // The local map is authoritative for private/session; if a
+                // handle is missing locally, we fall back to the global
+                // manifest so global entries written by child sessions are
+                // labelled "global" (not "session") — and the UI shows the
+                // 🌐 badge correctly.
                 let visibility_map = store
                     .load_manifest(&params.session_id)
                     .map(|m| m.visibility)
+                    .unwrap_or_default();
+                let global_handles: std::collections::HashSet<String> = store
+                    .load_manifest(crate::runtime::content_store::GLOBAL_SESSION_ID)
+                    .map(|m| m.names.values().cloned().collect())
                     .unwrap_or_default();
                 let files: Vec<serde_json::Value> = names_handles
                     .into_iter()
@@ -2301,7 +2315,7 @@ impl JsonRpcRouter {
                                 crate::runtime::content_store::ContentVisibility::Session => "session",
                                 crate::runtime::content_store::ContentVisibility::Global => "global",
                             })
-                            .unwrap_or("session");
+                            .unwrap_or(if global_handles.contains(&handle) { "global" } else { "session" });
                         serde_json::json!({
                             "name": name,
                             "handle": handle,
@@ -2348,11 +2362,26 @@ impl JsonRpcRouter {
                         );
                     }
                 };
-                match store.read_by_name_or_handle(&params.session_id, &params.name) {
+                // Resolve the handle ONCE first, then read by the resolved
+                // handle. A read that succeeds against a name/alias must have
+                // a real handle behind it; returning an empty string when
+                // resolution fails would produce an inconsistent response
+                // (bytes present, handle missing). If the name/handle does
+                // not resolve at all, fail fast with -32000.
+                let handle = match store
+                    .resolve_name_or_handle_to_handle(&params.session_id, &params.name)
+                {
+                    Ok(h) => h,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("content.read resolve failed: {}", e),
+                        );
+                    }
+                };
+                match store.read_by_name_or_handle(&params.session_id, &handle) {
                     Ok(bytes) => {
-                        let handle = store
-                            .resolve_name_or_handle_to_handle(&params.session_id, &params.name)
-                            .unwrap_or_default();
                         // Lossy UTF-8: the viewer is text-oriented (markdown);
                         // binary blobs surface a replacement-char placeholder.
                         let content = String::from_utf8_lossy(&bytes).into_owned();

--- a/autonoetic-gateway/src/runtime/content_store.rs
+++ b/autonoetic-gateway/src/runtime/content_store.rs
@@ -1084,4 +1084,64 @@ mod tests {
         );
         assert_eq!(root_session_id("a/b/c"), "a");
     }
+
+    #[test]
+    fn list_with_handles_and_visibility_then_read_round_trip() {
+        // Exercises the exact path the `content.list` + `content.read` JSON-RPC
+        // methods (router.rs) use: write a few entries under different
+        // visibilities, list them with handles + visibility, and read each back
+        // by name. This is the foundation of the Pillar-D content-tree pane.
+        let temp = tempdir().unwrap();
+        let store = ContentStore::new(temp.path()).unwrap();
+        let session = "root-session-content";
+
+        let h1 = store.write(b"# title\n\nbody of draft one").unwrap();
+        store
+            .register_name_with_visibility(
+                session,
+                "skills/weather/SKILL.md",
+                &h1,
+                ContentVisibility::Session,
+            )
+            .unwrap();
+        let h2 = store.write(b"SECRET-LIKE").unwrap();
+        store
+            .register_name_with_visibility(
+                session,
+                "config/secrets.yaml",
+                &h2,
+                ContentVisibility::Private,
+            )
+            .unwrap();
+
+        // list_names_with_handles returns (name, handle), sorted by name.
+        let listed = store.list_names_with_handles(session).unwrap();
+        assert_eq!(listed.len(), 2, "both drafts should be listed from t=0");
+        let names: Vec<&str> = listed.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["config/secrets.yaml", "skills/weather/SKILL.md"]);
+
+        // load_manifest gives visibility — the RPC's visibility badge source.
+        let manifest = store.load_manifest(session).unwrap();
+        let vis_for = |name: &str| -> &'static str {
+            let (_, handle) = listed.iter().find(|(n, _)| n == name).unwrap();
+            match manifest
+                .visibility
+                .get(handle)
+                .copied()
+                .unwrap_or(ContentVisibility::Session)
+            {
+                ContentVisibility::Private => "private",
+                ContentVisibility::Session => "session",
+                ContentVisibility::Global => "global",
+            }
+        };
+        assert_eq!(vis_for("config/secrets.yaml"), "private");
+        assert_eq!(vis_for("skills/weather/SKILL.md"), "session");
+
+        // read_by_name_or_handle resolves each name back to its bytes.
+        let one = store.read_by_name_or_handle(session, "skills/weather/SKILL.md").unwrap();
+        assert_eq!(String::from_utf8_lossy(&one), "# title\n\nbody of draft one");
+        let two = store.read_by_name_or_handle(session, "config/secrets.yaml").unwrap();
+        assert_eq!(String::from_utf8_lossy(&two), "SECRET-LIKE");
+    }
 }

--- a/autonoetic-gateway/src/runtime/content_store.rs
+++ b/autonoetic-gateway/src/runtime/content_store.rs
@@ -56,7 +56,10 @@ pub struct SessionManifest {
 }
 
 /// Session ID used for the global content manifest.
-const GLOBAL_SESSION_ID: &str = "__global__";
+/// Sentinel session id under which the content store tracks globally-visible
+/// handles. Exposed so callers (e.g. the `content.list` JSON-RPC method)
+/// can probe the global manifest to resolve cross-session visibility.
+pub const GLOBAL_SESSION_ID: &str = "__global__";
 
 /// Short alias prefix length (8 hex chars = 32 bits, collision probability < 1/4B)
 pub const SHORT_ALIAS_LEN: usize = 8;
@@ -1143,5 +1146,84 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&one), "# title\n\nbody of draft one");
         let two = store.read_by_name_or_handle(session, "config/secrets.yaml").unwrap();
         assert_eq!(String::from_utf8_lossy(&two), "SECRET-LIKE");
+    }
+
+    #[test]
+    fn global_manifest_probe_for_cross_session_visibility() {
+        // The `content.list` JSON-RPC method (router.rs) probes the
+        // GLOBAL_SESSION_ID manifest so a global entry written by a
+        // child session is labelled "global" (not "session") when the
+        // operator lists from a parent session. This test exercises the
+        // underlying ContentStore API that the router relies on.
+        let temp = tempdir().unwrap();
+        let store = ContentStore::new(temp.path()).unwrap();
+        let child = "root-x/child-a";
+
+        let h = store.write(b"shared").unwrap();
+        store
+            .register_name_with_visibility(
+                child,
+                "shared/lib.py",
+                &h,
+                ContentVisibility::Global,
+            )
+            .unwrap();
+
+        // The local child manifest knows the handle + global visibility.
+        let child_manifest = store.load_manifest(child).unwrap();
+        assert_eq!(
+            child_manifest.visibility.get(&h).copied(),
+            Some(ContentVisibility::Global)
+        );
+
+        // The global sentinel manifest contains the handle (this is the
+        // probe the router uses to promote missing-local entries to
+        // "global").
+        let global_manifest = store
+            .load_manifest(GLOBAL_SESSION_ID)
+            .expect("global manifest must exist after a global register");
+        let global_handles: std::collections::HashSet<String> =
+            global_manifest.names.values().cloned().collect();
+        assert!(
+            global_handles.contains(&h),
+            "the global manifest must record the handle for cross-session probes"
+        );
+
+        let got = store.read_by_name_or_handle(child, "shared/lib.py").unwrap();
+        assert_eq!(got, b"shared");
+    }
+
+    #[test]
+    fn resolve_handle_then_read_succeeds_for_named_entry() {
+        // Mirrors the router `content.read` path (Fix 2): resolve the
+        // handle once, then read by the resolved handle. Ensures the
+        // name->handle->bytes path returns the same content and the
+        // resolved handle is non-empty. Also locks in that a missing
+        // name surfaces a clear error (the bug Fix 2 closed).
+        let temp = tempdir().unwrap();
+        let store = ContentStore::new(temp.path()).unwrap();
+        let sid = "root-rs";
+        let h = store.write(b"body-of-draft").unwrap();
+        store
+            .register_name_with_visibility(sid, "notes.md", &h, ContentVisibility::Session)
+            .unwrap();
+
+        let resolved = store
+            .resolve_name_or_handle_to_handle(sid, "notes.md")
+            .expect("name must resolve");
+        assert_eq!(resolved, h);
+
+        let bytes = store.read_by_name_or_handle(sid, &resolved).unwrap();
+        assert_eq!(bytes, b"body-of-draft");
+
+        let err = store
+            .resolve_name_or_handle_to_handle(sid, "missing.md")
+            .err()
+            .expect("missing name must fail to resolve");
+        assert!(
+            err.to_string().contains("missing.md")
+                || err.to_string().to_lowercase().contains("not found"),
+            "resolve error should mention the missing name; got: {err}"
+        );
     }
 }

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -656,8 +656,10 @@ struct ContentEntry {
 }
 
 /// Live session content tree: every `content_write`/`content_patch` name the
-/// session has registered, listed from t=0. Toggle with `c`; `o`/`Enter` opens
-/// a markdown-aware viewer for the selected entry.
+/// session has registered, listed from t=0. Toggle with `c`, `j`/`k` to
+/// navigate, `o` to open a markdown-aware viewer for the selected entry.
+/// (Mirrors the `ArtifactViewer` keymap; `Enter` is intentionally not bound
+/// to opening the viewer because it is reserved for other dispatch in this TUI.)
 struct ContentTree {
     entries: Vec<ContentEntry>,
     selected: usize,
@@ -1867,6 +1869,8 @@ pub fn run(
                             } else if content_tree.is_some() {
                                 content_tree = None;
                             } else if artifact_file_view.is_some() {
+                                // no-op: 'o' is ignored while the artifact file view
+                                // is open; the operator closes it with Esc first.
                                 artifact_file_view = None;
                             } else if artifact_viewer.is_some() {
                                 artifact_viewer = None;
@@ -2244,7 +2248,6 @@ pub fn run(
                         }
                         KeyCode::Char('o') => {
                             // Content tree open → open a markdown-aware viewer
-                            // Content tree open → open a markdown-aware viewer
                             // for the selected entry (before the artifact branch).
                             if content_view.is_some() {
                                 // already viewing content; ignore
@@ -2266,6 +2269,8 @@ pub fn run(
                                                     content: content.to_string(),
                                                     scroll: 0,
                                                 });
+                                            } else {
+                                                status = Some("content.read: no content field in response".to_string());
                                             }
                                         }
                                         Err(e) => status = Some(format!("content read failed: {e}")),

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -646,6 +646,32 @@ struct ArtifactFileView {
     scroll: u16,
 }
 
+/// One entry in the live session content tree (Pillar D). The name is a
+/// mutable pointer over an immutable content-addressed blob — a *draft* the
+/// operator can watch being written, before any artifact is built.
+struct ContentEntry {
+    name: String,
+    alias: String,
+    visibility: String,
+}
+
+/// Live session content tree: every `content_write`/`content_patch` name the
+/// session has registered, listed from t=0. Toggle with `c`; `o`/`Enter` opens
+/// a markdown-aware viewer for the selected entry.
+struct ContentTree {
+    entries: Vec<ContentEntry>,
+    selected: usize,
+    scroll: u16,
+}
+
+/// Markdown-aware viewer for one content-store entry (mirror of
+/// `ArtifactFileView` but rendered through the markdown pipeline).
+struct ContentView {
+    name: String,
+    content: String,
+    scroll: u16,
+}
+
 /// Extract artifact_ref from a timeline entry, if it has one.
 /// Returns an `ar.*` or `art_*` ref that the gateway can resolve.
 fn artifact_ref_for_entry(entry: &SessionTimelineEntry) -> Option<String> {
@@ -1317,6 +1343,9 @@ pub fn run(
     let mut info_scroll: u16 = 0;
     let mut artifact_viewer: Option<ArtifactViewer> = None;
     let mut artifact_file_view: Option<ArtifactFileView> = None;
+    // Pillar D: live session content tree (drafts visible from t=0) + viewer.
+    let mut content_tree: Option<ContentTree> = None;
+    let mut content_view: Option<ContentView> = None;
     let mut quit_armed_until: Option<Instant> = None;
     let mut last_mouse_click: Option<(Instant, usize, u16, u16)> = None;
     let mut last_announced_plan_event: Option<String> = None;
@@ -1833,7 +1862,11 @@ pub fn run(
                     }
                     match key.code {
                         KeyCode::Esc => {
-                            if artifact_file_view.is_some() {
+                            if content_view.is_some() {
+                                content_view = None;
+                            } else if content_tree.is_some() {
+                                content_tree = None;
+                            } else if artifact_file_view.is_some() {
                                 artifact_file_view = None;
                             } else if artifact_viewer.is_some() {
                                 artifact_viewer = None;
@@ -2166,8 +2199,79 @@ pub fn run(
                                 status = Some("info: j/k scroll · Esc close".to_string());
                             }
                         }
+                        // c: toggle the live session content tree (Pillar D).
+                        // Lists every content_write/content_patch name from t=0
+                        // so the operator can watch what the session is producing
+                        // before any artifact is built.
+                        KeyCode::Char('c') => {
+                            if content_view.is_some() || artifact_file_view.is_some()
+                                || artifact_viewer.is_some() || detail.is_some()
+                                || input.is_some() || compose.is_some()
+                            {
+                                // don't grab 'c' while another overlay/text input is active
+                            } else if content_tree.is_some() {
+                                content_tree = None;
+                            } else {
+                                match rpc(
+                                    client,
+                                    "content.list",
+                                    serde_json::json!({ "session_id": root_session_id.clone() }),
+                                ) {
+                                    Ok(v) => {
+                                        let entries: Vec<ContentEntry> = v
+                                            .get("files")
+                                            .and_then(|f| f.as_array())
+                                            .map(|arr| {
+                                                arr.iter().filter_map(|f| {
+                                                    Some(ContentEntry {
+                                                        name: f.get("name")?.as_str()?.to_string(),
+                                                        alias: f.get("alias").and_then(|a| a.as_str()).unwrap_or("").to_string(),
+                                                        visibility: f.get("visibility").and_then(|v| v.as_str()).unwrap_or("session").to_string(),
+                                                    })
+                                                }).collect()
+                                            })
+                                            .unwrap_or_default();
+                                        if entries.is_empty() {
+                                            status = Some("no content entries yet (session has not written any drafts)".to_string());
+                                        } else {
+                                            content_tree = Some(ContentTree { entries, selected: 0, scroll: 0 });
+                                            status = Some(format!("content: {} entries · j/k navigate · o view · Esc close", content_tree.as_ref().unwrap().entries.len()));
+                                        }
+                                    }
+                                    Err(e) => status = Some(format!("content list failed: {e}")),
+                                }
+                            }
+                        }
                         KeyCode::Char('o') => {
-                            if artifact_file_view.is_some() {
+                            // Content tree open → open a markdown-aware viewer
+                            // Content tree open → open a markdown-aware viewer
+                            // for the selected entry (before the artifact branch).
+                            if content_view.is_some() {
+                                // already viewing content; ignore
+                            } else if let Some(tree) = content_tree.as_ref() {
+                                if let Some(entry) = tree.entries.get(tree.selected) {
+                                    let name = entry.name.clone();
+                                    match rpc(
+                                        client,
+                                        "content.read",
+                                        serde_json::json!({
+                                            "session_id": root_session_id.clone(),
+                                            "name": name,
+                                        }),
+                                    ) {
+                                        Ok(v) => {
+                                            if let Some(content) = v.get("content").and_then(|c| c.as_str()) {
+                                                content_view = Some(ContentView {
+                                                    name,
+                                                    content: content.to_string(),
+                                                    scroll: 0,
+                                                });
+                                            }
+                                        }
+                                        Err(e) => status = Some(format!("content read failed: {e}")),
+                                    }
+                                }
+                            } else if artifact_file_view.is_some() {
                             } else if let Some(ref viewer) = artifact_viewer {
                                 if let Some(file) = viewer.files.get(viewer.selected) {
                                     let result = rpc(
@@ -2252,7 +2356,11 @@ pub fn run(
                             }
                         }
                         KeyCode::Down | KeyCode::Char('j') => {
-                            if artifact_file_view.is_some() {
+                            if let Some(view) = content_view.as_mut() {
+                                view.scroll = view.scroll.saturating_add(1);
+                            } else if let Some(tree) = content_tree.as_mut() {
+                                tree.selected = (tree.selected + 1).min(tree.entries.len().saturating_sub(1));
+                            } else if artifact_file_view.is_some() {
                                 artifact_file_view.as_mut().unwrap().scroll = artifact_file_view.as_ref().unwrap().scroll.saturating_add(1);
                             } else if artifact_viewer.is_some() {
                                 let viewer = artifact_viewer.as_mut().unwrap();
@@ -2268,7 +2376,11 @@ pub fn run(
                             }
                         }
                         KeyCode::Up | KeyCode::Char('k') => {
-                            if artifact_file_view.is_some() {
+                            if let Some(view) = content_view.as_mut() {
+                                view.scroll = view.scroll.saturating_sub(1);
+                            } else if let Some(tree) = content_tree.as_mut() {
+                                tree.selected = tree.selected.saturating_sub(1);
+                            } else if artifact_file_view.is_some() {
                                 artifact_file_view.as_mut().unwrap().scroll = artifact_file_view.as_ref().unwrap().scroll.saturating_sub(1);
                             } else if artifact_viewer.is_some() {
                                 let viewer = artifact_viewer.as_mut().unwrap();
@@ -2721,6 +2833,8 @@ pub fn run(
                 gate_count,
                 artifact_viewer.as_ref(),
                 artifact_file_view.as_ref(),
+                content_tree.as_ref(),
+                content_view.as_ref(),
                 gate_modal.as_ref(),
                 gate_modal
                     .as_ref()
@@ -4209,6 +4323,8 @@ fn draw(
     gate_count: usize,
     artifact_viewer: Option<&ArtifactViewer>,
     artifact_file_view: Option<&ArtifactFileView>,
+    content_tree: Option<&ContentTree>,
+    content_view: Option<&ContentView>,
     gate_modal: Option<&GateModal>,
     gate_modal_entry: Option<&SessionTimelineEntry>,
 ) {
@@ -4558,6 +4674,89 @@ fn draw(
                         .borders(Borders::ALL)
                         .title(title)
                         .border_style(Style::default().fg(Color::Green))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    }
+
+    // Pillar D: live session content tree + markdown-aware viewer. These layer
+    // above the timeline/artifact overlays; the content viewer renders the
+    // blob through the markdown pipeline (the key win over ArtifactFileView's
+    // plain-text rendering).
+    if let Some(ref view) = content_view {
+        let area = centered_rect(80, 85, f.area());
+        f.render_widget(Clear, area);
+        let lines = super::markdown::render_markdown(
+            &super::markdown::normalize_narrative_prose(&view.content),
+        );
+        let inner_height = area.height.saturating_sub(2) as usize;
+        // Wrap-aware scroll: count wrapped lines, not raw Lines, so the scroll
+        // offset tracks what the operator sees (mirrors detail-pane wrap).
+        let wrap_w = area.width.saturating_sub(2) as u16;
+        let total = detail_wrap_line_count(&lines, wrap_w);
+        let max_scroll = total.saturating_sub(inner_height) as u16;
+        let scroll = view.scroll.min(max_scroll);
+        let title = format!(
+            " 📝 {} [draft · not a vetted artifact] [Esc back] ",
+            view.name
+        );
+        f.render_widget(
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(title)
+                        .border_style(Style::default().fg(Color::Cyan))
+                        .style(Style::default().bg(Color::Black)),
+                )
+                .scroll((scroll, 0)),
+            area,
+        );
+    } else if let Some(ref tree) = content_tree {
+        let area = centered_rect(65, 70, f.area());
+        f.render_widget(Clear, area);
+        let lines: Vec<Line> = tree
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| {
+                let marker = if i == tree.selected { " > " } else { "   " };
+                let style = if i == tree.selected {
+                    Style::default().fg(Color::Yellow).bg(Color::Black)
+                } else {
+                    Style::default().bg(Color::Black)
+                };
+                let vis_tag = match e.visibility.as_str() {
+                    "private" => " 🔒",
+                    "global" => " 🌐",
+                    _ => "",
+                };
+                Line::from(Span::styled(
+                    format!("{}{}{}", marker, e.name, vis_tag),
+                    style,
+                ))
+            })
+            .collect();
+        let inner_height = area.height.saturating_sub(2) as usize;
+        let max_scroll = lines.len().saturating_sub(inner_height);
+        let scroll = tree
+            .selected
+            .saturating_sub(inner_height / 2)
+            .min(max_scroll) as u16;
+        let title = format!(
+            " 📝 session content (drafts · t=0) — {} entries [o view · Esc close] ",
+            tree.entries.len()
+        );
+        f.render_widget(
+            Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(title)
+                        .border_style(Style::default().fg(Color::Cyan))
                         .style(Style::default().bg(Color::Black)),
                 )
                 .scroll((scroll, 0)),


### PR DESCRIPTION
Closes #496. Implements **Pillar D (first slice)** of [`docs/design/operator-legibility.md`](../blob/main/docs/design/operator-legibility.md).

## Why

In session `943eb58c` the operator couldn't see what the session was *producing* until the workbench ceremony fired — 11 minutes in. Visibility is coupled to immutability (only built artifacts surface). But the content store already holds content-addressed blobs under mutable name pointers (`content_write` registers name→handle), so "live files" are a **view** problem, not a storage problem.

## What

**Decouple visibility from immutability** — a new pane lists every `content_write`/`content_patch` name from t=0; selecting one opens a **markdown-aware** viewer. Drafts are labeled `"draft · not a vetted artifact"` so the operator never acts on a draft as promoted content. Blobs stay content-addressed and immutable; only pointer visibility changes.

| Surface | Change |
|---|---|
| **`router.rs`** | Two new JSON-RPC methods mirroring `artifact.list_files`/`read_file`: `content.list` (`list_names_with_handles` + `load_manifest` for visibility) and `content.read` (`read_by_name_or_handle`, lossy UTF-8). The `ContentStore` API already existed; it just wasn't exposed over JSON-RPC. |
| **`tui.rs`** | `ContentTree` + `ContentView` panes: `c` toggles the tree (live), `j/k` navigate, `o` opens the selected entry rendered through the markdown pipeline (the same fix that repaired tables), `Esc` closes (view→tree). Visibility badges 🔒 private / 🌐 global. |

## Try it

In a session room, press **`c`** → the content tree lists every file the session has written. `j/k` to a file, `o` to view it rendered (markdown), `Esc` to close.

## Verification

- Full workspace `cargo build` — clean.
- `content_store` tests: **16 passed** (+1 new round-trip test mirroring the exact RPC path: write under different visibilities → `list_names_with_handles` + `load_manifest` → `read_by_name_or_handle`).
- `room::` tests: **141 passed** (no regressions).
- Router tests: the existing parallel-test interference is pre-existing (`test_dispatch_ping` passes in isolation, fails in batch, on `main` too) — unrelated to this change.

## Non-goals (later slices)

- **Draft vs artifact badge** (📦) — needs cross-ref against `artifact_build`; the manifest only knows names + visibility today.
- **Workbench-as-mode** — folding the workbench into a review/freeze mode over this same tree (the structural Pillar-D finish).
- **Realtime audit hooks** over the live tree (enabled by this, but separate).

## Composes with

The merged operator-legibility PRs (#491 tiers, #493 altitude, #495 plan inherit) — this adds the *product* legibility axis alongside the *control-flow* legibility those delivered.