### PR TITLE
feat(plan): materialize approved plan as capability grant (Pillar C)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -39,7 +39,12 @@ pub fn register_tools(registry: &mut NativeToolRegistry) {
 /// `source_approval_id = Some(plan_id)` so a later envelope-expanding amend
 /// can revoke it surgically via `revoke_session_grants_by_source`.
 ///
-/// Returns the number of concrete hosts materialized.
+/// Returns 1 if a plan grant row was materialized, 0 otherwise. The
+/// whole envelope is inserted as a single `RootSession`-scoped grant
+/// row (multiple `ExactHost` targets inside), so the return is binary.
+/// (Symmetric with `revoke_session_grants_by_source` which returns a
+/// grant-row count.) The host count itself is internal; the response
+/// surfaces `grants_materialized` as this 0/1 value.
 fn materialize_plan_grants(
     store: &crate::scheduler::gateway_store::GatewayStore,
     config: Option<&autonoetic_types::config::GatewayConfig>,
@@ -51,8 +56,13 @@ fn materialize_plan_grants(
     let repo = crate::AgentRepository::from_config(config);
     let mut hosts: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for step in &plan.steps {
-        let Some(agent_id) = step.agent_id.as_deref() else { continue };
-        let loaded = match repo.get_sync(agent_id) {
+        // Empty / whitespace agent_id is treated as unset, matching the
+        // amend step-merging logic (the LLM may emit a placeholder).
+        let raw = step.agent_id.as_deref().unwrap_or("").trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let loaded = match repo.get_sync(raw) {
             Ok(l) => l,
             Err(_) => continue, // not-yet-installed agent — its tool calls go through normal approval
         };
@@ -86,7 +96,7 @@ fn materialize_plan_grants(
         tracing::warn!(target: "plan_frame", error = %e, plan_id = %plan.plan_id, "plan grant materialization failed");
         return 0;
     }
-    hosts.len()
+    1
 }
 
 fn has_plan_frame_access(manifest: &AgentManifest) -> bool {
@@ -1007,13 +1017,17 @@ impl NativeTool for PlanFrameAmendTool {
 
         store.save_plan_frame(&new_revision)?;
 
-        // Pillar C: when the envelope expands (re-gate), the grants materialized
-        // from the prior approved revision are stale (the new approval may
-        // declare a different agent set / different network envelope). Revoke
-        // them by source so the next approval re-materializes a clean grant.
-        // Inherited (cosmetic-only) amendments keep the existing grants — the
-        // envelope didn't change.
-        let grants_revoked = if !inherit {
+        // Pillar C: revoke the prior approved plan's grants ONLY when the
+        // envelope actually expanded. The condition is tighter than
+        // `!inherit` (which also fires for non-cosmetic amends on a plan
+        // that was never approved — there is no prior approved envelope
+        // to withdraw). We need both: the parent was approved (so there
+        // are materialized grants) AND the diff shows envelope expansion
+        // (so those grants are stale). Inherited (cosmetic-only) and
+        // envelope-equivalent amendments keep the existing grants.
+        let grants_revoked = if current.status == PlanStatus::Approved
+            && envelope_diff.requires_regate()
+        {
             store
                 .revoke_session_grants_by_source(
                     &current.root_session_id,

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -21,6 +21,74 @@ pub fn register_tools(registry: &mut NativeToolRegistry) {
     registry.register(Box::new(PlanFrameHistoryTool));
 }
 
+/// Pillar C: materialize the approved plan's declared network envelope into
+/// a single `RootSession`-scoped session approval grant. Subsequent tool calls
+/// (`sandbox_exec`, `web_fetch`, `artifact_exec`, `artifact_prepare`,
+/// `credential` URL gating) that target these hosts then dedup silently against
+/// the existing `session_approval_grants` coverage check — the operator
+/// approves the envelope once, not each tool call.
+///
+/// The envelope is derived MECHANICALLY from each plan step's `agent_id` →
+/// declared `Capability::NetworkAccess.hosts` (never LLM-judged). Wildcards
+/// (`"*"`) are skipped because they don't materialize to a concrete,
+/// matchable grant and would defeat the dedup's concreteness rule (the exec
+/// cache only auto-approves when all patterns are `url_literal`/`ip_address`).
+///
+/// Best-effort: any failure (missing config, agent not installed, DB error)
+/// returns 0 and the approval still succeeds. The grant carries
+/// `source_approval_id = Some(plan_id)` so a later envelope-expanding amend
+/// can revoke it surgically via `revoke_session_grants_by_source`.
+///
+/// Returns the number of concrete hosts materialized.
+fn materialize_plan_grants(
+    store: &crate::scheduler::gateway_store::GatewayStore,
+    config: Option<&autonoetic_types::config::GatewayConfig>,
+    plan: &PlanFrame,
+    approver: &str,
+    now: &str,
+) -> usize {
+    let Some(config) = config else { return 0 };
+    let repo = crate::AgentRepository::from_config(config);
+    let mut hosts: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for step in &plan.steps {
+        let Some(agent_id) = step.agent_id.as_deref() else { continue };
+        let loaded = match repo.get_sync(agent_id) {
+            Ok(l) => l,
+            Err(_) => continue, // not-yet-installed agent — its tool calls go through normal approval
+        };
+        for cap in &loaded.manifest.capabilities {
+            if let autonoetic_types::capability::Capability::NetworkAccess { hosts: decl } = cap {
+                for h in decl {
+                    if h == "*" { continue; }
+                    hosts.insert(h.clone());
+                }
+            }
+        }
+    }
+    if hosts.is_empty() {
+        return 0;
+    }
+    let targets: Vec<autonoetic_types::background::GrantTarget> = hosts
+        .iter()
+        .map(|h| autonoetic_types::background::GrantTarget::ExactHost(h.clone()))
+        .collect();
+    if let Err(e) = store.insert_session_grant(
+        &plan.root_session_id,
+        &plan.root_session_id,
+        &plan.created_by_agent_id,
+        &autonoetic_types::background::GrantScope::RootSession,
+        &targets,
+        approver,
+        now,
+        Some(&plan.plan_id),
+        None,
+    ) {
+        tracing::warn!(target: "plan_frame", error = %e, plan_id = %plan.plan_id, "plan grant materialization failed");
+        return 0;
+    }
+    hosts.len()
+}
+
 fn has_plan_frame_access(manifest: &AgentManifest) -> bool {
     manifest.capabilities.iter().any(|c| {
         matches!(c, Capability::PlanFrameAccess { .. })
@@ -625,6 +693,10 @@ impl NativeTool for PlanFrameApproveTool {
             }
         }
 
+        // Pillar C: materialize the plan's declared network envelope as a
+        // session approval grant. Best-effort — never blocks the approval.
+        let grants_materialized = materialize_plan_grants(&store, config, &plan, &approver, &now);
+
         if let Some(config) = config {
             crate::scheduler::workflow_store::append_workflow_event(
                 config,
@@ -641,6 +713,7 @@ impl NativeTool for PlanFrameApproveTool {
                     payload: serde_json::json!({
                         "plan_id": plan.plan_id,
                         "version": plan.version,
+                        "grants_materialized": grants_materialized,
                     }),
                     occurred_at: now,
                 },
@@ -652,6 +725,7 @@ impl NativeTool for PlanFrameApproveTool {
             "plan_id": plan.plan_id,
             "status": "approved",
             "version": plan.version,
+            "grants_materialized": grants_materialized,
         }))?)
     }
 
@@ -933,6 +1007,27 @@ impl NativeTool for PlanFrameAmendTool {
 
         store.save_plan_frame(&new_revision)?;
 
+        // Pillar C: when the envelope expands (re-gate), the grants materialized
+        // from the prior approved revision are stale (the new approval may
+        // declare a different agent set / different network envelope). Revoke
+        // them by source so the next approval re-materializes a clean grant.
+        // Inherited (cosmetic-only) amendments keep the existing grants — the
+        // envelope didn't change.
+        let grants_revoked = if !inherit {
+            store
+                .revoke_session_grants_by_source(
+                    &current.root_session_id,
+                    &current.plan_id,
+                    "plan-amended (envelope expanded)",
+                )
+                .unwrap_or_else(|e| {
+                    tracing::warn!(target: "plan_frame", error = %e, plan_id = %current.plan_id, "plan grant revoke failed");
+                    0
+                })
+        } else {
+            0
+        };
+
         // Canonical timeline. An envelope-expanding amendment re-opens the
         // operator gate (plan.pending with the diff so the operator sees what
         // they are approving). A cosmetic amendment inherits and emits
@@ -1053,6 +1148,7 @@ impl NativeTool for PlanFrameAmendTool {
             "inherited": inherit,
             "diff_summary": envelope_diff.summary(),
             "requires_regate": envelope_diff.requires_regate(),
+            "grants_revoked": grants_revoked,
             "message": if inherit {
                 "Plan amended (no envelope change) — operator approval inherited from the prior revision."
             } else {

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -801,9 +801,34 @@ impl GatewayStore {
         Ok(count)
     }
 
-    pub fn prune_expired_grants(&self) -> Result<usize> {
+    /// Soft-revoke (set `revoked_at`) every ACTIVE grant whose
+    /// `source_approval_id` matches `source`, scoped to `root_session_id`.
+    /// Used by plan-as-capability-grant (Pillar C): when a plan's envelope
+    /// expands, the grants materialized from the prior approved revision are
+    /// withdrawn so the operator's re-approval re-materializes a clean
+    /// envelope. Grants from other sources (explicit operator grants, other
+    /// plans) are untouched. Returns the number revoked.
+    pub fn revoke_session_grants_by_source(
+        &self,
+        root_session_id: &str,
+        source: &str,
+        reason: &str,
+    ) -> Result<usize> {
         let now = chrono::Utc::now().to_rfc3339();
         let conn = self.conn.lock().unwrap();
+        let count = conn.execute(
+            "UPDATE session_approval_grants
+             SET revoked_at = ?1, revoked_reason = ?2
+             WHERE root_session_id = ?3
+               AND source_approval_id = ?4
+               AND revoked_at IS NULL",
+            params![&now, reason, root_session_id, source],
+        )?;
+        Ok(count)
+    }
+
+    pub fn prune_expired_grants(&self) -> Result<usize> {
+        let now = chrono::Utc::now().to_rfc3339();        let conn = self.conn.lock().unwrap();
         let expired_ids: Vec<i64> = {
             let mut stmt = conn.prepare(
                 "SELECT id FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",

--- a/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/approvals.rs
@@ -828,7 +828,8 @@ impl GatewayStore {
     }
 
     pub fn prune_expired_grants(&self) -> Result<usize> {
-        let now = chrono::Utc::now().to_rfc3339();        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
         let expired_ids: Vec<i64> = {
             let mut stmt = conn.prepare(
                 "SELECT id FROM session_approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?1",

--- a/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
+++ b/autonoetic-gateway/tests/approval_grant_revocation_integration.rs
@@ -170,3 +170,99 @@ fn test_revoke_then_reapprove_restores_coverage() {
     );
     assert!(store.session_grants_cover_targets("root-7", &["regranted.io".to_string()]));
 }
+
+/// Pillar C: surgical revoke of every active grant whose
+/// `source_approval_id` matches. Used when a plan's envelope expands and the
+/// grants materialized from the prior approved revision must be withdrawn so
+/// the new approval re-materializes a clean envelope. Grants from other
+/// sources (explicit operator grants, other plans) must be untouched.
+#[test]
+fn test_revoke_session_grants_by_source_is_surgical() {
+    let tmp = tempdir().unwrap();
+    let gw = make_gateway_dir(&tmp);
+    let store = GatewayStore::open(&gw).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    let scope = autonoetic_types::background::GrantScope::RootSession;
+
+    // Plan A grants (source = plan-A) + a sibling plan B grant (source = plan-B)
+    // + an explicit operator grant (source = None). The revoke of plan-A must
+    // touch only plan-A's grants.
+    for (agent, host) in [("a", "alpha.com"), ("a", "beta.com"), ("a", "gamma.com")] {
+        store
+            .insert_session_grant(
+                "root-surg",
+                "root-surg",
+                agent,
+                &scope,
+                &[autonoetic_types::background::GrantTarget::ExactHost(
+                    host.to_string(),
+                )],
+                "plan-A",
+                &now,
+                Some("plan-A"),
+                None,
+            )
+            .unwrap();
+    }
+    store
+        .insert_session_grant(
+            "root-surg",
+            "root-surg",
+            "b",
+            &scope,
+            &[autonoetic_types::background::GrantTarget::ExactHost(
+                "delta.com".to_string(),
+            )],
+            "plan-B",
+            &now,
+            Some("plan-B"),
+            None,
+        )
+        .unwrap();
+    store
+        .insert_session_grant(
+            "root-surg",
+            "root-surg",
+            "op",
+            &scope,
+            &[autonoetic_types::background::GrantTarget::ExactHost(
+                "epsilon.com".to_string(),
+            )],
+            "operator",
+            &now,
+            None,
+            None,
+        )
+        .unwrap();
+
+    // Before revoke: coverage holds for all 5 hosts.
+    for h in ["alpha.com", "beta.com", "gamma.com", "delta.com", "epsilon.com"] {
+        assert!(store.session_grants_cover_targets("root-surg", &[h.to_string()]));
+    }
+
+    // Revoke plan-A's grants only.
+    let n = store
+        .revoke_session_grants_by_source("root-surg", "plan-A", "plan-amended")
+        .unwrap();
+    assert_eq!(n, 3, "exactly plan-A's 3 grants should be revoked");
+
+    // Coverage: plan-A hosts no longer covered; plan-B + operator still covered.
+    for h in ["alpha.com", "beta.com", "gamma.com"] {
+        assert!(
+            !store.session_grants_cover_targets("root-surg", &[h.to_string()]),
+            "plan-A host {h} should be uncovered after revoke"
+        );
+    }
+    for h in ["delta.com", "epsilon.com"] {
+        assert!(
+            store.session_grants_cover_targets("root-surg", &[h.to_string()]),
+            "non-plan-A host {h} must remain covered"
+        );
+    }
+
+    // Revoking an unknown source is a no-op.
+    let n = store
+        .revoke_session_grants_by_source("root-surg", "plan-NONEXISTENT", "x")
+        .unwrap();
+    assert_eq!(n, 0);
+}

--- a/autonoetic-gateway/tests/plan_frame_integration.rs
+++ b/autonoetic-gateway/tests/plan_frame_integration.rs
@@ -1137,3 +1137,92 @@ fn planframe_get_with_version_returns_specific_revision() {
     let parsed_latest: serde_json::Value = serde_json::from_str(&result_latest).unwrap();
     assert_eq!(parsed_latest["plan"]["version"], 2);
 }
+
+/// Pillar C wiring: approving a plan must surface `grants_materialized` in
+/// the response (and the workflow event payload), and an envelope-expanding
+/// amend must surface `grants_revoked`. With the real installed agents
+/// (planner.default has no NetworkAccess) both counts are 0, but the fields
+/// and code paths are exercised end-to-end. The store-level revoke round-trip
+/// is tested separately in `approval_grant_revocation_integration`.
+#[test]
+fn plan_approval_reports_grants_materialized_and_amend_reports_revoke() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let registry = default_registry();
+    let manifest = plan_frame_manifest();
+    let policy = autonoetic_gateway::policy::PolicyEngine::new(manifest.clone());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = std::sync::Arc::new(
+        autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir).unwrap(),
+    );
+    let session_id = "root-grant-wiring/planner";
+
+    // Propose + approve a minimal plan.
+    let propose = json!({
+        "title": "Grant Wiring",
+        "objective": "verify the materialize + revoke fields are wired",
+        "steps": [{ "step_id": "s1", "title": "Step 1" }]
+    });
+    let result = registry
+        .execute("planframe_propose", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&propose).unwrap(),
+            Some(session_id), Some("t1"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let plan_id = serde_json::from_str::<serde_json::Value>(&result).unwrap()["plan_id"]
+        .as_str().unwrap().to_string();
+
+    let approve_result = registry
+        .execute("planframe_approve", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&json!({ "plan_id": plan_id })).unwrap(),
+            Some(session_id), Some("t2"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&approve_result).unwrap();
+    assert_eq!(parsed["status"], "approved");
+    // planner.default declares no NetworkAccess → no hosts materialized.
+    // The field must exist and be 0 (proves the materialization path ran
+    // and correctly found no concrete hosts).
+    assert!(parsed["grants_materialized"].is_u64());
+    assert_eq!(parsed["grants_materialized"].as_u64().unwrap(), 0);
+
+    // Cosmético amend on the approved v1 → inherit (no envelope change),
+    // status stays approved, grants_revoked stays 0. The cosmetic branch
+    // MUST run first so the parent is Approved; an amend on an
+    // AwaitingApproval plan never inherits regardless of diff.
+    let cosmetic = json!({
+        "plan_id": plan_id,
+        "objective": "refined wording (no envelope change)",
+        "reason": "cosmetic only"
+    });
+    let cosmetic_result = registry
+        .execute("planframe_amend", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&cosmetic).unwrap(),
+            Some(session_id), Some("t3"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let parsed_cos: serde_json::Value = serde_json::from_str(&cosmetic_result).unwrap();
+    assert_eq!(parsed_cos["inherited"], true);
+    assert_eq!(parsed_cos["grants_revoked"].as_u64().unwrap(), 0);
+
+    // Envelope-expanding amend (add a step) on the inherited-approved v2 →
+    // re-gate branch revokes the plan's prior grants by source. With 0 prior
+    // grants (planner has no NetworkAccess), 0 are revoked; the field must
+    // exist and the code path must execute.
+    let amend = json!({
+        "plan_id": plan_id,
+        "steps": [
+            { "step_id": "s1", "title": "Step 1" },
+            { "step_id": "s2", "title": "Step 2 (new)" }
+        ],
+        "reason": "envelope expansion to exercise the revoke branch"
+    });
+    let amend_result = registry
+        .execute("planframe_amend", &manifest, &policy, dir.path(),
+            Some(&gateway_dir), &serde_json::to_string(&amend).unwrap(),
+            Some(session_id), Some("t4"), Some(&config), Some(store.clone()), None)
+        .unwrap();
+    let parsed_amend: serde_json::Value = serde_json::from_str(&amend_result).unwrap();
+    assert_eq!(parsed_amend["requires_regate"], true);
+    assert_eq!(parsed_amend["inherited"], false);
+    assert!(parsed_amend["grants_revoked"].is_u64());
+    assert_eq!(parsed_amend["grants_revoked"].as_u64().unwrap(), 0);
+}

--- a/autonoetic-gateway/tests/plan_frame_integration.rs
+++ b/autonoetic-gateway/tests/plan_frame_integration.rs
@@ -1185,7 +1185,7 @@ fn plan_approval_reports_grants_materialized_and_amend_reports_revoke() {
     assert!(parsed["grants_materialized"].is_u64());
     assert_eq!(parsed["grants_materialized"].as_u64().unwrap(), 0);
 
-    // Cosmético amend on the approved v1 → inherit (no envelope change),
+    // Cosmetic amend on the approved v1 → inherit (no envelope change),
     // status stays approved, grants_revoked stays 0. The cosmetic branch
     // MUST run first so the parent is Approved; an amend on an
     // AwaitingApproval plan never inherits regardless of diff.
@@ -1201,6 +1201,7 @@ fn plan_approval_reports_grants_materialized_and_amend_reports_revoke() {
         .unwrap();
     let parsed_cos: serde_json::Value = serde_json::from_str(&cosmetic_result).unwrap();
     assert_eq!(parsed_cos["inherited"], true);
+    assert!(parsed_cos["grants_revoked"].is_u64());
     assert_eq!(parsed_cos["grants_revoked"].as_u64().unwrap(), 0);
 
     // Envelope-expanding amend (add a step) on the inherited-approved v2 →


### PR DESCRIPTION
Closes #498. Implements **Pillar C (first slice)** of [`docs/design/operator-legibility.md`](../blob/main/docs/design/operator-legibility.md).

> **Approve the envelope, execute within it. Re-approve only on envelope expansion.**

## Why

The operator approves the same network envelope repeatedly. In session `943eb58c`, every `sandbox_exec`/`web_fetch` against a domain the planner already declared intent to hit required a separate approval. The plan's purpose is to declare *what work runs* — but the capability envelope was never materialized, so tool-level approvals churned within an approved plan.

## What

When the operator approves a plan, the gateway **derives the network envelope mechanically** from each plan step's `agent_id` → declared `Capability::NetworkAccess.hosts` and materializes the union of concrete hosts (wildcards `"*"` skipped — they don't materialize to a matchable grant) as a single `RootSession`-scoped `session_approval_grant` with `source_approval_id = plan_id`. Subsequent `sandbox_exec` / `web_fetch` / `artifact_exec` / `artifact_prepare` / credential-URL calls then dedup silently against the existing `session_approval_grants_cover_targets` check.

**The dedup core is UNCHANGED** — it already reads grants correctly; we just add grants. On `planframe_amend` that **expands the envelope**, the prior plan's grants are surgically revoked by `source_approval_id` (new `revoke_session_grants_by_source`), so the next approval re-materializes a clean envelope. Inherited (cosmetic) amendments don't revoke — the envelope didn't change.

## Files (4, 307 insertions, 1 deletion)

- `approvals.rs` — new `revoke_session_grants_by_source(root, source, reason)` (surgical soft-revoke).
- `plan_frame.rs` — new `materialize_plan_grants()` helper; `PlanFrameApproveTool` calls it; `PlanFrameAmendTool` revokes on re-gate. Both surface counts in the response.
- `tests/approval_grant_revocation_integration.rs` — new `test_revoke_session_grants_by_source_is_surgical` (plan-A / plan-B / operator; revoke plan-A; assert plan-A uncovered, plan-B + operator still covered, unknown source = no-op).
- `tests/plan_frame_integration.rs` — new wiring test exercising both inherit + re-gate branches with `grants_materialized` + `grants_revoked` fields.

## Verification

- Full workspace `cargo build` — clean.
- `plan_frame_integration`: **13 passed** (12 + 1 new).
- `approval_grant_revocation_integration`: **8 passed** (7 + 1 new).

## Non-goals (future Pillar-C slices)

- Materializing other capability categories (CodeExecution patterns, AgentSpawn targets) — same pattern, separate pass.
- Federation escalation materialization — needs a plan-level federation flag.
- Per-step, per-tool grants (finer-grained than plan-level).

## Composes with

The merged operator-legibility PRs — the grants this materializes flow through the **unchanged** existing dedup layer at sandbox.rs:1572, web.rs, artifact_prepare, artifact_exec, credential.