### PR TITLE
feat(orchestration): make build→promote→install→use obvious to agents (stop the loops)

### DIFF
--- a/agents/lead/planner.collaborative/SKILL.md
+++ b/agents/lead/planner.collaborative/SKILL.md
@@ -245,6 +245,12 @@ via `session.envelope.lock` or the TUI envelope prompt. If you omit
 `capability_envelope`, the gateway falls back to hosts observed earlier in the
 session.
 
+**Approve once, reused for the whole session.** Hosts used during the build are
+auto-locked into session grants, and a locked `PromoteWith` envelope covers the
+capability acknowledgement. Once a host or capability is granted, every later use
+of it this session is auto-approved — never re-propose the envelope for, or
+re-ask the operator about, something already granted.
+
 ### After approval (execution phase)
 
 1. Call `planframe_get` to confirm status is `approved`.
@@ -325,6 +331,11 @@ On resume (after `workflow_wait`, child completion, plan approval, or workbench 
 1. Call `planframe_get` (compact if you only need summary).
 2. Identify completed vs pending steps; continue from the current step — do not restart.
 3. If the event is `workbench_reconciled`, apply the semantic summary before spawning more work.
+4. **Trust a child step's terminal result; don't re-spawn to "confirm" it.** A build
+   step that promoted an agent reports `installed: true` — the agent is the active
+   revision, so advance the plan (spawn or use it), don't rebuild or re-promote.
+   A pending approval resumes automatically — relay the `request_id`, end your
+   turn, and do not re-issue the step.
 
 ## Tools
 

--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -106,9 +106,9 @@ surface the session envelope so repeated network prompts do not fatigue them:
 - You do not call `session.envelope.lock` yourself unless the operator asks —
   propose the scope in the plan or let the gateway propose from observed usage,
   then end the turn so they can lock once.
-- **Approve once, reused all session.** Network hosts discovered during exec are
-  auto-locked: `sandbox_exec` then returns `network_grant: {hosts, locked:true}`.
-  Once a host is granted, every later call to it this session is auto-approved —
+- **Approve once, reused for the whole session.** Network hosts discovered during
+  exec are auto-locked: `sandbox_exec` then returns `network_grant: {hosts, locked}`.
+  Once a host is granted (`locked: true`), every later call to it this session is auto-approved —
   never re-request approval for, or re-ask the operator about, a host already in
   a `network_grant`. The same holds for capability acknowledgements covered by a
   locked `PromoteWith` envelope.
@@ -439,7 +439,7 @@ re-running a stage to "confirm" it (that is the main cause of wasted loops):
 | Tool result | Means | Next action |
 |---|---|---|
 | `agent_revision_promote` → `status:"promoted"`, `installed:true` | The agent is the **active installed revision** | Use it: `agent_spawn` with that `agent_id`. Do NOT rebuild, re-promote, or re-inspect. |
-| `artifact_build` → `ok:true` + `next:"…promote…"` (agent bundle) | Bundle is built | Promote it once (or let agent-factory's pipeline do so). Do NOT rebuild. |
+| `artifact_build` → `ok:true` + `next:"…"` (agent bundle) | Bundle is built (not yet a live agent) | Create a revision (`agent_revision_create_from_intent` with the `artifact_ref`), then `agent_revision_promote` it — or let agent-factory's pipeline do so. Do NOT rebuild. |
 | `sandbox_exec` → `network_grant:{hosts,locked:true}` | Those hosts are granted for the session | Continue; never re-request approval for them. |
 | `approval_required:true` + `request_id` (any tool) | Operator must decide once | Relay the `request_id`, end your turn. The gateway resumes the call for you — do NOT re-spawn or re-issue. |
 

--- a/agents/lead/planner.default/SKILL.md
+++ b/agents/lead/planner.default/SKILL.md
@@ -106,6 +106,12 @@ surface the session envelope so repeated network prompts do not fatigue them:
 - You do not call `session.envelope.lock` yourself unless the operator asks —
   propose the scope in the plan or let the gateway propose from observed usage,
   then end the turn so they can lock once.
+- **Approve once, reused all session.** Network hosts discovered during exec are
+  auto-locked: `sandbox_exec` then returns `network_grant: {hosts, locked:true}`.
+  Once a host is granted, every later call to it this session is auto-approved —
+  never re-request approval for, or re-ask the operator about, a host already in
+  a `network_grant`. The same holds for capability acknowledgements covered by a
+  locked `PromoteWith` envelope.
 
 ## Tool vs Agent Invocation Contract
 
@@ -424,6 +430,18 @@ If the operator requests sealed evaluation:
 Do NOT run sealed evaluation unless the operator explicitly requests it. The sealed evaluator is an operator-invokable diagnostic tool, not a mandatory gate.
 
 ---
+
+## Terminal signals — proceed, don't re-check
+
+Tools now report when a step is done and what comes next. Trust these instead of
+re-running a stage to "confirm" it (that is the main cause of wasted loops):
+
+| Tool result | Means | Next action |
+|---|---|---|
+| `agent_revision_promote` → `status:"promoted"`, `installed:true` | The agent is the **active installed revision** | Use it: `agent_spawn` with that `agent_id`. Do NOT rebuild, re-promote, or re-inspect. |
+| `artifact_build` → `ok:true` + `next:"…promote…"` (agent bundle) | Bundle is built | Promote it once (or let agent-factory's pipeline do so). Do NOT rebuild. |
+| `sandbox_exec` → `network_grant:{hosts,locked:true}` | Those hosts are granted for the session | Continue; never re-request approval for them. |
+| `approval_required:true` + `request_id` (any tool) | Operator must decide once | Relay the `request_id`, end your turn. The gateway resumes the call for you — do NOT re-spawn or re-issue. |
 
 ## Approval & Clarification Handling
 

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -1990,6 +1990,25 @@ impl NativeTool for AgentRevisionPromoteTool {
             .any(|cap| matches!(cap, Capability::AgentRevision { .. }))
     }
 
+    fn guidance(&self) -> Vec<crate::runtime::guidance::GuidanceBlock> {
+        use crate::runtime::guidance::{GuidanceBlock, GuidanceCondition};
+        vec![GuidanceBlock {
+            id: "promote.approval_continuation",
+            when: GuidanceCondition::ToolPresent("agent_revision_promote"),
+            priority: 9,
+            prose: "**Promotion resumes automatically — don't loop.** If `agent_revision_promote` \
+returns `approval_required: true` (e.g. `capability_delta_requires_approval`), return the exact \
+`request_id`/`approval_ref` to your caller and end your turn. The gateway wakes you when the operator \
+decides and re-runs the promotion for you with the real result — do **not** re-spawn the builder, \
+re-run the gates, or re-issue the promote. A locked session capability envelope (PromoteWith) \
+pre-authorizes the capability acknowledgement, so a covered promotion needs no new approval at all. \
+On success the response is terminal: `status:\"promoted\"`, `installed:true`. That means the agent is \
+now the **active installed revision** — use it by calling `agent_spawn` with its `agent_id`; do not \
+rebuild, re-promote, or re-inspect to \"confirm\" it."
+                .to_string(),
+        }]
+    }
+
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
@@ -2938,6 +2957,15 @@ impl NativeTool for AgentRevisionPromoteTool {
             "short_ref": short_ref,
             "previous_revision_id": previous_revision_id,
             "promotion_id": promotion_id,
+            // Terminal signal: promotion IS installation — the alias now points
+            // at this revision. Make the single next action explicit so the
+            // orchestrator spawns the agent instead of rebuilding/re-promoting.
+            "installed": true,
+            "next": format!(
+                "Agent '{}' is now the active (installed) revision. To use it, call \
+                 agent_spawn with agent_id '{}'. Do not rebuild or promote it again.",
+                args.agent_id, args.agent_id
+            ),
         });
         if let Some(eid) = pre_auth_envelope_id {
             response["pre_authorized_by_envelope"] = serde_json::json!(eid);

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2004,7 +2004,9 @@ re-run the gates, or re-issue the promote. A locked session capability envelope 
 pre-authorizes the capability acknowledgement, so a covered promotion needs no new approval at all. \
 On success the response is terminal: `status:\"promoted\"`, `installed:true`. That means the agent is \
 now the **active installed revision** — use it by calling `agent_spawn` with its `agent_id`; do not \
-rebuild, re-promote, or re-inspect to \"confirm\" it."
+rebuild, re-promote, or re-inspect to \"confirm\" it. If it returns `status:\"coalesced\"` with \
+`retry_advice:\"wait\"`, an equivalent promote is already running: end your turn and let it finish — \
+do not re-issue."
                 .to_string(),
         }]
     }

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -368,15 +368,23 @@ impl NativeTool for ArtifactBuildTool {
                 obj.insert("artifact_ref_scope".to_string(), scope);
             }
         }
-        // Make the next step explicit so the orchestrator goes straight to
-        // promotion instead of rebuilding or re-inspecting.
-        if matches!(bundle.kind, autonoetic_types::artifact::ArtifactKind::AgentBundle) {
+        // Make the next step explicit so the orchestrator goes straight ahead
+        // instead of rebuilding or re-inspecting. Only when we actually have an
+        // artifact_ref to act on, and naming the REAL tool contract: a bundle
+        // becomes a live agent via create-revision (which takes the artifact_ref)
+        // then promote (which takes agent_id + revision_id, NOT artifact_ref).
+        if matches!(bundle.kind, autonoetic_types::artifact::ArtifactKind::AgentBundle)
+            && out.get("artifact_ref").is_some()
+        {
             if let Some(obj) = out.as_object_mut() {
                 obj.insert(
                     "next".to_string(),
                     serde_json::Value::String(
-                        "Agent bundle built. Next: promote it with agent_revision_promote \
-                         (pass this artifact_ref). Do not rebuild it."
+                        "Agent bundle built. To make it a live agent: create a revision with \
+                         agent_revision_create_from_intent (pass this artifact_ref), then \
+                         agent_revision_promote that revision_id. Do not rebuild the bundle. \
+                         (If agent-factory is driving this pipeline, it performs these steps — \
+                         do not duplicate them.)"
                             .to_string(),
                     ),
                 );

--- a/autonoetic-gateway/src/runtime/tools/artifact.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact.rs
@@ -368,6 +368,20 @@ impl NativeTool for ArtifactBuildTool {
                 obj.insert("artifact_ref_scope".to_string(), scope);
             }
         }
+        // Make the next step explicit so the orchestrator goes straight to
+        // promotion instead of rebuilding or re-inspecting.
+        if matches!(bundle.kind, autonoetic_types::artifact::ArtifactKind::AgentBundle) {
+            if let Some(obj) = out.as_object_mut() {
+                obj.insert(
+                    "next".to_string(),
+                    serde_json::Value::String(
+                        "Agent bundle built. Next: promote it with agent_revision_promote \
+                         (pass this artifact_ref). Do not rebuild it."
+                            .to_string(),
+                    ),
+                );
+            }
+        }
 
         if let Some(gs) = gateway_store.as_ref() {
             let root = crate::runtime::content_store::root_session_id(sid);

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -2728,21 +2728,34 @@ file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shre
         // observed remote hosts so subsequent tool calls are covered by
         // grants without manual operator intervention.
         if let (Some(gs), Some(root)) = (gateway_store.as_ref(), root_session_id.as_deref()) {
-            if let Err(e) =
-                crate::runtime::session_envelope::propose_discovered_envelope(
-                    gs,
-                    root,
-                    "sandbox_exec",
-                    None,
-                    &manifest.agent.id,
-                )
-            {
-                tracing::debug!(
-                    target: "session_envelope",
-                    error = %e,
-                    root_session_id = root,
-                    "envelope proposal after sandbox_exec failed"
-                );
+            match crate::runtime::session_envelope::propose_discovered_envelope(
+                gs,
+                root,
+                "sandbox_exec",
+                None,
+                &manifest.agent.id,
+            ) {
+                // Surface the auto-locked grant so the agent KNOWS these hosts
+                // are now covered and never re-requests approval for them — the
+                // silent auto-lock was a prime cause of redundant approval loops.
+                Ok(Some(result)) if !result.hosts.is_empty() => {
+                    body["network_grant"] = serde_json::json!({
+                        "hosts": result.hosts,
+                        "locked": true,
+                        "note": "These hosts are now covered by a session grant — \
+                                 subsequent calls to them this session are auto-approved; \
+                                 do not re-request approval for them.",
+                    });
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::debug!(
+                        target: "session_envelope",
+                        error = %e,
+                        root_session_id = root,
+                        "envelope proposal after sandbox_exec failed"
+                    );
+                }
             }
         }
 

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -2735,16 +2735,26 @@ file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shre
                 None,
                 &manifest.agent.id,
             ) {
-                // Surface the auto-locked grant so the agent KNOWS these hosts
-                // are now covered and never re-requests approval for them — the
-                // silent auto-lock was a prime cause of redundant approval loops.
+                // Surface the grant so the agent KNOWS whether these hosts are
+                // now covered and need no re-approval — the silent auto-lock was
+                // a prime cause of redundant approval loops. Report `locked` from
+                // the ACTUAL grant coverage, not optimistically: auto-lock can
+                // fail (it logs and leaves the envelope merely proposed), and a
+                // false `locked:true` would tell the agent not to seek approval
+                // it still needs.
                 Ok(Some(result)) if !result.hosts.is_empty() => {
+                    let covered = gs.session_grants_cover_targets(root, &result.hosts);
                     body["network_grant"] = serde_json::json!({
                         "hosts": result.hosts,
-                        "locked": true,
-                        "note": "These hosts are now covered by a session grant — \
-                                 subsequent calls to them this session are auto-approved; \
-                                 do not re-request approval for them.",
+                        "locked": covered,
+                        "note": if covered {
+                            "These hosts are now covered by a session grant — subsequent \
+                             calls to them this session are auto-approved; do not re-request \
+                             approval for them."
+                        } else {
+                            "These hosts were proposed but not yet locked — a later call may \
+                             still require operator approval."
+                        },
                     });
                 }
                 Ok(_) => {}

--- a/autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs
+++ b/autonoetic-gateway/tests/protected_agents_promotion_gate_integration.rs
@@ -276,6 +276,13 @@ fn protected_agent_with_passed_eval_run_proceeds() {
 
     assert_eq!(result["ok"], true, "unexpected: {:?}", result);
     assert_eq!(result["status"], "promoted");
+    // Terminal signals so the orchestrator goes straight to spawning the agent
+    // instead of looping to "confirm" the install.
+    assert_eq!(result["installed"], true, "promote success must signal installed: {result:?}");
+    assert!(
+        result["next"].as_str().is_some_and(|n| n.contains("agent_spawn")),
+        "promote success must tell the orchestrator to spawn the agent: {result:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem
In testing, orchestration agents kept looping / missing steps during the build-an-agent workflow. I traced it: the loop-avoidance **mechanics already work** — grant reuse (`sandbox.rs:1572`), host auto-lock (`4fa25c47`), turn-continuation resume (`continuation.rs`), and `PromoteWith` pre-auth (`agent_revision.rs:2242`). But they're **silent**: every step ends with a bare `ok` and no explicit "this is done, here's the one next action." When an LLM can't tell whether a step landed, it re-checks — that's the looping.

## Fix — make every step's completion and next action legible

**Tool responses (terminal/next-step signals):**
- `sandbox_exec` → surfaces `network_grant: {hosts, locked:true, note}` after the post-exec auto-lock (the `propose_discovered_envelope` Ok result was previously thrown away). The agent now knows those hosts are covered and won't re-request approval.
- `artifact_build` (agent bundle) → `next: "…promote it with agent_revision_promote…"`.
- `agent_revision_promote` success → `installed:true` + `next: "agent '<id>' is the active installed revision — spawn it with agent_spawn; do not rebuild or re-promote"`. Promotion **is** installation (the alias now points at the revision).

**Guidance:**
- New `promote.approval_continuation` block (gated on `agent_revision_promote`): promotion approval **resumes automatically** — return `request_id`, end turn, don't re-spawn/re-issue; a locked `PromoteWith` envelope means no new approval at all; on success the agent is installed, just `agent_spawn` it.
- `planner.default/SKILL.md`: a **"Terminal signals — proceed, don't re-check"** table mapping each tool result → meaning → single next action, plus the **"approve once, reused all session"** grant-reuse contract.

## Test plan
- [x] New asserts: `agent_revision_promote` success carries `installed:true` + `next` mentioning `agent_spawn` (protected-agents suite, full-success path).
- [x] `skill_doctrine_guard` (no SKILL.md re-paste of centralized doctrine), `guidance::` unit, `promotion_governor`, `phase2_promotion_stability`, `session_envelope_promote_with`, `plan_frame`, `artifact_ref_global_on_promote` — all green.
- [x] gateway builds clean.

All changes are additive (new response fields + new guidance) — no behavior change to the gateway's enforcement, just visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)