### PR TITLE
fix(suspension): enforce 'no new session' at the spawn boundary, keep suspended agents readable (#514)

### DIFF
--- a/autonoetic-gateway/src/agent/repository.rs
+++ b/autonoetic-gateway/src/agent/repository.rs
@@ -338,16 +338,11 @@ impl AgentRepository {
                     ),
                 };
 
-                // Check if the agent is suspended — block dispatch.
-                if let Some(ref suspended_at) = alias.suspended_at {
-                    let reason = alias.suspended_reason.as_deref().unwrap_or("no reason given");
-                    let by = alias.suspended_by.as_deref().unwrap_or("unknown");
-                    anyhow::bail!(
-                        "Agent '{}' is suspended (since {}) by {}: {}. \
-                         Unsuspend or re-promote the agent before dispatching.",
-                        alias_id, suspended_at, by, reason,
-                    );
-                }
+                // NOTE: suspension is intentionally NOT checked here. Resolving
+                // an agent is read-only (evaluation/diff of a suspended agent
+                // must remain possible so an operator can decide whether to
+                // lift the suspension). The "no new session" gate lives at the
+                // session-start boundary in `resolve_and_pin_session`.
 
                 let rev = match gateway_store.get_agent_revision(&alias.revision_id)? {
                     Some(r) => r,
@@ -398,6 +393,27 @@ impl AgentRepository {
         }
 
         let (agent_ref, rev) = self.resolve_agent(target, gateway_store)?;
+
+        // No-new-session gate: a suspended agent must not start a *new* session,
+        // regardless of how it was addressed (alias OR explicit `agent@rev_…`
+        // ref). Already-running sessions are unaffected — they returned above
+        // via the existing-binding grace period. Keyed on the resolved
+        // agent_id's alias, so suspending the agent blocks spawning any of its
+        // revisions. (Read-only resolution in `resolve_agent` stays open.)
+        if let Some(gs) = gateway_store {
+            if let Some(alias) = gs.resolve_alias(&agent_ref.agent_id)? {
+                if let Some(ref suspended_at) = alias.suspended_at {
+                    let reason = alias.suspended_reason.as_deref().unwrap_or("no reason given");
+                    let by = alias.suspended_by.as_deref().unwrap_or("unknown");
+                    anyhow::bail!(
+                        "Agent '{}' is suspended (since {}) by {}: {}. \
+                         No new session can be started; unsuspend or re-promote \
+                         the agent first.",
+                        agent_ref.agent_id, suspended_at, by, reason,
+                    );
+                }
+            }
+        }
 
         // Determine alias_id from shared target parsing: explicit refs bypass aliases.
         let alias_id = match parse_agent_target(target) {

--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2126,6 +2126,109 @@ impl JsonRpcRouter {
                 }
             }
 
+            // Suspend an agent: block new sessions while leaving in-flight
+            // sessions running. An operator decision, decoupled from envelope
+            // revocation. Read-only resolution stays open.
+            "agent.suspend" => {
+                #[derive(Deserialize)]
+                struct SuspendParams {
+                    agent_id: String,
+                    #[serde(default)]
+                    reason: Option<String>,
+                    #[serde(default = "default_suspended_by")]
+                    suspended_by: String,
+                }
+                fn default_suspended_by() -> String {
+                    "operator".to_string()
+                }
+                let params: SuspendParams = match serde_json::from_value(req.params) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for agent.suspend: {}", e),
+                        );
+                    }
+                };
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                match store.suspend_agent(
+                    &params.agent_id,
+                    &params.suspended_by,
+                    params.reason.as_deref(),
+                ) {
+                    Ok(changed) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::json!({
+                            "ok": true,
+                            "agent_id": params.agent_id,
+                            // false when the agent was already suspended or has
+                            // no promoted alias to suspend.
+                            "suspended": changed,
+                        }),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("agent.suspend failed: {}", e),
+                    ),
+                }
+            }
+
+            // Lift a suspension. Re-promotion also clears it (unless the
+            // promotion was envelope-pre-authorized); this is the explicit lever.
+            "agent.unsuspend" => {
+                #[derive(Deserialize)]
+                struct UnsuspendParams {
+                    agent_id: String,
+                }
+                let params: UnsuspendParams = match serde_json::from_value(req.params) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for agent.unsuspend: {}", e),
+                        );
+                    }
+                };
+                let store = match self.execution.gateway_store() {
+                    Some(s) => s,
+                    None => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            "Gateway store not available".to_string(),
+                        );
+                    }
+                };
+                match store.unsuspend_agent(&params.agent_id) {
+                    Ok(changed) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::json!({
+                            "ok": true,
+                            "agent_id": params.agent_id,
+                            // false when the agent was not suspended.
+                            "unsuspended": changed,
+                        }),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("agent.unsuspend failed: {}", e),
+                    ),
+                }
+            }
+
             // Session fork - fork a session from a snapshot
             "session.fork" => {
                 #[derive(Deserialize)]

--- a/autonoetic-gateway/tests/agent_suspend_rpc_integration.rs
+++ b/autonoetic-gateway/tests/agent_suspend_rpc_integration.rs
@@ -1,0 +1,138 @@
+//! `agent.suspend` / `agent.unsuspend` JSON-RPC operator surface (#514).
+//!
+//! These methods are what lets an operator actually invoke the suspension
+//! lever; the enforcement (no new session, in-flight survives, read stays
+//! open) is covered in `phase2_promotion_stability_integration`.
+
+mod support;
+
+use autonoetic_gateway::router::{JsonRpcRequest, JsonRpcRouter};
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent_revision::AgentAliasRecord;
+use autonoetic_types::principal::PrincipalKind;
+use std::sync::{Arc, OnceLock};
+use support::TestWorkspace;
+
+struct SharedEnv {
+    _ws: TestWorkspace,
+    store: Arc<GatewayStore>,
+    router: JsonRpcRouter,
+}
+
+static SHARED: OnceLock<SharedEnv> = OnceLock::new();
+
+// `JsonRpcRouter::new` initializes the process-global constitution runtime,
+// which can only happen once per process — so all tests share one router.
+fn shared() -> &'static SharedEnv {
+    SHARED.get_or_init(|| {
+        let ws = TestWorkspace::new().expect("workspace");
+        let store = Arc::new(GatewayStore::open(ws.path()).expect("store open"));
+        let router = JsonRpcRouter::new(ws.gateway_config(), Some(store.clone()));
+        SharedEnv {
+            _ws: ws,
+            store,
+            router,
+        }
+    })
+}
+
+fn make_jsonrpc(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: "suspend-test".to_string(),
+        method: method.to_string(),
+        params,
+        auth_token: None,
+    }
+}
+
+fn seed_alias(store: &GatewayStore, alias_id: &str) {
+    store
+        .upsert_agent_alias(&AgentAliasRecord {
+            alias_id: alias_id.to_string(),
+            agent_id: alias_id.to_string(),
+            revision_id: "rev_seed".to_string(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            updated_by_type: PrincipalKind::Human.tag().to_string(),
+            updated_by_id: "test".to_string(),
+            reason: None,
+            suspended_at: None,
+            suspended_reason: None,
+            suspended_by: None,
+        })
+        .unwrap();
+}
+
+#[tokio::test]
+async fn agent_suspend_unsuspend_rpc_roundtrip() {
+    let env = shared();
+    let store = &env.store;
+    let router = &env.router;
+    let agent_id = "roundtrip.agent";
+    seed_alias(store, agent_id);
+
+    // Suspend → changes the row.
+    let resp = router
+        .dispatch(make_jsonrpc(
+            "agent.suspend",
+            serde_json::json!({ "agent_id": agent_id, "reason": "over-privileged", "suspended_by": "operator" }),
+        ))
+        .await;
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let r = resp.result.expect("result");
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["suspended"], true);
+
+    // Suspension is persisted with attribution.
+    let alias = store.resolve_alias(agent_id).unwrap().expect("alias");
+    assert!(alias.suspended_at.is_some());
+    assert_eq!(alias.suspended_reason.as_deref(), Some("over-privileged"));
+    assert_eq!(alias.suspended_by.as_deref(), Some("operator"));
+
+    // Suspending again is a no-op (idempotent).
+    let resp = router
+        .dispatch(make_jsonrpc(
+            "agent.suspend",
+            serde_json::json!({ "agent_id": agent_id }),
+        ))
+        .await;
+    assert_eq!(resp.result.expect("result")["suspended"], false);
+
+    // Unsuspend → clears it.
+    let resp = router
+        .dispatch(make_jsonrpc(
+            "agent.unsuspend",
+            serde_json::json!({ "agent_id": agent_id }),
+        ))
+        .await;
+    let r = resp.result.expect("result");
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["unsuspended"], true);
+    assert!(store.resolve_alias(agent_id).unwrap().unwrap().suspended_at.is_none());
+
+    // Unsuspending again is a no-op.
+    let resp = router
+        .dispatch(make_jsonrpc(
+            "agent.unsuspend",
+            serde_json::json!({ "agent_id": agent_id }),
+        ))
+        .await;
+    assert_eq!(resp.result.expect("result")["unsuspended"], false);
+}
+
+#[tokio::test]
+async fn agent_suspend_unknown_agent_is_noop() {
+    let env = shared();
+    let router = &env.router;
+
+    let resp = router
+        .dispatch(make_jsonrpc(
+            "agent.suspend",
+            serde_json::json!({ "agent_id": "does.not.exist" }),
+        ))
+        .await;
+    // No alias to suspend → ok, but nothing changed (not an error).
+    let r = resp.result.expect("result");
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["suspended"], false);
+}

--- a/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
+++ b/autonoetic-gateway/tests/phase2_promotion_stability_integration.rs
@@ -433,3 +433,103 @@ fn envelope_preauthorized_promotion_preserves_suspension() {
         "operator re-promotion (no pre-auth) clears suspension"
     );
 }
+
+/// Helper: a promoted agent with one revision, then suspended.
+fn setup_suspended_agent() -> (TempDir, Arc<GatewayStore>, AgentRepository, String, AgentRevisionRecord)
+{
+    let (tmp, store, repo) = setup_store_and_repo();
+    let agent_id = "planner.default".to_string();
+    let rev = make_revision(
+        &agent_id,
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    );
+    store.insert_agent_revision(&rev).unwrap();
+    upsert_alias(store.as_ref(), &agent_id, &rev.revision_id, "initial");
+    assert!(store
+        .suspend_agent(&agent_id, "operator", Some("over-privileged"))
+        .unwrap());
+    (tmp, store, repo, agent_id, rev)
+}
+
+#[test]
+fn suspended_agent_cannot_start_new_session_via_alias() {
+    let (_tmp, store, repo, agent_id, _rev) = setup_suspended_agent();
+    let err = repo
+        .resolve_and_pin_session(
+            "session-new-alias",
+            "session-new-alias",
+            &agent_id,
+            Some(store.as_ref()),
+            "host:test",
+        )
+        .expect_err("suspended agent must not start a new session via alias");
+    assert!(err.to_string().contains("suspended"), "unexpected: {err}");
+}
+
+#[test]
+fn suspended_agent_cannot_start_new_session_via_explicit_ref() {
+    let (_tmp, store, repo, agent_id, rev) = setup_suspended_agent();
+    // Explicit revision ref bypasses the alias — the gate must still fire,
+    // keyed on the resolved agent_id.
+    let explicit_target = format!("{agent_id}@{}", rev.revision_id);
+    let err = repo
+        .resolve_and_pin_session(
+            "session-new-explicit",
+            "session-new-explicit",
+            &explicit_target,
+            Some(store.as_ref()),
+            "host:test",
+        )
+        .expect_err("suspended agent must not start a new session via explicit ref");
+    assert!(err.to_string().contains("suspended"), "unexpected: {err}");
+}
+
+#[test]
+fn suspended_agent_remains_readable() {
+    let (_tmp, store, repo, agent_id, rev) = setup_suspended_agent();
+    // Read-only resolution (evaluation/diff) must succeed while suspended so an
+    // operator can decide whether to lift the suspension.
+    let (agent_ref, _rev) = repo
+        .resolve_agent(&agent_id, Some(store.as_ref()))
+        .expect("resolving a suspended agent for read must succeed");
+    assert_eq!(agent_ref.revision_id, rev.revision_id);
+}
+
+#[test]
+fn running_session_survives_agent_suspension() {
+    let (_tmp, store, repo) = setup_store_and_repo();
+    let agent_id = "planner.default";
+    let rev = make_revision(
+        agent_id,
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    );
+    store.insert_agent_revision(&rev).unwrap();
+    upsert_alias(store.as_ref(), agent_id, &rev.revision_id, "initial");
+
+    // Session starts before suspension and pins its binding.
+    repo.resolve_and_pin_session(
+        "session-running",
+        "session-running",
+        agent_id,
+        Some(store.as_ref()),
+        "host:test",
+    )
+    .unwrap();
+
+    // Operator suspends the agent mid-flight.
+    assert!(store
+        .suspend_agent(agent_id, "operator", Some("over-privileged"))
+        .unwrap());
+
+    // The already-running session keeps resolving via its existing binding.
+    let (agent_ref, _rev, _binding) = repo
+        .resolve_and_pin_session(
+            "session-running",
+            "session-running",
+            agent_id,
+            Some(store.as_ref()),
+            "host:test",
+        )
+        .expect("in-flight session must survive suspension (grace period)");
+    assert_eq!(agent_ref.revision_id, rev.revision_id);
+}

--- a/autonoetic/src/cli/agent.rs
+++ b/autonoetic/src/cli/agent.rs
@@ -807,6 +807,53 @@ pub fn handle_agent_alias(config_path: &Path, command: &AgentAliasCommands) -> a
                 }
             }
         }
+        AgentAliasCommands::Suspend {
+            alias_id,
+            reason,
+            by,
+            json,
+        } => {
+            // Confirm the alias exists for a clearer error than a silent no-op.
+            if store.resolve_alias(alias_id)?.is_none() {
+                anyhow::bail!("Alias '{}' not found. Promote a revision first.", alias_id);
+            }
+            let changed = store.suspend_agent(alias_id, by, reason.as_deref())?;
+            if *json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "alias_id": alias_id,
+                        "suspended": changed,
+                    }))?
+                );
+            } else if changed {
+                println!(
+                    "Agent '{}' suspended. In-flight sessions keep running; no new session can start until unsuspended or re-promoted.",
+                    alias_id
+                );
+            } else {
+                println!("Agent '{}' was already suspended; no change.", alias_id);
+            }
+        }
+        AgentAliasCommands::Unsuspend { alias_id, json } => {
+            if store.resolve_alias(alias_id)?.is_none() {
+                anyhow::bail!("Alias '{}' not found. Promote a revision first.", alias_id);
+            }
+            let changed = store.unsuspend_agent(alias_id)?;
+            if *json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "alias_id": alias_id,
+                        "unsuspended": changed,
+                    }))?
+                );
+            } else if changed {
+                println!("Agent '{}' unsuspended; it can start new sessions again.", alias_id);
+            } else {
+                println!("Agent '{}' was not suspended; no change.", alias_id);
+            }
+        }
     }
     Ok(())
 }

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -988,6 +988,29 @@ pub enum AgentAliasCommands {
         #[arg(long)]
         json: bool,
     },
+    /// Suspend an agent: block new sessions while leaving in-flight sessions
+    /// running. Read-only resolution (evaluation/diff) stays available.
+    Suspend {
+        /// Alias ID to suspend (MVP default alias is agent_id)
+        alias_id: String,
+        /// Why the agent is being suspended (recorded on the alias)
+        #[arg(long)]
+        reason: Option<String>,
+        /// Who is suspending (recorded on the alias)
+        #[arg(long, default_value = "operator")]
+        by: String,
+        /// Emit machine-readable JSON output
+        #[arg(long)]
+        json: bool,
+    },
+    /// Lift a suspension so the agent can start new sessions again.
+    Unsuspend {
+        /// Alias ID to unsuspend (MVP default alias is agent_id)
+        alias_id: String,
+        /// Emit machine-readable JSON output
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -425,6 +425,33 @@ Inspect one alias and its active revision details.
 autonoetic agent alias inspect <alias_id> [--json]
 ```
 
+### `autonoetic agent alias suspend`
+
+Suspend an agent: block new sessions while leaving in-flight sessions running.
+Read-only resolution (evaluation/diff) stays available, so an operator can keep
+inspecting a suspended agent to decide whether to lift it. Use when an already
+promoted agent is found to hold too much capability — pair with
+`session.envelope.revoke` to also strip its auto-approved grants.
+
+```bash
+autonoetic agent alias suspend <alias_id> [--reason <TEXT>] [--by <WHO>] [--json]
+```
+
+- Idempotent: suspending an already-suspended agent reports no change.
+- Re-promotion lifts the suspension automatically — unless the promotion was
+  pre-authorized by a locked session envelope.
+
+### `autonoetic agent alias unsuspend`
+
+Lift a suspension so the agent can start new sessions again.
+
+```bash
+autonoetic agent alias unsuspend <alias_id> [--json]
+```
+
+> Over the gateway API these map to the `agent.suspend` / `agent.unsuspend`
+> JSON-RPC methods.
+
 ### `autonoetic agent promotion-history`
 
 Inspect durable promote/rollback history.


### PR DESCRIPTION
## Summary

Realizes the intended agent-suspension model — **don't kill running sessions, block new ones** — closes the explicit-ref bypass tracked in #514, and wires the operator surface that was missing.

### 1. Enforce "no new session" at the spawn boundary
Previously the suspension block lived only in `resolve_agent`'s `AliasId` arm:
- a **new session via an explicit `agent@rev_…` ref** bypassed it, and
- **read-only resolution** of a suspended agent (evaluation/diff) was wrongly refused.

The gate now lives at the **session-start boundary** (`resolve_and_pin_session`), keyed on the *resolved* `agent_id`'s alias:
- fires for **both** alias and explicit-ref spawns → the "no new session" guarantee holds regardless of addressing;
- `resolve_agent` read paths stay **un-gated** → a suspended agent remains readable (per maintainer decision), so an operator can evaluate it to decide whether to lift the suspension;
- the in-flight grace period is unchanged → already-running sessions survive a mid-flight suspension.

### 2. Wire the operator surface (was missing entirely)
`GatewayStore::suspend_agent` / `unsuspend_agent` had **no production caller** — no RPC, no CLI — so nothing could set `suspended_at` and the enforcement was dormant. Now:
- **RPC:** `agent.suspend` `{ agent_id, reason?, suspended_by? }` and `agent.unsuspend` `{ agent_id }`, returning whether the row changed (idempotent no-op otherwise).
- **CLI:** `autonoetic agent alias suspend|unsuspend` (mirrors `alias list`/`inspect`, talks to the store directly).
- **docs/CLI.md** updated.

## Test plan
- [x] `phase2_promotion_stability_integration` (9): new-session refused via alias **and** explicit ref; suspended agent still readable; running session survives suspension; envelope-pre-auth promotion preserves suspension.
- [x] `agent_suspend_rpc_integration` (2): suspend/unsuspend round-trip with attribution persisted + idempotent/unknown-agent no-ops.
- [x] `agent::repository` unit, `full_lifecycle_integration`, `session_fork_integration`, `protected_agents_promotion_gate_integration` — green.

Partially addresses #514 (the in-flight-session grace period is intended behavior and is kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)