### PR TITLE
feat(promote): structured gate failures with stable error codes (P-5.11 rollout, step 1)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2433,81 +2433,136 @@ do not re-issue."
             FullJury,
         }
 
+        // Returns Ok(None) when the gate passes, Ok(Some(json)) carrying a
+        // structured P-5.11 failure envelope (ok:false + stable `error` code)
+        // when blocked, and Err only for genuine infrastructure failures.
+        // Messages are kept verbatim (callers/tests read them); the stable code
+        // lets an orchestrator branch on one field instead of parsing prose.
         let enforce_promotion_gate = |artifact_id: &str,
                                       mode: PromotionGateMode,
                                       missing_record_message: &str|
-         -> anyhow::Result<()> {
+         -> anyhow::Result<Option<String>> {
+            use autonoetic_types::tool_error::ToolError;
             let promo_store = crate::runtime::promotion_store::PromotionStore::new(gateway_dir)?;
             let _ = promo_store.bind_content_digest_if_unset(artifact_id, &rev.content_digest)?;
-            let record = promo_store
-                .get_promotion(artifact_id)
-                .ok_or_else(|| anyhow::anyhow!("{}", missing_record_message))?;
+            let Some(record) = promo_store.get_promotion(artifact_id) else {
+                return Ok(Some(
+                    ToolError::permission(missing_record_message.to_string())
+                        .with_code("promotion_record_missing")
+                        .with_repair_hint(
+                            "Obtain the required gate pass record(s) for this artifact, then retry agent_revision_promote.",
+                        )
+                        .to_error_response(),
+                ));
+            };
 
             let record_content_digest = record.content_digest.as_deref().unwrap_or("<none>");
-            anyhow::ensure!(
-                    record.content_digest.as_deref() == Some(rev.content_digest.as_str()),
-                    "Promotion gate: promotion record for artifact '{}' is bound to content digest '{}' \
-                     but revision requires '{}'. Re-run gate roles for this revision content.",
-                    artifact_id,
-                    record_content_digest,
-                    rev.content_digest
-                );
+            if record.content_digest.as_deref() != Some(rev.content_digest.as_str()) {
+                return Ok(Some(
+                    ToolError::permission(format!(
+                        "Promotion gate: promotion record for artifact '{}' is bound to content digest '{}' \
+                         but revision requires '{}'. Re-run gate roles for this revision content.",
+                        artifact_id, record_content_digest, rev.content_digest
+                    ))
+                    .with_code("promotion_gate_content_digest_mismatch")
+                    .with_repair_hint("Re-run the gate roles against this revision's content, then retry.")
+                    .to_error_response(),
+                ));
+            }
 
-            anyhow::ensure!(
-                record.auditor_pass,
-                "Promotion gate: auditor did not pass for artifact '{}'. \
+            if !record.auditor_pass {
+                return Ok(Some(
+                    ToolError::permission(format!(
+                        "Promotion gate: auditor did not pass for artifact '{}'. \
                      Fix the audit findings and re-run auditor.default.",
-                artifact_id
-            );
-            let audit_id = record.auditor_id.as_deref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Promotion gate: auditor identity missing for artifact '{}' (P-2.17). \
+                        artifact_id
+                    ))
+                    .with_code("auditor_pass_missing")
+                    .with_repair_hint("Obtain a passing auditor record for this artifact, then retry.")
+                    .to_error_response(),
+                ));
+            }
+            let Some(audit_id) = record.auditor_id.as_deref() else {
+                return Ok(Some(
+                    ToolError::permission(format!(
+                        "Promotion gate: auditor identity missing for artifact '{}' (P-2.17). \
                      Re-run auditor.default to record its identity.",
-                    artifact_id
-                )
-            })?;
+                        artifact_id
+                    ))
+                    .with_code("auditor_identity_missing")
+                    .with_repair_hint("Re-record the audit with an attributed identity, then retry.")
+                    .with_enforced_rules(vec!["P-2.17".to_string()])
+                    .to_error_response(),
+                ));
+            };
 
             match mode {
                 PromotionGateMode::Full => {
-                    anyhow::ensure!(
-                        record.evaluator_pass
-                            || record.sealed_evaluator_pass
-                            || record.static_evaluator_pass,
-                        "Promotion gate: no evaluator role passed for artifact '{}'. \
+                    if !(record.evaluator_pass
+                        || record.sealed_evaluator_pass
+                        || record.static_evaluator_pass)
+                    {
+                        return Ok(Some(
+                            ToolError::permission(format!(
+                                "Promotion gate: no evaluator role passed for artifact '{}'. \
                          Fix the evaluation findings and re-run sealed_evaluator.default or static_evaluator.default.",
-                        artifact_id
-                    );
-                    let eval_id = record
+                                artifact_id
+                            ))
+                            .with_code("evaluator_pass_missing")
+                            .with_repair_hint("Obtain a passing evaluator record (evaluator/sealed/static), then retry.")
+                            .to_error_response(),
+                        ));
+                    }
+                    let Some(eval_id) = record
                         .evaluator_id
                         .as_deref()
                         .or(record.sealed_evaluator_id.as_deref())
                         .or(record.static_evaluator_id.as_deref())
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
+                    else {
+                        return Ok(Some(
+                            ToolError::permission(format!(
                                 "Promotion gate: evaluator identity missing for artifact '{}' (P-2.17). \
                                  Re-run an evaluator role to record its identity.",
                                 artifact_id
-                            )
-                        })?;
-                    anyhow::ensure!(
-                        eval_id != audit_id,
-                        "Promotion gate: evaluator and auditor are the same agent '{}' (P-2.17). \
+                            ))
+                            .with_code("evaluator_identity_missing")
+                            .with_repair_hint("Re-record the evaluation with an attributed identity, then retry.")
+                            .with_enforced_rules(vec!["P-2.17".to_string()])
+                            .to_error_response(),
+                        ));
+                    };
+                    if eval_id == audit_id {
+                        return Ok(Some(
+                            ToolError::permission(format!(
+                                "Promotion gate: evaluator and auditor are the same agent '{}' (P-2.17). \
                          A single agent cannot self-approve. Use distinct evaluator and auditor agents.",
-                        eval_id
-                    );
+                                eval_id
+                            ))
+                            .with_code("gate_identity_collision")
+                            .with_repair_hint("Use distinct evaluator and auditor identities, then retry.")
+                            .with_enforced_rules(vec!["P-2.17".to_string()])
+                            .to_error_response(),
+                        ));
+                    }
                 }
                 PromotionGateMode::AuditOnly => {
                     // P-2.17 reduced: auditor must be a distinct identity
                     // from the agent that proposed the install. With no
                     // evaluator in this mode, the proposer is the relevant
                     // counterparty for the self-approval ban.
-                    anyhow::ensure!(
-                        audit_id != rev.created_by_id,
-                        "Promotion gate: auditor '{}' is the same identity that proposed revision '{}' (P-2.17, audit-only). \
+                    if audit_id == rev.created_by_id {
+                        return Ok(Some(
+                            ToolError::permission(format!(
+                                "Promotion gate: auditor '{}' is the same identity that proposed revision '{}' (P-2.17, audit-only). \
                          A single agent cannot propose and audit. Use a distinct auditor identity.",
-                        audit_id,
-                        args.revision_id
-                    );
+                                audit_id, args.revision_id
+                            ))
+                            .with_code("gate_identity_collision")
+                            .with_repair_hint("Use an auditor identity distinct from the proposer, then retry.")
+                            .with_enforced_rules(vec!["P-2.17".to_string()])
+                            .to_error_response(),
+                        ));
+                    }
                 }
                 // FullJury enforcement is handled separately after the
                 // legacy gate; this variant is only used for event emission.
@@ -2515,13 +2570,18 @@ do not re-issue."
             }
 
             // P-2.26: All executed gate roles must pass.
-            if record.unit_test_runner_id.is_some() {
-                anyhow::ensure!(
-                    record.unit_test_runner_pass,
-                    "Promotion gate: unit_test_runner did not pass for artifact '{}' (P-2.26). \
+            if record.unit_test_runner_id.is_some() && !record.unit_test_runner_pass {
+                return Ok(Some(
+                    ToolError::permission(format!(
+                        "Promotion gate: unit_test_runner did not pass for artifact '{}' (P-2.26). \
                      Fix the failing tests and re-run unit_test_runner.default.",
-                    artifact_id
-                );
+                        artifact_id
+                    ))
+                    .with_code("unit_test_runner_pass_missing")
+                    .with_repair_hint("Resolve the failing tests and re-record a unit_test_runner pass, then retry.")
+                    .with_enforced_rules(vec!["P-2.26".to_string()])
+                    .to_error_response(),
+                ));
             }
 
             let has_unresolved = rev
@@ -2529,13 +2589,20 @@ do not re-issue."
                 .get("has_unresolved_dependencies")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            anyhow::ensure!(
-                !has_unresolved,
-                "Promotion gate: revision has unresolved dependencies. \
+            if has_unresolved {
+                return Ok(Some(
+                    ToolError::permission(
+                        "Promotion gate: revision has unresolved dependencies. \
                      Run packager.default to install dependencies as layers, \
-                     then re-submit the revision.",
-            );
-            Ok(())
+                     then re-submit the revision."
+                            .to_string(),
+                    )
+                    .with_code("unresolved_dependencies")
+                    .with_repair_hint("Resolve the revision's dependencies (install as layers), then re-submit and retry.")
+                    .to_error_response(),
+                ));
+            }
+            Ok(None)
         };
 
         // Emit a causal event after each enforced promotion gate so forensics
@@ -2582,7 +2649,7 @@ do not re-issue."
                     args.revision_id
                 )
             })?;
-            enforce_promotion_gate(
+            if let Some(json) = enforce_promotion_gate(
                 artifact_id,
                 PromotionGateMode::Full,
                 &format!(
@@ -2591,13 +2658,15 @@ do not re-issue."
                      evaluator and auditor pass records before promotion.",
                     artifact_id
                 ),
-            )?;
+            )? {
+                return Ok(json);
+            }
             emit_gate_event(PromotionGateMode::Full, Some(artifact_id));
         } else if has_high_risk && rev.artifact_id.is_some() {
             // NetworkAccess without CodeExecution/AgentSpawn, but an artifact was provided.
             // Still apply the full eval+audit gate since code exists to review.
             let artifact_id = rev.artifact_id.as_deref().unwrap();
-            enforce_promotion_gate(
+            if let Some(json) = enforce_promotion_gate(
                 artifact_id,
                 PromotionGateMode::Full,
                 &format!(
@@ -2606,7 +2675,9 @@ do not re-issue."
                      evaluator and auditor pass records before promotion.",
                     artifact_id
                 ),
-            )?;
+            )? {
+                return Ok(json);
+            }
             emit_gate_event(PromotionGateMode::Full, Some(artifact_id));
         } else if rev.artifact_id.is_some() && !current_capabilities.is_empty() {
             // Pure-skill intent-only bundle (no CodeExecution/AgentSpawn, no
@@ -2622,7 +2693,7 @@ do not re-issue."
             // for such an agent is trivial. Runtime capability enforcement
             // on every tool call remains the security gate for that case.
             let artifact_id = rev.artifact_id.as_deref().unwrap();
-            enforce_promotion_gate(
+            if let Some(json) = enforce_promotion_gate(
                 artifact_id,
                 PromotionGateMode::AuditOnly,
                 &format!(
@@ -2632,7 +2703,9 @@ do not re-issue."
                      promotion.",
                     artifact_id
                 ),
-            )?;
+            )? {
+                return Ok(json);
+            }
             emit_gate_event(PromotionGateMode::AuditOnly, Some(artifact_id));
         } else {
             // Reaching here ⇒ either zero declared capabilities, or a
@@ -2700,26 +2773,34 @@ do not re-issue."
                 // revision proposer.
                 let proposer = rev.created_by_id.as_str();
                 for id in &fed_ids {
-                    anyhow::ensure!(
-                        id != proposer,
-                        "Promotion gate (FullJury): federation role '{}' is the same identity \
+                    if id == proposer {
+                        return Ok(autonoetic_types::tool_error::ToolError::permission(format!(
+                            "Promotion gate (FullJury): federation role '{}' is the same identity \
                          that proposed revision '{}' (P-2.17). Each federation role must be \
                          a distinct agent from the proposer.",
-                        id,
-                        args.revision_id
-                    );
+                            id, args.revision_id
+                        ))
+                        .with_code("jury_identity_collision")
+                        .with_repair_hint("Use federation role identities distinct from the proposer, then retry.")
+                        .with_enforced_rules(vec!["P-2.17".to_string()])
+                        .to_error_response());
+                    }
                 }
                 if fed_ids.len() > 1 {
                     for i in 0..fed_ids.len() {
                         for j in (i + 1)..fed_ids.len() {
-                            anyhow::ensure!(
-                                fed_ids[i] != fed_ids[j],
-                                "Promotion gate (FullJury): federation roles '{}' and '{}' \
+                            if fed_ids[i] == fed_ids[j] {
+                                return Ok(autonoetic_types::tool_error::ToolError::permission(format!(
+                                    "Promotion gate (FullJury): federation roles '{}' and '{}' \
                                  are the same agent (P-2.17). Each federation role must be \
                                  a distinct agent.",
-                                fed_ids[i],
-                                fed_ids[j]
-                            );
+                                    fed_ids[i], fed_ids[j]
+                                ))
+                                .with_code("jury_identity_collision")
+                                .with_repair_hint("Use distinct identities for each federation role, then retry.")
+                                .with_enforced_rules(vec!["P-2.17".to_string()])
+                                .to_error_response());
+                            }
                         }
                     }
                 }
@@ -2733,15 +2814,19 @@ do not re-issue."
                     Some(e) => Some(e),
                     None => gateway_store.find_approved_escalation_for_artifact(artifact_id)?,
                 };
-                anyhow::ensure!(
-                    escalation.is_some(),
-                    "Promotion gate (FullJury): revision '{}' has federation role verdicts \
+                if escalation.is_none() {
+                    return Ok(autonoetic_types::tool_error::ToolError::permission(format!(
+                        "Promotion gate (FullJury): revision '{}' has federation role verdicts \
                      but no approved operator escalation. \
                      The planner must call federation.escalate with revision_id='{}' \
                      and the operator must approve before promotion.",
-                    args.revision_id,
-                    args.revision_id
-                );
+                        args.revision_id, args.revision_id
+                    ))
+                    .with_code("jury_escalation_required")
+                    .with_repair_hint("Obtain an approved operator escalation for this revision, then retry.")
+                    .with_enforced_rules(vec!["P-2.17".to_string()])
+                    .to_error_response());
+                }
 
                 emit_gate_event(PromotionGateMode::FullJury, Some(artifact_id));
             }

--- a/autonoetic-gateway/src/runtime/tools/agent_revision.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_revision.rs
@@ -2782,7 +2782,7 @@ do not re-issue."
                         ))
                         .with_code("jury_identity_collision")
                         .with_repair_hint("Use federation role identities distinct from the proposer, then retry.")
-                        .with_enforced_rules(vec!["P-2.17".to_string()])
+                        .with_enforced_rules(vec!["P-2.17".to_string(), "P-2.22".to_string()])
                         .to_error_response());
                     }
                 }
@@ -2798,7 +2798,7 @@ do not re-issue."
                                 ))
                                 .with_code("jury_identity_collision")
                                 .with_repair_hint("Use distinct identities for each federation role, then retry.")
-                                .with_enforced_rules(vec!["P-2.17".to_string()])
+                                .with_enforced_rules(vec!["P-2.17".to_string(), "P-2.22".to_string()])
                                 .to_error_response());
                             }
                         }
@@ -2824,7 +2824,7 @@ do not re-issue."
                     ))
                     .with_code("jury_escalation_required")
                     .with_repair_hint("Obtain an approved operator escalation for this revision, then retry.")
-                    .with_enforced_rules(vec!["P-2.17".to_string()])
+                    .with_enforced_rules(vec!["P-2.22".to_string()])
                     .to_error_response());
                 }
 

--- a/autonoetic-gateway/tests/constitution_federation_e2e.rs
+++ b/autonoetic-gateway/tests/constitution_federation_e2e.rs
@@ -343,6 +343,17 @@ fn try_promote(
     }
 }
 
+/// Re-present a structured P-5.11 gate *block* (`Ok(ok:false)`) as `Err(message)`
+/// so the `unwrap_err` FullJury failure assertions below read naturally.
+fn as_outcome(result: Result<serde_json::Value, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(v) if v["ok"] == serde_json::Value::Bool(false) => {
+            Err(v["message"].as_str().unwrap_or_default().to_string())
+        }
+        other => other,
+    }
+}
+
 struct TestSetup {
     _temp: tempfile::TempDir,
     #[allow(dead_code)]
@@ -676,10 +687,10 @@ fn test_federation_blocks_without_approved_escalation() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail without approved escalation"
     );
-    let err = result.unwrap_err();
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("FullJury") && err.contains("no approved operator escalation"),
         "error should mention FullJury and missing escalation: {err}"
@@ -758,10 +769,10 @@ fn test_federation_blocks_with_pending_escalation() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail with only a pending (not approved) escalation"
     );
-    let err = result.unwrap_err();
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("FullJury") && err.contains("no approved operator escalation"),
         "error should mention FullJury: {err}"
@@ -832,10 +843,10 @@ fn test_federation_blocks_when_role_shares_proposer_identity() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail when federation role shares proposer identity"
     );
-    let err = result.unwrap_err();
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("FullJury") && err.contains("P-2.17"),
         "error should mention P-2.17 distinct identity: {err}"
@@ -912,10 +923,10 @@ fn test_federation_blocks_when_roles_share_identity() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail when federation roles share identity"
     );
-    let err = result.unwrap_err();
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("FullJury")
             && err.contains("P-2.17")
@@ -1064,10 +1075,10 @@ fn test_federation_escalation_rejected_does_not_allow_promotion() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail with rejected escalation"
     );
-    let err = result.unwrap_err();
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("FullJury") && err.contains("no approved operator escalation"),
         "error should mention FullJury: {err}"

--- a/autonoetic-gateway/tests/constitution_p_2_26_unit_test_runner_gate.rs
+++ b/autonoetic-gateway/tests/constitution_p_2_26_unit_test_runner_gate.rs
@@ -251,6 +251,17 @@ fn try_promote(
     }
 }
 
+/// Re-present a structured P-5.11 gate *block* (`Ok(ok:false)`) as `Err(message)`
+/// so the failure assertions below read naturally; a genuine success stays `Ok`.
+fn as_outcome(result: Result<serde_json::Value, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(v) if v["ok"] == serde_json::Value::Bool(false) => {
+            Err(v["message"].as_str().unwrap_or_default().to_string())
+        }
+        other => other,
+    }
+}
+
 #[test]
 fn promotion_blocked_when_unit_test_runner_failed() {
     let agent_id = "p226.test.agent";
@@ -345,8 +356,8 @@ fn promotion_blocked_when_unit_test_runner_failed() {
         &revision_id,
     );
 
-    assert!(result.is_err(), "promotion should be blocked when unit_test_runner failed");
-    let err = result.unwrap_err();
+    assert!(as_outcome(result.clone()).is_err(), "promotion should be blocked when unit_test_runner failed");
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("P-2.26") || err.contains("unit_test_runner"),
         "error message should mention P-2.26 or unit_test_runner, got: {err}"

--- a/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_distinct_identity.rs
@@ -251,6 +251,17 @@ fn try_promote(
     }
 }
 
+/// Re-present a structured P-5.11 gate *block* (`Ok(ok:false)`) as `Err(message)`
+/// so the `unwrap_err` failure assertions below read naturally.
+fn as_outcome(result: Result<serde_json::Value, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(v) if v["ok"] == serde_json::Value::Bool(false) => {
+            Err(v["message"].as_str().unwrap_or_default().to_string())
+        }
+        other => other,
+    }
+}
+
 #[test]
 fn same_agent_identity_rejected_even_if_both_passed() {
     let agent_id = "rpp3.test.agent";
@@ -328,10 +339,10 @@ fn same_agent_identity_rejected_even_if_both_passed() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail when evaluator and auditor share identity"
     );
-    let err = result.unwrap_err();
+    let err = as_outcome(result).unwrap_err();
     assert!(
         err.contains("P-2.17"),
         "error should reference P-2.17: {err}"
@@ -426,7 +437,7 @@ fn distinct_identities_allowed() {
     assert!(
         result.is_ok(),
         "promote should succeed with distinct identities, got err: {:?}",
-        result.unwrap_err()
+        as_outcome(result).unwrap_err()
     );
     let promoted = result.unwrap();
     assert_eq!(promoted["ok"], true);

--- a/autonoetic-gateway/tests/constitution_promotion_gate_audit_only.rs
+++ b/autonoetic-gateway/tests/constitution_promotion_gate_audit_only.rs
@@ -364,6 +364,17 @@ fn try_promote(
     }
 }
 
+/// Re-present a structured P-5.11 gate *block* (`Ok(ok:false)`) as `Err(message)`
+/// so the failure match arms below read naturally; a genuine success stays `Ok`.
+fn as_outcome(result: Result<serde_json::Value, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(v) if v["ok"] == serde_json::Value::Bool(false) => {
+            Err(v["message"].as_str().unwrap_or_default().to_string())
+        }
+        other => other,
+    }
+}
+
 struct Fixture {
     _temp: tempfile::TempDir,
     gateway_dir: PathBuf,
@@ -462,7 +473,7 @@ fn audit_only_promote_fails_without_auditor_record() {
         &f.revision_id,
     );
 
-    match result {
+    match as_outcome(result) {
         Err(msg) => {
             assert!(
                 msg.contains("Promotion gate") && msg.contains("no auditor promotion.record"),
@@ -560,7 +571,7 @@ fn audit_only_promote_fails_with_auditor_record_pass_false() {
         &f.revision_id,
     );
 
-    match result {
+    match as_outcome(result) {
         Err(msg) => assert!(
             msg.contains("Promotion gate") && msg.contains("auditor did not pass"),
             "expected auditor-fail rejection, got: {}",
@@ -626,7 +637,7 @@ fn audit_only_promote_fails_when_auditor_is_proposer_self_approval() {
         &f.revision_id,
     );
 
-    match result {
+    match as_outcome(result) {
         Err(msg) => {
             assert!(
                 msg.contains("P-2.17") && msg.contains("same identity that proposed"),
@@ -679,7 +690,7 @@ fn high_risk_intent_only_artifact_still_requires_full_gate() {
         &f.revision_id,
     );
 
-    match result {
+    match as_outcome(result) {
         Err(msg) => {
             assert!(
                 msg.contains("no evaluator role passed") || msg.contains("no promotion.record"),

--- a/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
+++ b/autonoetic-gateway/tests/promotion_gate_hardening_integration.rs
@@ -371,6 +371,31 @@ fn try_promote(
     }
 }
 
+/// Extract the failure message from a `try_promote` result. Promotion-gate
+/// blocks are now structured `Ok(ok:false)` envelopes (P-5.11); only genuine
+/// infra failures surface as `Err`.
+fn gate_err(result: Result<serde_json::Value, String>) -> String {
+    match result {
+        Ok(v) => {
+            assert_eq!(v["ok"], false, "expected a failure envelope, got: {v}");
+            v["message"].as_str().unwrap_or_default().to_string()
+        }
+        Err(e) => e,
+    }
+}
+
+/// Re-present a structured P-5.11 gate *block* (`Ok(ok:false)`) as `Err` so the
+/// `.is_err()` "promote should fail" preconditions read naturally; a genuine
+/// success stays `Ok`.
+fn as_outcome(result: Result<serde_json::Value, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(v) if v["ok"] == serde_json::Value::Bool(false) => {
+            Err(v["message"].as_str().unwrap_or_default().to_string())
+        }
+        other => other,
+    }
+}
+
 struct TestSetup {
     _temp: tempfile::TempDir,
     #[allow(dead_code)]
@@ -453,10 +478,10 @@ fn test_promote_rejects_high_risk_without_promotion_records() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail without promotion records"
     );
-    let err = result.unwrap_err();
+    let err = gate_err(result);
     assert!(
         err.contains("Promotion gate") && err.contains("no promotion.record"),
         "error should mention promotion gate: {err}"
@@ -567,8 +592,8 @@ fn test_promote_rejects_when_evaluator_fails() {
         &revision_id,
     );
 
-    assert!(result.is_err(), "promote should fail when evaluator fails");
-    let err = result.unwrap_err();
+    assert!(as_outcome(result.clone()).is_err(), "promote should fail when evaluator fails");
+    let err = gate_err(result);
     assert!(
         err.contains("no evaluator role passed"),
         "error should mention evaluator failure: {err}"
@@ -610,10 +635,10 @@ fn test_promote_rejects_when_auditor_missing() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail when auditor is missing"
     );
-    let err = result.unwrap_err();
+    let err = gate_err(result);
     assert!(
         err.contains("auditor did not pass"),
         "error should mention auditor failure: {err}"
@@ -756,10 +781,10 @@ fn test_promote_rejects_high_risk_with_unresolved_dependencies() {
     );
 
     assert!(
-        result.is_err(),
+        as_outcome(result.clone()).is_err(),
         "promote should fail with unresolved dependencies"
     );
-    let err = result.unwrap_err();
+    let err = gate_err(result);
     assert!(
         err.contains("unresolved dependencies"),
         "error should mention unresolved dependencies: {err}"
@@ -892,10 +917,10 @@ fn test_full_pipeline_with_builder_and_promotion_gates() {
         &revision_id,
     );
     assert!(
-        fail_result.is_err(),
+        as_outcome(fail_result.clone()).is_err(),
         "Step 1: promote should fail without records"
     );
-    assert!(fail_result.unwrap_err().contains("no promotion.record"));
+    assert!(gate_err(fail_result).contains("no promotion.record"));
 
     // Step 2: Evaluator records pass
     let eval_manifest = evaluator_manifest();
@@ -925,10 +950,10 @@ fn test_full_pipeline_with_builder_and_promotion_gates() {
         &revision_id,
     );
     assert!(
-        partial_result.is_err(),
+        as_outcome(partial_result.clone()).is_err(),
         "Step 3: promote should fail with only evaluator"
     );
-    assert!(partial_result.unwrap_err().contains("auditor did not pass"));
+    assert!(gate_err(partial_result).contains("auditor did not pass"));
 
     // Step 4: Auditor records pass
     let audit_manifest = auditor_manifest();

--- a/autonoetic-types/src/tool_error.rs
+++ b/autonoetic-types/src/tool_error.rs
@@ -172,6 +172,13 @@ impl ToolError {
         self
     }
 
+    /// Override the `repair_hint` (the mechanical remedy). Useful with
+    /// constructors like `permission` that only take a message.
+    pub fn with_repair_hint(mut self, repair_hint: impl Into<String>) -> Self {
+        self.repair_hint = Some(repair_hint.into());
+        self
+    }
+
     /// Creates a new validation error.
     pub fn validation(message: impl Into<String>, repair_hint: Option<impl Into<String>>) -> Self {
         Self::new(
@@ -778,5 +785,15 @@ mod tests {
         let plain = ToolError::permission("denied");
         let v2: serde_json::Value = serde_json::from_str(&plain.to_json_string()).unwrap();
         assert!(v2.get("error").is_none(), "error code omitted when absent: {v2}");
+    }
+
+    #[test]
+    fn with_repair_hint_overrides_default() {
+        let err = ToolError::permission("auditor did not pass")
+            .with_code("auditor_pass_missing")
+            .with_repair_hint("Obtain an auditor pass record, then retry.");
+        let v: serde_json::Value = serde_json::from_str(&err.to_json_string()).unwrap();
+        assert_eq!(v["error"], "auditor_pass_missing");
+        assert_eq!(v["repair_hint"], "Obtain an auditor pass record, then retry.");
     }
 }


### PR DESCRIPTION
First rollout step of the tool-error homogenization (P-5.11, now active via #531). Brings the **promotion auditor/evaluator/identity/jury gates** onto the canonical envelope.

## Change
These gates previously failed with bare `Err(anyhow)` — inconsistent with the sibling promote branches (`capability_delta_requires_approval`, `promotion_incomplete`, `sentinel_*`) that return `Ok(ok:false, error_type, error:<code>, message, repair_hint)`. They now return the same structured envelope, so an orchestrator branches on one stable field instead of parsing prose.

Stable codes added: `promotion_record_missing`, `promotion_gate_content_digest_mismatch`, `auditor_pass_missing`, `auditor_identity_missing`, `evaluator_pass_missing`, `evaluator_identity_missing`, `gate_identity_collision`, `unit_test_runner_pass_missing`, `unresolved_dependencies`, `jury_identity_collision`, `jury_escalation_required`.

- `enforce_promotion_gate` → `Result<Option<String>>` (None = pass, Some = structured block); the 3 call sites + the FullJury block return the block.
- **Messages kept verbatim**; `error_type: permission`; mechanism-level `repair_hint` (no "spawn agent X" prescription — gateway states the unmet rule, not the plan); `enforced_rules` carries P-2.17/P-2.26 where the rule applies.
- `Err` is now reserved for genuine infra failures. **Consumer sweep**: no `src` path branches on promote returning `Err` (the approval-resume path passes the result through).
- New `ToolError::with_repair_hint` builder.

## Tests
Migrated the gate-block assertions (a local `as_outcome` adapter re-presents a structured block as `Err(message)` so `is_err`/`unwrap_err`/`match Err(msg)` arms read unchanged; messages asserted verbatim). All green:
- `promotion_gate_hardening_integration` (8), `constitution_promotion_gate_audit_only` (5), `constitution_promotion_distinct_identity` (2), `constitution_federation_e2e` (7), `constitution_p_2_26_unit_test_runner_gate` (2)
- regression: `promotion_governor` (13), `phase2_promotion_stability` (9), `session_envelope_promote_with` (5), `protected_agents_promotion_gate` (6), `constitution_promotion_capability_delta` (11), `constitution_r_5_11_uniform_error_envelope` (1), `tool_error` unit (10)
- full `cargo test -p autonoetic-gateway --no-run` compiles clean.

## Rollout context
Step 1 of the P-5.11 rollout (see `docs/tool-error-contract.md`). Next: the ~19 hand-built `Ok({ok:false,"error":<code>})` JSONs → construct via `ToolError::…with_code`; then the bare-`anyhow` long tail (expected-outcomes get codes; infra stays `Err`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)