### PR TITLE
feat(promotion-audit-suspension): persist pre-authorization cross-reference + agent suspension

### DIFF
--- a/autonoetic-gateway/src/agent/repository.rs
+++ b/autonoetic-gateway/src/agent/repository.rs
@@ -338,6 +338,17 @@ impl AgentRepository {
                     ),
                 };
 
+                // Check if the agent is suspended — block dispatch.
+                if let Some(ref suspended_at) = alias.suspended_at {
+                    let reason = alias.suspended_reason.as_deref().unwrap_or("no reason given");
+                    let by = alias.suspended_by.as_deref().unwrap_or("unknown");
+                    anyhow::bail!(
+                        "Agent '{}' is suspended (since {}) by {}: {}. \
+                         Unsuspend or re-promote the agent before dispatching.",
+                        alias_id, suspended_at, by, reason,
+                    );
+                }
+
                 let rev = match gateway_store.get_agent_revision(&alias.revision_id)? {
                     Some(r) => r,
                     None => anyhow::bail!(

--- a/autonoetic-gateway/src/bootstrap.rs
+++ b/autonoetic-gateway/src/bootstrap.rs
@@ -385,6 +385,7 @@ fn bootstrap_agent_inner(
         "cli",
         Some("Auto-promoted during agent bootstrap"),
         None,
+        None,
     )?;
 
     update_latest_symlink(gateway_dir, agent_id, &revision_id);

--- a/autonoetic-gateway/src/capsule/import.rs
+++ b/autonoetic-gateway/src/capsule/import.rs
@@ -575,6 +575,9 @@ fn bind_alias(
         updated_by_type: autonoetic_types::principal::PrincipalKind::Script.tag().to_string(),
         updated_by_id: "capsule.import".to_string(),
         reason: Some("capsule import --activate".to_string()),
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias)?;
     Ok(())

--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -165,6 +165,16 @@ pub fn promotion_preauthorized_by_envelope(
     agent_id: &str,
     artifact_capabilities: &[Capability],
 ) -> Result<bool> {
+    Ok(find_promote_with_envelope_id(store, root_session_id, agent_id, artifact_capabilities)?.is_some())
+}
+
+/// Find the envelope ID of a locked `PromoteWith` that covers `artifact_capabilities`.
+pub fn find_promote_with_envelope_id(
+    store: &GatewayStore,
+    root_session_id: &str,
+    agent_id: &str,
+    artifact_capabilities: &[Capability],
+) -> Result<Option<i64>> {
     for record in store.get_active_envelopes(root_session_id)? {
         if let Capability::PromoteWith {
             agent_id: pw_agent,
@@ -177,11 +187,11 @@ pub fn promotion_preauthorized_by_envelope(
                     artifact_capabilities,
                 )
             {
-                return Ok(true);
+                return Ok(Some(record.id));
             }
         }
     }
-    Ok(false)
+    Ok(None)
 }
 
 fn promote_with_sets_equivalent(a: &[Capability], b: &[Capability]) -> bool {

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2216,6 +2216,10 @@ impl NativeTool for AgentRevisionPromoteTool {
                 false
             };
 
+        // pre_auth_envelope_id is set inside the gate bypass block,
+        // but referenced in the response — declared here for scope.
+        let mut pre_auth_envelope_id: Option<i64> = None;
+
         if !gate_bypassed_by_approval {
             let gate_new_agents = config
                 .map(|c| c.require_operator_approval_for_new_agents)
@@ -2236,22 +2240,24 @@ impl NativeTool for AgentRevisionPromoteTool {
             )?;
             if capability_delta.is_some() {
                 if let Some(ref root) = root_sid {
-                    match crate::runtime::session_envelope::promotion_preauthorized_by_envelope(
+                    match crate::runtime::session_envelope::find_promote_with_envelope_id(
                         &gateway_store,
                         root,
                         &args.agent_id,
                         &current_capabilities,
                     ) {
-                        Ok(true) => {
+                        Ok(Some(eid)) => {
                             tracing::info!(
                                 target: "promotion",
                                 agent_id = %args.agent_id,
                                 root_session_id = %root,
-                                "pre-authorized by session envelope PromoteWith"
+                                envelope_id = eid,
+                                "pre-authorized by session envelope PromoteWith (P-2.27)"
                             );
+                            pre_auth_envelope_id = Some(eid);
                             capability_delta = None;
                         }
-                        Ok(false) => {}
+                        Ok(None) => {}
                         Err(e) => {
                             tracing::debug!(
                                 target: "promotion",
@@ -2898,6 +2904,13 @@ impl NativeTool for AgentRevisionPromoteTool {
             ),
         );
 
+        let pre_authorization = pre_auth_envelope_id.map(|eid| {
+            serde_json::json!({
+                "method": "envelope",
+                "envelope_id": eid,
+                "rule": "P-2.27",
+            }).to_string()
+        });
         let previous_revision_id = gateway_store.atomic_promote(
             &args.agent_id,
             &args.revision_id,
@@ -2906,6 +2919,7 @@ impl NativeTool for AgentRevisionPromoteTool {
             &manifest.agent.id,
             args.reason.as_deref(),
             args.required_eval_run_id.as_deref(),
+            pre_authorization.as_deref(),
         )?;
 
         crate::bootstrap::update_latest_symlink(gateway_dir, &args.agent_id, &args.revision_id);
@@ -2921,7 +2935,7 @@ impl NativeTool for AgentRevisionPromoteTool {
         }
 
         let short_ref = format!("{}@rev_{}", args.agent_id, rev.short_id);
-        Ok(serde_json::json!({
+        let mut response = serde_json::json!({
             "ok": true,
             "status": "promoted",
             "agent_id": args.agent_id,
@@ -2929,8 +2943,12 @@ impl NativeTool for AgentRevisionPromoteTool {
             "short_ref": short_ref,
             "previous_revision_id": previous_revision_id,
             "promotion_id": promotion_id,
-        })
-        .to_string())
+        });
+        if let Some(eid) = pre_auth_envelope_id {
+            response["pre_authorized_by_envelope"] = serde_json::json!(eid);
+            response["pre_auth_rule"] = serde_json::json!("P-2.27");
+        }
+        Ok(response.to_string())
     }
 }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
@@ -582,10 +582,20 @@ impl GatewayStore {
         );
 
         let now = chrono::Utc::now().to_rfc3339();
+        // Preserve existing suspension state during rollback — do not auto-unsuspend.
+        let (suspended_at, suspended_reason, suspended_by): (Option<String>, Option<String>, Option<String>) = tx
+            .query_row(
+                "SELECT suspended_at, suspended_reason, suspended_by FROM agent_aliases WHERE alias_id = ?1",
+                params![agent_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?
+            .unwrap_or((None, None, None));
         tx.execute(
             "INSERT OR REPLACE INTO agent_aliases (
-                alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
+                suspended_at, suspended_reason, suspended_by
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 agent_id,
                 agent_id,
@@ -593,7 +603,10 @@ impl GatewayStore {
                 now,
                 created_by_type,
                 created_by_id,
-                reason
+                reason,
+                suspended_at,
+                suspended_reason,
+                suspended_by,
             ],
         )?;
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
@@ -244,8 +244,9 @@ impl GatewayStore {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT OR REPLACE INTO agent_aliases (
-                alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
+                suspended_at, suspended_reason, suspended_by
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 &alias.alias_id,
                 &alias.agent_id,
@@ -254,6 +255,9 @@ impl GatewayStore {
                 &alias.updated_by_type,
                 &alias.updated_by_id,
                 alias.reason,
+                alias.suspended_at,
+                alias.suspended_reason,
+                alias.suspended_by,
             ],
         )?;
         Ok(())
@@ -266,7 +270,8 @@ impl GatewayStore {
     pub fn resolve_alias(&self, alias_id: &str) -> Result<Option<AgentAliasRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason
+            "SELECT alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
+                    suspended_at, suspended_reason, suspended_by
              FROM agent_aliases WHERE alias_id = ?1",
         )?;
         let rows = stmt.query_map(params![alias_id], |row| {
@@ -278,6 +283,9 @@ impl GatewayStore {
                 updated_by_type: row.get(4)?,
                 updated_by_id: row.get(5)?,
                 reason: row.get(6)?,
+                suspended_at: row.get(7)?,
+                suspended_reason: row.get(8)?,
+                suspended_by: row.get(9)?,
             })
         })?;
         let mut results = Vec::new();
@@ -291,7 +299,8 @@ impl GatewayStore {
         let conn = self.conn.lock().unwrap();
         if let Some(value) = filter {
             let mut stmt = conn.prepare(
-                "SELECT alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason
+                "SELECT alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
+                        suspended_at, suspended_reason, suspended_by
                  FROM agent_aliases
                  WHERE agent_id = ?1 OR alias_id = ?1
                  ORDER BY agent_id ASC, alias_id ASC",
@@ -305,6 +314,9 @@ impl GatewayStore {
                     updated_by_type: row.get(4)?,
                     updated_by_id: row.get(5)?,
                     reason: row.get(6)?,
+                    suspended_at: row.get(7)?,
+                    suspended_reason: row.get(8)?,
+                    suspended_by: row.get(9)?,
                 })
             })?;
             let mut results = Vec::new();
@@ -314,7 +326,8 @@ impl GatewayStore {
             return Ok(results);
         } else {
             let mut stmt = conn.prepare(
-                "SELECT alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason
+                "SELECT alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
+                        suspended_at, suspended_reason, suspended_by
                  FROM agent_aliases
                  ORDER BY agent_id ASC, alias_id ASC",
             )?;
@@ -327,6 +340,9 @@ impl GatewayStore {
                     updated_by_type: row.get(4)?,
                     updated_by_id: row.get(5)?,
                     reason: row.get(6)?,
+                    suspended_at: row.get(7)?,
+                    suspended_reason: row.get(8)?,
+                    suspended_by: row.get(9)?,
                 })
             })?;
             let mut results = Vec::new();
@@ -407,8 +423,8 @@ impl GatewayStore {
             "INSERT INTO promotion_history (
                 promotion_id, kind, alias_id, agent_id, previous_revision_id,
                 new_revision_id, source_eval_run_id, reason, created_at,
-                created_by_type, created_by_id, origin_node_id
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                created_by_type, created_by_id, origin_node_id, pre_authorization
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 &record.promotion_id,
                 &format!("{:?}", record.kind),
@@ -422,6 +438,7 @@ impl GatewayStore {
                 &record.created_by_type,
                 &record.created_by_id,
                 &record.origin_node_id,
+                record.pre_authorization,
             ],
         )?;
         Ok(())
@@ -436,6 +453,7 @@ impl GatewayStore {
         created_by_id: &str,
         reason: Option<&str>,
         source_eval_run_id: Option<&str>,
+        pre_authorization: Option<&str>,
     ) -> Result<Option<String>> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
@@ -468,10 +486,13 @@ impl GatewayStore {
         );
 
         let now = chrono::Utc::now().to_rfc3339();
+
+        // Clear any suspension when promoting — re-promotion = implicit unsuspend.
         tx.execute(
             "INSERT OR REPLACE INTO agent_aliases (
-                alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
+                suspended_at, suspended_reason, suspended_by
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 agent_id,
                 agent_id,
@@ -479,7 +500,10 @@ impl GatewayStore {
                 now,
                 created_by_type,
                 created_by_id,
-                reason
+                reason,
+                None::<&str>, // suspended_at — cleared
+                None::<&str>, // suspended_reason — cleared
+                None::<&str>, // suspended_by — cleared
             ],
         )?;
 
@@ -501,8 +525,8 @@ impl GatewayStore {
             "INSERT INTO promotion_history (
                 promotion_id, kind, alias_id, agent_id, previous_revision_id,
                 new_revision_id, source_eval_run_id, reason, created_at,
-                created_by_type, created_by_id, origin_node_id
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                created_by_type, created_by_id, origin_node_id, pre_authorization
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 promotion_id,
                 "Promote",
@@ -516,6 +540,7 @@ impl GatewayStore {
                 created_by_type,
                 created_by_id,
                 "gateway",
+                pre_authorization,
             ],
         )?;
 
@@ -596,8 +621,8 @@ impl GatewayStore {
             "INSERT INTO promotion_history (
                 promotion_id, kind, alias_id, agent_id, previous_revision_id,
                 new_revision_id, source_eval_run_id, reason, created_at,
-                created_by_type, created_by_id, origin_node_id
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                created_by_type, created_by_id, origin_node_id, pre_authorization
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 promotion_id,
                 "Rollback",
@@ -611,11 +636,46 @@ impl GatewayStore {
                 created_by_type,
                 created_by_id,
                 "gateway",
+                None::<&str>, // pre_authorization — rollbacks don't use this
             ],
         )?;
 
         tx.commit()?;
         Ok(current_revision_id)
+    }
+
+    /// Suspend an agent by setting its suspension fields. Use `agent.suspend` RPC.
+    pub fn suspend_agent(
+        &self,
+        agent_id: &str,
+        suspended_by: &str,
+        reason: Option<&str>,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let updated = conn.execute(
+            "UPDATE agent_aliases SET
+                suspended_at = ?1,
+                suspended_reason = ?2,
+                suspended_by = ?3
+             WHERE alias_id = ?4 AND suspended_at IS NULL",
+            params![now, reason, suspended_by, agent_id],
+        )?;
+        Ok(updated > 0)
+    }
+
+    /// Clear suspension fields on an agent. Use `agent.unsuspend` RPC.
+    pub fn unsuspend_agent(&self, agent_id: &str) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE agent_aliases SET
+                suspended_at = NULL,
+                suspended_reason = NULL,
+                suspended_by = NULL
+             WHERE alias_id = ?1 AND suspended_at IS NOT NULL",
+            params![agent_id],
+        )?;
+        Ok(updated > 0)
     }
 
     /// Count `Promote` (not `Rollback`) entries for an alias whose
@@ -648,7 +708,7 @@ impl GatewayStore {
         let mut stmt = conn.prepare(
             "SELECT promotion_id, kind, alias_id, agent_id, previous_revision_id,
                     new_revision_id, source_eval_run_id, reason, created_at,
-                    created_by_type, created_by_id, origin_node_id
+                    created_by_type, created_by_id, origin_node_id, pre_authorization
              FROM promotion_history WHERE agent_id = ?1 ORDER BY created_at DESC
              LIMIT ?2",
         )?;
@@ -672,6 +732,7 @@ impl GatewayStore {
                 created_by_type: row.get(9)?,
                 created_by_id: row.get(10)?,
                 origin_node_id: row.get(11)?,
+                pre_authorization: row.get(12)?,
             })
         })?;
         let mut results = Vec::new();
@@ -686,7 +747,7 @@ impl GatewayStore {
         let mut stmt = conn.prepare(
             "SELECT promotion_id, kind, alias_id, agent_id, previous_revision_id,
                     new_revision_id, source_eval_run_id, reason, created_at,
-                    created_by_type, created_by_id, origin_node_id
+                    created_by_type, created_by_id, origin_node_id, pre_authorization
              FROM promotion_history WHERE agent_id = ?1 ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map(params![agent_id], |row| {
@@ -709,6 +770,7 @@ impl GatewayStore {
                 created_by_type: row.get(9)?,
                 created_by_id: row.get(10)?,
                 origin_node_id: row.get(11)?,
+                pre_authorization: row.get(12)?,
             })
         })?;
         let mut results = Vec::new();

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::WorkflowIndexFile;
 
-const SCHEMA_VERSION_LATEST: i64 = 51;
+const SCHEMA_VERSION_LATEST: i64 = 53;
 
 pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
@@ -536,6 +536,8 @@ pub(super) fn migrate(conn: &mut Connection) -> Result<()> {
     apply_session_inference_bindings_v49(conn)?;
     apply_session_envelopes_v50(conn)?;
     apply_plan_frame_capability_envelope_v51(conn)?;
+    apply_promotion_pre_authorization_v52(conn)?;
+    apply_agent_suspension_v53(conn)?;
 
     Ok(())
 }
@@ -561,6 +563,40 @@ fn apply_plan_frame_capability_envelope_v51(conn: &mut Connection) -> Result<()>
             "plan_frame_capability_envelope",
             chrono::Utc::now().to_rfc3339()
         ],
+    )?;
+    Ok(())
+}
+
+fn apply_promotion_pre_authorization_v52(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 52 { return Ok(()); }
+    conn.execute_batch("ALTER TABLE promotion_history ADD COLUMN pre_authorization TEXT;")?;
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![52_i64, "promotion_pre_authorization", chrono::Utc::now().to_rfc3339()],
+    )?;
+    Ok(())
+}
+
+fn apply_agent_suspension_v53(conn: &mut Connection) -> Result<()> {
+    let current: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )?;
+    if current >= 53 { return Ok(()); }
+    conn.execute_batch(
+        "ALTER TABLE agent_aliases ADD COLUMN suspended_at TEXT;
+         ALTER TABLE agent_aliases ADD COLUMN suspended_reason TEXT;
+         ALTER TABLE agent_aliases ADD COLUMN suspended_by TEXT;",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
+        params![53_i64, "agent_suspension", chrono::Utc::now().to_rfc3339()],
     )?;
     Ok(())
 }

--- a/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/migrate.rs
@@ -589,15 +589,17 @@ fn apply_agent_suspension_v53(conn: &mut Connection) -> Result<()> {
         |row| row.get(0),
     )?;
     if current >= 53 { return Ok(()); }
-    conn.execute_batch(
+    let tx = conn.transaction()?;
+    tx.execute_batch(
         "ALTER TABLE agent_aliases ADD COLUMN suspended_at TEXT;
          ALTER TABLE agent_aliases ADD COLUMN suspended_reason TEXT;
          ALTER TABLE agent_aliases ADD COLUMN suspended_by TEXT;",
     )?;
-    conn.execute(
+    tx.execute(
         "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
         params![53_i64, "agent_suspension", chrono::Utc::now().to_rfc3339()],
     )?;
+    tx.commit()?;
     Ok(())
 }
 

--- a/autonoetic-gateway/tests/background_scheduler_integration.rs
+++ b/autonoetic-gateway/tests/background_scheduler_integration.rs
@@ -132,6 +132,9 @@ fn register_revision_mirror(
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "background_scheduler_integration".to_string(),
         reason: Some("integration test seed".to_string()),
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias)?;
     Ok(())

--- a/autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs
+++ b/autonoetic-gateway/tests/capsule_phase4_advanced_modes.rs
@@ -73,6 +73,9 @@ fn fixture(agent_id: &str, revision_id: &str) -> Fixture {
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "test".to_string(),
         reason: None,
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias).unwrap();
 

--- a/autonoetic-gateway/tests/capsule_pipeline_integration.rs
+++ b/autonoetic-gateway/tests/capsule_pipeline_integration.rs
@@ -73,6 +73,9 @@ fn make_fixture(agent_id: &str, revision_id: &str) -> Fixture {
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "test".to_string(),
         reason: None,
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias).unwrap();
 

--- a/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_capability_delta.rs
@@ -153,6 +153,9 @@ fn setup_promote_harness(outgoing_caps_yaml: &str, incoming_caps_yaml: &str) -> 
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "test".to_string(),
         reason: None,
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias).unwrap();
 
@@ -589,6 +592,9 @@ fn approval_ref_bypass_is_invalidated_when_alias_moves() {
             updated_by_type: PrincipalKind::Human.tag().to_string(),
             updated_by_id: "test".to_string(),
             reason: None,
+            suspended_at: None,
+            suspended_reason: None,
+            suspended_by: None,
         })
         .unwrap();
 

--- a/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
+++ b/autonoetic-gateway/tests/improvement_ab_replay_integration.rs
@@ -89,6 +89,9 @@ fn seed_alias(store: &GatewayStore, agent_id: &str, revision_id: &str) -> anyhow
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "improvement_ab_replay_test".to_string(),
         reason: Some("test seed".to_string()),
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias)?;
     Ok(())

--- a/autonoetic-gateway/tests/knowledge_revision_provenance_integration.rs
+++ b/autonoetic-gateway/tests/knowledge_revision_provenance_integration.rs
@@ -49,6 +49,9 @@ fn seed_alias(store: &GatewayStore, agent_id: &str, revision_id: &str) {
             updated_by_type: PrincipalKind::Human.tag().to_string(),
             updated_by_id: "test".to_string(),
             reason: Some("test".to_string()),
+            suspended_at: None,
+            suspended_reason: None,
+            suspended_by: None,
         })
         .unwrap();
 }

--- a/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
+++ b/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
@@ -85,6 +85,9 @@ fn upsert_alias(store: &GatewayStore, agent_id: &str, revision_id: &str, reason:
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "test".to_string(),
         reason: Some(reason.to_string()),
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias).unwrap();
 }
@@ -151,6 +154,7 @@ fn test_promote_changes_only_future_alias_resolution_and_running_session_stays_p
             "test-promoter",
             Some("promote for test"),
             None,
+            None,
         )
         .unwrap();
 
@@ -216,6 +220,7 @@ fn test_explicit_agent_ref_sessions_are_unaffected_by_later_promotion() {
             "agent",
             "test-promoter",
             Some("promote for explicit test"),
+            None,
             None,
         )
         .unwrap();

--- a/autonoetic-gateway/tests/promotion_governor_integration.rs
+++ b/autonoetic-gateway/tests/promotion_governor_integration.rs
@@ -58,6 +58,7 @@ fn seed_promotion(
         created_by_type: PrincipalKind::Human.tag().to_string(),
         created_by_id: "promotion_governor_integration".to_string(),
         origin_node_id: "gateway".to_string(),
+        pre_authorization: None,
     };
     store.insert_promotion_record(&rec).unwrap();
 }

--- a/autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs
+++ b/autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs
@@ -174,6 +174,9 @@ fn setup_harness(agent_id: &str) -> PromoteHarness {
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "test".to_string(),
         reason: None,
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias).unwrap();
 

--- a/autonoetic-gateway/tests/support/mod.rs
+++ b/autonoetic-gateway/tests/support/mod.rs
@@ -358,6 +358,9 @@ pub fn seed_agent_revision(
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "support".to_string(),
         reason: Some("test seed".to_string()),
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias)?;
     Ok(revision_id)

--- a/autonoetic-gateway/tests/turn_continuation_approval_integration.rs
+++ b/autonoetic-gateway/tests/turn_continuation_approval_integration.rs
@@ -122,6 +122,9 @@ fn seed_present_test_agents(
             updated_by_type: PrincipalKind::Human.tag().to_string(),
             updated_by_id: "turn_continuation_approval_integration".to_string(),
             reason: Some("seed test alias".to_string()),
+            suspended_at: None,
+            suspended_reason: None,
+            suspended_by: None,
         })?;
     }
     Ok(())

--- a/autonoetic-types/src/agent_revision.rs
+++ b/autonoetic-types/src/agent_revision.rs
@@ -208,6 +208,41 @@ pub struct AgentAliasRecord {
     pub updated_by_id: String,
     /// Optional free-text reason for the update.
     pub reason: Option<String>,
+    /// RFC3339 timestamp when the agent was suspended (None = active).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suspended_at: Option<String>,
+    /// Reason for suspension.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suspended_reason: Option<String>,
+    /// Actor that suspended the agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suspended_by: Option<String>,
+}
+
+impl AgentAliasRecord {
+    /// Create a basic alias record with no suspension.
+    pub fn new(
+        alias_id: String,
+        agent_id: String,
+        revision_id: String,
+        updated_at: String,
+        updated_by_type: String,
+        updated_by_id: String,
+        reason: Option<String>,
+    ) -> Self {
+        Self {
+            alias_id,
+            agent_id,
+            revision_id,
+            updated_at,
+            updated_by_type,
+            updated_by_id,
+            reason,
+            suspended_at: None,
+            suspended_reason: None,
+            suspended_by: None,
+        }
+    }
 }
 
 /// Session-to-agent-revision binding, pinned at session start.
@@ -271,6 +306,13 @@ pub struct PromotionRecord {
     pub created_by_id: String,
     /// Origin node for provenance.
     pub origin_node_id: String,
+    /// JSON-encoded pre-authorization metadata when the capability gate was
+    /// bypassed. Examples:
+    /// `{"method":"envelope","envelope_id":42,"rule":"P-2.27"}`
+    /// `{"method":"escalation","escalation_id":"fed-xxx"}`
+    /// `{"method":"approval","approval_id":"appr-yyy"}`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pre_authorization: Option<String>,
 }
 
 /// Crockford Base32 alphabet for human-friendly short IDs.

--- a/autonoetic/src/cli/agent.rs
+++ b/autonoetic/src/cli/agent.rs
@@ -902,6 +902,7 @@ pub fn handle_agent_seed(
         "cli.seed",
         reason,
         None,
+        None,
     )?;
     let payload = serde_json::json!({
         "ok": true,
@@ -2805,6 +2806,9 @@ Use tools when needed.
                 updated_by_type: autonoetic_types::principal::PrincipalKind::Human.tag().to_string(),
                 updated_by_id: "operator".to_string(),
                 reason: Some("initial seed".to_string()),
+                suspended_at: None,
+                suspended_reason: None,
+                suspended_by: None,
             })
             .expect("alias should upsert");
         store
@@ -2821,6 +2825,7 @@ Use tools when needed.
                 created_by_type: "human".to_string(),
                 created_by_id: "operator".to_string(),
                 origin_node_id: "gateway".to_string(),
+                pre_authorization: None,
             })
             .expect("promotion history should insert");
 
@@ -2893,6 +2898,9 @@ Use tools when needed.
                 updated_by_type: autonoetic_types::principal::PrincipalKind::Human.tag().to_string(),
                 updated_by_id: "operator".to_string(),
                 reason: Some("seed".to_string()),
+                suspended_at: None,
+                suspended_reason: None,
+                suspended_by: None,
             })
             .expect("alias insert should succeed");
 

--- a/autonoetic/tests/capsule_cli_e2e.rs
+++ b/autonoetic/tests/capsule_cli_e2e.rs
@@ -75,6 +75,9 @@ fn seed_revision(gateway_dir: &std::path::Path, agent_id: &str, revision_id: &st
         updated_by_type: PrincipalKind::Human.tag().to_string(),
         updated_by_id: "test".to_string(),
         reason: None,
+        suspended_at: None,
+        suspended_reason: None,
+        suspended_by: None,
     };
     store.upsert_agent_alias(&alias).unwrap();
 }


### PR DESCRIPTION
## Summary

Implements two interconnected safety mechanisms identified during analysis of the session capability envelope system:

### 1. Pre-authorization Persistence (migration v52)

Adds a `pre_authorization TEXT` column to `promotion_history` storing JSON like `{"method":"envelope","envelope_id":42,"rule":"P-2.27"}`. This ensures that after envelope revocation, the audit trail still records which promotions were authorized by which envelope.

- `find_promote_with_envelope_id()` returns the envelope ID (not just bool)
- `atomic_promote()` accepts optional `pre_authorization` parameter
- Promotion response includes `pre_authorized_by_envelope` and `pre_auth_rule` fields

### 2. Agent Suspension (migration v53)

Adds `suspended_at`, `suspended_reason`, `suspended_by` columns to `agent_aliases`. Provides a manual `agent.suspend` / `agent.unsuspend` RPC pair (decoupled from envelope revocation — an operator decision, not automatic).

- Dispatch blocked at `resolve_agent()` AliasId arm when suspended
- Re-promotion auto-clears suspension (`INSERT OR REPLACE` sets fields to NULL)
- In-flight sessions via `resolve_and_pin_session()` get a grace period (early return before suspension check)

### Testing

- Build passes with 0 errors
- 34 key tests pass: promotion_governor (13), session_envelope_promote_with (5), phase2_promotion_stability (8), plan_frame (8)