### PR TITLE
fix(constitution): recompute_lock.py seeds a missing lock from the prior version

### DIFF
--- a/docs/constitution/recompute_lock.py
+++ b/docs/constitution/recompute_lock.py
@@ -102,6 +102,29 @@ def load_signing_key(args: argparse.Namespace) -> tuple[SigningKey, bool]:
     )
 
 
+def find_template_lock(versions_root: Path, current_version: str) -> Path | None:
+    """Newest sibling version's lock, used to seed a brand-new version's lock.
+
+    A freshly-prepared version dir ships `constitution.md` only (the operator
+    signs the lock). The fields this script does NOT recompute — `format_version`,
+    `constitution_id`, `canonicalization` — are stable across versions, so they
+    are inherited from the most recent prior version that has a lock. Version dirs
+    are date-named (`YYYY.MM.DD`), so lexical sort == chronological.
+    """
+    if not versions_root.is_dir():
+        return None
+    siblings = sorted(
+        (d for d in versions_root.iterdir() if d.is_dir() and d.name != current_version),
+        key=lambda d: d.name,
+        reverse=True,
+    )
+    for d in siblings:
+        candidate = d / "gateway-constitution.lock.json"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def main() -> None:
     args = parse_args()
     repo_root = args.repo_root.resolve()
@@ -111,8 +134,20 @@ def main() -> None:
 
     if not constitution_path.exists():
         raise SystemExit(f"Constitution markdown not found: {constitution_path}")
-    if not lock_path.exists():
-        raise SystemExit(f"Constitution lock not found: {lock_path}")
+
+    # A freshly-prepared version dir may ship constitution.md only. Seed the lock
+    # structure from the most recent prior version (stable fields), then recompute.
+    if lock_path.exists():
+        lock = json.loads(lock_path.read_text())
+    else:
+        template = find_template_lock(version_dir.parent, args.version)
+        if template is None:
+            raise SystemExit(
+                f"Constitution lock not found and no prior version lock to seed from: {lock_path}"
+            )
+        print(f"No lock at {lock_path}; seeding structure from {template}")
+        lock = json.loads(template.read_text())
+        lock.pop("signature", None)  # inherited signature is invalid here; this run re-signs
 
     text = constitution_path.read_text()
     rights = extract_enforcement_table(text, "Ri-")
@@ -125,7 +160,6 @@ def main() -> None:
     }
     constitution_digest = hashlib.sha256(compact_json_bytes(digest_payload)).hexdigest()
 
-    lock = json.loads(lock_path.read_text())
     lock["constitution_version"] = args.version
     lock["constitution_source"] = f"docs/constitution/versions/{args.version}/constitution.md"
     lock["constitution_digest"] = constitution_digest


### PR DESCRIPTION
## Problem
Signing the 2026.06.16 amendment (#529) failed:
`Constitution lock not found: docs/constitution/versions/2026.06.16/gateway-constitution.lock.json`

A freshly-prepared version dir ships `constitution.md` only (the operator signs the lock), but `recompute_lock.py` required a pre-existing lock to read the stable fields it does **not** recompute (`format_version`, `constitution_id`, `canonicalization`).

## Fix
When the target lock is missing, seed its structure from the **most recent prior version's** lock (date-named dirs → lexical sort == chronological), drop the inherited signature, then recompute digest/counts and sign exactly as before. If no prior lock exists, it still errors clearly.

This unblocks the 2026.06.16 signing and removes the friction for every future amendment that follows the "prepare new version dir, operator signs" pattern.

## Verified
- `py_compile` clean.
- `find_template_lock(versions/, "2026.06.16")` selects `versions/2026.06.15/gateway-constitution.lock.json` (the correct, newest prior lock).
- Signing itself unchanged (still your key, still re-signs).

## After merging — to sign 2026.06.16
```
python3 docs/constitution/recompute_lock.py --version 2026.06.16 \
  --signing-sk-b64 "$AUTONOETIC_CONSTITUTION_SIGNING_SK_B64"
```
then point the config at `2026.06.16` to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)