### PR TITLE
fix(envelope): suspension hardening, PromoteWith timeline legibility, wildcard hosts

### DIFF
--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -61,14 +61,13 @@ pub fn materialize_network_grant(
     // A declared `*.example.com` is a subdomain wildcard, not a literal host:
     // materialize it as `HostSuffix` so it actually matches subdomains rather
     // than becoming a dead `ExactHost("*.example.com")` that never fires.
+    // `HostSuffix` stores the canonical bare suffix (the CLI prepends `*.` on
+    // display and `matches()` trims it), so strip the leading `*.` here.
     let targets: Vec<GrantTarget> = concrete
         .iter()
-        .map(|h| {
-            if h.starts_with("*.") {
-                GrantTarget::HostSuffix(h.clone())
-            } else {
-                GrantTarget::ExactHost(h.clone())
-            }
+        .map(|h| match h.strip_prefix("*.") {
+            Some(suffix) => GrantTarget::HostSuffix(suffix.to_string()),
+            None => GrantTarget::ExactHost(h.clone()),
         })
         .collect();
     let grant_agent = agent_id.unwrap_or(root_session_id);
@@ -741,6 +740,16 @@ mod tests {
         assert!(
             store.session_grants_cover_targets(root, &["api.example.com".to_string()]),
             "subdomain wildcard grant should cover a concrete subdomain"
+        );
+        // Stored as the canonical bare suffix (CLI prepends `*.` on display).
+        let grants = store.get_session_grants_structured(root)?;
+        assert!(
+            grants.iter().flat_map(|g| &g.targets).any(|t| matches!(
+                t,
+                GrantTarget::HostSuffix(s) if s == "example.com"
+            )),
+            "wildcard host should be stored as HostSuffix(\"example.com\"), got: {:?}",
+            grants.iter().map(|g| &g.targets).collect::<Vec<_>>()
         );
         Ok(())
     }

--- a/autonoetic-gateway/src/runtime/session_envelope.rs
+++ b/autonoetic-gateway/src/runtime/session_envelope.rs
@@ -58,9 +58,18 @@ pub fn materialize_network_grant(
     if concrete.is_empty() {
         return 0;
     }
+    // A declared `*.example.com` is a subdomain wildcard, not a literal host:
+    // materialize it as `HostSuffix` so it actually matches subdomains rather
+    // than becoming a dead `ExactHost("*.example.com")` that never fires.
     let targets: Vec<GrantTarget> = concrete
         .iter()
-        .map(|h| GrantTarget::ExactHost(h.clone()))
+        .map(|h| {
+            if h.starts_with("*.") {
+                GrantTarget::HostSuffix(h.clone())
+            } else {
+                GrantTarget::ExactHost(h.clone())
+            }
+        })
         .collect();
     let grant_agent = agent_id.unwrap_or(root_session_id);
     if let Err(e) = store.insert_session_grant(
@@ -227,6 +236,14 @@ pub fn propose_promote_with_envelope(
     if capabilities.is_empty() {
         return Ok(None);
     }
+    // An empty agent_id is the wildcard ("any agent") form, which is reserved
+    // for deliberate operator action — the automated proposal path must always
+    // bind the proposal to a concrete agent.
+    if agent_id.is_empty() {
+        return Err(anyhow!(
+            "PromoteWith proposal requires a non-empty agent_id"
+        ));
+    }
     if capabilities.iter().any(|c| matches!(c, Capability::PromoteWith { .. })) {
         return Err(anyhow!(
             "PromoteWith capabilities cannot contain nested PromoteWith"
@@ -259,6 +276,7 @@ pub fn propose_promote_with_envelope(
         source,
         actor_id,
         None,
+        Some(&promote_with),
     );
     Ok(Some(envelope_id))
 }
@@ -365,7 +383,7 @@ pub fn propose_discovered_envelope(
         &now,
     )?;
 
-    emit_envelope_proposed_timeline(store, root_session_id, envelope_id, &hosts, source, actor_id, plan_id);
+    emit_envelope_proposed_timeline(store, root_session_id, envelope_id, &hosts, source, actor_id, plan_id, Some(&capabilities[0]));
 
     Ok(Some(EnvelopeProposalResult {
         envelope_id,
@@ -436,7 +454,7 @@ pub fn propose_envelope_from_capabilities(
             );
         }
     }
-    emit_envelope_proposed_timeline(store, root_session_id, envelope_id, &hosts, source, actor_id, plan_id);
+    emit_envelope_proposed_timeline(store, root_session_id, envelope_id, &hosts, source, actor_id, plan_id, Some(&network_capability));
     Ok(Some(EnvelopeProposalResult {
         envelope_id,
         hosts,
@@ -587,12 +605,15 @@ fn emit_envelope_proposed_timeline(
     source: &str,
     actor_id: &str,
     plan_id: Option<&str>,
+    capability: Option<&Capability>,
 ) {
     let (principal, role) = crate::runtime::session_timeline::decider_seat(actor_id);
     let refs = TimelineRefs {
         plan_id: plan_id.map(str::to_string),
         ..Default::default()
     };
+    // Surface the proposed capability (esp. PromoteWith, whose `hosts` is empty)
+    // so the operator deciding the lock sees exactly what they would bless.
     let event = crate::runtime::session_timeline::build_timeline_event(
         root_session_id.to_string(),
         root_session_id.to_string(),
@@ -605,6 +626,7 @@ fn emit_envelope_proposed_timeline(
             "envelope_id": envelope_id,
             "hosts": hosts,
             "source": source,
+            "capability": capability,
         })),
         refs,
     );
@@ -637,6 +659,7 @@ fn emit_envelope_locked_timeline(
             "envelope_id": record.id,
             "hosts": hosts,
             "source": record.source,
+            "capability": record.capability,
             "grants_materialized": grants_materialized,
             "locked_by": locked_by,
         })),
@@ -696,6 +719,53 @@ mod tests {
         let lock = lock_session_envelope(&store, proposal.envelope_id, "operator")?;
         assert_eq!(lock.grants_materialized, 1);
         assert!(store.session_grants_cover_targets(root, &["api.open-meteo.com".to_string()]));
+        Ok(())
+    }
+
+    #[test]
+    fn wildcard_host_materializes_as_host_suffix_grant() -> Result<()> {
+        let dir = tempdir()?;
+        let store = GatewayStore::open(dir.path())?;
+        let root = "session-wildcard-host";
+
+        let caps = vec![Capability::NetworkAccess {
+            hosts: vec!["*.example.com".to_string()],
+        }];
+        let proposal =
+            propose_envelope_from_capabilities(&store, root, &caps, "plan:test", None, "operator")?
+                .expect("proposal");
+        let lock = lock_session_envelope(&store, proposal.envelope_id, "operator")?;
+        assert_eq!(lock.grants_materialized, 1);
+        // A subdomain wildcard must actually cover concrete subdomains, not be
+        // dropped as a dead ExactHost("*.example.com").
+        assert!(
+            store.session_grants_cover_targets(root, &["api.example.com".to_string()]),
+            "subdomain wildcard grant should cover a concrete subdomain"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn propose_promote_with_rejects_empty_agent_id() -> Result<()> {
+        let dir = tempdir()?;
+        let store = GatewayStore::open(dir.path())?;
+        let root = "session-empty-agent";
+
+        let err = propose_promote_with_envelope(
+            &store,
+            root,
+            "",
+            &[Capability::ReadAccess {
+                scopes: vec!["self.*".to_string()],
+            }],
+            "test",
+            "operator",
+        )
+        .expect_err("empty agent_id should be rejected");
+        assert!(
+            err.to_string().contains("non-empty agent_id"),
+            "unexpected error: {err}"
+        );
         Ok(())
     }
 

--- a/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
+++ b/autonoetic-gateway/src/scheduler/gateway_store/agent_registry.rs
@@ -487,7 +487,25 @@ impl GatewayStore {
 
         let now = chrono::Utc::now().to_rfc3339();
 
-        // Clear any suspension when promoting — re-promotion = implicit unsuspend.
+        // Operator re-promotion clears suspension — re-promotion = implicit
+        // unsuspend. But an envelope-pre-authorized promotion is automatic (no
+        // fresh operator decision), so it must NOT silently reactivate a
+        // suspended agent: preserve the suspension in that case.
+        let (suspended_at, suspended_reason, suspended_by): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = if pre_authorization.is_some() {
+            tx.query_row(
+                "SELECT suspended_at, suspended_reason, suspended_by FROM agent_aliases WHERE alias_id = ?1",
+                params![agent_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?
+            .unwrap_or((None, None, None))
+        } else {
+            (None, None, None)
+        };
         tx.execute(
             "INSERT OR REPLACE INTO agent_aliases (
                 alias_id, agent_id, revision_id, updated_at, updated_by_type, updated_by_id, reason,
@@ -501,9 +519,9 @@ impl GatewayStore {
                 created_by_type,
                 created_by_id,
                 reason,
-                None::<&str>, // suspended_at — cleared
-                None::<&str>, // suspended_reason — cleared
-                None::<&str>, // suspended_by — cleared
+                suspended_at,
+                suspended_reason,
+                suspended_by,
             ],
         )?;
 

--- a/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
+++ b/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
@@ -365,3 +365,71 @@ fn test_promotion_fails_for_mismatched_alias_and_agent() {
         "unexpected error: {err}"
     );
 }
+
+/// An envelope-pre-authorized promotion is automatic (no fresh operator
+/// decision), so it must not silently un-suspend a suspended agent. A normal
+/// operator re-promotion (no pre-authorization) still clears suspension.
+#[test]
+fn envelope_preauthorized_promotion_preserves_suspension() {
+    let (_tmp, store, _repo) = setup_store_and_repo();
+    let agent_id = "planner.default";
+    let rev1 = make_revision(
+        agent_id,
+        "1111111111111111111111111111111111111111111111111111111111111111",
+    );
+    let rev2 = make_revision(
+        agent_id,
+        "2222222222222222222222222222222222222222222222222222222222222222",
+    );
+    let rev3 = make_revision(
+        agent_id,
+        "3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    store.insert_agent_revision(&rev1).unwrap();
+    store.insert_agent_revision(&rev2).unwrap();
+    store.insert_agent_revision(&rev3).unwrap();
+    upsert_alias(store.as_ref(), agent_id, &rev1.revision_id, "initial");
+
+    // Operator suspends the agent.
+    assert!(store
+        .suspend_agent(agent_id, "operator", Some("under review"))
+        .unwrap());
+
+    // Envelope pre-authorized promotion (pre_authorization = Some) preserves it.
+    store
+        .atomic_promote(
+            agent_id,
+            &rev2.revision_id,
+            "prom-preauth",
+            "gateway",
+            "gateway",
+            Some("envelope pre-auth"),
+            None,
+            Some(r#"{"method":"envelope","envelope_id":7,"rule":"P-2.27"}"#),
+        )
+        .unwrap();
+    let alias = store.resolve_alias(agent_id).unwrap().expect("alias");
+    assert!(
+        alias.suspended_at.is_some(),
+        "envelope-pre-authorized promotion must NOT clear suspension"
+    );
+
+    // Plain operator re-promotion (pre_authorization = None) clears it.
+    store
+        .atomic_promote(
+            agent_id,
+            &rev3.revision_id,
+            "prom-operator",
+            "human",
+            "operator",
+            Some("operator re-promote"),
+            None,
+            None,
+        )
+        .unwrap();
+    let alias = store.resolve_alias(agent_id).unwrap().expect("alias");
+    assert!(
+        alias.suspended_at.is_none(),
+        "operator re-promotion (no pre-auth) clears suspension"
+    );
+}


### PR DESCRIPTION
## Summary

Four follow-ups from the post-merge review of the session capability envelope cluster (#507–#512). Each is independently scoped and low-risk.

1. **Suspension preserved on envelope-pre-authorized promotion** (`atomic_promote`)
   `atomic_promote` previously NULLed `suspended_*` unconditionally. When a locked `PromoteWith` envelope covers an agent, the capability-ack gate is auto-skipped — so the promotion would *silently un-suspend* a suspended agent with no fresh operator action, contradicting #512's "suspend is an operator decision, not automatic." Now: a promotion carrying `pre_authorization` (envelope) **preserves** suspension; a plain operator re-promotion (no pre-auth) still clears it.

2. **PromoteWith capabilities surfaced on the timeline** (`session_envelope`)
   `PromoteWith` proposals emitted `envelope.proposed` with empty hosts and no capability detail, yet locking one is what lets a brand-new agent's full capability set skip the operator ack. The `envelope.proposed` / `envelope.locked` payloads now include the proposed `capability`, so the operator deciding the lock sees exactly what they would bless.

3. **Subdomain wildcard hosts honored** (`materialize_network_grant`)
   A declared `*.example.com` was materialized as `ExactHost("*.example.com")`, a dead grant that never matches a concrete request. It is now mapped to `GrantTarget::HostSuffix`, which covers subdomains. Bare `*` is still stripped by `concrete_hosts` (too broad to auto-materialize).

4. **Empty `agent_id` rejected on the automated PromoteWith path** (`propose_promote_with_envelope`)
   The empty-`agent_id` ("any agent") wildcard is an **intended operator** feature (tested by `any_matching_locked_promote_with_preauthorizes`) but should never be reachable from the automated proposal path. `propose_promote_with_envelope` now rejects an empty `agent_id`; the matcher wildcard is left intact.

## Out of scope (left as design decisions)
- Suspension is bypassed by **explicit revision refs** (`agent@rev_…`, no check in `resolve_agent`'s `ExplicitRef` arm) and by **in-flight pinned sessions** (intentional grace period). These affect evaluation flows and need owner direction — not changed here.

## Test plan
- [x] `cargo test -p autonoetic-gateway --lib session_envelope` (12, incl. new `wildcard_host_materializes_as_host_suffix_grant`, `propose_promote_with_rejects_empty_agent_id`)
- [x] `cargo test -p autonoetic-gateway --test phase2_promotion_stability_integration` (5, incl. new `envelope_preauthorized_promotion_preserves_suspension`)
- [x] `session_envelope_promote_with_integration`, `session_envelope_locking_integration`, `session_envelope_discovery_integration`, `plan_frame_integration`, `constitution_p_2_27_session_envelope`, `promotion_governor_integration` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Closes #515, #516, #517. Partially addresses #514 (remaining explicit-ref / in-flight-session bypass left as design decisions).