### PR TITLE
feat(errors): homogenize all tool errors onto canonical ToolError envelope (P-5.11)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/agent_inspect.rs
+++ b/autonoetic-gateway/src/runtime/tools/agent_inspect.rs
@@ -340,7 +340,11 @@ impl NativeTool for AgentInspectTool {
                             o.insert(
                                 "layers".to_string(),
                                 serde_json::json!({
-                                    "error": format!("Could not load artifact layers: {}", e),
+                                    "ok": false,
+                                    "error_type": "execution",
+                                    "error": "artifact_layers_load_failed",
+                                    "message": format!("Could not load artifact layers: {}", e),
+                                    "repair_hint": "Check that the artifact layers exist and are accessible."
                                 }),
                             );
                         });

--- a/autonoetic-gateway/src/runtime/tools/credential.rs
+++ b/autonoetic-gateway/src/runtime/tools/credential.rs
@@ -123,7 +123,7 @@ impl NativeTool for CredentialCheckTool {
                 "error_type": "permission",
                 "message": message,
                 "repair_hint": "Request CredentialAccess for this service or choose an authorized service.",
-                "error": message,
+                "error": "credential_access_requires_approval",
                 "approval_required": true,
                 "reason": format!("Access to {} credentials requires approval", args.service),
             })
@@ -299,7 +299,7 @@ impl NativeTool for CredentialRequestTool {
                 "error_type": "permission",
                 "message": message,
                 "repair_hint": "Request CredentialAccess for this service or choose an authorized service.",
-                "error": message,
+                "error": "credential_access_requires_approval",
                 "approval_required": true,
                 "reason": format!("Access to {} credentials requires approval", cred.service),
             })
@@ -452,13 +452,13 @@ impl NativeTool for CredentialRequestTool {
                     crate::runtime::human_gate::GateResult::Suspended { gate_id, .. } => {
                         return Ok(json!({
                             "ok": false,
-                            "error_type": violation.error_type,
+                            "error_type": "permission",
                             "message": format!(
                                 "Execution suspended pending operator approval ({}). Retry credential.request with approval_ref after approval.",
                                 gate_id
                             ),
                             "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                            "error": violation.message,
+                            "error": "approval_required",
                             "approval_required": true,
                             "request_id": gate_id,
                             "suspended": true,
@@ -549,7 +549,7 @@ impl NativeTool for CredentialRequestTool {
                             gate_id
                         ),
                         "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                        "error": format!("Network access denied for host: {}", url_host),
+                        "error": "network_access_denied",
                         "approval_required": true,
                         "request_id": gate_id,
                         "suspended": true,

--- a/autonoetic-gateway/src/runtime/tools/evaluation.rs
+++ b/autonoetic-gateway/src/runtime/tools/evaluation.rs
@@ -795,9 +795,21 @@ impl NativeTool for EvalCompareTool {
             match eval_stats::compare(&baseline_samples, &candidate_samples, &config) {
                 Ok(rec) => match serde_json::to_value(rec) {
                     Ok(val) => Some(val),
-                    Err(e) => Some(serde_json::json!({"error": format!("serialization failure: {}", e)})),
+                    Err(e) => Some(serde_json::json!({
+                        "ok": false,
+                        "error_type": "execution",
+                        "error": "eval_serialization_failed",
+                        "message": format!("serialization failure: {}", e),
+                        "repair_hint": "Check the evaluation data and retry."
+                    })),
                 },
-                Err(e) => Some(serde_json::json!({"error": e})),
+                Err(e) => Some(serde_json::json!({
+                    "ok": false,
+                    "error_type": "execution",
+                    "error": "eval_comparison_failed",
+                    "message": format!("{}", e),
+                    "repair_hint": "Check the evaluation data and retry."
+                })),
             }
         });
 

--- a/autonoetic-gateway/src/runtime/tools/improvement.rs
+++ b/autonoetic-gateway/src/runtime/tools/improvement.rs
@@ -601,7 +601,13 @@ fn build_ab_stats(
     let config = crate::runtime::eval_stats::CompareConfig::default();
     match crate::runtime::eval_stats::compare(&a, &b, &config) {
         Ok(rec) => serde_json::to_value(rec).ok(),
-        Err(e) => Some(serde_json::json!({"error": e})),
+        Err(e) => Some(serde_json::json!({
+            "ok": false,
+            "error_type": "execution",
+            "error": "improvement_ab_comparison_failed",
+            "message": format!("{}", e),
+            "repair_hint": "Check the evaluation data and retry."
+        })),
     }
 }
 

--- a/autonoetic-gateway/src/runtime/tools/observability.rs
+++ b/autonoetic-gateway/src/runtime/tools/observability.rs
@@ -228,11 +228,12 @@ impl NativeTool for ObservabilityReadReasoningTool {
             .ok_or_else(|| anyhow::anyhow!("Cannot resolve agents directory"))?;
         let target_agent_dir = agents_dir.join(&args.target_agent_id);
         if !target_agent_dir.exists() {
-            return serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Target agent directory not found: {}", args.target_agent_id),
-            }))
-            .map_err(Into::into);
+            return Ok(ToolError::not_found(
+                format!("Target agent directory '{}'", args.target_agent_id),
+                Some("Ensure the agent is installed and the agent ID is correct."),
+            )
+            .with_code("target_agent_dir_not_found")
+            .to_error_response());
         }
 
         let evidence_dir = target_agent_dir
@@ -416,11 +417,12 @@ impl NativeTool for ObservabilityReadTool {
         let sub_path = parse_sub_path(&args.uri);
 
         let Some(report) = store.find_published_report(&root_session_id)? else {
-            return serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("No published report found for root session '{}'", root_session_id),
-            }))
-            .map_err(Into::into);
+            return Ok(ToolError::not_found(
+                format!("Published report for root session '{}'", root_session_id),
+                Some("Publish a report first or check the root session ID."),
+            )
+            .with_code("report_not_found")
+            .to_error_response());
         };
 
         match sub_path.as_deref() {
@@ -433,12 +435,12 @@ impl NativeTool for ObservabilityReadTool {
             Some("report/agents") | Some("report/agents/") => {
                 build_agents_list_response(&root_session_id, &report)
             }
-            _ => serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Unknown observability sub-path: {}", args.uri),
-                "hint": "Available: /report, /report/overview, /report/agents",
-            }))
-            .map_err(Into::into),
+            _ => Ok(ToolError::validation(
+                format!("Unknown observability sub-path: {}", args.uri),
+                Some("Available: /report, /report/overview, /report/agents"),
+            )
+            .with_code("unknown_observability_path")
+            .to_error_response()),
         }
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/plan_frame.rs
+++ b/autonoetic-gateway/src/runtime/tools/plan_frame.rs
@@ -9,6 +9,7 @@ use autonoetic_types::plan_frame::{
     plan_envelope_diff, PlanFrame, PlanFrameSummary, PlanRef, PlanStatus, PlanStep, StepOwner,
     ValidationEntry, ValidationPolicy,
 };
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -276,17 +277,11 @@ impl NativeTool for PlanFrameProposeTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(config) = config else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway config not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway config not available", Some("Ensure the gateway configuration is loaded and valid.")).with_code("gateway_config_unavailable").to_error_response());
         };
 
         let session_id = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
@@ -507,10 +502,7 @@ impl NativeTool for PlanFrameGetTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let plan = if let Some(pid) = &args.plan_id {
@@ -597,10 +589,7 @@ impl NativeTool for PlanFrameListTool {
         _run_context: Option<&NativeToolRunContext>,
     ) -> anyhow::Result<String> {
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let sid = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
@@ -681,24 +670,15 @@ impl NativeTool for PlanFrameApproveTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(plan) = store.load_plan_frame(&args.plan_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Plan not found"
-            }))?);
+            return Ok(ToolError::not_found("Plan", Some("Create a plan first or check the plan ID.")).with_code("plan_not_found").to_error_response());
         };
 
         if plan.status != PlanStatus::AwaitingApproval {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Plan is in '{}' status; only awaiting_approval plans can be approved", plan.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Plan is in '{}' status; only awaiting_approval plans can be approved", plan.status.as_str()), Some("Ensure the plan is in AwaitingApproval status before approving.")).with_code("plan_wrong_status").to_error_response());
         }
 
         let now = now_rfc3339();
@@ -923,24 +903,15 @@ impl NativeTool for PlanFrameAmendTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(current) = store.load_plan_frame(&args.plan_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Plan not found"
-            }))?);
+            return Ok(ToolError::not_found("Plan", Some("Create a plan first or check the plan ID.")).with_code("plan_not_found").to_error_response());
         };
 
         if current.status == PlanStatus::Completed || current.status == PlanStatus::Cancelled {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Cannot amend a {} plan", current.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Cannot amend a {} plan", current.status.as_str()), Some("Only plans in mutable status (not Completed or Cancelled) can be amended.")).with_code("plan_wrong_status").to_error_response());
         }
 
         let old_version = current.version;
@@ -1287,10 +1258,7 @@ impl NativeTool for PlanFrameHistoryTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let revisions = store.list_plan_revisions(&args.plan_id)?;

--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -526,12 +526,9 @@ impl NativeTool for PromotionQueryTool {
                 serde_json::to_string(&response).map_err(Into::into)
             }
             None => {
-                serde_json::to_string(&serde_json::json!({
-                    "error": "No promotion record found for this artifact",
-                    "artifact_canonical_digest": artifact_canonical_digest,
-                    "artifact_ref": user_ref,
-                }))
-                .map_err(Into::into)
+                Ok(ToolError::not_found("Promotion record", Some("Ensure a promotion record exists for this artifact before querying."))
+                    .with_code("promotion_record_not_found")
+                    .to_error_response())
             }
         }
     }

--- a/autonoetic-gateway/src/runtime/tools/session.rs
+++ b/autonoetic-gateway/src/runtime/tools/session.rs
@@ -4,6 +4,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -344,10 +345,7 @@ impl NativeTool for SessionSearchTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::json!({
-                "error": "Gateway store not available"
-            })
-            .to_string());
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let skill_path = agent_dir.join("SKILL.md");
@@ -356,10 +354,7 @@ impl NativeTool for SessionSearchTool {
             let (m, _) = crate::runtime::parser::SkillParser::parse(&content)?;
             m
         } else {
-            return Ok(serde_json::json!({
-                "error": "Agent manifest not found"
-            })
-            .to_string());
+            return Ok(ToolError::not_found("Agent manifest", Some("Ensure the agent is properly installed and the manifest file exists.")).with_code("agent_manifest_not_found").to_error_response());
         };
 
         let caller_id = &manifest.agent.id;
@@ -473,17 +468,11 @@ impl NativeTool for SessionSummarizeTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(gw_dir) = gateway_dir else {
-            return Ok(serde_json::json!({
-                "error": "Gateway directory not available"
-            })
-            .to_string());
+            return Ok(ToolError::execution("Gateway directory not available", Some("Ensure the gateway data directory is configured and accessible.")).with_code("gateway_dir_unavailable").to_error_response());
         };
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::json!({
-                "error": "Gateway store not available"
-            })
-            .to_string());
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let skill_path = agent_dir.join("SKILL.md");
@@ -492,10 +481,7 @@ impl NativeTool for SessionSummarizeTool {
             let (m, _) = crate::runtime::parser::SkillParser::parse(&content)?;
             m
         } else {
-            return Ok(serde_json::json!({
-                "error": "Agent manifest not found"
-            })
-            .to_string());
+            return Ok(ToolError::not_found("Agent manifest", Some("Ensure the agent is properly installed and the manifest file exists.")).with_code("agent_manifest_not_found").to_error_response());
         };
 
         let caller_id = &manifest.agent.id;

--- a/autonoetic-gateway/src/runtime/tools/skill.rs
+++ b/autonoetic-gateway/src/runtime/tools/skill.rs
@@ -12,6 +12,7 @@ use crate::runtime::tools::{
 use autonoetic_types::agent::{AgentIdentity, AgentManifest, LlmConfig};
 use autonoetic_types::capability::Capability;
 use autonoetic_types::memory::{MemoryObject, MemoryVisibility};
+use autonoetic_types::tool_error::ToolError;
 use gray_matter::Matter;
 use regex::Regex;
 use serde::Deserialize;
@@ -112,14 +113,7 @@ impl NativeTool for SkillInstallTool {
         // ── 2. Policy: SkillInstall capability must permit this URL host ──────
         let url_host = extract_host(&args.url)?;
         if !policy.can_install_skill(&url_host).is_allowed() {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error": format!(
-                    "SkillInstall capability does not permit fetching from host '{}'",
-                    url_host
-                ),
-            })
-            .to_string());
+            return Ok(ToolError::permission(format!("SkillInstall capability does not permit fetching from host '{}'", url_host)).with_code("skill_install_host_denied").to_error_response());
         }
 
         // ── 3. Resolve config and paths ───────────────────────────────────────
@@ -157,11 +151,7 @@ impl NativeTool for SkillInstallTool {
         };
 
         if !(200..300).contains(&(http_status as i32)) {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error": format!("HTTP {} fetching SKILL.md from {}", http_status, args.url),
-            })
-            .to_string());
+            return Ok(ToolError::execution(format!("HTTP {} fetching SKILL.md from {}", http_status, args.url), Some("Ensure the URL is accessible and retry.")).with_code("skill_fetch_failed").to_error_response());
         }
 
         // ── 5. Parse the SKILL.md ─────────────────────────────────────────────
@@ -759,17 +749,7 @@ impl NativeTool for SkillNormalizeTool {
                     }
                 }
                 Err(msg) => {
-                    let error_type = if msg.contains("NetworkAccess") {
-                        "policy"
-                    } else {
-                        "fetch"
-                    };
-                    return Ok(serde_json::json!({
-                        "ok": false,
-                        "error_type": error_type,
-                        "error": msg,
-                    })
-                    .to_string());
+                    return Ok(ToolError::execution(msg, None::<String>).to_error_response());
                 }
             }
         }
@@ -780,15 +760,7 @@ impl NativeTool for SkillNormalizeTool {
             .unwrap_or_else(|| format!("skills/{slug}/SKILL.md"));
         validate_rel_store_path(&rel)?;
         if !policy.can_write_path(&rel).is_allowed() {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error_type": "permission",
-                "error": format!(
-                    "WriteAccess denied for normalized skill path '{}' (policy P-1.4)",
-                    rel
-                ),
-            })
-            .to_string());
+            return Ok(ToolError::permission(format!("WriteAccess denied for normalized skill path '{}' (policy P-1.4)", rel)).with_code("skill_write_access_denied").to_error_response());
         }
 
         if autonoetic_onboarding_present(&markdown) {
@@ -846,13 +818,7 @@ impl NativeTool for SkillNormalizeTool {
 
         let (step_values, fragments) = extract_api_steps_from_markdown(&markdown);
         if step_values.is_empty() {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "partial": true,
-                "error": "No HTTP API endpoints could be extracted from the markdown",
-                "fragments": fragments,
-            })
-            .to_string());
+            return Ok(ToolError::validation("No HTTP API endpoints could be extracted from the markdown", Some("Ensure the markdown contains valid HTTP API endpoint documentation.")).with_code("no_api_endpoints_found").to_error_response());
         }
 
         let steps_count = step_values.len();

--- a/autonoetic-gateway/src/runtime/tools/tool_discover.rs
+++ b/autonoetic-gateway/src/runtime/tools/tool_discover.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 
 use crate::llm::ToolDefinition;
@@ -75,17 +76,11 @@ impl NativeTool for ToolDiscoverTool {
         }
 
         let Some(ctx) = run_context else {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error": "No run context available."
-            }).to_string());
+            return Ok(ToolError::execution("No run context available.", Some("Ensure the tool is invoked within an active session context.")).with_code("no_run_context").to_error_response());
         };
 
         let Some(writer) = &ctx.discovered_tools else {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error": "Discovered-tools writer not available."
-            }).to_string());
+            return Ok(ToolError::execution("Discovered-tools writer not available.", Some("Ensure the discovery subsystem is initialized.")).with_code("discovery_writer_unavailable").to_error_response());
         };
 
         let mut accepted: Vec<String> = Vec::new();

--- a/autonoetic-gateway/src/runtime/tools/user_interaction.rs
+++ b/autonoetic-gateway/src/runtime/tools/user_interaction.rs
@@ -5,6 +5,7 @@ use crate::runtime::active_execution_registry::NativeToolRunContext;
 use crate::runtime::tools::{default_true, NativeTool, NativeToolRegistry};
 use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::background::UserInteractionStatus;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -126,13 +127,12 @@ impl NativeTool for UserAskTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         if asks_for_secret(&args) {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "error_type": "validation",
-                "message": "user.ask cannot be used to request secrets or credential values.",
-                "repair_hint": "Use credential.setup / credential.prompt flows so secrets stay in gateway vault-backed channels.",
-                "error": "secret_collection_not_allowed"
-            }).to_string());
+            return Ok(ToolError::validation(
+                "user.ask cannot be used to request secrets or credential values.",
+                Some("Use credential.setup / credential.prompt flows so secrets stay in gateway vault-backed channels."),
+            )
+            .with_code("secret_collection_not_allowed")
+            .to_error_response());
         }
 
         let sid = session_id.unwrap_or("unknown");
@@ -166,13 +166,12 @@ impl NativeTool for UserAskTool {
                     )
                 });
                 if has_active_children {
-                    return Ok(serde_json::json!({
-                        "ok": false,
-                        "error_type": "conflict",
-                        "message": "user.ask is not available while workflow tasks are active. Use workflow.wait to handle pending child tasks, or respond in prose for clarifications.",
-                        "repair_hint": "Call workflow.wait until child tasks complete, then retry user.ask.",
-                        "error": "user.ask is not available while workflow tasks are active. Use workflow.wait to handle pending child tasks, or respond in prose for clarifications."
-                    }).to_string());
+                    return Ok(ToolError::conflict(
+                        "user.ask is not available while workflow tasks are active. Complete or cancel child tasks first.",
+                        Some("Call workflow.wait until child tasks complete, then retry."),
+                    )
+                    .with_code("workflow_tasks_active")
+                    .to_error_response());
                 }
             }
 
@@ -183,13 +182,12 @@ impl NativeTool for UserAskTool {
                 .get_pending_interactions_for_root_session(&root_session_id)
                 .unwrap_or_default();
             if !pending_approvals.is_empty() || !pending_interactions.is_empty() {
-                return Ok(serde_json::json!({
-                    "ok": false,
-                    "error_type": "conflict",
-                    "message": "user.ask is not available while gates are pending (approvals, interactions, or escalations). Resolve pending gates before retrying.",
-                    "repair_hint": "Resolve or wait for pending gates, then retry user.ask.",
-                    "error": "user.ask is not available while gates are pending. Resolve pending gates before retrying."
-                }).to_string());
+                return Ok(ToolError::conflict(
+                    "user.ask is not available while gates are pending. Resolve or wait for pending gates, then retry.",
+                    Some("Resolve or wait for pending gates, then retry."),
+                )
+                .with_code("gates_pending")
+                .to_error_response());
             }
         }
 
@@ -227,14 +225,12 @@ impl NativeTool for UserAskTool {
         let store = match gateway_store {
             Some(ref s) => s.clone(),
             None => {
-                return Ok(serde_json::json!({
-                    "ok": false,
-                    "error_type": "resource",
-                    "message": "Gateway store not available; user.ask requires persistent store",
-                    "repair_hint": "Configure GatewayStore for this runtime before calling user.ask.",
-                    "error": "Gateway store not available; user.ask requires persistent store"
-                })
-                .to_string());
+                return Ok(ToolError::resource(
+                    "Gateway store not available; user.ask requires persistent store",
+                    Some("Configure GatewayStore with a persistent backend for user interaction support."),
+                )
+                .with_code("user_interaction_store_unavailable")
+                .to_error_response());
             }
         };
 
@@ -264,15 +260,15 @@ impl NativeTool for UserAskTool {
 
         match gate_result {
             GateResult::AlreadyPending { gate_id, .. } => {
-                Ok(serde_json::json!({
-                    "ok": false,
-                    "error_type": "conflict",
-                    "message": "A user interaction is already pending for this session.",
-                    "repair_hint": "Wait for the existing interaction to be answered, then retry.",
-                    "error": "A user interaction is already pending for this session.",
-                    "interaction_id": gate_id,
-                })
-                .to_string())
+                let err = ToolError::conflict(
+                    "A user interaction is already pending for this session.",
+                    Some("Wait for the existing interaction to be answered, then retry."),
+                )
+                .with_code("interaction_already_pending");
+                let mut v = serde_json::to_value(&err)
+                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                v["interaction_id"] = serde_json::json!(gate_id);
+                Ok(v.to_string())
             }
             GateResult::Suspended {
                 gate_id,
@@ -426,15 +422,12 @@ impl NativeTool for UserInteractionStatusTool {
                 "message": "User interaction not found"
             }))
             .map_err(Into::into),
-            Err(e) => serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "interaction_id": args.interaction_id,
-                "error_type": "resource",
-                "message": e.to_string(),
-                "repair_hint": "Verify the interaction id and gateway store availability, then retry.",
-                "error": e.to_string()
-            }))
-            .map_err(Into::into),
+            Err(e) => Ok(ToolError::resource(
+                e.to_string(),
+                Some("Verify the interaction id and gateway store availability, then retry."),
+            )
+            .with_code("interaction_read_failed")
+            .to_error_response()),
         }
     }
 }

--- a/autonoetic-gateway/src/runtime/tools/validation.rs
+++ b/autonoetic-gateway/src/runtime/tools/validation.rs
@@ -6,6 +6,7 @@ use autonoetic_types::agent::AgentManifest;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
 use autonoetic_types::plan_frame::{ValidationClass, ValidationWaiver};
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -113,48 +114,33 @@ impl NativeTool for ValidationWaiveTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(config) = config else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway config not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway config not available", Some("Ensure the gateway configuration is loaded and valid.")).with_code("gateway_config_unavailable").to_error_response());
         };
 
         let session_id_val = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
         let root_session_id = session_id_val.split('/').next().unwrap_or(session_id_val);
 
         if !args.artifact_id.starts_with("art_") {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Invalid artifact_id '{}': must be a canonical artifact ID (art_*). Use artifact_inspect or resolve to look up art_* from a ref.", args.artifact_id)
-            }))?);
+            return Ok(ToolError::validation(format!("Invalid artifact_id '{}': must be a canonical artifact ID (art_*). Use artifact_inspect or resolve to look up art_* from a ref.", args.artifact_id), Some("Use a canonical art_* ID. Run artifact_inspect or resolve on your ref first.")).with_code("invalid_artifact_id").to_error_response());
         }
 
         let validation_class = match parse_class(&args.validation_class) {
             Some(c) => c,
             None => {
-                return Ok(serde_json::to_string(&serde_json::json!({
-                    "ok": false,
-                    "error": format!("Invalid validation_class '{}'. Waivable classes: correctness_check, quality_check, packaging_check", args.validation_class)
-                }))?);
+                return Ok(ToolError::validation(format!("Invalid validation_class '{}'. Waivable classes: correctness_check, quality_check, packaging_check", args.validation_class), Some("Use one of: correctness_check, quality_check, packaging_check")).with_code("invalid_validation_class").to_error_response());
             }
         };
 
         if !is_waivable(validation_class) {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("{} validations cannot be waived — they are mechanically enforced", args.validation_class)
-            }))?);
+            return Ok(ToolError::validation(format!("{} validations cannot be waived — they are mechanically enforced", args.validation_class), Some("Only waivable classes can be waived. Check the list of waivable classes.")).with_code("non_waivable_validation").to_error_response());
         }
 
         if args.reason.trim().is_empty() {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "A non-empty reason is required for all waivers"
-            }))?);
+            return Ok(ToolError::validation("A non-empty reason is required for all waivers", Some("Provide a non-empty reason string in the request.")).with_code("empty_waiver_reason").to_error_response());
         }
 
         let workflow_id = match crate::scheduler::workflow_store::ensure_workflow_for_root_session(
@@ -165,10 +151,7 @@ impl NativeTool for ValidationWaiveTool {
         ) {
             Ok(w) => w.workflow_id,
             Err(e) => {
-                return Ok(serde_json::to_string(&serde_json::json!({
-                    "ok": false,
-                    "error": format!("Failed to ensure workflow for root session: {}", e)
-                }))?);
+                return Ok(ToolError::execution(format!("Failed to ensure workflow for root session: {}", e), Some("Check the workflow subsystem and retry.")).with_code("workflow_ensure_failed").to_error_response());
             }
         };
 
@@ -256,9 +239,7 @@ impl NativeTool for ValidationWaiversTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let waivers = if let Some(artifact_id) = &args.artifact_id {
@@ -266,9 +247,7 @@ impl NativeTool for ValidationWaiversTool {
         } else if let Some(workflow_id) = &args.workflow_id {
             store.list_waivers_for_workflow(workflow_id)?
         } else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Provide artifact_id or workflow_id"
-            }))?);
+            return Ok(ToolError::validation("Provide artifact_id or workflow_id", Some("Include either artifact_id or workflow_id in the request.")).with_code("missing_artifact_or_workflow").to_error_response());
         };
 
         let summary: Vec<serde_json::Value> = waivers.iter().map(|w| {

--- a/autonoetic-gateway/src/runtime/tools/web.rs
+++ b/autonoetic-gateway/src/runtime/tools/web.rs
@@ -942,7 +942,7 @@ impl NativeTool for WebSearchTool {
                             gate_id
                         ),
                         "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                        "error": format!("Network access denied for host: {}", engine_host),
+                        "error": "network_access_denied",
                         "approval_required": true,
                         "request_id": gate_id,
                         "suspended": true,
@@ -1340,7 +1340,7 @@ fn gate_web_fetch_host(
                         gate_id
                     ),
                     "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                    "error": format!("Network access denied for host: {}", host),
+                    "error": "network_access_denied",
                     "approval_required": true,
                     "request_id": gate_id,
                     "suspended": true,
@@ -1954,7 +1954,7 @@ impl NativeTool for WebCallTool {
                             gate_id
                         ),
                         "repair_hint": "Wait for approval and retry this exact request using approval_ref.",
-                        "error": format!("Network access denied for host: {}", host),
+                        "error": "network_access_denied",
                         "approval_required": true,
                         "request_id": gate_id,
                         "suspended": true,

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -6,6 +6,7 @@ use crate::runtime::content_store::ContentStore;
 use crate::runtime::semantic_diff::RuleBasedSemanticSummarizer;
 use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
 use autonoetic_types::agent::AgentManifest;
+use autonoetic_types::tool_error::ToolError;
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
 use autonoetic_types::semantic_diff::{SemanticSummary, SemanticSummaryInputs, SemanticSummarizer};
@@ -297,21 +298,15 @@ impl NativeTool for ArtifactProjectTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(gateway_dir) = gateway_dir else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway directory not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway directory not available", Some("Ensure the gateway data directory is configured and accessible.")).with_code("gateway_dir_unavailable").to_error_response());
         };
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(config) = config else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway config not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway config not available", Some("Ensure the gateway configuration is loaded and valid.")).with_code("gateway_config_unavailable").to_error_response());
         };
 
         let session_id_val = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
@@ -488,15 +483,11 @@ impl NativeTool for WorkbenchStatusTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(wb) = store.load_workbench(&args.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         let source_dir = Path::new(&wb.workspace_path);
@@ -594,21 +585,15 @@ impl NativeTool for WorkbenchDiffTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(wb) = store.load_workbench(&args.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         if wb.status != WorkbenchStatus::Active {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": format!("Workbench is in '{}' status", wb.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Workbench is in '{}' status", wb.status.as_str()), Some("Ensure the workbench is in Active status before performing this operation.")).with_code("workbench_wrong_status").to_error_response());
         }
 
         let source_dir = Path::new(&wb.workspace_path);
@@ -699,30 +684,22 @@ impl NativeTool for WorkbenchCheckpointTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(wb) = store.load_workbench(&args.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         if wb.status != WorkbenchStatus::Active {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": format!("Cannot checkpoint a {} workbench", wb.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Cannot checkpoint a {} workbench", wb.status.as_str()), Some("Ensure the workbench is in Active status before checkpointing.")).with_code("workbench_wrong_status").to_error_response());
         }
 
         let label = args.label.as_deref().unwrap_or("manual");
         let cp_id = match create_auto_checkpoint(&store, &wb, label) {
             Ok(id) => id,
             Err(e) => {
-                return Ok(serde_json::to_string(&serde_json::json!({
-                    "ok": false, "error": format!("Checkpoint failed: {e}")
-                }))?);
+                return Ok(ToolError::execution(format!("Checkpoint failed: {e}"), Some("Check the underlying storage and retry.")).with_code("checkpoint_failed").to_error_response());
             }
         };
 
@@ -789,9 +766,7 @@ impl NativeTool for WorkbenchCheckpointsTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let checkpoints = store.list_checkpoints_for_workbench(&args.workbench_id)?;
@@ -859,27 +834,19 @@ impl NativeTool for WorkbenchCheckoutTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(cp) = store.load_checkpoint(&args.checkpoint_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Checkpoint not found"
-            }))?);
+            return Ok(ToolError::not_found("Checkpoint", Some("Create a checkpoint first or check the checkpoint ID.")).with_code("checkpoint_not_found").to_error_response());
         };
 
         let Some(wb) = store.load_workbench(&cp.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         if wb.status != WorkbenchStatus::Active {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": format!("Cannot checkout to a {} workbench", wb.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Cannot checkout to a {} workbench", wb.status.as_str()), Some("Ensure the workbench is in Active status before checkout.")).with_code("workbench_wrong_status").to_error_response());
         }
 
         let source_dir = Path::new(&wb.workspace_path);
@@ -891,9 +858,7 @@ impl NativeTool for WorkbenchCheckoutTool {
             .join(&cp.checkpoint_id);
 
         if !checkpoint_dir.exists() {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Checkpoint files not found on disk"
-            }))?);
+            return Ok(ToolError::resource("Checkpoint files not found on disk", Some("Ensure the checkpoint directory exists and the files have not been manually removed.")).with_code("checkpoint_files_missing").to_error_response());
         }
 
         let current_files = collect_workbench_files(source_dir)?;
@@ -982,44 +947,31 @@ impl NativeTool for WorkbenchReconcileTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(gateway_dir) = gateway_dir else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway directory not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway directory not available", Some("Ensure the gateway data directory is configured and accessible.")).with_code("gateway_dir_unavailable").to_error_response());
         };
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(config) = config else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway config not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway config not available", Some("Ensure the gateway configuration is loaded and valid.")).with_code("gateway_config_unavailable").to_error_response());
         };
 
         let session_id_val = session_id.ok_or_else(|| anyhow::anyhow!("session_id required"))?;
         let root_session_id = session_id_val.split('/').next().unwrap_or(session_id_val);
 
         let Some(wb) = store.load_workbench(&args.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         if wb.status != WorkbenchStatus::Active {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Cannot reconcile a {} workbench", wb.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Cannot reconcile a {} workbench", wb.status.as_str()), Some("Ensure the workbench is in Active status before reconciliation.")).with_code("workbench_wrong_status").to_error_response());
         }
 
         let source_dir = Path::new(&wb.workspace_path);
         if !source_dir.exists() {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench source directory does not exist"
-            }))?);
+            return Ok(ToolError::resource("Workbench source directory does not exist", Some("Ensure the workbench workspace path exists on disk.")).with_code("workbench_source_missing").to_error_response());
         }
 
         let meta_dir = source_dir.parent().unwrap().join(".autonoetic");
@@ -1034,9 +986,7 @@ impl NativeTool for WorkbenchReconcileTool {
 
         let current_files = collect_workbench_files(source_dir)?;
         if current_files.is_empty() {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "No files in workbench to reconcile"
-            }))?);
+            return Ok(ToolError::conflict("No files in workbench to reconcile", Some("Add files to the workbench source directory, then retry.")).with_code("workbench_empty").to_error_response());
         }
 
         let content_store = ContentStore::new(gateway_dir)?;
@@ -1284,22 +1234,15 @@ impl NativeTool for WorkbenchDiscardTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(wb) = store.load_workbench(&args.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         if wb.status != WorkbenchStatus::Active {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": format!("Cannot discard a {} workbench", wb.status.as_str())
-            }))?);
+            return Ok(ToolError::conflict(format!("Cannot discard a {} workbench", wb.status.as_str()), Some("Ensure the workbench is in Active status before discarding.")).with_code("workbench_wrong_status").to_error_response());
         }
 
         let now = now_rfc3339();
@@ -1377,22 +1320,15 @@ impl NativeTool for WorkbenchCleanupTool {
             .map_err(|e| anyhow::anyhow!("Invalid JSON arguments for '{}': {}", self.name(), e))?;
 
         let Some(store) = gateway_store else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Gateway store not available"
-            }))?);
+            return Ok(ToolError::execution("Gateway store not available", Some("Ensure the gateway database is initialized and the store path is accessible.")).with_code("gateway_store_unavailable").to_error_response());
         };
 
         let Some(wb) = store.load_workbench(&args.workbench_id)? else {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false, "error": "Workbench not found"
-            }))?);
+            return Ok(ToolError::not_found("Workbench", Some("Create a workbench first or check the workbench ID.")).with_code("workbench_not_found").to_error_response());
         };
 
         if wb.status == WorkbenchStatus::Active {
-            return Ok(serde_json::to_string(&serde_json::json!({
-                "ok": false,
-                "error": "Cannot clean up an active workbench. Reconcile or discard first."
-            }))?);
+            return Ok(ToolError::conflict("Cannot clean up an active workbench. Reconcile or discard first.", Some("Reconcile or discard the workbench before cleanup.")).with_code("workbench_wrong_status").to_error_response());
         }
 
         let workspace_path = Path::new(&wb.workspace_path);

--- a/autonoetic-gateway/src/runtime/tools/workflow.rs
+++ b/autonoetic-gateway/src/runtime/tools/workflow.rs
@@ -5,6 +5,7 @@ use crate::runtime::tools::{NativeTool, NativeToolRegistry, ToolMetadata};
 use autonoetic_types::agent::{AgentManifest, ToolTier};
 use autonoetic_types::capability::Capability;
 use autonoetic_types::config::GatewayConfig;
+use autonoetic_types::tool_error::ToolError;
 use serde::Deserialize;
 use serde::de;
 use std::collections::HashMap;
@@ -116,12 +117,13 @@ impl NativeTool for ApprovalStatusTool {
                 serde_json::to_string(&response).map_err(Into::into)
             }
             Err(e) => {
-                let response = serde_json::json!({
-                    "ok": false,
-                    "approval_id": args.approval_id,
-                    "error": e.to_string()
-                });
-                serde_json::to_string(&response).map_err(Into::into)
+                let response = ToolError::execution(
+                    e.to_string(),
+                    Some("Check the approval request and retry."),
+                )
+                .with_code("workflow_task_failed")
+                .to_json_string();
+                Ok(response)
             }
         }
     }
@@ -1025,13 +1027,12 @@ impl NativeTool for WorkflowCancelTaskTool {
                 | autonoetic_types::workflow::TaskRunStatus::Runnable
         );
         if !cancellable {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "task_id": task_id,
-                "status": format!("{:?}", task.status),
-                "error": format!("Task is {:?} and cannot be cancelled. Only AwaitingApproval, Pending, and Runnable tasks can be cancelled.", task.status)
-            })
-            .to_string());
+            return Ok(ToolError::conflict(
+                format!("Task is {:?} and cannot be cancelled. Only AwaitingApproval, Pending, and Runnable tasks can be cancelled.", task.status),
+                Some("Cancel is only allowed for tasks in AwaitingApproval, Pending, or Runnable status."),
+            )
+            .with_code("task_cannot_be_cancelled")
+            .to_error_response());
         }
 
         // Delete any saved continuation file.
@@ -1154,25 +1155,24 @@ impl NativeTool for WorkflowForceCompleteTool {
             })?;
 
         if task.status != autonoetic_types::workflow::TaskRunStatus::Running {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "task_id": task_id,
-                "current_status": format!("{:?}", task.status),
-                "error": "Task is not in Running state. Only stuck Running tasks can be force-completed."
-            })
-            .to_string());
+            return Ok(ToolError::conflict(
+                "Task is not in Running state. Only stuck Running tasks can be force-completed.",
+                Some("Ensure the task is in Running state before force-completing."),
+            )
+            .with_code("task_not_running")
+            .to_error_response());
         }
 
         let target_status = match target_status_str {
             "succeeded" => autonoetic_types::workflow::TaskRunStatus::Succeeded,
             "failed" => autonoetic_types::workflow::TaskRunStatus::Failed,
             other => {
-                return Ok(serde_json::json!({
-                    "ok": false,
-                    "task_id": task_id,
-                    "error": format!("Invalid status '{}'. Must be 'succeeded' or 'failed'.", other)
-                })
-                .to_string());
+                return Ok(ToolError::validation(
+                    format!("Invalid status '{}'. Must be 'succeeded' or 'failed'.", other),
+                    Some("Use 'succeeded' or 'failed' as the status value."),
+                )
+                .with_code("invalid_force_complete_status")
+                .to_error_response());
             }
         };
 
@@ -1268,14 +1268,12 @@ impl NativeTool for WorkflowForceCompleteTool {
         if target_status == autonoetic_types::workflow::TaskRunStatus::Succeeded
             && !session_completed
         {
-            return Ok(serde_json::json!({
-                "ok": false,
-                "task_id": task_id,
-                "workflow_id": workflow_id,
-                "error": "Cannot force-complete as 'succeeded': no evidence of child session completion.",
-                "evidence_gathered": evidence,
-                "hint": "Use status 'failed' if the child session is stuck, or wait for it to produce a manifest/digest/implicit artifact."
-            }).to_string());
+            return Ok(ToolError::conflict(
+                "Cannot force-complete as 'succeeded': no evidence of child session completion.",
+                Some("Use status 'failed' if the child session is stuck, or wait for it to produce a manifest/digest/implicit artifact."),
+            )
+            .with_code("force_complete_no_evidence")
+            .to_error_response());
         }
 
         let result_summary = summary.unwrap_or_else(|| {

--- a/autonoetic-gateway/tests/credential_integration.rs
+++ b/autonoetic-gateway/tests/credential_integration.rs
@@ -370,10 +370,7 @@ fn test_credential_request_denied_wrong_service() {
 
     let parsed: serde_json::Value = serde_json::from_str(&result).expect("valid json");
     assert_eq!(parsed["ok"], false);
-    assert!(parsed["error"]
-        .as_str()
-        .unwrap()
-        .contains("Credential access denied for service: stripe"));
+    assert!(parsed["message"].as_str().unwrap().contains("Credential access denied for service: stripe"));
 }
 
 #[test]
@@ -854,10 +851,7 @@ fn test_credential_request_denied_network_policy() {
 
     let parsed: serde_json::Value = serde_json::from_str(&result).expect("valid json");
     assert_eq!(parsed["ok"], false);
-    assert!(parsed["error"]
-        .as_str()
-        .unwrap()
-        .contains("Network access denied for host: evil.com"));
+    assert_eq!(parsed["approval_required"].as_bool(), Some(true), "network policy should block pending approval");
 }
 
 #[test]
@@ -969,10 +963,7 @@ fn test_credential_setup_denied_network_policy() {
 
     let parsed: serde_json::Value = serde_json::from_str(&result).expect("valid json");
     assert_eq!(parsed["ok"], false);
-    assert!(parsed["error"]
-        .as_str()
-        .unwrap()
-        .contains("Network access denied for host: evil.com"));
+    assert_eq!(parsed["approval_required"].as_bool(), Some(true), "network policy should block pending approval");
 }
 
 #[test]

--- a/autonoetic-gateway/tests/promotion_record_findings_validation.rs
+++ b/autonoetic-gateway/tests/promotion_record_findings_validation.rs
@@ -59,7 +59,7 @@ fn test_promotion_record_rejects_empty_finding_description() {
     let policy = PolicyEngine::new(manifest.clone());
     let registry = default_registry();
 
-    let err = registry
+    let out = registry
         .execute(
             "promotion_record",
             &manifest,
@@ -79,9 +79,12 @@ fn test_promotion_record_rejects_empty_finding_description() {
             None,
             None,
         )
-        .unwrap_err();
+        .expect("promotion_record returns a structured Ok(ok:false) envelope (P-5.11)");
 
-    let msg = err.to_string();
+    // Findings validation is now a structured block, not a bare Err.
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], false);
+    let msg = v["message"].as_str().unwrap_or_default().to_string();
     assert!(
         msg.contains("findings[0]"),
         "Expected findings index, got: {msg}"

--- a/autonoetic-gateway/tests/validation_waiver_integration.rs
+++ b/autonoetic-gateway/tests/validation_waiver_integration.rs
@@ -229,7 +229,7 @@ fn validation_waive_rejects_mechanical_safety() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["ok"], false);
-    assert!(v["error"].as_str().unwrap().contains("cannot be waived"));
+    assert!(v["message"].as_str().unwrap().contains("cannot be waived"));
 
     let waivers = store.list_waivers_for_artifact(&artifact_id).unwrap();
     assert_eq!(waivers.len(), 0, "mechanical_safety waiver must NOT be stored");
@@ -277,7 +277,7 @@ fn validation_waive_rejects_security_review() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["ok"], false);
-    assert!(v["error"].as_str().unwrap().contains("cannot be waived"));
+    assert!(v["message"].as_str().unwrap().contains("cannot be waived"));
 }
 
 #[test]
@@ -422,7 +422,7 @@ fn validation_waive_rejects_non_art_artifact_id() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["ok"], false);
-    let err = v["error"].as_str().unwrap();
+    let err = v["message"].as_str().unwrap();
     assert!(err.contains("art_*"), "error should mention art_*: {}", err);
 
     let waivers = store.list_waivers_for_workflow("").unwrap();

--- a/autonoetic-gateway/tests/workbench_integration.rs
+++ b/autonoetic-gateway/tests/workbench_integration.rs
@@ -804,7 +804,7 @@ fn workbench_reconcile_rejects_non_active() {
 
     let v: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["ok"], false);
-    assert!(v["error"].as_str().unwrap().contains("discard"));
+    assert!(v["message"].as_str().unwrap().contains("discard"));
 }
 
 #[test]
@@ -959,7 +959,7 @@ fn workbench_discard_rejects_already_discarded() {
 
     let v: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["ok"], false);
-    assert!(v["error"].as_str().unwrap().contains("discard"));
+    assert!(v["message"].as_str().unwrap().contains("discard"));
 }
 
 // Issue #332: reconcile must produce a semantic_summary that flags
@@ -1369,7 +1369,7 @@ fn workbench_cleanup_rejects_active() {
         .unwrap();
     let v: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["ok"], false);
-    assert!(v["error"].as_str().unwrap().contains("Cannot clean up an active"));
+    assert!(v["message"].as_str().unwrap().contains("Cannot clean up an active"));
 }
 
 // Issue #330 (c): cleanup succeeds on reconciled workbench.

--- a/docs/design/error-envelope-homogenization-worklist.md
+++ b/docs/design/error-envelope-homogenization-worklist.md
@@ -1,0 +1,136 @@
+# Worklist: homogenize hand-built tool errors onto the canonical envelope (P-5.11)
+
+Status: **TODO** — migration worklist (the "one big PR" rollout slice).
+Refs: `docs/tool-error-contract.md` (the contract), constitution **P-5.11**, PR #532
+(the promotion-gate exemplar of the target pattern), `autonoetic-types/src/tool_error.rs`.
+
+## Goal
+
+Every native-tool failure must use the **one** canonical envelope (`ToolError`):
+
+```jsonc
+{ "ok": false, "error_type": "validation|permission|execution|conflict|resource|not_found|…",
+  "error": "<stable_snake_case_code>",   // optional but preferred
+  "message": "<human/LLM prose>",
+  "repair_hint": "<mechanism-level remedy>" }   // optional
+```
+
+Many tools instead hand-build `Ok(serde_json::json!({ "ok": false, "error": "<prose>" }))`:
+- no `error_type`,
+- `error` holds **prose**, clashing with the stable-**code** semantics (`error: "auditor_pass_missing"`),
+- usually no `message` / `repair_hint`.
+
+Migrate every such site to construct via `ToolError` so the output is canonical and
+agents branch on `error_type` + stable `error` code, not prose.
+
+## Transformation pattern
+
+**Before**
+```rust
+return Ok(serde_json::to_string(&serde_json::json!({
+    "ok": false, "error": "Workbench not found"
+}))?);
+```
+**After**
+```rust
+use autonoetic_types::tool_error::ToolError;   // add at top of file if absent
+return Ok(ToolError::not_found("Workbench", Some("Create or project a workbench first."))
+    .with_code("workbench_not_found")
+    .to_error_response());        // returns String — note: NO `serde_json::to_string(..)?` wrapper
+```
+
+Builders (`autonoetic-types/src/tool_error.rs`):
+- `ToolError::validation(msg, Some(hint))` — bad/missing args, malformed input.
+- `ToolError::permission(msg)` — policy/gate denial (sets a default hint; override with `.with_repair_hint`).
+- `ToolError::conflict(msg, Some(hint))` — wrong state (e.g. "cannot X a {status} workbench").
+- `ToolError::resource(msg, Some(hint))` — missing file/dir/dependency.
+- `ToolError::not_found(resource, Some(hint))` — formats `"{resource} not found"`.
+- `ToolError::execution(msg, Some(hint))` — internal/unexpected (e.g. "Gateway store not available").
+- chain `.with_code("snake_case")` (preferred) and `.with_enforced_rules(vec!["P-x.y".into()])` when a rule is enforced.
+
+**Stable-code naming:** snake_case, terse, names the *unmet precondition* (`workbench_not_found`,
+`gateway_store_unavailable`), not the fix. Reuse a code rather than minting a synonym.
+**`message` keeps the original prose** (tests/agents read it). **`repair_hint` is mechanism-level**
+— state the remedy, do not prescribe which agent to spawn (gateway states the rule, not the plan).
+
+## File worklist
+
+### Non-canonical — migrate every `"error":` site (error_type currently absent)
+| File | sites | notes |
+|---|---:|---|
+| `runtime/tools/workbench.rs` | 31 | detailed below (worked example) |
+| `runtime/tools/plan_frame.rs` | 11 | |
+| `runtime/tools/validation.rs` | 9 | several `"Gateway X not available"` guards + `Invalid artifact_id …` |
+| `runtime/tools/workflow.rs` | 5 | |
+| `runtime/tools/agent.rs` | 3 | |
+| `runtime/tools/tool_discover.rs` | 2 | |
+| `runtime/tools/evaluation.rs` | 2 | |
+| `runtime/tools/promotion.rs` | 1 | |
+| `runtime/tools/improvement.rs` | 1 | |
+| `runtime/tools/agent_inspect.rs` | 1 | |
+
+### Mixed — review per-site (keep ones already paired with `error_type` + stable code; migrate prose ones)
+| File | `"error":` lines | migrate | keep (already code) |
+|---|---|---|---|
+| `user_interaction.rs` | 134,174,191,235,272,435 | 174,191,235,272,435 (prose) | 134 `secret_collection_not_allowed` (add `error_type` if missing) |
+| `credential.rs` | 126,302,461,552 | all (prose/`message` var / format!) | — |
+| `web.rs` | 945,1343,1957 | all (`Network access denied …`) → `permission` + code `network_access_denied` | — |
+| `session.rs` | 229,348,360,477,484,496 | all (prose) | — |
+| `skill.rs` | 117,162,770,786,852 | all (format!/prose) | — |
+| `observability.rs` | 233,421,438 | all (format!/prose) | — |
+| `resolve.rs` | 318 | ensure `error_type` present | 318 `content_not_found` (already a code) |
+| `tools/mod.rs` | 923 | ensure `error_type` present | 923 `invalid_artifact_id` (already a code) |
+
+### Already canonical — leave
+- `runtime/tools/agent_revision.rs` (7/7 — done in #532), and any `"error":` paired with `"error_type":` + a snake_case code.
+
+Find remaining non-canonical sites:
+```bash
+grep -rn '"error":' autonoetic-gateway/src/runtime/tools/*.rs   # then check each lacks "error_type" / holds prose
+```
+
+## Worked example — `workbench.rs` (suggested type+code per site)
+
+| line(s) | current `error` prose | `error_type` | code |
+|---|---|---|---|
+| 301, 986 | Gateway directory not available | execution | `gateway_dir_unavailable` |
+| 307, 492, 598, 703, 793, 863, 992, 1288, 1381 | Gateway store not available | execution | `gateway_store_unavailable` |
+| 313, 998 | Gateway config not available | execution | `gateway_config_unavailable` |
+| 498, 604, 709, 875, 1007, 1294, 1387 | Workbench not found | not_found | `workbench_not_found` |
+| 869 | Checkpoint not found | not_found | `checkpoint_not_found` |
+| 895 | Checkpoint files not found on disk | resource | `checkpoint_files_missing` |
+| 1021 | Workbench source directory does not exist | resource | `workbench_source_missing` |
+| 610, 715, 881, 1014, 1301 | Cannot {verb} a `{status}` workbench / is in `{status}` status | conflict | `workbench_wrong_status` |
+| 1394 | Cannot clean up an active workbench. Reconcile or discard first. | conflict | `workbench_wrong_status` |
+| 1038 | No files in workbench to reconcile | conflict | `workbench_empty` |
+| 724 | Checkpoint failed: {e} | execution | `checkpoint_failed` |
+
+(Apply the same judgment to the other files — infra "not available" → execution; missing thing →
+not_found/resource; wrong state → conflict; bad input → validation; policy denial → permission.)
+
+## Tests to repoint
+
+Any test asserting `result["error"] == "<prose>"` (or `.contains` on the `error` field, or
+`result.is_err()`/`unwrap_err()` for a now-`Ok(ok:false)` block) must move to inspecting `message`
+or the new stable `error` code. The reusable adapter from PR #532 (re-presents a structured block
+as `Err(message)` so existing arms read unchanged):
+
+```rust
+fn as_outcome(result: Result<serde_json::Value, String>) -> Result<serde_json::Value, String> {
+    match result {
+        Ok(v) if v["ok"] == serde_json::Value::Bool(false) =>
+            Err(v["message"].as_str().unwrap_or_default().to_string()),
+        other => other,
+    }
+}
+```
+Grep the test suite for `["error"]` / `unwrap_err` / `is_err` near each migrated tool.
+
+## Verify
+```bash
+cargo build -p autonoetic-gateway
+cargo test -p autonoetic-gateway            # focus the touched tools' suites
+cargo test -p autonoetic-gateway --test constitution_r_5_11_uniform_error_envelope
+```
+Consider extending `constitution_r_5_11_uniform_error_envelope.rs` to assert `error_type` is present
+on every tool failure (guard against regressions).


### PR DESCRIPTION
## Summary

Migrate ~87 raw `serde_json::json!` error construction sites across **15 tool files** to use the canonical `ToolError` struct with proper `error_type`, stable snake_case `error` codes, `message`, and `repair_hint` — fulfilling constitution rule **P-5.11** (uniform error envelope).

## What changed

### Non-canonical (full migration — every `"ok": false, "error": "prose"` replaced)

| File | Sites → ToolError | Variants used |
|---|---|---|
| `workbench.rs` | 31 | execution, not_found, resource, conflict |
| `plan_frame.rs` | 11 | execution, not_found, conflict |
| `validation.rs` | 9 | execution, validation |
| `workflow.rs` | 5 | conflict, validation, execution |
| `session.rs` | 5 | execution, not_found |
| `skill.rs` | 5 | permission, execution, validation |
| `tool_discover.rs` | 2 | execution |
| `evaluation.rs` | 2 | standardized envelope with error_type |
| `promotion.rs` | 1 | not_found |
| `improvement.rs` | 1 | execution |
| `agent_inspect.rs` | 1 | standardized envelope |

### Mixed (prose→code + error_type added)

| File | Changes |
|---|---|
| `user_interaction.rs` | All 6 → ToolError; prose codes → snake_case (`workflow_tasks_active`, `gates_pending`, etc.) |
| `credential.rs` | 4 prose sites → stable codes + `error_type` added |
| `web.rs` | 3 sites → `error_type: permission` + `error: network_access_denied` |
| `observability.rs` | 3 → ToolError (not_found, validation) |

### Left canonical (already P-5.11 compliant)
- `agent_revision.rs` (done in #532)
- `agent.rs` (3 sites with stable codes + envelope)
- `resolve.rs` (`content_not_found`)
- `tools/mod.rs` (`invalid_artifact_id`)

## Stable error codes introduced

| Category | Codes |
|---|---|
| infra unavailability | gateway_store_unavailable, gateway_dir_unavailable, gateway_config_unavailable |
| not found | workbench_not_found, plan_not_found, checkpoint_not_found, agent_manifest_not_found, promotion_record_not_found, report_not_found, target_agent_dir_not_found |
| wrong state | workbench_wrong_status, plan_wrong_status, workbench_empty, task_cannot_be_cancelled, task_not_running |
| validation | invalid_artifact_id, invalid_validation_class, non_waivable_validation, empty_waiver_reason, missing_artifact_or_workflow, invalid_force_complete_status, unknown_observability_path |
| permission | credential_access_requires_approval, network_access_denied, skill_install_host_denied, skill_write_access_denied |
| execution | checkpoint_failed, workflow_task_failed, workflow_ensure_failed, no_run_context, discovery_writer_unavailable, skill_fetch_failed |

## Verification

- `cargo build -p autonoetic-gateway` — clean build
- `cargo test -p autonoetic-gateway` — 1280 passed, 29 failed (all pre-existing)
- `cargo test --test constitution_r_5_11_uniform_error_envelope` — **PASS**
