### PR TITLE
fix(envelope): surgical revocation + causal chain traceability + nested PromoteWith validation

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2015,6 +2015,63 @@ impl JsonRpcRouter {
                 }
             }
 
+            "session.envelope.revoke" => {
+                #[derive(Deserialize)]
+                struct EnvelopeRevokeParams {
+                    envelope_id: i64,
+                    #[serde(default = "default_envelope_revoked_by")]
+                    revoked_by: String,
+                }
+                fn default_envelope_revoked_by() -> String {
+                    "operator".to_string()
+                }
+                let params: EnvelopeRevokeParams = match serde_json::from_value(req.params) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for session.envelope.revoke: {}", e),
+                        );
+                    }
+                };
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                match crate::runtime::session_envelope::revoke_session_envelope(
+                    store.as_ref(),
+                    params.envelope_id,
+                    &params.revoked_by,
+                ) {
+                    Ok(Some(record)) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::json!({
+                            "ok": true,
+                            "envelope_id": params.envelope_id,
+                            "was_locked": record.locked_at.is_some(),
+                            "root_session_id": record.root_session_id,
+                        }),
+                    ),
+                    Ok(None) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("session envelope {} not found", params.envelope_id),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("session.envelope.revoke failed: {}", e),
+                    ),
+                }
+            }
+
             "session.envelope.list" => {
                 #[derive(Deserialize)]
                 struct EnvelopeListParams {

--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -511,17 +511,17 @@ pub fn revoke_session_envelope(
         _ => Vec::new(),
     };
 
-    if !store.revoke_session_envelope_by_id(envelope_id)? {
-        return Ok(None);
-    }
-
     if was_locked {
         let source = format!("session-envelope:{envelope_id}");
-        let _ = store.revoke_session_grants_by_source(
+        store.revoke_session_grants_by_source(
             &record.root_session_id,
             &source,
             &format!("envelope revoked by {revoked_by}"),
-        );
+        )?;
+    }
+
+    if !store.revoke_session_envelope_by_id(envelope_id)? {
+        return Ok(None);
     }
 
     let (principal, role) = crate::runtime::session_timeline::decider_seat(revoked_by);
@@ -753,6 +753,35 @@ mod tests {
             Capability::NetworkAccess { hosts } if hosts == &vec!["api.example.com".to_string()]
         ));
         assert_eq!(store.get_proposed_envelopes(root)?.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn propose_promote_with_rejects_nested_promote_with() -> Result<()> {
+        let dir = tempdir()?;
+        let store = GatewayStore::open(dir.path())?;
+        let root = "session-511-nested";
+
+        let err = propose_promote_with_envelope(
+            &store,
+            root,
+            "agent.test",
+            &[Capability::PromoteWith {
+                agent_id: "nested".to_string(),
+                capabilities: vec![Capability::ReadAccess {
+                    scopes: vec!["self.*".to_string()],
+                }],
+            }],
+            "test",
+            "operator",
+        )
+        .expect_err("nested PromoteWith should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("PromoteWith capabilities cannot contain nested PromoteWith"),
+            "unexpected error: {err}"
+        );
         Ok(())
     }
 

--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -165,6 +165,18 @@ pub fn promotion_preauthorized_by_envelope(
     agent_id: &str,
     artifact_capabilities: &[Capability],
 ) -> Result<bool> {
+    Ok(find_promote_with_envelope_id(store, root_session_id, agent_id, artifact_capabilities)?.is_some())
+}
+
+/// Find the envelope ID of a locked `PromoteWith` that covers `artifact_capabilities`.
+/// Checks ALL matching entries (wildcard `agent_id: ""` + specific), returns the first
+/// that covers. Used for causal chain cross-referencing (P-2.27 traceability).
+pub fn find_promote_with_envelope_id(
+    store: &GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+    artifact_capabilities: &[Capability],
+) -> Result<Option<i64>> {
     for record in store.get_active_envelopes(root_session_id)? {
         if let Capability::PromoteWith {
             agent_id: pw_agent,
@@ -177,11 +189,11 @@ pub fn promotion_preauthorized_by_envelope(
                     artifact_capabilities,
                 )
             {
-                return Ok(true);
+                return Ok(Some(record.id));
             }
         }
     }
-    Ok(false)
+    Ok(None)
 }
 
 fn promote_with_sets_equivalent(a: &[Capability], b: &[Capability]) -> bool {
@@ -214,6 +226,11 @@ pub fn propose_promote_with_envelope(
 ) -> Result<Option<i64>> {
     if capabilities.is_empty() {
         return Ok(None);
+    }
+    if capabilities.iter().any(|c| matches!(c, Capability::PromoteWith { .. })) {
+        return Err(anyhow!(
+            "PromoteWith capabilities cannot contain nested PromoteWith"
+        ));
     }
     if promotion_preauthorized_by_envelope(store, root_session_id, agent_id, capabilities)? {
         return Ok(None);
@@ -473,6 +490,67 @@ pub fn lock_session_envelope(
         locked_at: now,
         hosts,
     })
+}
+
+/// Revoke a single envelope by ID. If it was locked and materialized as network
+/// grants, those grants are surgically revoked too (by source). Emits an
+/// `envelope.revoked` timeline event. Returns the envelope record that was
+/// revoked (for the response payload), or None if not found.
+pub fn revoke_session_envelope(
+    store: &GatewayStore,
+    envelope_id: i64,
+    revoked_by: &str,
+) -> Result<Option<SessionEnvelopeRecord>> {
+    let Some(record) = store.get_envelope_by_id(envelope_id)? else {
+        return Ok(None);
+    };
+
+    let was_locked = record.locked_at.is_some();
+    let hosts = match &record.capability {
+        Capability::NetworkAccess { hosts } => concrete_hosts(hosts),
+        _ => Vec::new(),
+    };
+
+    if !store.revoke_session_envelope_by_id(envelope_id)? {
+        return Ok(None);
+    }
+
+    if was_locked {
+        let source = format!("session-envelope:{envelope_id}");
+        let _ = store.revoke_session_grants_by_source(
+            &record.root_session_id,
+            &source,
+            &format!("envelope revoked by {revoked_by}"),
+        );
+    }
+
+    let (principal, role) = crate::runtime::session_timeline::decider_seat(revoked_by);
+    let refs = autonoetic_types::session_timeline::TimelineRefs {
+        plan_id: record.plan_id.clone(),
+        ..Default::default()
+    };
+    let event = crate::runtime::session_timeline::build_timeline_event(
+        record.root_session_id.clone(),
+        record.root_session_id.clone(),
+        None,
+        &principal,
+        &role,
+        "envelope.revoked",
+        None,
+        Some(serde_json::json!({
+            "envelope_id": envelope_id,
+            "hosts": hosts,
+            "source": record.source,
+            "was_locked": was_locked,
+            "revoked_by": revoked_by,
+        })),
+        refs,
+    );
+    if let Err(e) = store.create_live_digest_event(&event) {
+        tracing::debug!(target: "session_timeline", error = %e, "envelope.revoked timeline emit failed");
+    }
+
+    Ok(Some(record))
 }
 
 /// Hosts previously observed in-session but not yet covered by a locked envelope.

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2237,30 +2237,24 @@ impl NativeTool for AgentRevisionPromoteTool {
             )?;
             if capability_delta.is_some() {
                 if let Some(ref root) = root_sid {
-                    match crate::runtime::session_envelope::promotion_preauthorized_by_envelope(
+                    match crate::runtime::session_envelope::find_promote_with_envelope_id(
                         &gateway_store,
                         root,
                         &args.agent_id,
                         &current_capabilities,
                     ) {
-                        Ok(true) => {
-                            let envelope_id = crate::runtime::session_envelope::find_promote_with_envelope_id(
-                                &gateway_store,
-                                root,
-                                &args.agent_id,
-                                &current_capabilities,
-                            ).unwrap_or(None);
+                        Ok(Some(envelope_id)) => {
                             tracing::info!(
                                 target: "promotion",
                                 agent_id = %args.agent_id,
                                 root_session_id = %root,
-                                envelope_id = ?envelope_id,
+                                envelope_id,
                                 "pre-authorized by session envelope PromoteWith (P-2.27)"
                             );
-                            pre_auth_envelope_id = envelope_id;
+                            pre_auth_envelope_id = Some(envelope_id);
                             capability_delta = None;
                         }
-                        Ok(false) => {}
+                        Ok(None) => {}
                         Err(e) => {
                             tracing::debug!(
                                 target: "promotion",

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2215,6 +2215,7 @@ impl NativeTool for AgentRevisionPromoteTool {
             } else {
                 false
             };
+        let mut pre_auth_envelope_id: Option<i64> = None;
 
         if !gate_bypassed_by_approval {
             let gate_new_agents = config
@@ -2243,12 +2244,20 @@ impl NativeTool for AgentRevisionPromoteTool {
                         &current_capabilities,
                     ) {
                         Ok(true) => {
+                            let envelope_id = crate::runtime::session_envelope::find_promote_with_envelope_id(
+                                &gateway_store,
+                                root,
+                                &args.agent_id,
+                                &current_capabilities,
+                            ).unwrap_or(None);
                             tracing::info!(
                                 target: "promotion",
                                 agent_id = %args.agent_id,
                                 root_session_id = %root,
-                                "pre-authorized by session envelope PromoteWith"
+                                envelope_id = ?envelope_id,
+                                "pre-authorized by session envelope PromoteWith (P-2.27)"
                             );
+                            pre_auth_envelope_id = envelope_id;
                             capability_delta = None;
                         }
                         Ok(false) => {}
@@ -2921,7 +2930,7 @@ impl NativeTool for AgentRevisionPromoteTool {
         }
 
         let short_ref = format!("{}@rev_{}", args.agent_id, rev.short_id);
-        Ok(serde_json::json!({
+        let mut response = serde_json::json!({
             "ok": true,
             "status": "promoted",
             "agent_id": args.agent_id,
@@ -2929,8 +2938,12 @@ impl NativeTool for AgentRevisionPromoteTool {
             "short_ref": short_ref,
             "previous_revision_id": previous_revision_id,
             "promotion_id": promotion_id,
-        })
-        .to_string())
+        });
+        if let Some(eid) = pre_auth_envelope_id {
+            response["pre_authorized_by_envelope"] = serde_json::json!(eid);
+            response["pre_auth_rule"] = serde_json::json!("P-2.27");
+        }
+        Ok(response.to_string())
     }
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/session_envelopes.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/session_envelopes.rs
@@ -160,6 +160,17 @@ impl GatewayStore {
         )?;
         Ok(count)
     }
+
+    /// Delete a single envelope row by ID. Returns true if a row was deleted.
+    /// Called by surgical revocation (`session.envelope.revoke` RPC).
+    pub fn revoke_session_envelope_by_id(&self, envelope_id: i64) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let count = conn.execute(
+            "DELETE FROM session_envelopes WHERE id = ?1",
+            params![envelope_id],
+        )?;
+        Ok(count > 0)
+    }
 }
 
 fn load_envelopes<P>(

--- a/autonoetic-gateway/src/scheduler/gateway_store/session_envelopes.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/session_envelopes.rs
@@ -519,4 +519,21 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn revoke_session_envelope_by_id_deletes_exactly_one_row() -> Result<()> {
+        let dir = tempdir()?;
+        let store = GatewayStore::open(dir.path())?;
+        let root = "session-511-store-revoke";
+        let now = "2026-06-14T12:00:00Z";
+        let cap = Capability::NetworkAccess {
+            hosts: vec!["api.example.com".to_string()],
+        };
+        let id = store.insert_envelope_proposal(root, &cap, "test", Some(now), None, now)?;
+        assert!(store.revoke_session_envelope_by_id(id)?);
+        assert!(!store.revoke_session_envelope_by_id(id)?);
+        assert!(!store.revoke_session_envelope_by_id(999_999)?);
+        assert!(store.get_envelope_by_id(id)?.is_none());
+        Ok(())
+    }
 }

--- a/autonoetic-gateway/tests/session_envelope_locking_integration.rs
+++ b/autonoetic-gateway/tests/session_envelope_locking_integration.rs
@@ -2,6 +2,7 @@
 
 use autonoetic_gateway::runtime::session_envelope::{
     envelope_expansion_hint, lock_session_envelope, propose_discovered_envelope,
+    revoke_session_envelope,
 };
 use autonoetic_gateway::scheduler::{
     list_session_envelopes, lock_session_envelope_operator, propose_session_envelope,
@@ -162,5 +163,39 @@ fn approval_timeline_gets_expansion_hint_for_observed_host() -> anyhow::Result<(
         .expect("approval.pending event");
     let payload: serde_json::Value = serde_json::from_str(pending.payload.as_deref().unwrap_or("{}"))?;
     assert!(payload.get("envelope_expansion_hint").is_some());
+    Ok(())
+}
+
+#[test]
+fn revoke_locked_envelope_revokes_grants_and_removes_row() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let store = GatewayStore::open(dir.path())?;
+    let root = "session-511-revoke";
+
+    store.create_execution_trace(&curl_trace(
+        root,
+        "curl -s https://api.open-meteo.com/v1/forecast",
+    ))?;
+
+    let proposal = propose_discovered_envelope(&store, root, "discovered", None, "operator")?
+        .expect("proposal");
+    lock_session_envelope(&store, proposal.envelope_id, "operator")?;
+    assert!(store.session_grants_cover_targets(root, &["api.open-meteo.com".to_string()]));
+
+    let revoked = revoke_session_envelope(&store, proposal.envelope_id, "operator")?
+        .expect("revoked record");
+    assert_eq!(revoked.root_session_id, root);
+    assert!(revoked.locked_at.is_some());
+    assert!(store.get_envelope_by_id(proposal.envelope_id)?.is_none());
+    assert!(!store.session_grants_cover_targets(root, &["api.open-meteo.com".to_string()]));
+    Ok(())
+}
+
+#[test]
+fn revoke_missing_envelope_returns_none() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let store = GatewayStore::open(dir.path())?;
+    assert!(revoke_session_envelope(&store, 999_999, "operator")?.is_none());
+    assert!(!store.revoke_session_envelope_by_id(999_999)?);
     Ok(())
 }

--- a/autonoetic-gateway/tests/session_envelope_promote_with_integration.rs
+++ b/autonoetic-gateway/tests/session_envelope_promote_with_integration.rs
@@ -207,7 +207,7 @@ fn locked_promote_with_skips_capability_ack_approval() {
     let incoming_caps = "capabilities:\n  - type: NetworkAccess\n    hosts: [\"api.open-meteo.com\"]\n  - type: ReadAccess\n    scopes: [\"self.*\"]";
     let h = setup_new_agent_harness(incoming_caps);
 
-    lock_promote_with(
+    let envelope_id = lock_promote_with(
         &h.store,
         &h.root_session,
         AGENT_ID,
@@ -234,6 +234,24 @@ fn locked_promote_with_skips_capability_ack_approval() {
         revision_promote_approvals(&h.store),
         0,
         "no RevisionPromote approval should be created when pre-authorized"
+    );
+    assert_eq!(
+        autonoetic_gateway::runtime::session_envelope::find_promote_with_envelope_id(
+            &h.store,
+            &h.root_session,
+            AGENT_ID,
+            &[
+                Capability::NetworkAccess {
+                    hosts: vec!["api.open-meteo.com".to_string()],
+                },
+                Capability::ReadAccess {
+                    scopes: vec!["self.*".to_string()],
+                },
+            ],
+        )
+        .expect("envelope lookup"),
+        Some(envelope_id),
+        "locked PromoteWith should be traceable to envelope ID"
     );
 }
 


### PR DESCRIPTION
Three hardening fixes from the post-PR-#510 security analysis:

### #2 — Surgical envelope revocation (`session.envelope.revoke` RPC)

Adds a new JSON-RPC method to revoke a single envelope by ID without nuking the entire session. When a locked (materialized) envelope is revoked, its associated network grants are also revoked by source. An `envelope.revoked` timeline event is emitted for audit.

- `router.rs`: `session.envelope.revoke` handler with `envelope_id` and `revoked_by` params
- `session_envelope.rs`: `revoke_session_envelope()` — deletes row, revokes grants by source, emits timeline event
- `session_envelopes.rs`: `revoke_session_envelope_by_id()` — DELETE by id

### #3 — Causal chain cross-reference in promotion response

When a promotion is pre-authorized by a locked `PromoteWith` envelope, the response now carries:
- `pre_authorized_by_envelope`: the envelope ID
- `pre_auth_rule`: `"P-2.27"`

Sentinels can trace why the capability-ack gate was skipped. Refactored `promotion_preauthorized_by_envelope()` into `find_promote_with_envelope_id()` to expose the matching envelope ID.

### #4 — Nested `PromoteWith` validation at proposal time

Rejects `propose_promote_with_envelope()` calls where the capability list contains nested `PromoteWith` variants. This prevents confusion about which envelope's grants apply and ensures the capability set stays flat.