### PR TITLE
feat(room): operator live file comments (file-anchored, next-turn, comment-only)

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2730,6 +2730,199 @@ impl JsonRpcRouter {
                 }
             }
 
+            // Attach an operator comment to a live content file (file-level +
+            // optional line hint), record it on the timeline, and deliver it to
+            // the owning agent at its next turn. Comment-only — never mutates
+            // agent state. See `docs/design/operator-live-comments.md`.
+            "content.comment" => {
+                #[derive(Deserialize)]
+                struct ContentCommentParams {
+                    session_id: String,
+                    name: String,
+                    /// The content version the operator was viewing (anchor).
+                    /// Omitted → anchor to the current version.
+                    #[serde(default)]
+                    handle: Option<String>,
+                    #[serde(default)]
+                    line_start: Option<u32>,
+                    #[serde(default)]
+                    line_end: Option<u32>,
+                    body: String,
+                    #[serde(default = "default_commented_by")]
+                    commented_by: String,
+                }
+                fn default_commented_by() -> String {
+                    "operator".to_string()
+                }
+
+                let id = req.id.clone();
+                let auth_token = req.auth_token.clone();
+                let params: ContentCommentParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            id,
+                            -32602,
+                            format!("Invalid params for content.comment: {}", e),
+                        );
+                    }
+                };
+
+                if params.body.trim().is_empty() {
+                    return JsonRpcResponse::error(
+                        id,
+                        -32602,
+                        "content.comment requires a non-empty body".to_string(),
+                    );
+                }
+                if let (Some(s), Some(e)) = (params.line_start, params.line_end) {
+                    if e < s {
+                        return JsonRpcResponse::error(
+                            id,
+                            -32602,
+                            format!(
+                                "content.comment line_end ({e}) precedes line_start ({s})"
+                            ),
+                        );
+                    }
+                }
+
+                let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
+                let store = match crate::runtime::content_store::ContentStore::new(&gateway_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            id,
+                            -32000,
+                            format!("content store open failed: {}", e),
+                        );
+                    }
+                };
+                // Resolve the current version. A comment must reference a name
+                // that actually exists in the session.
+                let current_handle = match store
+                    .resolve_name_or_handle_to_handle(&params.session_id, &params.name)
+                {
+                    Ok(h) => h,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            id,
+                            -32000,
+                            format!("content.comment resolve failed: {}", e),
+                        );
+                    }
+                };
+                // Anchor to the viewed version; flag drift when the file has
+                // moved on since then.
+                let anchor_handle =
+                    params.handle.clone().unwrap_or_else(|| current_handle.clone());
+                let drifted = anchor_handle != current_handle;
+
+                let comment_id = format!(
+                    "cmt_{}",
+                    &uuid::Uuid::new_v4().to_string().replace('-', "")[..12]
+                );
+                let redacted_body =
+                    crate::log_redaction::redact_text_for_logs(&params.body);
+
+                let line_hint = match (params.line_start, params.line_end) {
+                    (Some(s), Some(e)) if e != s => format!(", lines {s}–{e}"),
+                    (Some(s), _) => format!(", line {s}"),
+                    _ => String::new(),
+                };
+
+                // Presentation: operator.comment row on the canonical timeline
+                // (Attention) so every channel surfaces it.
+                if let Some(ts) = self.execution.gateway_store() {
+                    let payload = serde_json::json!({
+                        "comment_id": comment_id,
+                        "name": params.name,
+                        "handle": anchor_handle,
+                        "current_handle": current_handle,
+                        "drifted": drifted,
+                        "line_start": params.line_start,
+                        "line_end": params.line_end,
+                        "body": redacted_body,
+                    });
+                    let event = crate::runtime::session_timeline::operator_comment_event(
+                        &params.session_id,
+                        &params.commented_by,
+                        payload,
+                    );
+                    if let Err(e) = ts.create_live_digest_event(&event) {
+                        tracing::debug!(
+                            target: "session_timeline",
+                            error = %e,
+                            "operator.comment timeline emit failed"
+                        );
+                    }
+                }
+
+                // Delivery: frame the comment and hand it to the owning agent at
+                // its next turn via the existing event.ingest path. A distinct
+                // event_type ("operator_comment", not "chat") avoids emitting a
+                // duplicate operator.message row.
+                let mut framed = format!(
+                    "Operator comment on file `{}` (version {}{}):\n> {}",
+                    params.name,
+                    anchor_handle,
+                    line_hint,
+                    params.body.trim()
+                );
+                if drifted {
+                    framed.push_str(&format!(
+                        "\n[note: this file has changed since the commented version \
+                         (current {current_handle}); re-read the current version \
+                         before acting on the line numbers.]"
+                    ));
+                }
+                framed.push_str(
+                    "\nAcknowledge this operator comment, then either address it \
+                     (say how) or explain why not.",
+                );
+
+                let ingest_req = JsonRpcRequest {
+                    jsonrpc: "2.0".to_string(),
+                    id: id.clone(),
+                    method: "event.ingest".to_string(),
+                    params: serde_json::json!({
+                        "event_type": "operator_comment",
+                        "message": framed,
+                        "session_id": params.session_id,
+                        "async_mode": true,
+                        "metadata": {
+                            "source": "session_room",
+                            "kind": "operator_comment",
+                            "comment_id": comment_id,
+                            "name": params.name,
+                            "handle": anchor_handle,
+                            "current_handle": current_handle,
+                            "drifted": drifted,
+                        },
+                    }),
+                    auth_token,
+                };
+                let ingest_resp = Box::pin(self.dispatch(ingest_req)).await;
+                if let Some(err) = ingest_resp.error {
+                    return JsonRpcResponse::error(
+                        id,
+                        -32000,
+                        format!("content.comment delivery failed: {}", err.message),
+                    );
+                }
+
+                JsonRpcResponse::success(
+                    id,
+                    serde_json::json!({
+                        "ok": true,
+                        "comment_id": comment_id,
+                        "name": params.name,
+                        "handle": anchor_handle,
+                        "drifted": drifted,
+                    }),
+                )
+            }
+
             "gate.get_messages" => {
                 #[derive(Deserialize)]
                 struct GetMessagesParams {

--- a/autonoetic-gateway/src/runtime/session_timeline.rs
+++ b/autonoetic-gateway/src/runtime/session_timeline.rs
@@ -402,6 +402,38 @@ pub fn operator_message_event(
     )
 }
 
+/// Build the `operator.comment` timeline event — an operator comment anchored to
+/// a live content file (file-level + optional line hint). Attention altitude:
+/// the operator is flagging something they want addressed, so it must clear the
+/// default (Normal) floor. The `payload` carries the anchor + redacted body
+/// (built by the caller, which has the content handles). See
+/// `docs/design/operator-live-comments.md`.
+pub fn operator_comment_event(
+    session_id: &str,
+    commented_by: &str,
+    payload: serde_json::Value,
+) -> LiveDigestEventRecord {
+    let by = if commented_by.is_empty() {
+        "operator"
+    } else {
+        commented_by
+    };
+    let principal = Principal::human(by);
+    let role = SessionRole::Operator;
+    let root = crate::runtime::content_store::root_session_id(session_id);
+    build_timeline_event(
+        root.to_string(),
+        session_id.to_string(),
+        None,
+        &principal,
+        &role,
+        "operator.comment",
+        None, // derive: max(base=Attention, role_floor(Operator))
+        Some(payload),
+        TimelineRefs::default(),
+    )
+}
+
 /// Base importance of a digest event type, before any role refinement.
 /// Base importance for a timeline event type. The effective altitude written
 /// to a row is normally `max(base_altitude(et), role_floor(role))` (see
@@ -466,6 +498,7 @@ pub fn operator_message_event(
 /// | `approval.cancelled` | Normal | abandonment, not a decision |
 /// | `escalation.pending` | Attention | escalation gate request |
 /// | `user.ask.pending` | Attention | conversational clarification gate |
+/// | `operator.comment` | Attention | operator comment anchored to a live file — an issue the agent should address |
 /// | `wiki.proposed` / `wiki.promoted` / `wiki.rejected` | Attention | wiki-contribution gate lifecycle |
 /// | `wiki.withdrawn` | Normal | abandonment, not a decision |
 /// | `divergence.intervention` | Attention | sentinel intervention (emit site raises to Error when critical) |
@@ -496,6 +529,7 @@ pub fn base_altitude(event_type: &str) -> Altitude {
         | "approval.pending" | "approval.approved" | "approval.rejected"
         | "escalation.pending"
         | "user.ask.pending"
+        | "operator.comment"
         | "wiki.proposed" | "wiki.promoted" | "wiki.rejected"
         | "divergence.intervention"
         | "runtime.lock_drift"
@@ -897,6 +931,23 @@ mod tests {
         ] {
             assert_eq!(base_altitude(et), Altitude::Normal, "{et}");
         }
+    }
+
+    #[test]
+    fn operator_comment_is_attention_and_attributed() {
+        // An anchored operator comment flags an issue the agent should address;
+        // it must clear the Normal floor so a channel showing normal-and-above
+        // does not hide it.
+        assert_eq!(base_altitude("operator.comment"), Altitude::Attention);
+
+        let event = operator_comment_event(
+            "root-x/agent.coder",
+            "operator",
+            serde_json::json!({ "name": "config.yaml", "body": "secret here" }),
+        );
+        assert_eq!(event.event_type, "operator.comment");
+        assert_eq!(event.role.as_deref(), Some("operator"));
+        assert_eq!(event.altitude.as_deref(), Some("attention"));
     }
 
     #[test]

--- a/autonoetic-gateway/tests/content_comment_integration.rs
+++ b/autonoetic-gateway/tests/content_comment_integration.rs
@@ -1,0 +1,190 @@
+//! `content.comment` JSON-RPC — operator comments anchored to a live content
+//! file, recorded on the timeline and delivered to the owning agent at its next
+//! turn (#521). See `docs/design/operator-live-comments.md`.
+
+mod support;
+
+use autonoetic_gateway::router::{JsonRpcRequest, JsonRpcRouter};
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent_revision::SessionAgentBinding;
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+use support::TestWorkspace;
+
+struct Env {
+    _ws: TestWorkspace,
+    store: Arc<GatewayStore>,
+    router: JsonRpcRouter,
+    gateway_dir: PathBuf,
+}
+
+static SHARED: OnceLock<Env> = OnceLock::new();
+
+// `JsonRpcRouter::new` initializes the process-global constitution runtime once
+// per process, so all tests share a single router/env. Tests isolate via unique
+// session ids and content names.
+fn shared() -> &'static Env {
+    SHARED.get_or_init(|| {
+        let ws = TestWorkspace::new().expect("workspace");
+        let config = ws.gateway_config();
+        // gateway_root_dir(config) == agents_dir/.gateway (where the router's
+        // ContentStore lives); the passed-in GatewayStore is at ws.path().
+        let gateway_dir = ws.path().join("agents").join(".gateway");
+        let store = Arc::new(GatewayStore::open(ws.path()).expect("store open"));
+        let router = JsonRpcRouter::new(config, Some(store.clone()));
+        Env {
+            _ws: ws,
+            store,
+            router,
+            gateway_dir,
+        }
+    })
+}
+
+fn req(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: "cmt-test".to_string(),
+        method: method.to_string(),
+        params,
+        auth_token: None,
+    }
+}
+
+// Seed a session→agent binding so event.ingest target resolution succeeds.
+// (The background turn it spawns fails harmlessly — no real revision/LLM — but
+// content.comment returns as soon as the async ingest is accepted.)
+fn seed_binding(store: &GatewayStore, session_id: &str) {
+    store
+        .upsert_session_agent_binding(&SessionAgentBinding {
+            session_id: session_id.to_string(),
+            root_session_id: session_id.to_string(),
+            alias_id: Some("planner.default".to_string()),
+            agent_id: "planner.default".to_string(),
+            revision_id: "rev_seed".to_string(),
+            runtime_lock_hash: "sha256:seed".to_string(),
+            home_node_id: "gateway".to_string(),
+            created_at: "2026-06-15T00:00:00Z".to_string(),
+            requested_target: "planner.default".to_string(),
+        })
+        .unwrap();
+}
+
+async fn timeline_event_types(env: &Env, root: &str) -> Vec<String> {
+    let resp = env
+        .router
+        .dispatch(req(
+            "session.timeline.list",
+            serde_json::json!({ "root_session_id": root, "min_altitude": "detail", "limit": 200 }),
+        ))
+        .await;
+    resp.result
+        .and_then(|r| r["entries"].as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|e| e["event_type"].as_str().map(String::from))
+        .collect()
+}
+
+#[tokio::test]
+async fn content_comment_happy_path_acks_and_emits_timeline() {
+    let env = shared();
+    let root = "root-cmt-happy";
+    seed_binding(&env.store, root);
+
+    let cs = ContentStore::new(&env.gateway_dir).unwrap();
+    let handle = cs.write(b"port: 8080\nsecret: hunter2\n").unwrap();
+    cs.register_name(root, "config.yaml", &handle).unwrap();
+
+    let resp = env
+        .router
+        .dispatch(req(
+            "content.comment",
+            serde_json::json!({
+                "session_id": root,
+                "name": "config.yaml",
+                "handle": handle,
+                "line_start": 2,
+                "body": "you hardcoded a secret here",
+            }),
+        ))
+        .await;
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let r = resp.result.expect("result");
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["drifted"], false);
+    assert!(
+        r["comment_id"].as_str().unwrap_or("").starts_with("cmt_"),
+        "comment_id: {:?}",
+        r["comment_id"]
+    );
+
+    let types = timeline_event_types(env, root).await;
+    assert!(
+        types.iter().any(|t| t == "operator.comment"),
+        "expected an operator.comment timeline event, got: {types:?}"
+    );
+}
+
+#[tokio::test]
+async fn content_comment_flags_drift_when_file_changed() {
+    let env = shared();
+    let root = "root-cmt-drift";
+    seed_binding(&env.store, root);
+
+    let cs = ContentStore::new(&env.gateway_dir).unwrap();
+    let old = cs.write(b"v1\n").unwrap();
+    let new = cs.write(b"v2\n").unwrap();
+    // Name now points at the new version; the operator comments on the old one.
+    cs.register_name(root, "drift.txt", &new).unwrap();
+
+    let resp = env
+        .router
+        .dispatch(req(
+            "content.comment",
+            serde_json::json!({
+                "session_id": root,
+                "name": "drift.txt",
+                "handle": old,
+                "body": "this line looks wrong",
+            }),
+        ))
+        .await;
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    assert_eq!(resp.result.expect("result")["drifted"], true);
+}
+
+#[tokio::test]
+async fn content_comment_rejects_empty_body() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(req(
+            "content.comment",
+            serde_json::json!({ "session_id": "root-cmt-empty", "name": "x", "body": "   " }),
+        ))
+        .await;
+    let err = resp.error.expect("error");
+    assert_eq!(err.code, -32602, "{}", err.message);
+}
+
+#[tokio::test]
+async fn content_comment_unknown_name_is_error() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(req(
+            "content.comment",
+            serde_json::json!({
+                "session_id": "root-cmt-unknown",
+                "name": "does-not-exist.txt",
+                "body": "hello",
+            }),
+        ))
+        .await;
+    let err = resp.error.expect("error");
+    assert_eq!(err.code, -32000, "{}", err.message);
+}

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -670,6 +670,9 @@ struct ContentTree {
 /// `ArtifactFileView` but rendered through the markdown pipeline).
 struct ContentView {
     name: String,
+    /// Content version (SHA-256 handle) being viewed — the anchor for any
+    /// operator comment composed against this file.
+    handle: String,
     content: String,
     scroll: u16,
 }
@@ -1327,6 +1330,9 @@ pub fn run(
     let mut detail_h_scroll: u16 = 0; // horizontal scroll offset for detail pane
     let mut input: Option<GateInput> = None; // in-flight gate decision
     let mut compose: Option<ComposeInput> = None; // in-flight free-form message to the session
+    // When Some, the active compose targets a file comment (name, version handle)
+    // and submits via `content.comment` instead of a freeform session message.
+    let mut compose_comment: Option<(String, String)> = None;
     let mut clipboard =
         std::panic::catch_unwind(|| arboard::Clipboard::new().ok()).unwrap_or(None);
     let mut slash: Option<String> = None; // in-flight slash-command buffer (no leading `/`)
@@ -1389,14 +1395,27 @@ pub fn run(
                     if let Some(c) = compose.as_mut() {
                         match handle_compose_key(c, &key, &mut clipboard) {
                             ComposeKeyResult::Continue => {}
-                            ComposeKeyResult::Cancel => compose = None,
+                            ComposeKeyResult::Cancel => {
+                                compose = None;
+                                compose_comment = None;
+                            }
                             ComposeKeyResult::Send(text) => {
-                                status = Some(send_message(
-                                    client,
-                                    root_session_id,
-                                    &text,
-                                    target_agent_id.as_deref(),
-                                ));
+                                status = Some(if let Some((name, handle)) = compose_comment.take() {
+                                    send_comment(
+                                        client,
+                                        root_session_id,
+                                        &name,
+                                        &handle,
+                                        &text,
+                                    )
+                                } else {
+                                    send_message(
+                                        client,
+                                        root_session_id,
+                                        &text,
+                                        target_agent_id.as_deref(),
+                                    )
+                                });
                                 compose = None;
                                 follow = true;
                                 force_timeline_refresh = true;
@@ -2264,8 +2283,14 @@ pub fn run(
                                     ) {
                                         Ok(v) => {
                                             if let Some(content) = v.get("content").and_then(|c| c.as_str()) {
+                                                let handle = v
+                                                    .get("handle")
+                                                    .and_then(|h| h.as_str())
+                                                    .unwrap_or("")
+                                                    .to_string();
                                                 content_view = Some(ContentView {
                                                     name,
+                                                    handle,
                                                     content: content.to_string(),
                                                     scroll: 0,
                                                 });
@@ -2358,6 +2383,22 @@ pub fn run(
                                         status = Some(format!("no artifact on this row (type={} tool={})", entry.event_type, tool_name));
                                     }
                                 }
+                            }
+                        }
+                        // m: comment on the file currently open in the content
+                        // viewer. Opens the composer in comment mode; the comment
+                        // anchors to the viewed version and is delivered to the
+                        // agent at its next turn. Prefix the body with `L12:` or
+                        // `L12-14:` to attach an optional line hint.
+                        KeyCode::Char('m') if content_view.is_some() => {
+                            if let Some(view) = content_view.as_ref() {
+                                compose_comment =
+                                    Some((view.name.clone(), view.handle.clone()));
+                                compose = Some(ComposeInput::new());
+                                status = Some(format!(
+                                    "comment on `{}` · prefix `L12:` or `L12-14:` for a line hint · Enter send · Esc cancel",
+                                    view.name
+                                ));
                             }
                         }
                         KeyCode::Down | KeyCode::Char('j') => {
@@ -3189,6 +3230,75 @@ fn send_message(
     }
     match rpc(client, "event.ingest", params) {
         Ok(_) => "✓ sent".to_string(),
+        Err(e) => format!("✗ {e}"),
+    }
+}
+
+/// Parse an optional leading line hint (`L12:` or `L12-14:`) from a comment
+/// body. Returns `(line_start, line_end, remaining_body)`. The hint is best
+/// effort — anything that doesn't parse is left as part of the body.
+fn parse_line_hint(text: &str) -> (Option<u32>, Option<u32>, String) {
+    let trimmed = text.trim_start();
+    let Some(rest) = trimmed.strip_prefix(['L', 'l']) else {
+        return (None, None, text.to_string());
+    };
+    let Some(colon) = rest.find(':') else {
+        return (None, None, text.to_string());
+    };
+    let (spec, body) = rest.split_at(colon);
+    let body = body[1..].trim_start().to_string();
+    let parse_u32 = |s: &str| s.trim().parse::<u32>().ok();
+    match spec.split_once('-') {
+        Some((a, b)) => match (parse_u32(a), parse_u32(b)) {
+            (Some(s), Some(e)) => (Some(s), Some(e), body),
+            _ => (None, None, text.to_string()),
+        },
+        None => match parse_u32(spec) {
+            Some(s) => (Some(s), None, body),
+            None => (None, None, text.to_string()),
+        },
+    }
+}
+
+/// Attach an operator comment to a live content file (`content.comment`). The
+/// comment anchors to the version handle the operator was viewing and is
+/// delivered to the owning agent at its next turn. An optional `L12:`/`L12-14:`
+/// prefix on the body becomes the line hint.
+fn send_comment(
+    client: &RoomClient,
+    root_session_id: &str,
+    name: &str,
+    handle: &str,
+    text: &str,
+) -> String {
+    let (line_start, line_end, body) = parse_line_hint(text);
+    if body.trim().is_empty() {
+        return "✗ empty comment".to_string();
+    }
+    let mut params = serde_json::json!({
+        "session_id": root_session_id,
+        "name": name,
+        "body": body,
+    });
+    if let Some(map) = params.as_object_mut() {
+        if !handle.is_empty() {
+            map.insert("handle".to_string(), serde_json::json!(handle));
+        }
+        if let Some(s) = line_start {
+            map.insert("line_start".to_string(), serde_json::json!(s));
+        }
+        if let Some(e) = line_end {
+            map.insert("line_end".to_string(), serde_json::json!(e));
+        }
+    }
+    match rpc(client, "content.comment", params) {
+        Ok(v) => {
+            if v.get("drifted").and_then(|d| d.as_bool()) == Some(true) {
+                "✓ commented (file changed since — agent will re-read)".to_string()
+            } else {
+                "✓ commented".to_string()
+            }
+        }
         Err(e) => format!("✗ {e}"),
     }
 }
@@ -4704,7 +4814,7 @@ fn draw(
         let max_scroll = total.saturating_sub(inner_height) as u16;
         let scroll = view.scroll.min(max_scroll);
         let title = format!(
-            " 📝 {} [draft · not a vetted artifact] [Esc back] ",
+            " 📝 {} [draft · not a vetted artifact] [m comment · Esc back] ",
             view.name
         );
         f.render_widget(
@@ -6086,6 +6196,42 @@ mod tests {
         assert!(
             !text.iter().any(|t| t.contains("|------")),
             "raw delimiter should not appear; table should be rendered, got:\n{joined}"
+        );
+    }
+
+    #[test]
+    fn parse_line_hint_extracts_single_and_range() {
+        assert_eq!(
+            parse_line_hint("L12: secret here"),
+            (Some(12), None, "secret here".to_string())
+        );
+        assert_eq!(
+            parse_line_hint("L12-14: range"),
+            (Some(12), Some(14), "range".to_string())
+        );
+        // Case-insensitive prefix.
+        assert_eq!(
+            parse_line_hint("l3: lower"),
+            (Some(3), None, "lower".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_line_hint_leaves_plain_and_malformed_bodies_intact() {
+        // No prefix.
+        assert_eq!(
+            parse_line_hint("just a comment"),
+            (None, None, "just a comment".to_string())
+        );
+        // Looks like a hint but isn't a number → treat whole thing as body.
+        assert_eq!(
+            parse_line_hint("Login: broken"),
+            (None, None, "Login: broken".to_string())
+        );
+        // Prefix without colon → body untouched.
+        assert_eq!(
+            parse_line_hint("L12 no colon"),
+            (None, None, "L12 no colon".to_string())
         );
     }
 }

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -3249,8 +3249,11 @@ fn parse_line_hint(text: &str) -> (Option<u32>, Option<u32>, String) {
     let body = body[1..].trim_start().to_string();
     let parse_u32 = |s: &str| s.trim().parse::<u32>().ok();
     match spec.split_once('-') {
+        // A reversed range (`L14-12:`) is a typo, not a valid hint — the gateway
+        // would reject it and block the comment. Treat it as malformed and leave
+        // the body intact so the comment still sends (just without a line hint).
         Some((a, b)) => match (parse_u32(a), parse_u32(b)) {
-            (Some(s), Some(e)) => (Some(s), Some(e), body),
+            (Some(s), Some(e)) if e >= s => (Some(s), Some(e), body),
             _ => (None, None, text.to_string()),
         },
         None => match parse_u32(spec) {
@@ -6232,6 +6235,12 @@ mod tests {
         assert_eq!(
             parse_line_hint("L12 no colon"),
             (None, None, "L12 no colon".to_string())
+        );
+        // Reversed range is a typo, not a valid hint → leave the body intact so
+        // the comment still sends (the gateway would otherwise reject it).
+        assert_eq!(
+            parse_line_hint("L14-12: oops"),
+            (None, None, "L14-12: oops".to_string())
         );
     }
 }


### PR DESCRIPTION
Implements the operator comment loop from the design in #519 / `docs/design/operator-live-comments.md`. Umbrella: #520.

An operator reading a live session draft (the t=0 content tree pane) can now attach a comment to the file they're viewing; it's recorded on the timeline and delivered to the owning agent at its **next turn**. **Comment-only** — it never mutates agent state.

## Gateway (#521)
- **`content.comment` RPC** — resolves the content name, anchors the comment to the **version handle** the operator was viewing, computes `drifted` when the file has moved on since, emits an `operator.comment` timeline event, and delivers a framed comment to the owning agent via the existing async `event.ingest` path. Uses a distinct `event_type` (`operator_comment`) so it does **not** emit a duplicate `operator.message` row.
- **`operator.comment` timeline event** at **Attention** altitude (an operator flagging an issue should clear the Normal floor), Operator attribution — mirrors `operator_message_event`.

## Agent uptake (#522)
The delivery framing carries the instruction **inline** — *"acknowledge, then either address it (say how) or explain why not; if drifted, re-read the current version first."* This is deliberately the per-turn **content**, not a standing system-prompt guidance block: a comment is per-turn input, not a capability the agent holds, so a contextual instruction is the correct (and non-bloating) mechanism. (Marked partial on #522 in case a standing block is still wanted.)

## Room TUI (#523)
- `ContentView` retains the version `handle` from `content.read`.
- **`m`** in the content viewer opens the composer in comment mode; an optional **`L12:` / `L12-14:`** body prefix becomes the line hint; `send_comment()` issues `content.comment`. Status reflects drift (`✓ commented (file changed since — agent will re-read)`).

## Anchor drift
A comment binds to the handle viewed. At delivery the gateway compares to the current handle; on mismatch it sets `drifted` and tells the agent to re-read before trusting line numbers. No fragile line-remapping — the line hint is explicitly best-effort.

## Test plan
- [x] `content_comment_integration` (4): happy path (acks + `operator.comment` on timeline), drift detection, empty-body `-32602`, unknown-name `-32000`.
- [x] `session_timeline` lib (30): `operator.comment` → Attention + Operator attribution.
- [x] `tui` unit (2): `parse_line_hint` single/range/case-insensitive + plain/malformed passthrough.
- [x] Regression: `session_timeline_jsonrpc_integration`, full gateway + CLI build.

Closes #521, #523. Partially addresses #522 (inline delivery framing; standing guidance block optional). Part of #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)