### PR TITLE
feat(room): live workbench — project session drafts to an editor (#524)

### DIFF
--- a/autonoetic-gateway/src/router.rs
+++ b/autonoetic-gateway/src/router.rs
@@ -2660,6 +2660,56 @@ impl JsonRpcRouter {
                 )
             }
 
+            // Materialize the session's live content drafts into a real
+            // directory the operator can open in an external editor. Read-only
+            // snapshot, rebuilt on each call; never feeds back into the store
+            // (the agent's working state is untouched). Tier 1 of the live
+            // workbench (#524).
+            "content.project_live" => {
+                #[derive(Deserialize)]
+                struct ContentProjectLiveParams {
+                    session_id: String,
+                }
+                let params: ContentProjectLiveParams = match serde_json::from_value(req.params) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32602,
+                            format!("Invalid params for content.project_live: {}", e),
+                        );
+                    }
+                };
+                let gateway_dir = crate::execution::gateway_root_dir(self.config.as_ref());
+                let store = match crate::runtime::content_store::ContentStore::new(&gateway_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return JsonRpcResponse::error(
+                            req.id,
+                            -32000,
+                            format!("content store open failed: {}", e),
+                        );
+                    }
+                };
+                match store.project_live(&params.session_id) {
+                    Ok((dir, files)) => JsonRpcResponse::success(
+                        req.id,
+                        serde_json::json!({
+                            "ok": true,
+                            "session_id": params.session_id,
+                            "path": dir.to_string_lossy(),
+                            "files": files,
+                            "count": files.len(),
+                        }),
+                    ),
+                    Err(e) => JsonRpcResponse::error(
+                        req.id,
+                        -32000,
+                        format!("content.project_live failed: {}", e),
+                    ),
+                }
+            }
+
             "content.read" => {
                 // Read a content-store entry's bytes by name or handle. Mirrors
                 // `artifact.read_file` but over the live content store.

--- a/autonoetic-gateway/src/runtime/content_store.rs
+++ b/autonoetic-gateway/src/runtime/content_store.rs
@@ -82,6 +82,28 @@ pub struct ContentStore {
     manifests: Arc<Mutex<HashMap<String, SessionManifest>>>,
 }
 
+/// True when `s` is safe to join under a base directory: relative, with no
+/// escaping/absolute components, and at least one real path segment. Rejects
+/// `""`, `.`, `..`, `/abs`, `C:\…`, and anything containing a `..` — so it can't
+/// resolve to the base dir itself or escape it. Used by `project_live` for both
+/// the `session_id` (which feeds `remove_dir_all`) and each content name.
+fn safe_relative_path(s: &str) -> bool {
+    let path = Path::new(s);
+    if path.is_absolute() {
+        return false;
+    }
+    let mut has_normal = false;
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(_) => has_normal = true,
+            std::path::Component::CurDir => {}
+            // ParentDir, RootDir, Prefix — any of these can escape the base.
+            _ => return false,
+        }
+    }
+    has_normal
+}
+
 impl ContentStore {
     /// Creates a new ContentStore.
     pub fn new(gateway_dir: &Path) -> anyhow::Result<Self> {
@@ -599,6 +621,14 @@ impl ContentStore {
     /// never feeds back into the store — immutability of the underlying blobs is
     /// untouched. Returns the directory and the names written.
     pub fn project_live(&self, session_id: &str) -> anyhow::Result<(PathBuf, Vec<String>)> {
+        // `session_id` flows into a filesystem path AND a `remove_dir_all`, so a
+        // traversal value ("../..", "/etc", "") could delete outside the sessions
+        // tree. Reject anything that isn't a safe relative path before touching
+        // the filesystem.
+        anyhow::ensure!(
+            safe_relative_path(session_id),
+            "unsafe session_id for live projection: {session_id:?}"
+        );
         let live_dir = self.sessions_dir.join(session_id).join("live");
         // Refresh from scratch so renames/deletions since the last call are
         // reflected rather than leaving stale files behind.
@@ -610,18 +640,9 @@ impl ContentStore {
         let mut written = Vec::new();
         for (name, handle) in self.list_names_with_handles(session_id)? {
             // A content name is operator/agent-supplied; never let it escape the
-            // live directory (absolute paths, `..`, drive prefixes).
-            let rel = Path::new(&name);
-            let unsafe_component = rel.is_absolute()
-                || rel.components().any(|c| {
-                    matches!(
-                        c,
-                        std::path::Component::ParentDir
-                            | std::path::Component::RootDir
-                            | std::path::Component::Prefix(_)
-                    )
-                });
-            if unsafe_component {
+            // live directory (absolute, `..`, drive prefixes) or resolve to the
+            // directory itself (empty / `.`-only), which would error the write.
+            if !safe_relative_path(&name) {
                 tracing::warn!(
                     target: "content_store",
                     %name,
@@ -629,7 +650,7 @@ impl ContentStore {
                 );
                 continue;
             }
-            let out = live_dir.join(rel);
+            let out = live_dir.join(&name);
             if let Some(parent) = out.parent() {
                 std::fs::create_dir_all(parent)?;
             }
@@ -775,6 +796,10 @@ mod tests {
         store
             .register_name(session, "../escape.txt", &h1)
             .unwrap();
+        // Empty and `.`-only names resolve to the dir itself — must be skipped,
+        // not error the whole projection.
+        store.register_name(session, "", &h1).unwrap();
+        store.register_name(session, ".", &h1).unwrap();
 
         let (dir, written) = store.project_live(session).unwrap();
         assert!(dir.ends_with("live"));
@@ -796,6 +821,31 @@ mod tests {
         assert_eq!(written2, vec!["only.txt".to_string()]);
         assert!(!dir2.join("config.yaml").exists(), "stale file should be cleared");
         assert!(dir2.join("only.txt").exists());
+    }
+
+    #[test]
+    fn project_live_rejects_unsafe_session_id() {
+        let temp = tempdir().unwrap();
+        let store = ContentStore::new(temp.path()).unwrap();
+        for bad in ["../escape", "/abs", "..", ""] {
+            assert!(
+                store.project_live(bad).is_err(),
+                "unsafe session_id {bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_relative_path_classifies_correctly() {
+        assert!(safe_relative_path("config.yaml"));
+        assert!(safe_relative_path("src/main.rs"));
+        assert!(safe_relative_path("./a")); // CurDir + Normal is fine
+        assert!(safe_relative_path("root/agent.coder")); // nested session id
+        assert!(!safe_relative_path(""));
+        assert!(!safe_relative_path("."));
+        assert!(!safe_relative_path(".."));
+        assert!(!safe_relative_path("../x"));
+        assert!(!safe_relative_path("/abs"));
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/content_store.rs
+++ b/autonoetic-gateway/src/runtime/content_store.rs
@@ -590,6 +590,56 @@ impl ContentStore {
         Ok(entries)
     }
 
+    /// Materialize the session's current content drafts into a real directory
+    /// the operator can open in an external editor (`sessions/<id>/live/`).
+    ///
+    /// Read-only **snapshot**: the directory is rebuilt from the content store
+    /// on every call, so it always reflects the current name→version mapping
+    /// (and drops files whose names disappeared). Copying bytes out for viewing
+    /// never feeds back into the store — immutability of the underlying blobs is
+    /// untouched. Returns the directory and the names written.
+    pub fn project_live(&self, session_id: &str) -> anyhow::Result<(PathBuf, Vec<String>)> {
+        let live_dir = self.sessions_dir.join(session_id).join("live");
+        // Refresh from scratch so renames/deletions since the last call are
+        // reflected rather than leaving stale files behind.
+        if live_dir.exists() {
+            std::fs::remove_dir_all(&live_dir)?;
+        }
+        std::fs::create_dir_all(&live_dir)?;
+
+        let mut written = Vec::new();
+        for (name, handle) in self.list_names_with_handles(session_id)? {
+            // A content name is operator/agent-supplied; never let it escape the
+            // live directory (absolute paths, `..`, drive prefixes).
+            let rel = Path::new(&name);
+            let unsafe_component = rel.is_absolute()
+                || rel.components().any(|c| {
+                    matches!(
+                        c,
+                        std::path::Component::ParentDir
+                            | std::path::Component::RootDir
+                            | std::path::Component::Prefix(_)
+                    )
+                });
+            if unsafe_component {
+                tracing::warn!(
+                    target: "content_store",
+                    %name,
+                    "skipping unsafe content name in live projection"
+                );
+                continue;
+            }
+            let out = live_dir.join(rel);
+            if let Some(parent) = out.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let bytes = self.read_by_name_or_handle(session_id, &handle)?;
+            std::fs::write(&out, bytes)?;
+            written.push(name);
+        }
+        Ok((live_dir, written))
+    }
+
     /// Clears a session manifest.
     pub fn cleanup_session(&self, session_id: &str) -> anyhow::Result<usize> {
         let manifest = self.load_manifest(session_id)?;
@@ -709,6 +759,43 @@ mod tests {
 
         assert!(handle.starts_with("sha256:"));
         assert_eq!(store.read(&handle).unwrap(), content);
+    }
+
+    #[test]
+    fn project_live_materializes_drafts_refreshes_and_skips_unsafe_names() {
+        let temp = tempdir().unwrap();
+        let store = ContentStore::new(temp.path()).unwrap();
+        let session = "root-proj";
+
+        let h1 = store.write(b"port: 8080\n").unwrap();
+        let h2 = store.write(b"fn main() {}\n").unwrap();
+        store.register_name(session, "config.yaml", &h1).unwrap();
+        store.register_name(session, "src/main.rs", &h2).unwrap(); // nested
+        // A malicious/odd name must never escape the live directory.
+        store
+            .register_name(session, "../escape.txt", &h1)
+            .unwrap();
+
+        let (dir, written) = store.project_live(session).unwrap();
+        assert!(dir.ends_with("live"));
+        assert!(written.contains(&"config.yaml".to_string()));
+        assert!(written.contains(&"src/main.rs".to_string()));
+        assert!(
+            !written.iter().any(|n| n.contains("..")),
+            "unsafe name must be skipped: {written:?}"
+        );
+        assert_eq!(std::fs::read(dir.join("config.yaml")).unwrap(), b"port: 8080\n");
+        assert_eq!(std::fs::read(dir.join("src/main.rs")).unwrap(), b"fn main() {}\n");
+        // The traversal name must not have written outside `live/`.
+        assert!(!dir.parent().unwrap().join("escape.txt").exists());
+
+        // Refresh: drop config.yaml from the manifest, reproject → stale file gone.
+        store.cleanup_session(session).unwrap();
+        store.register_name(session, "only.txt", &h2).unwrap();
+        let (dir2, written2) = store.project_live(session).unwrap();
+        assert_eq!(written2, vec!["only.txt".to_string()]);
+        assert!(!dir2.join("config.yaml").exists(), "stale file should be cleared");
+        assert!(dir2.join("only.txt").exists());
     }
 
     #[test]

--- a/autonoetic-gateway/tests/content_project_live_integration.rs
+++ b/autonoetic-gateway/tests/content_project_live_integration.rs
@@ -1,0 +1,87 @@
+//! `content.project_live` JSON-RPC — materialize live session drafts into a real
+//! directory the operator can open in an external editor (#524, Tier 1).
+
+mod support;
+
+use autonoetic_gateway::router::{JsonRpcRequest, JsonRpcRouter};
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+use support::TestWorkspace;
+
+struct Env {
+    _ws: TestWorkspace,
+    router: JsonRpcRouter,
+    gateway_dir: PathBuf,
+}
+
+static SHARED: OnceLock<Env> = OnceLock::new();
+
+// `JsonRpcRouter::new` initializes the process-global constitution runtime once,
+// so all tests share one router.
+fn shared() -> &'static Env {
+    SHARED.get_or_init(|| {
+        let ws = TestWorkspace::new().expect("workspace");
+        let config = ws.gateway_config();
+        let gateway_dir = ws.path().join("agents").join(".gateway");
+        let store = Arc::new(GatewayStore::open(ws.path()).expect("store open"));
+        let router = JsonRpcRouter::new(config, Some(store));
+        Env {
+            _ws: ws,
+            router,
+            gateway_dir,
+        }
+    })
+}
+
+fn req(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: "proj-test".to_string(),
+        method: method.to_string(),
+        params,
+        auth_token: None,
+    }
+}
+
+#[tokio::test]
+async fn content_project_live_writes_real_files() {
+    let env = shared();
+    let session = "root-projlive";
+
+    let cs = ContentStore::new(&env.gateway_dir).unwrap();
+    let h = cs.write(b"port: 8080\n").unwrap();
+    cs.register_name(session, "config.yaml", &h).unwrap();
+
+    let resp = env
+        .router
+        .dispatch(req(
+            "content.project_live",
+            serde_json::json!({ "session_id": session }),
+        ))
+        .await;
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let r = resp.result.expect("result");
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["count"], 1);
+    let path = r["path"].as_str().expect("path");
+    // The projected file exists on disk with the real bytes.
+    let on_disk = std::fs::read(std::path::Path::new(path).join("config.yaml")).unwrap();
+    assert_eq!(on_disk, b"port: 8080\n");
+}
+
+#[tokio::test]
+async fn content_project_live_empty_session_is_ok() {
+    let env = shared();
+    let resp = env
+        .router
+        .dispatch(req(
+            "content.project_live",
+            serde_json::json!({ "session_id": "root-projlive-empty" }),
+        ))
+        .await;
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    assert_eq!(resp.result.expect("result")["count"], 0);
+}

--- a/autonoetic/src/cli/room/tui.rs
+++ b/autonoetic/src/cli/room/tui.rs
@@ -2258,7 +2258,7 @@ pub fn run(
                                             status = Some("no content entries yet (session has not written any drafts)".to_string());
                                         } else {
                                             content_tree = Some(ContentTree { entries, selected: 0, scroll: 0 });
-                                            status = Some(format!("content: {} entries · j/k navigate · o view · Esc close", content_tree.as_ref().unwrap().entries.len()));
+                                            status = Some(format!("content: {} entries · j/k navigate · o view · O open in editor · Esc close", content_tree.as_ref().unwrap().entries.len()));
                                         }
                                     }
                                     Err(e) => status = Some(format!("content list failed: {e}")),
@@ -2400,6 +2400,14 @@ pub fn run(
                                     view.name
                                 ));
                             }
+                        }
+                        // O: project the live session drafts to a real directory
+                        // and open it in an external editor (read-only snapshot).
+                        // Available whenever the content pane is up.
+                        KeyCode::Char('O')
+                            if content_view.is_some() || content_tree.is_some() =>
+                        {
+                            status = Some(project_live_and_open(client, root_session_id));
                         }
                         KeyCode::Down | KeyCode::Char('j') => {
                             if let Some(view) = content_view.as_mut() {
@@ -3300,6 +3308,59 @@ fn send_comment(
                 "✓ commented (file changed since — agent will re-read)".to_string()
             } else {
                 "✓ commented".to_string()
+            }
+        }
+        Err(e) => format!("✗ {e}"),
+    }
+}
+
+/// Best-effort: launch a GUI editor on `dir`. `code`/`$VISUAL` are GUI launchers
+/// that fork and return immediately, so spawning them from inside the TUI does
+/// not hijack the terminal. Terminal editors (vim, …) would, so we only try
+/// known GUI openers. Returns true if a launch was spawned.
+fn try_open_in_editor(dir: &str) -> bool {
+    // `$VISUAL` is the conventional GUI editor; otherwise try VS Code by name.
+    let candidates: Vec<String> = std::env::var("VISUAL")
+        .ok()
+        .into_iter()
+        .chain(["code".to_string(), "codium".to_string()])
+        .collect();
+    for cmd in candidates {
+        if std::process::Command::new(&cmd)
+            .arg(dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .is_ok()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Project the session's live content drafts to a real directory
+/// (`content.project_live`) and open it in an external editor. The directory is
+/// a read-only snapshot on the **gateway host**; the launch is best-effort and
+/// only succeeds when the room runs on that same host. Either way the path is
+/// surfaced so the operator can open it manually (or over a remote mount).
+fn project_live_and_open(client: &RoomClient, root_session_id: &str) -> String {
+    match rpc(
+        client,
+        "content.project_live",
+        serde_json::json!({ "session_id": root_session_id }),
+    ) {
+        Ok(v) => {
+            let path = v.get("path").and_then(|p| p.as_str()).unwrap_or_default();
+            let count = v.get("count").and_then(|c| c.as_u64()).unwrap_or(0);
+            if path.is_empty() {
+                return "✗ project_live: no path in response".to_string();
+            }
+            if try_open_in_editor(path) {
+                format!("✓ opened {count} live file(s) in editor → {path}")
+            } else {
+                format!("live dir ({count} file(s)) → {path}  (open it in your editor)")
             }
         }
         Err(e) => format!("✗ {e}"),
@@ -4817,7 +4878,7 @@ fn draw(
         let max_scroll = total.saturating_sub(inner_height) as u16;
         let scroll = view.scroll.min(max_scroll);
         let title = format!(
-            " 📝 {} [draft · not a vetted artifact] [m comment · Esc back] ",
+            " 📝 {} [draft · not a vetted artifact] [m comment · O open in editor · Esc back] ",
             view.name
         );
         f.render_widget(
@@ -4865,7 +4926,7 @@ fn draw(
             .saturating_sub(inner_height / 2)
             .min(max_scroll) as u16;
         let title = format!(
-            " 📝 session content (drafts · t=0) — {} entries [o view · Esc close] ",
+            " 📝 session content (drafts · t=0) — {} entries [o view · O open in editor · Esc close] ",
             tree.entries.len()
         );
         f.render_widget(


### PR DESCRIPTION
Implements #524 (Tier 1 of the live workbench): let the operator read **live session content in a real external editor** (e.g. VS Code), not just the in-TUI markdown pane.

## What it does
- **`ContentStore::project_live`** — materializes the session's current drafts into `sessions/<id>/live/` as real files. Read-only **snapshot**, rebuilt on each call so renames/deletions are reflected; content names are path-traversal-guarded (absolute / `..` / drive-prefix names are skipped). Copying bytes out never feeds back into the store — blob immutability is untouched.
- **Gateway RPC `content.project_live { session_id }`** → `{ ok, path, files, count }`.
- **Room TUI `O`** (in the content tree or viewer) — projects and best-effort launches a GUI editor (`$VISUAL`, then `code` / `codium`); it always surfaces the gateway-host path in the status line, so it's useful even when the launch can't run (remote gateway, no GUI opener).

## Boundaries
- **Read-only.** Edits go through the existing workbench reconcile flow (`artifact_project` → edit → `workbench_reconcile`), not this pane.
- The projected dir lives on the **gateway host**; the editor launch only works when the room runs on that host. Otherwise the path is informational (mount/remote-open).
- FUSE/virtual-FS stays out of scope — a refreshed projection dir captures ~all the value (per the design doc).

## Test plan
- [x] `content_store::project_live` unit — materialize, refresh drops stale files, unsafe names skipped, nested paths.
- [x] `content_project_live_integration` — RPC writes real files on disk; empty session is a clean no-op.
- [x] gateway + CLI build clean.

## Docs
The `O` key + `content.project_live` docs ride with the live-content user-doc PR (#526), which owns the content-pane key table (avoids a table-merge conflict). Closes #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)