### PR TITLE
docs(room): document live content viewing + operator file comments

### DIFF
--- a/docs/session-room-architecture.md
+++ b/docs/session-room-architecture.md
@@ -191,6 +191,10 @@ agents and the gateway, applied to presentation surfaces.
 - **`content.list`** / **`content.read`** — list the live session content drafts
   (name → handle + visibility) and read one version's bytes (the content tree
   pane).
+- **`content.project_live`** — materialize the session's current drafts into a
+  real directory (`sessions/<id>/live/`) the operator can open in an external
+  editor. Read-only snapshot, rebuilt on each call; never feeds back into the
+  store (the live workbench, Tier 1).
 - **`content.comment`** — attach an operator comment to a live content file
   (anchored to the viewed version handle, optional line hint); writes an
   `operator.comment` timeline row and delivers the framed comment to the owning

--- a/docs/session-room-architecture.md
+++ b/docs/session-room-architecture.md
@@ -95,6 +95,7 @@ columns: `principal_kind`, `principal_id`, `role`, `altitude`, `refs_json`.
 | `agent.message` | session tracer (LLM completion text) | Normal |
 | `agent.reasoning` | session tracer (extended thinking) | Detail |
 | `operator.message` | router (`event.ingest` chat path) | Normal |
+| `operator.comment` | router (`content.comment`) — operator comment anchored to a live content file | Attention |
 | `user.ask.pending` | `user_ask` tool | Attention |
 | `approval.pending` | human gate | Attention |
 | `approval.{approved,rejected,cancelled}` | approvals store (decision chokepoint) | Normal |
@@ -187,6 +188,14 @@ agents and the gateway, applied to presentation surfaces.
 - **`event.ingest`** (`event_type: "chat"`) — send a free-form message into the
   session; the gateway also writes the `operator.message` timeline row, so both
   sides of the conversation appear.
+- **`content.list`** / **`content.read`** — list the live session content drafts
+  (name → handle + visibility) and read one version's bytes (the content tree
+  pane).
+- **`content.comment`** — attach an operator comment to a live content file
+  (anchored to the viewed version handle, optional line hint); writes an
+  `operator.comment` timeline row and delivers the framed comment to the owning
+  agent at its next turn via the `event.ingest` path (comment-only, never mutates
+  agent state). See [operator live file comments](design/operator-live-comments.md).
 
 ### The render core and the `Channel` trait
 

--- a/docs/session-room.md
+++ b/docs/session-room.md
@@ -80,7 +80,7 @@ Each line is one event: `‹glyph› [‹actor›] ‹summary›`.
 |---|---|---|
 | `·` | detail | turn start/end, LLM rounds, tool requests, workbench bookkeeping |
 | `▸` | normal | tool completed, session start, **your messages** |
-| `⚠` | attention | approval requested, a clarification (`user.ask`), plan proposed, a sentinel divergence |
+| `⚠` | attention | approval requested, a clarification (`user.ask`), plan proposed, a sentinel divergence, an operator file comment |
 | `✗` | error | LLM/tool failures |
 
 The `--min-altitude` floor (and the `a` key in the TUI) hides anything below the
@@ -117,6 +117,16 @@ normal autonoetic agent:
 | `r` | a **clarification** is selected (`⚠ asks: …`) | Reply to the question |
 | `i` | any time | **Compose a message** to send into the session |
 
+### Watching & commenting on live content
+The agent's in-progress files (drafts written via `content_write`/`content_patch`)
+are visible from the first turn — before any artifact is built.
+
+| Key | Available when | Action |
+|---|---|---|
+| `c` | any time | Toggle the **live content tree** — every draft name the session has produced |
+| `o` | the content tree is open | **Open** the selected draft in a read-only viewer |
+| `m` | a draft is open in the viewer | **Comment** on this file (see [Commenting on live files](#commenting-on-live-files)) |
+
 ### Input prompts (approve / reject / reply / message)
 When a prompt is open at the bottom of the screen:
 
@@ -148,6 +158,28 @@ in. Sending is asynchronous — the UI never freezes while the agent works.
 
 > v1 attaches to an **existing** session. Start a brand-new session with
 > `autonoetic chat` or `autonoetic run`, then open the room on it.
+
+## Commenting on live files
+
+When you're reviewing a draft and spot an issue, you can attach a comment to
+**that file** instead of describing it in a free-form message:
+
+1. Press `c` to open the content tree, select the file, and `o` to open it.
+2. Press `m` to comment. Type your remark and press `Enter`.
+3. Optionally prefix the body with a **line hint** — `L12: …` for a single line or
+   `L12-14: …` for a range. (A malformed or reversed hint is ignored and the whole
+   text is kept as the comment.)
+
+The comment is **anchored to the exact version** you were viewing, appears on the
+timeline as `⚠ [🧑 operator] commented on ‹file›`, and is delivered to the agent
+**at its next turn** — it does not interrupt the current one. If the agent has
+already written a newer version of that file, the room confirms with
+`✓ commented (file changed since — agent will re-read)` and the agent is told to
+re-read before acting on the line numbers.
+
+Comments are **observations, not edits**: they never change the agent's files —
+the agent decides how to respond. To make changes yourself, use the workbench
+flow (`artifact_project` → edit → `workbench_reconcile`) instead.
 
 ## How it relates to `chat` and `trace`
 

--- a/docs/session-room.md
+++ b/docs/session-room.md
@@ -124,7 +124,8 @@ are visible from the first turn — before any artifact is built.
 | Key | Available when | Action |
 |---|---|---|
 | `c` | any time | Toggle the **live content tree** — every draft name the session has produced |
-| `o` | the content tree is open | **Open** the selected draft in a read-only viewer |
+| `o` | the content tree is open | **Open** the selected draft in the in-room read-only viewer |
+| `O` | the content pane is up | **Open in your editor** — project the live drafts to a real folder and launch it (see [Reading live code in your editor](#reading-live-code-in-your-editor)) |
 | `m` | a draft is open in the viewer | **Comment** on this file (see [Commenting on live files](#commenting-on-live-files)) |
 
 ### Input prompts (approve / reject / reply / message)
@@ -158,6 +159,28 @@ in. Sending is asynchronous — the UI never freezes while the agent works.
 
 > v1 attaches to an **existing** session. Start a brand-new session with
 > `autonoetic chat` or `autonoetic run`, then open the room on it.
+
+## Reading live code in your editor
+
+The in-room viewer (`o`) is markdown-oriented and fine for prose, but for code or
+multi-file drafts you'll want a real editor. Press **`O`** (from the content tree
+or a draft) to **project the session's current drafts to a real folder** and open
+it:
+
+- The gateway writes the live drafts to `…/.gateway/sessions/<id>/live/` — a
+  **read-only snapshot**, rebuilt each time you press `O` so it reflects the
+  current versions (renamed/deleted drafts drop out).
+- The room then best-effort launches a GUI editor (`$VISUAL`, else `code` /
+  `codium`). Either way the status line shows the folder path, so you can open it
+  manually if no launcher is found.
+- The folder lives **on the gateway host**. When the room runs on that same
+  machine (the usual local-dev setup) the editor opens directly; against a remote
+  gateway, use the printed path over your own mount/SSH.
+
+This is **read-only** — editing these files does not change what the agent is
+doing. To make changes the agent picks up, use the workbench flow
+(`artifact_project` → edit → `workbench_reconcile`); to flag an issue without
+editing, leave a comment (below).
 
 ## Commenting on live files
 


### PR DESCRIPTION
User-facing docs for the operator comment loop (impl #525, design #519) — the design doc alone wasn't enough.

While adding the comment feature I noticed the **live content tree** (`c`/`o`, from the earlier t=0 content-pane work) was never documented in the user guide either, so this covers both.

- **`docs/session-room.md`** (the how-to-use guide):
  - New "Watching & commenting on live content" key table — `c` (content tree), `o` (open viewer), `m` (comment).
  - New "Commenting on live files" walkthrough — the `L12:` / `L12-14:` line-hint syntax, version anchoring, next-turn delivery, the drift confirmation, and the comment-vs-edit distinction (comments are observations; use the workbench flow to edit).
  - Operator comments added to the `⚠ attention` glyph examples.
- **`docs/session-room-architecture.md`** (the how-it-works doc):
  - `operator.comment` added to the event-type/altitude table.
  - `content.list` / `content.read` / `content.comment` added to the RPC surface, linking the design doc.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)