### PR TITLE
feat(errors): mop up last non-canonical error site + lock-in guard (P-5.11)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/session.rs
+++ b/autonoetic-gateway/src/runtime/tools/session.rs
@@ -226,10 +226,14 @@ impl NativeTool for SessionEscalateTool {
                 })
             }
             _ => {
-                serde_json::json!({
-                    "error": "Unknown escalation target",
-                    "valid_targets": ["reasoning_llm", "specialist", "human"]
-                })
+                // Invalid target: return the canonical envelope and do NOT log an
+                // escalation event (early return, before the event append below).
+                return Ok(ToolError::validation(
+                    "Unknown escalation target",
+                    Some("Use one of: reasoning_llm, specialist, human."),
+                )
+                .with_code("unknown_escalation_target")
+                .to_error_response());
             }
         };
 

--- a/autonoetic-gateway/tests/constitution_r_5_11_uniform_error_envelope.rs
+++ b/autonoetic-gateway/tests/constitution_r_5_11_uniform_error_envelope.rs
@@ -83,6 +83,18 @@ fn assert_error_envelope_shape(payload: &serde_json::Value) {
             .unwrap_or(false),
         "message must be a non-empty string"
     );
+    // The optional stable `error` code (P-5.11) is a machine token, NOT prose:
+    // snake_case `[a-z0-9_]+`. Guards against regressing to the old
+    // `"error": "<free-text message>"` shape.
+    if let Some(code) = payload.get("error").and_then(|v| v.as_str()) {
+        assert!(
+            !code.is_empty()
+                && code
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "`error` must be a snake_case code, not prose: {code:?}"
+        );
+    }
 }
 
 #[test]
@@ -103,6 +115,25 @@ fn r_5_11_uniform_error_envelope_contract() -> anyhow::Result<()> {
             .unwrap_or(false),
         "expected repair_hint on user.ask secret rejection"
     );
+
+    // Migrated tools (PR #532/#533): every failure path is the canonical envelope.
+    // Invoked here without a gateway store / with minimal args, so each returns a
+    // structured precondition/validation error — proving none regress to a
+    // hand-built `{ "error": "<prose>" }`. (The snake_case `error` check in
+    // assert_error_envelope_shape catches the regression.)
+    for (tool, args) in [
+        ("validation_waive", r#"{"artifact_id":"not-canonical","validation_class":"correctness_check","reason":"x"}"#),
+        ("workbench_status", r#"{"workbench_id":"wb_missing"}"#),
+        ("planframe_approve", r#"{"plan_id":"plan_missing"}"#),
+        ("session_escalate", r#"{"target":"bogus_target","reason":"x","context":"y"}"#),
+        ("workflow_wait", r#"{"task_ids":[]}"#),
+    ] {
+        // Tolerate arg-parse / availability Errs (a separate boundary); only the
+        // tool's own returned envelope must be canonical.
+        if let Ok(payload) = invoke(tool, args) {
+            assert_error_envelope_shape(&payload);
+        }
+    }
 
     Ok(())
 }

--- a/autonoetic-gateway/tests/constitution_r_5_11_uniform_error_envelope.rs
+++ b/autonoetic-gateway/tests/constitution_r_5_11_uniform_error_envelope.rs
@@ -85,14 +85,16 @@ fn assert_error_envelope_shape(payload: &serde_json::Value) {
     );
     // The optional stable `error` code (P-5.11) is a machine token, NOT prose:
     // snake_case `[a-z0-9_]+`. Guards against regressing to the old
-    // `"error": "<free-text message>"` shape.
-    if let Some(code) = payload.get("error").and_then(|v| v.as_str()) {
+    // `"error": "<free-text message>"` shape. When the key is present it must
+    // be a non-empty snake_case string — null/number/absent-key are all caught.
+    if let Some(error_val) = payload.get("error") {
+        let code = error_val.as_str().unwrap_or("");
         assert!(
             !code.is_empty()
                 && code
                     .chars()
                     .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
-            "`error` must be a snake_case code, not prose: {code:?}"
+            "`error` must be a non-empty snake_case string when present, got: {error_val:?}"
         );
     }
 }
@@ -129,9 +131,18 @@ fn r_5_11_uniform_error_envelope_contract() -> anyhow::Result<()> {
         ("workflow_wait", r#"{"task_ids":[]}"#),
     ] {
         // Tolerate arg-parse / availability Errs (a separate boundary); only the
-        // tool's own returned envelope must be canonical.
-        if let Ok(payload) = invoke(tool, args) {
-            assert_error_envelope_shape(&payload);
+        // tool's own returned envelope must be canonical.  But an "Unknown native
+        // tool" error means the tool has been renamed/removed — that is a
+        // regression we must not silently ignore.
+        match invoke(tool, args) {
+            Ok(payload) => assert_error_envelope_shape(&payload),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains("Unknown native tool"),
+                    "tool {tool:?} should exist but was not found: {msg}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Finishes the tool-error homogenization (after #532/#533).

## Changes
1. **Last straggler** — `session.rs` `session_escalate` had one remaining hand-built `{ "error": "Unknown escalation target", "valid_targets": […] }` (no `ok:false`/`error_type`) in the `_ =>` arm. It now **early-returns** the canonical `ToolError::validation(…).with_code("unknown_escalation_target")` — and as a bonus no longer logs a spurious `workflow.escalated` event for an invalid target.
2. **Lock-in guard** — `constitution_r_5_11_uniform_error_envelope`:
   - `assert_error_envelope_shape` now also asserts the optional `error` field, **when present, is a snake_case machine code** (`[a-z0-9_]+`) — i.e. catches any regression back to `"error": "<free-text prose>"`.
   - Adds invocations of migrated tools (`validation_waive`, `workbench_status`, `planframe_approve`, `session_escalate`, `workflow_wait`); their returned failure envelopes are shape-checked (arg-parse/availability Errs tolerated — a separate boundary).

## Test plan
- [x] `constitution_r_5_11_uniform_error_envelope` — green.
- [x] `session_escalate_integration` — 3/4 pass; the 1 failure (`test_escalation_approval_resume_injects_guidance`) is the **pre-existing** R++4 dwell-time failure (deterministic, red on `main`, unrelated to this change).
- [x] full `cargo test -p autonoetic-gateway --no-run` compiles.

## Not in scope (by prior agreement)
- The bare-`anyhow` tail (~525 sites) already emits the canonical *shape* via `decorate_tool_error` at the boundary; adding fine codes is selective/optional.
- The pre-existing `session_escalate` dwell-time failure + the apparent gateway-integration CI gap are separate concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)