### PR TITLE
feat(gateway): PromoteWith promotion pre-authorization (#503)

### DIFF
--- a/autonoetic-gateway/src/runtime/analysis/mod.rs
+++ b/autonoetic-gateway/src/runtime/analysis/mod.rs
@@ -146,6 +146,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::CapsuleExport => "CapsuleExport",
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
         Capability::WikiContribute => "WikiContribute",
+        Capability::PromoteWith { .. } => "PromoteWith",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/capability_inference.rs
+++ b/autonoetic-gateway/src/runtime/capability_inference.rs
@@ -273,6 +273,7 @@ fn capability_type_name(cap: &Capability) -> &'static str {
         Capability::CapsuleExport => "CapsuleExport",
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
         Capability::WikiContribute => "WikiContribute",
+        Capability::PromoteWith { .. } => "PromoteWith",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/guidance.rs
+++ b/autonoetic-gateway/src/runtime/guidance.rs
@@ -158,6 +158,7 @@ pub fn capability_kind(cap: &Capability) -> &'static str {
         Capability::CapsuleExport => "capsule_export",
         Capability::WikiContribute => "wiki_contribute",
         Capability::PlanFrameAccess { .. } => "plan_frame_access",
+        Capability::PromoteWith { .. } => "promote_with",
     }
 }
 

--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -106,7 +106,9 @@ pub fn materialize_envelope(
                     None,
                 );
             }
-            // PromoteWith and future variants are stored in session_envelopes only.
+            Capability::PromoteWith { .. } => {
+                // Stored in session_envelopes only; checked at promotion time (P-2.27).
+            }
             _ => {}
         }
     }
@@ -154,6 +156,151 @@ fn find_matching_pending_envelope_id(
             )
         })
         .map(|p| p.id))
+}
+
+/// Locked `PromoteWith` capabilities for `agent_id` (empty `agent_id` matches any).
+pub fn promote_with_capabilities(
+    store: &GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+) -> Result<Option<Vec<Capability>>> {
+    Ok(store
+        .get_active_envelopes(root_session_id)?
+        .into_iter()
+        .rev()
+        .find_map(|record| {
+            if let Capability::PromoteWith {
+                agent_id: pw_agent,
+                capabilities,
+            } = record.capability
+            {
+                if pw_agent.is_empty() || pw_agent == agent_id {
+                    return Some(capabilities);
+                }
+            }
+            None
+        }))
+}
+
+/// True when a locked session envelope `PromoteWith` covers `artifact_capabilities`.
+pub fn promotion_preauthorized_by_envelope(
+    store: &GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+    artifact_capabilities: &[Capability],
+) -> Result<bool> {
+    let Some(declared) = promote_with_capabilities(store, root_session_id, agent_id)? else {
+        return Ok(false);
+    };
+    Ok(autonoetic_types::capability::capability_set_covers(
+        &declared,
+        artifact_capabilities,
+    ))
+}
+
+fn promote_with_sets_equivalent(a: &[Capability], b: &[Capability]) -> bool {
+    autonoetic_types::capability::capability_set_covers(a, b)
+        && autonoetic_types::capability::capability_set_covers(b, a)
+}
+
+fn has_matching_pending_promote_with(
+    store: &GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+    capabilities: &[Capability],
+) -> Result<bool> {
+    Ok(store.get_proposed_envelopes(root_session_id)?.into_iter().any(|record| {
+        matches!(
+            &record.capability,
+            Capability::PromoteWith { agent_id: pw, capabilities: pending }
+                if pw == agent_id && promote_with_sets_equivalent(pending, capabilities)
+        )
+    }))
+}
+
+pub fn propose_promote_with_envelope(
+    store: &GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+    capabilities: &[Capability],
+    source: &str,
+    actor_id: &str,
+) -> Result<Option<i64>> {
+    if capabilities.is_empty() {
+        return Ok(None);
+    }
+    if promotion_preauthorized_by_envelope(store, root_session_id, agent_id, capabilities)? {
+        return Ok(None);
+    }
+    if has_matching_pending_promote_with(store, root_session_id, agent_id, capabilities)? {
+        return Ok(None);
+    }
+    let now = chrono::Utc::now().to_rfc3339();
+    let promote_with = Capability::PromoteWith {
+        agent_id: agent_id.to_string(),
+        capabilities: capabilities.to_vec(),
+    };
+    let envelope_id = store.insert_envelope_proposal(
+        root_session_id,
+        &promote_with,
+        source,
+        Some(&now),
+        None,
+        &now,
+    )?;
+    emit_envelope_proposed_timeline(
+        store,
+        root_session_id,
+        envelope_id,
+        &[],
+        source,
+        actor_id,
+        None,
+    );
+    Ok(Some(envelope_id))
+}
+
+/// After `artifact_build`: propose observed network hosts and promotion pre-auth.
+pub fn propose_envelopes_after_artifact_build(
+    store: &GatewayStore,
+    gateway_dir: &std::path::Path,
+    root_session_id: &str,
+    artifact_id: &str,
+    kind: &autonoetic_types::artifact::ArtifactKind,
+    actor_id: &str,
+) -> Result<()> {
+    let _ = propose_discovered_envelope(store, root_session_id, "discovered", None, actor_id)?;
+
+    use autonoetic_types::artifact::ArtifactKind;
+    if *kind != ArtifactKind::AgentBundle {
+        return Ok(());
+    }
+
+    let artifact = crate::ArtifactStore::new(gateway_dir)?;
+    let files = artifact.resolve_files(artifact_id)?;
+    let Some(skill_bytes) = files
+        .into_iter()
+        .find(|(path, _)| path == "SKILL.md")
+        .map(|(_, bytes)| bytes)
+    else {
+        return Ok(());
+    };
+    let skill_text = String::from_utf8_lossy(&skill_bytes);
+    let (manifest, _) = crate::runtime::parser::SkillParser::parse(&skill_text)
+        .map_err(|e| anyhow::anyhow!("artifact SKILL.md parse: {e}"))?;
+    if manifest.capabilities.is_empty() {
+        return Ok(());
+    }
+
+    let _ = propose_promote_with_envelope(
+        store,
+        root_session_id,
+        &manifest.agent.id,
+        &manifest.capabilities,
+        &format!("artifact:{artifact_id}"),
+        actor_id,
+    )?;
+    Ok(())
 }
 
 /// Propose a session envelope after plan approval: declared envelope when present,

--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -158,30 +158,6 @@ fn find_matching_pending_envelope_id(
         .map(|p| p.id))
 }
 
-/// Locked `PromoteWith` capabilities for `agent_id` (empty `agent_id` matches any).
-pub fn promote_with_capabilities(
-    store: &GatewayStore,
-    root_session_id: &str,
-    agent_id: &str,
-) -> Result<Option<Vec<Capability>>> {
-    Ok(store
-        .get_active_envelopes(root_session_id)?
-        .into_iter()
-        .rev()
-        .find_map(|record| {
-            if let Capability::PromoteWith {
-                agent_id: pw_agent,
-                capabilities,
-            } = record.capability
-            {
-                if pw_agent.is_empty() || pw_agent == agent_id {
-                    return Some(capabilities);
-                }
-            }
-            None
-        }))
-}
-
 /// True when a locked session envelope `PromoteWith` covers `artifact_capabilities`.
 pub fn promotion_preauthorized_by_envelope(
     store: &GatewayStore,
@@ -189,13 +165,23 @@ pub fn promotion_preauthorized_by_envelope(
     agent_id: &str,
     artifact_capabilities: &[Capability],
 ) -> Result<bool> {
-    let Some(declared) = promote_with_capabilities(store, root_session_id, agent_id)? else {
-        return Ok(false);
-    };
-    Ok(autonoetic_types::capability::capability_set_covers(
-        &declared,
-        artifact_capabilities,
-    ))
+    for record in store.get_active_envelopes(root_session_id)? {
+        if let Capability::PromoteWith {
+            agent_id: pw_agent,
+            capabilities,
+        } = &record.capability
+        {
+            if (pw_agent.is_empty() || pw_agent == agent_id)
+                && autonoetic_types::capability::capability_set_covers(
+                    capabilities,
+                    artifact_capabilities,
+                )
+            {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 fn promote_with_sets_equivalent(a: &[Capability], b: &[Capability]) -> bool {

--- a/autonoetic-gateway/src/runtime/state_attestation.rs
+++ b/autonoetic-gateway/src/runtime/state_attestation.rs
@@ -250,6 +250,7 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::CapsuleExport => "CapsuleExport",
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess",
         Capability::WikiContribute => "WikiContribute",
+        Capability::PromoteWith { .. } => "PromoteWith",
     }
     .to_string()
 }

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2220,7 +2220,12 @@ impl NativeTool for AgentRevisionPromoteTool {
             let gate_new_agents = config
                 .map(|c| c.require_operator_approval_for_new_agents)
                 .unwrap_or(true);
-            if let Some(delta) = check_capability_delta(
+            let root_sid = run_context
+                .and_then(|rc| Some(rc.root_session_id.clone()).filter(|s| !s.is_empty()))
+                .or_else(|| {
+                    session_id.map(|s| crate::runtime::content_store::root_session_id(s).to_string())
+                });
+            let mut capability_delta = check_capability_delta(
                 &gateway_store,
                 gateway_dir,
                 &args.agent_id,
@@ -2228,7 +2233,36 @@ impl NativeTool for AgentRevisionPromoteTool {
                 &current_capabilities,
                 delta_mode,
                 gate_new_agents,
-            )? {
+            )?;
+            if capability_delta.is_some() {
+                if let Some(ref root) = root_sid {
+                    match crate::runtime::session_envelope::promotion_preauthorized_by_envelope(
+                        &gateway_store,
+                        root,
+                        &args.agent_id,
+                        &current_capabilities,
+                    ) {
+                        Ok(true) => {
+                            tracing::info!(
+                                target: "promotion",
+                                agent_id = %args.agent_id,
+                                root_session_id = %root,
+                                "pre-authorized by session envelope PromoteWith"
+                            );
+                            capability_delta = None;
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            tracing::debug!(
+                                target: "promotion",
+                                error = %e,
+                                "session envelope pre-auth check failed; falling through to capability gate"
+                            );
+                        }
+                    }
+                }
+            }
+            if let Some(delta) = capability_delta {
                 let outgoing_revision_id = gateway_store
                     .resolve_alias(&args.agent_id)?
                     .map(|alias| alias.revision_id)

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -371,11 +371,12 @@ impl NativeTool for ArtifactBuildTool {
 
         if let Some(gs) = gateway_store.as_ref() {
             let root = crate::runtime::content_store::root_session_id(sid);
-            if let Err(e) = crate::runtime::session_envelope::propose_discovered_envelope(
+            if let Err(e) = crate::runtime::session_envelope::propose_envelopes_after_artifact_build(
                 gs,
+                gw_dir,
                 root,
-                "discovered",
-                None,
+                &bundle.artifact_id,
+                &bundle.kind,
                 &_manifest.agent.id,
             ) {
                 tracing::debug!(

--- a/autonoetic-gateway/src/runtime/tools/mod.rs
+++ b/autonoetic-gateway/src/runtime/tools/mod.rs
@@ -640,6 +640,7 @@ pub(crate) fn capability_type_name(cap: &Capability) -> String {
         Capability::CapsuleExport => "CapsuleExport".to_string(),
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess".to_string(),
         Capability::WikiContribute => "WikiContribute".to_string(),
+        Capability::PromoteWith { .. } => "PromoteWith".to_string(),
     }
 }
 

--- a/autonoetic-gateway/tests/session_envelope_promote_with_integration.rs
+++ b/autonoetic-gateway/tests/session_envelope_promote_with_integration.rs
@@ -1,0 +1,325 @@
+//! Promotion pre-authorization via locked session envelope PromoteWith (#503).
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::session_envelope::lock_session_envelope;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::agent_revision::{AgentRevisionRecord, AgentRevisionStatus};
+use autonoetic_types::background::ScheduledAction;
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::principal::PrincipalKind;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+const AGENT_ID: &str = "weather.forecast";
+const INCOMING_REVISION: &str = "rev_incoming";
+
+fn manifest_with_capabilities(caps: Vec<Capability>) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: AGENT_ID.to_string(),
+            name: AGENT_ID.to_string(),
+            description: "test".to_string(),
+        },
+        capabilities: caps,
+        llm_overrides: None,
+        llm_preset: None,
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+fn skill_md(capabilities_yaml: &str) -> String {
+    format!(
+        "---\nversion: \"1.0\"\nruntime:\n  engine: autonoetic\n  gateway_version: \"0.1.0\"\n  sdk_version: \"0.1.0\"\n  type: stateful\n  sandbox: bubblewrap\n  runtime_lock: runtime.lock\nagent:\n  id: {}\n  name: {}\n  description: test\n{}\n---\n# Test\n",
+        AGENT_ID, AGENT_ID, capabilities_yaml,
+    )
+}
+
+fn write_revision_skill(gateway_dir: &std::path::Path, revision_id: &str, capabilities_yaml: &str) {
+    let dir = gateway_dir
+        .join("revisions/agents")
+        .join(AGENT_ID)
+        .join(revision_id);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("SKILL.md"), skill_md(capabilities_yaml)).unwrap();
+}
+
+fn make_revision_record(revision_id: &str) -> AgentRevisionRecord {
+    AgentRevisionRecord {
+        revision_id: revision_id.to_string(),
+        agent_id: AGENT_ID.to_string(),
+        base_revision_id: None,
+        artifact_id: None,
+        content_digest: format!("sha256:{}", revision_id),
+        runtime_lock_hash: "sha256:lock".to_string(),
+        manifest_hash: "sha256:manifest".to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        created_by_type: PrincipalKind::Human.tag().to_string(),
+        created_by_id: "test".to_string(),
+        source_kind: "artifact".to_string(),
+        source_ref: None,
+        origin_node_id: "local".to_string(),
+        trust_domain: "local".to_string(),
+        status: AgentRevisionStatus::Candidate,
+        metadata_json: serde_json::Value::Null,
+        short_id: revision_id.chars().take(8).collect(),
+        signature: None,
+        signer_id: None,
+    }
+}
+
+struct PromoteHarness {
+    _temp: tempfile::TempDir,
+    store: Arc<GatewayStore>,
+    agent_dir: std::path::PathBuf,
+    gateway_dir: std::path::PathBuf,
+    root_session: String,
+}
+
+fn setup_new_agent_harness(incoming_caps_yaml: &str) -> PromoteHarness {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join("agents");
+    let agent_dir = agents_dir.join(AGENT_ID);
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).expect("store opens"));
+
+    write_revision_skill(&gateway_dir, INCOMING_REVISION, incoming_caps_yaml);
+    store
+        .insert_agent_revision(&make_revision_record(INCOMING_REVISION))
+        .unwrap();
+
+    PromoteHarness {
+        _temp: temp,
+        store,
+        agent_dir,
+        gateway_dir,
+        root_session: "root-promote-preauth".to_string(),
+    }
+}
+
+fn lock_promote_with(
+    store: &GatewayStore,
+    root_session: &str,
+    agent_id: &str,
+    capabilities: Vec<Capability>,
+) -> i64 {
+    let now = chrono::Utc::now().to_rfc3339();
+    let promote_with = Capability::PromoteWith {
+        agent_id: agent_id.to_string(),
+        capabilities,
+    };
+    let envelope_id = store
+        .insert_envelope_proposal(root_session, &promote_with, "test", Some(&now), None, &now)
+        .unwrap();
+    lock_session_envelope(store, envelope_id, "operator").unwrap();
+    envelope_id
+}
+
+fn invoke_promote(h: &PromoteHarness, args_json: &str) -> serde_json::Value {
+    let manifest = manifest_with_capabilities(vec![Capability::AgentRevision {
+        patterns: vec!["*".to_string()],
+    }]);
+    let policy = PolicyEngine::new(manifest.clone());
+    let registry = default_registry();
+    let config = GatewayConfig {
+        agents_dir: h
+            .agent_dir
+            .parent()
+            .expect("agent dir parent")
+            .to_path_buf(),
+        ..GatewayConfig::default()
+    };
+    let session_id = format!("{}/promoter", h.root_session);
+    let raw = registry
+        .execute(
+            "agent_revision_promote",
+            &manifest,
+            &policy,
+            &h.agent_dir,
+            Some(&h.gateway_dir),
+            args_json,
+            Some(&session_id),
+            Some("turn-000001"),
+            Some(&config),
+            Some(h.store.clone()),
+            None,
+        )
+        .expect("execute should not error for normal cases");
+    serde_json::from_str(&raw).expect("response is JSON")
+}
+
+fn revision_promote_approvals(store: &GatewayStore) -> usize {
+    store
+        .get_pending_approvals()
+        .expect("pending approvals")
+        .into_iter()
+        .filter(|a| matches!(a.action, ScheduledAction::RevisionPromote { .. }))
+        .count()
+}
+
+#[test]
+fn locked_promote_with_skips_capability_ack_approval() {
+    let incoming_caps = "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.open-meteo.com\"]\n  - type: ReadAccess\n    scopes: [\"self.*\"]";
+    let h = setup_new_agent_harness(incoming_caps);
+
+    lock_promote_with(
+        &h.store,
+        &h.root_session,
+        AGENT_ID,
+        vec![
+            Capability::NetworkAccess {
+                hosts: vec!["api.open-meteo.com".to_string()],
+            },
+            Capability::ReadAccess {
+                scopes: vec!["self.*".to_string()],
+            },
+        ],
+    );
+
+    let resp = invoke_promote(
+        &h,
+        &format!(r#"{{"agent_id":"{AGENT_ID}","revision_id":"{INCOMING_REVISION}"}}"#),
+    );
+    assert_ne!(
+        resp["error"].as_str(),
+        Some("capability_delta_requires_approval"),
+        "PromoteWith should pre-authorize promotion: {resp}"
+    );
+    assert_eq!(
+        revision_promote_approvals(&h.store),
+        0,
+        "no RevisionPromote approval should be created when pre-authorized"
+    );
+}
+
+#[test]
+fn promote_with_extra_capability_still_requires_ack() {
+    let incoming_caps = "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.open-meteo.com\"]\n  - type: ReadAccess\n    scopes: [\"self.*\"]\n  - type: WriteAccess\n    scopes: [\"self.*\"]";
+    let h = setup_new_agent_harness(incoming_caps);
+
+    lock_promote_with(
+        &h.store,
+        &h.root_session,
+        AGENT_ID,
+        vec![
+            Capability::NetworkAccess {
+                hosts: vec!["api.open-meteo.com".to_string()],
+            },
+            Capability::ReadAccess {
+                scopes: vec!["self.*".to_string()],
+            },
+        ],
+    );
+
+    let resp = invoke_promote(
+        &h,
+        &format!(r#"{{"agent_id":"{AGENT_ID}","revision_id":"{INCOMING_REVISION}"}}"#),
+    );
+    assert_eq!(resp["error"], "capability_delta_requires_approval");
+    assert_eq!(resp["approval_required"], true);
+    assert_eq!(revision_promote_approvals(&h.store), 1);
+}
+
+#[test]
+fn promote_with_agent_id_mismatch_does_not_apply() {
+    let incoming_caps = "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.open-meteo.com\"]";
+    let h = setup_new_agent_harness(incoming_caps);
+
+    lock_promote_with(
+        &h.store,
+        &h.root_session,
+        "other.agent",
+        vec![Capability::NetworkAccess {
+            hosts: vec!["api.open-meteo.com".to_string()],
+        }],
+    );
+
+    let resp = invoke_promote(
+        &h,
+        &format!(r#"{{"agent_id":"{AGENT_ID}","revision_id":"{INCOMING_REVISION}"}}"#),
+    );
+    assert_eq!(resp["error"], "capability_delta_requires_approval");
+    assert_eq!(revision_promote_approvals(&h.store), 1);
+}
+
+#[test]
+fn artifact_build_proposes_promote_with_from_skill_md() -> anyhow::Result<()> {
+    use autonoetic_gateway::artifact_store::ArtifactStore;
+    use autonoetic_gateway::runtime::content_store::ContentStore;
+    use autonoetic_gateway::runtime::session_envelope::propose_envelopes_after_artifact_build;
+    use autonoetic_types::artifact::ArtifactKind;
+
+    let dir = tempdir()?;
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir)?;
+    let store = GatewayStore::open(&gateway_dir)?;
+    let content_store = ContentStore::new(&gateway_dir)?;
+    let artifact_store = ArtifactStore::new(&gateway_dir)?;
+    let session_id = "root-artifact-promote/agent";
+
+    let skill = skill_md(
+        "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.open-meteo.com\"]\n  - type: CodeExecution\n    patterns: [\"python*\"]",
+    );
+    let handle = content_store.write(skill.as_bytes())?;
+    content_store
+        .register_name(session_id, "SKILL.md", &handle)?;
+
+    let bundle = artifact_store.build_with_kind(
+        &["SKILL.md".to_string()],
+        None,
+        None,
+        ArtifactKind::AgentBundle,
+        session_id,
+    )?;
+
+    let root = "root-artifact-promote";
+    propose_envelopes_after_artifact_build(
+        &store,
+        &gateway_dir,
+        root,
+        &bundle.artifact_id,
+        &ArtifactKind::AgentBundle,
+        "coder.default",
+    )?;
+
+    let proposed = store.get_proposed_envelopes(root)?;
+    assert!(
+        proposed.iter().any(|p| matches!(
+            &p.capability,
+            Capability::PromoteWith { agent_id, capabilities }
+                if agent_id == AGENT_ID
+                    && capabilities.iter().any(|c| matches!(c, Capability::NetworkAccess { .. }))
+                    && capabilities.iter().any(|c| matches!(c, Capability::CodeExecution { .. }))
+        )),
+        "expected PromoteWith proposal from agent_bundle SKILL.md: {:?}",
+        proposed
+    );
+    Ok(())
+}

--- a/autonoetic-gateway/tests/session_envelope_promote_with_integration.rs
+++ b/autonoetic-gateway/tests/session_envelope_promote_with_integration.rs
@@ -142,6 +142,24 @@ fn lock_promote_with(
     envelope_id
 }
 
+fn lock_promote_with_at(
+    store: &GatewayStore,
+    root_session: &str,
+    agent_id: &str,
+    capabilities: Vec<Capability>,
+    created_at: &str,
+) -> i64 {
+    let promote_with = Capability::PromoteWith {
+        agent_id: agent_id.to_string(),
+        capabilities,
+    };
+    let envelope_id = store
+        .insert_envelope_proposal(root_session, &promote_with, "test", Some(created_at), None, created_at)
+        .unwrap();
+    lock_session_envelope(store, envelope_id, "operator").unwrap();
+    envelope_id
+}
+
 fn invoke_promote(h: &PromoteHarness, args_json: &str) -> serde_json::Value {
     let manifest = manifest_with_capabilities(vec![Capability::AgentRevision {
         patterns: vec!["*".to_string()],
@@ -267,6 +285,49 @@ fn promote_with_agent_id_mismatch_does_not_apply() {
     );
     assert_eq!(resp["error"], "capability_delta_requires_approval");
     assert_eq!(revision_promote_approvals(&h.store), 1);
+}
+
+#[test]
+fn any_matching_locked_promote_with_preauthorizes() {
+    let incoming_caps = "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.open-meteo.com\"]\n  - type: ReadAccess\n    scopes: [\"self.*\"]";
+    let h = setup_new_agent_harness(incoming_caps);
+
+    // Newer agent-specific entry is too narrow (network only).
+    lock_promote_with_at(
+        &h.store,
+        &h.root_session,
+        AGENT_ID,
+        vec![Capability::NetworkAccess {
+            hosts: vec!["api.open-meteo.com".to_string()],
+        }],
+        "2026-06-15T10:00:00Z",
+    );
+    // Older wildcard entry covers the full artifact capability set.
+    lock_promote_with_at(
+        &h.store,
+        &h.root_session,
+        "",
+        vec![
+            Capability::NetworkAccess {
+                hosts: vec!["api.open-meteo.com".to_string()],
+            },
+            Capability::ReadAccess {
+                scopes: vec!["self.*".to_string()],
+            },
+        ],
+        "2026-06-15T09:00:00Z",
+    );
+
+    let resp = invoke_promote(
+        &h,
+        &format!(r#"{{"agent_id":"{AGENT_ID}","revision_id":"{INCOMING_REVISION}"}}"#),
+    );
+    assert_ne!(
+        resp["error"].as_str(),
+        Some("capability_delta_requires_approval"),
+        "any matching PromoteWith should pre-authorize: {resp}"
+    );
+    assert_eq!(revision_promote_approvals(&h.store), 0);
 }
 
 #[test]

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -184,6 +184,14 @@ pub enum Capability {
         #[serde(default = "default_patterns_all")]
         patterns: Vec<String>,
     },
+
+    /// Pre-authorizes promotion of an agent whose declared capabilities fall
+    /// within this set. Checked at promotion time against locked session envelopes.
+    PromoteWith {
+        #[serde(default)]
+        agent_id: String,
+        capabilities: Vec<Capability>,
+    },
 }
 
 fn default_patterns_all() -> Vec<String> {
@@ -301,6 +309,7 @@ pub fn all_capability_kind_names() -> &'static [&'static str] {
         "SecurityRedTeam",
         "CapsuleExport",
         "PlanFrameAccess",
+        "PromoteWith",
     ]
 }
 
@@ -331,7 +340,21 @@ fn capability_type_name(cap: &Capability) -> String {
         Capability::CapsuleExport => "CapsuleExport".to_string(),
         Capability::PlanFrameAccess { .. } => "PlanFrameAccess".to_string(),
         Capability::WikiContribute => "WikiContribute".to_string(),
+        Capability::PromoteWith { .. } => "PromoteWith".to_string(),
     }
+}
+
+/// True when every capability in `artifact_caps` is equal to or narrower than
+/// some capability in `declared`.
+pub fn capability_set_covers(declared: &[Capability], artifact_caps: &[Capability]) -> bool {
+    let declared_map = capability_map(declared);
+    artifact_caps.iter().all(|ac| {
+        let name = capability_type_name(ac);
+        match declared_map.get(&name) {
+            None => false,
+            Some(dc) => capability_broadening(&name, dc, ac).is_none(),
+        }
+    })
 }
 
 fn capability_broadening(
@@ -709,6 +732,12 @@ mod tests {
             Capability::SecurityRedTeam,
             Capability::CapsuleExport,
             Capability::PlanFrameAccess { patterns: vec![] },
+            Capability::PromoteWith {
+                agent_id: "agent.test".into(),
+                capabilities: vec![Capability::ReadAccess {
+                    scopes: vec!["self.*".into()],
+                }],
+            },
         ];
         for cap in &samples {
             let name = capability_type_name(cap);
@@ -719,5 +748,27 @@ mod tests {
                 name
             );
         }
+    }
+
+    #[test]
+    fn capability_set_covers_equal_and_narrower() {
+        let declared = vec![
+            Capability::NetworkAccess {
+                hosts: vec!["api.example.com".into(), "cdn.example.com".into()],
+            },
+            Capability::ReadAccess {
+                scopes: vec!["self.*".into()],
+            },
+        ];
+        let artifact = vec![
+            Capability::NetworkAccess {
+                hosts: vec!["api.example.com".into()],
+            },
+            Capability::ReadAccess {
+                scopes: vec!["self.*".into()],
+            },
+        ];
+        assert!(capability_set_covers(&declared, &artifact));
+        assert!(!capability_set_covers(&artifact, &declared));
     }
 }

--- a/autonoetic-types/src/capability.rs
+++ b/autonoetic-types/src/capability.rs
@@ -309,6 +309,7 @@ pub fn all_capability_kind_names() -> &'static [&'static str] {
         "SecurityRedTeam",
         "CapsuleExport",
         "PlanFrameAccess",
+        "WikiContribute",
         "PromoteWith",
     ]
 }
@@ -732,6 +733,7 @@ mod tests {
             Capability::SecurityRedTeam,
             Capability::CapsuleExport,
             Capability::PlanFrameAccess { patterns: vec![] },
+            Capability::WikiContribute,
             Capability::PromoteWith {
                 agent_id: "agent.test".into(),
                 capabilities: vec![Capability::ReadAccess {


### PR DESCRIPTION
## Summary
- Add `Capability::PromoteWith { agent_id, capabilities }` plus `capability_set_covers()` for subset checking via existing broadening logic.
- On `artifact_build` (agent bundles), propose a `PromoteWith` envelope row from SKILL.md capabilities alongside discovered network hosts.
- `agent_revision_promote` skips the capability-ack `RevisionPromote` approval when a locked session envelope `PromoteWith` covers the revision capabilities.

Closes #503 (umbrella #506).

## Test plan
- [x] `cargo test -p autonoetic-types capability_set_covers`
- [x] `cargo test -p autonoetic-gateway --test session_envelope_promote_with_integration`
- [x] `cargo test -p autonoetic-gateway --test constitution_promotion_capability_delta`


Made with [Cursor](https://cursor.com)