### PR TITLE
fix(promotion-gate): trust sandbox isolation instead of pre-denying unit tests on import detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,13 @@ Integration tests are in `autonoetic-gateway/tests/` (30+ tests). They use `temp
 Notable suite for approval continuation:
 - `autonoetic-gateway/tests/turn_continuation_approval_integration.rs` — suspend/resume, timeout, cancellation, restart, and parallel-join behavior
 
+**Ignored (manual) sandbox e2e** — require a host `bwrap` and execute real code, so they are NOT run in CI:
+- `autonoetic-gateway/tests/promotion_gate_mocked_network_e2e.rs` — proves the promotion gate runs a `urllib`-importing but mocked test suite offline (passes) and that a real network call fails offline. Run with:
+  ```bash
+  cargo test -p autonoetic-gateway --test promotion_gate_mocked_network_e2e -- --ignored --nocapture
+  ```
+  Its CI-safe decision counterpart (no sandbox) is `promotion_gate_network_isolation_decision.rs`.
+
 ## Key Documentation
 
 - `docs/ARCHITECTURE.md` — System design, security model, data flow

--- a/agents/specialists/unit_test_runner.default/SKILL.md
+++ b/agents/specialists/unit_test_runner.default/SKILL.md
@@ -69,12 +69,18 @@ You run in a **promotion-gate sandbox with network permanently disabled** — ev
 - Do NOT run `pip install`, `npm install`, `curl`, `wget`, or any fetch against the internet.
 - Do NOT retry failed network tests with different commands — one network signal is terminal.
 
-**When you detect network dependency** (any of):
-- `artifact_exec` returns `promotion_gate_network_denied: true` or `approval_required: true` because tests touch URLs/hosts
-- Test output contains `ECONNREFUSED`, `ConnectionError`, `Name or service not known`, `Network is unreachable`, `getaddrinfo failed`, `timeout` to external hosts, or HTTP 5xx from live services
-- Test source (from `artifact_inspect`) imports `requests`/`httpx`/`urllib` **and** calls them without mocks
+**Run first, judge from the runtime outcome — do not pre-judge from imports.**
+The sandbox is physically network-isolated, so it is safe to *run* the suite even
+when the source imports `requests`/`httpx`/`urllib`. A suite that mocks the HTTP
+caller will **pass** — that is the correct, idempotent design, and it is a `pass`,
+not `unable_to_evaluate`. Importing a network library is **not** itself a network
+dependency; only an actual live call is. Do not read mocked code and guess.
 
-→ Return `status: "unable_to_evaluate"` immediately with a finding that tests require live network and cannot be evaluated in the sealed promotion sandbox. **Do not** return `status: "fail"` for environment/network blockers — that invites the planner to send you back in a loop.
+**A genuine network dependency is proven by the run, by any of:**
+- Test output contains `ECONNREFUSED`, `ConnectionError`, `Name or service not known`, `Network is unreachable`, `getaddrinfo failed`, `timeout` to external hosts, or HTTP 5xx from live services
+- `artifact_exec` returns `promotion_gate_network_denied: true` or `approval_required: true` (this only happens on sandbox drivers that cannot guarantee isolation; the default bubblewrap promotion sandbox runs the tests instead of pre-denying)
+
+→ Then return `status: "unable_to_evaluate"` with a finding that the tests require live network and cannot be evaluated in the sealed promotion sandbox. **Do not** return `status: "fail"` for environment/network blockers — that invites the planner to send you back in a loop.
 
 If the entire suite is network/integration-only, skip `promotion_record` and return `unable_to_evaluate` (same as “no tests”).
 

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -1021,7 +1021,8 @@ impl NativeTool for ArtifactExecTool {
         if !informational_remote_patterns.is_empty() {
             body["network_isolated_run"] = serde_json::Value::Bool(true);
             body["detected_patterns"] =
-                serde_json::to_value(&informational_remote_patterns).unwrap_or_default();
+                serde_json::to_value(&informational_remote_patterns)
+                    .unwrap_or(serde_json::Value::Array(vec![]));
         }
 
         if !overrides.share_net {

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -433,20 +433,21 @@ impl NativeTool for ArtifactExecTool {
         }
 
         // Promotion-verdict roles (unit_test_runner, evaluators, auditor) run in
-        // a physically network-isolated sandbox: promotion_gate_overrides() sets
-        // force_network_off, which the bubblewrap driver enforces via
-        // `--unshare-all` (no `--share-net`). On that driver we do NOT statically
-        // pre-deny when RemoteAccessAnalyzer merely *detects* a network import:
-        // the deterministic suite is run inside the isolated sandbox. Mocked tests
-        // pass; tests that genuinely reach the network fail at runtime with a
-        // ConnectionError, which the verdict role reports as `unable_to_evaluate`.
-        // The detected patterns are surfaced as informational findings on the run
-        // output, not a hard block — so a service that imports `urllib` but mocks
-        // the HTTP caller is no longer falsely blocked from promotion.
+        // a physically network-isolated sandbox under promotion_gate_overrides()
+        // (force_network_off). When the configured driver *guarantees* the run is
+        // offline (see SandboxDriverKind::guarantees_network_off — bubblewrap with
+        // force_network_off, docker `--network none`, wasm WASI-no-sockets), we do
+        // NOT statically pre-deny when RemoteAccessAnalyzer merely *detects* a
+        // network import: the deterministic suite is run inside the isolated
+        // sandbox. Mocked tests pass; tests that genuinely reach the network fail
+        // at runtime with a ConnectionError, which the verdict role reports as
+        // `unable_to_evaluate`. The detected patterns are surfaced as informational
+        // findings on the run output, not a hard block — so a service that imports
+        // `urllib` but mocks the HTTP caller is no longer falsely blocked.
         //
-        // Drivers that do not honor force_network_off (docker/microvm/wasm) cannot
-        // guarantee the run is offline, so the deterministic-without-network
-        // pre-deny (P-3.10) is preserved for them.
+        // Drivers that cannot guarantee the run is offline (today: microvm, whose
+        // NIC is controlled by the operator firecracker config) keep the
+        // deterministic-without-network pre-deny (P-3.10).
         let promotion_verdict_role = manifest_may_record_promotion_verdicts(manifest);
         let promotion_isolated_run = promotion_run_is_network_isolated(manifest);
         let informational_remote_patterns = if promotion_isolated_run {
@@ -1050,16 +1051,21 @@ impl NativeTool for ArtifactExecTool {
 /// sandbox (mocked tests pass; tests that genuinely reach the network fail at
 /// runtime → the verdict role reports `unable_to_evaluate`).
 ///
-/// True only for promotion-verdict roles (`manifest_may_record_promotion_verdicts`)
-/// on a driver that enforces `force_network_off`. Today that is the bubblewrap
-/// driver (`--unshare-all` without `--share-net`, set by
-/// `BwrapIsolationOverrides::promotion_gate_overrides`). The docker/microvm/wasm
-/// drivers do not honor `force_network_off`, so their promotion runs keep the
-/// deterministic-without-network pre-deny (P-3.10).
+/// True for promotion-verdict roles (`manifest_may_record_promotion_verdicts`)
+/// on any driver that *guarantees* the run is offline under the promotion-gate
+/// overrides — see [`SandboxDriverKind::guarantees_network_off`] for the
+/// per-driver truth (bubblewrap with `force_network_off`, docker `--network none`,
+/// wasm WASI-no-sockets → yes; microvm → no, the operator firecracker config
+/// controls the NIC, so its promotion runs keep the deterministic-without-network
+/// pre-deny, P-3.10).
 pub fn promotion_run_is_network_isolated(manifest: &AgentManifest) -> bool {
     manifest_may_record_promotion_verdicts(manifest)
         && SandboxDriverKind::parse(&manifest.runtime.sandbox)
-            .map(|d| matches!(d, SandboxDriverKind::Bubblewrap))
+            .map(|d| {
+                d.guarantees_network_off(
+                    &crate::sandbox::BwrapIsolationOverrides::promotion_gate_overrides(),
+                )
+            })
             .unwrap_or(false)
 }
 

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -432,13 +432,39 @@ impl NativeTool for ArtifactExecTool {
             }
         }
 
-        if remote_analysis.requires_approval && !approval_validated_for_command {
-            if manifest_may_record_promotion_verdicts(manifest) {
+        // Promotion-verdict roles (unit_test_runner, evaluators, auditor) run in
+        // a physically network-isolated sandbox: promotion_gate_overrides() sets
+        // force_network_off, which the bubblewrap driver enforces via
+        // `--unshare-all` (no `--share-net`). On that driver we do NOT statically
+        // pre-deny when RemoteAccessAnalyzer merely *detects* a network import:
+        // the deterministic suite is run inside the isolated sandbox. Mocked tests
+        // pass; tests that genuinely reach the network fail at runtime with a
+        // ConnectionError, which the verdict role reports as `unable_to_evaluate`.
+        // The detected patterns are surfaced as informational findings on the run
+        // output, not a hard block — so a service that imports `urllib` but mocks
+        // the HTTP caller is no longer falsely blocked from promotion.
+        //
+        // Drivers that do not honor force_network_off (docker/microvm/wasm) cannot
+        // guarantee the run is offline, so the deterministic-without-network
+        // pre-deny (P-3.10) is preserved for them.
+        let promotion_verdict_role = manifest_may_record_promotion_verdicts(manifest);
+        let promotion_isolated_run = promotion_run_is_network_isolated(manifest);
+        let informational_remote_patterns = if promotion_isolated_run {
+            remote_analysis.detected_patterns.clone()
+        } else {
+            Vec::new()
+        };
+
+        if remote_analysis.requires_approval
+            && !approval_validated_for_command
+            && !promotion_isolated_run
+        {
+            if promotion_verdict_role {
                 return Ok(serde_json::json!({
                     "ok": false,
                     "exit_code": null,
                     "stdout": "",
-                    "stderr": "Promotion-gate execution (P-3.10): artifact test run requires network access. Unit tests must be deterministic without live network.",
+                    "stderr": "Promotion-gate execution (P-3.10): artifact test run requires network access and the configured sandbox driver cannot guarantee network isolation. Unit tests must be deterministic without live network.",
                     "promotion_gate_network_denied": true,
                     "recommendation": "unable_to_evaluate",
                     "detected_patterns": remote_analysis.detected_patterns,
@@ -987,6 +1013,16 @@ impl NativeTool for ArtifactExecTool {
             "entrypoint": entrypoint,
         });
 
+        // Informational only: on the network-isolated promotion-gate path the
+        // detected remote-access patterns are NOT a block — the run already
+        // happened offline. Surface them so the verdict role can reason about
+        // mocked-vs-live coverage without re-running its own analyzer.
+        if !informational_remote_patterns.is_empty() {
+            body["network_isolated_run"] = serde_json::Value::Bool(true);
+            body["detected_patterns"] =
+                serde_json::to_value(&informational_remote_patterns).unwrap_or_default();
+        }
+
         if !overrides.share_net {
             let has_network_cap = manifest
                 .capabilities
@@ -1005,6 +1041,26 @@ impl NativeTool for ArtifactExecTool {
 
         serde_json::to_string(&body).map_err(Into::into)
     }
+}
+
+/// Whether a promotion-verdict artifact run executes in a physically
+/// network-isolated sandbox. When true, `RemoteAccessAnalyzer` detections are
+/// treated as informational findings on the run output rather than a static
+/// pre-deny: the deterministic suite is allowed to run inside the isolated
+/// sandbox (mocked tests pass; tests that genuinely reach the network fail at
+/// runtime → the verdict role reports `unable_to_evaluate`).
+///
+/// True only for promotion-verdict roles (`manifest_may_record_promotion_verdicts`)
+/// on a driver that enforces `force_network_off`. Today that is the bubblewrap
+/// driver (`--unshare-all` without `--share-net`, set by
+/// `BwrapIsolationOverrides::promotion_gate_overrides`). The docker/microvm/wasm
+/// drivers do not honor `force_network_off`, so their promotion runs keep the
+/// deterministic-without-network pre-deny (P-3.10).
+pub fn promotion_run_is_network_isolated(manifest: &AgentManifest) -> bool {
+    manifest_may_record_promotion_verdicts(manifest)
+        && SandboxDriverKind::parse(&manifest.runtime.sandbox)
+            .map(|d| matches!(d, SandboxDriverKind::Bubblewrap))
+            .unwrap_or(false)
 }
 
 fn build_command(entrypoint: &str, args: &[String]) -> String {

--- a/autonoetic-gateway/src/sandbox.rs
+++ b/autonoetic-gateway/src/sandbox.rs
@@ -173,6 +173,30 @@ impl SandboxDriverKind {
             other => anyhow::bail!("Unsupported sandbox driver '{}'", other),
         }
     }
+
+    /// Whether this driver guarantees the run has **no network access** under the
+    /// given isolation overrides. Single source of truth for "is this execution
+    /// physically offline" — used by the promotion gate to decide whether a
+    /// deterministic test suite can be trusted to run in isolation (P-3.10)
+    /// instead of being statically pre-denied on mere import detection.
+    ///
+    /// - **Bubblewrap**: offline iff `force_network_off` (the gate sets it via
+    ///   [`BwrapIsolationOverrides::promotion_gate_overrides`]); enforced by
+    ///   `--unshare-all` with no `--share-net`.
+    /// - **Docker**: always offline — `docker_command` hardcodes `--network none`.
+    /// - **Wasm**: always offline — the in-process WASI preview1 tier exposes no
+    ///   sockets (only a preopened workspace dir, args, env).
+    /// - **MicroVm**: NOT guaranteed — network is whatever the operator's
+    ///   firecracker `--config-file` declares; the gateway passes only that file
+    ///   and cannot assert the absence of a NIC. Conservative `false`.
+    pub fn guarantees_network_off(self, overrides: &BwrapIsolationOverrides) -> bool {
+        match self {
+            Self::Bubblewrap => overrides.force_network_off,
+            Self::Docker => true,
+            Self::Wasm => true,
+            Self::MicroVm => false,
+        }
+    }
 }
 
 /// Dependency runtime ecosystem used to install generated code dependencies.

--- a/autonoetic-gateway/tests/promotion_gate_mocked_network_e2e.rs
+++ b/autonoetic-gateway/tests/promotion_gate_mocked_network_e2e.rs
@@ -1,0 +1,277 @@
+//! Full-sandbox e2e for the promotion-gate network-isolation fix (P-3.10).
+//!
+//! These tests are `#[ignore]`d because they require a working **bubblewrap**
+//! (`bwrap`) on the host and actually execute Python in the sandbox — they are
+//! NOT run in CI. The CI-safe decision coverage lives in
+//! `promotion_gate_network_isolation_decision.rs`; this file proves the
+//! end-to-end runtime behavior that CI cannot.
+//!
+//! Run locally with:
+//! ```bash
+//! cargo test -p autonoetic-gateway --test promotion_gate_mocked_network_e2e -- --ignored --nocapture
+//! ```
+//!
+//! What they prove (the original bug + its boundary):
+//! 1. `unit_test_runner.default` runs a suite that imports `urllib` but **mocks**
+//!    the HTTP caller. The gate no longer statically pre-denies on import
+//!    detection: the suite runs in the network-off bubblewrap sandbox and
+//!    **passes** (exit 0, no `promotion_gate_network_denied`). This is the
+//!    false-deny the fix removes.
+//! 2. A suite that makes a **real** network call (no mock) still runs, but fails
+//!    at runtime inside the offline sandbox (URLError/ConnectionError → non-zero
+//!    exit), which the verdict role maps to `unable_to_evaluate`.
+
+mod support;
+
+use autonoetic_gateway::policy::PolicyEngine;
+use autonoetic_gateway::runtime::content_store::ContentStore;
+use autonoetic_gateway::runtime::tools::default_registry;
+use autonoetic_gateway::scheduler::gateway_store::GatewayStore;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+use autonoetic_types::config::GatewayConfig;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn base_manifest(id: &str, name: &str, capabilities: Vec<Capability>) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: "bubblewrap".to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: "test agent".to_string(),
+        },
+        capabilities,
+        llm_overrides: None,
+        llm_preset: None,
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+/// Writer (needs WriteAccess) used to mint the artifact_ref.
+fn writer_manifest() -> AgentManifest {
+    base_manifest(
+        "coder.default",
+        "coder",
+        vec![Capability::WriteAccess {
+            scopes: vec!["*".to_string()],
+        }],
+    )
+}
+
+/// `unit_test_runner.default` — a promotion-verdict role on bubblewrap with
+/// CodeExecution but NO NetworkAccess (so the gate's network-off isolation, not
+/// an auto-approval, is what lets the suite run).
+fn unit_test_runner_manifest() -> AgentManifest {
+    base_manifest(
+        "unit_test_runner.default",
+        "Unit Test Runner",
+        vec![Capability::CodeExecution {
+            patterns: vec!["python3 ".to_string()],
+            commands: vec![],
+        }],
+    )
+}
+
+/// Build an artifact from the given (filename, content) files in `session`, run
+/// `entrypoint` through `artifact_exec` as the unit_test_runner, and return the
+/// parsed response JSON.
+fn build_and_exec(
+    session: &str,
+    files: &[(&str, &str)],
+    entrypoint: &str,
+) -> serde_json::Value {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join("agents");
+    let gateway_dir = agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).expect("gateway dir");
+    let writer_dir = agents_dir.join("coder.default");
+    std::fs::create_dir_all(&writer_dir).expect("writer dir");
+    let runner_dir = agents_dir.join("unit_test_runner.default");
+    std::fs::create_dir_all(&runner_dir).expect("runner dir");
+
+    let config = GatewayConfig {
+        agents_dir: agents_dir.clone(),
+        ..GatewayConfig::default()
+    };
+    let store = Arc::new(GatewayStore::open(&gateway_dir).expect("gateway store"));
+    let writer = writer_manifest();
+    let writer_policy = PolicyEngine::new(writer.clone());
+    let runner = unit_test_runner_manifest();
+    let runner_policy = PolicyEngine::new(runner.clone());
+    let registry = default_registry();
+
+    // Register the artifact files in the content store, then mint a ref.
+    let cs = ContentStore::new(&gateway_dir).expect("content store");
+    let inputs: Vec<String> = files
+        .iter()
+        .map(|(name, content)| {
+            let h = cs.write(content.as_bytes()).expect("cs write");
+            cs.register_name(session, name, &h).expect("register name");
+            name.to_string()
+        })
+        .collect();
+
+    let build_args = serde_json::json!({ "inputs": inputs });
+    let build_out = registry
+        .execute(
+            "artifact_build",
+            &writer,
+            &writer_policy,
+            &writer_dir,
+            Some(&gateway_dir),
+            &build_args.to_string(),
+            Some(session),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .expect("artifact_build");
+    let build_v: serde_json::Value = serde_json::from_str(&build_out).expect("build json");
+    let artifact_ref = build_v["artifact_ref"]
+        .as_str()
+        .expect("artifact_ref")
+        .to_string();
+
+    let exec_args = serde_json::json!({
+        "artifact_ref": artifact_ref,
+        "entrypoint": entrypoint,
+    });
+    let exec_out = registry
+        .execute(
+            "artifact_exec",
+            &runner,
+            &runner_policy,
+            &runner_dir,
+            Some(&gateway_dir),
+            &exec_args.to_string(),
+            Some(session),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .expect("artifact_exec");
+    serde_json::from_str(&exec_out).expect("exec json")
+}
+
+/// Imports `urllib` but mocks the HTTP caller — deterministic, hermetic. Must
+/// run offline and PASS (this is the false-deny the fix removes).
+const MOCKED_SUITE: &str = r#"
+import urllib.request
+import unittest
+from unittest import mock
+
+def fetch(url):
+    with urllib.request.urlopen(url) as r:
+        return r.read().decode()
+
+class TestFetch(unittest.TestCase):
+    @mock.patch("urllib.request.urlopen")
+    def test_fetch_mocked(self, m):
+        cm = mock.MagicMock()
+        cm.read.return_value = b"hello"
+        m.return_value.__enter__.return_value = cm
+        self.assertEqual(fetch("http://example.com"), "hello")
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+"#;
+
+/// Makes a REAL network call with no mock — must fail in the offline sandbox.
+const LIVE_SUITE: &str = r#"
+import urllib.request
+import unittest
+
+class TestLive(unittest.TestCase):
+    def test_real_call(self):
+        with urllib.request.urlopen("http://example.com", timeout=5) as r:
+            self.assertTrue(len(r.read()) > 0)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+"#;
+
+#[test]
+#[ignore = "requires bubblewrap; runs Python in the sandbox — not run in CI"]
+fn mocked_urllib_suite_runs_and_passes_offline() {
+    let v = build_and_exec(
+        "sess-mocked",
+        &[("test_service.py", MOCKED_SUITE)],
+        "test_service.py",
+    );
+    assert_ne!(
+        v.get("promotion_gate_network_denied"),
+        Some(&serde_json::json!(true)),
+        "fixed gate must NOT statically pre-deny a mocked suite: {v}"
+    );
+    assert_eq!(
+        v.get("ok"),
+        Some(&serde_json::json!(true)),
+        "mocked urllib suite should run and pass offline: {v}"
+    );
+    assert_eq!(
+        v.get("exit_code"),
+        Some(&serde_json::json!(0)),
+        "unittest should exit 0: {v}"
+    );
+    // The detected import is surfaced as informational, not a block.
+    assert_eq!(
+        v.get("network_isolated_run"),
+        Some(&serde_json::json!(true)),
+        "isolated promotion run should flag network_isolated_run: {v}"
+    );
+}
+
+#[test]
+#[ignore = "requires bubblewrap; runs Python in the sandbox — not run in CI"]
+fn live_network_suite_runs_but_fails_offline() {
+    let v = build_and_exec(
+        "sess-live",
+        &[("test_service.py", LIVE_SUITE)],
+        "test_service.py",
+    );
+    assert_ne!(
+        v.get("promotion_gate_network_denied"),
+        Some(&serde_json::json!(true)),
+        "the gate runs the suite rather than pre-denying: {v}"
+    );
+    assert_eq!(
+        v.get("ok"),
+        Some(&serde_json::json!(false)),
+        "a real network call must fail in the offline sandbox: {v}"
+    );
+    let stderr = v.get("stderr").and_then(|s| s.as_str()).unwrap_or("");
+    assert!(
+        stderr.contains("URLError")
+            || stderr.contains("ConnectionError")
+            || stderr.contains("Network is unreachable")
+            || stderr.contains("Name or service not known")
+            || stderr.contains("getaddrinfo")
+            || v.get("network_blocked") == Some(&serde_json::json!(true)),
+        "expected a runtime network failure signal, got: {v}"
+    );
+}

--- a/autonoetic-gateway/tests/promotion_gate_network_isolation_decision.rs
+++ b/autonoetic-gateway/tests/promotion_gate_network_isolation_decision.rs
@@ -12,8 +12,29 @@
 //! They are pure (no sandbox), so they run in CI without bubblewrap.
 
 use autonoetic_gateway::runtime::tools::artifact_exec::promotion_run_is_network_isolated;
+use autonoetic_gateway::sandbox::{BwrapIsolationOverrides, SandboxDriverKind};
 use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
 use autonoetic_types::capability::Capability;
+
+#[test]
+fn driver_network_off_guarantee_truth_table() {
+    let gate = BwrapIsolationOverrides::promotion_gate_overrides();
+    let normal = BwrapIsolationOverrides::default();
+
+    // Bubblewrap: offline only when force_network_off is set.
+    assert!(SandboxDriverKind::Bubblewrap.guarantees_network_off(&gate));
+    assert!(!SandboxDriverKind::Bubblewrap.guarantees_network_off(&normal));
+
+    // Docker (`--network none`) and wasm (WASI, no sockets) are always offline.
+    assert!(SandboxDriverKind::Docker.guarantees_network_off(&gate));
+    assert!(SandboxDriverKind::Docker.guarantees_network_off(&normal));
+    assert!(SandboxDriverKind::Wasm.guarantees_network_off(&gate));
+    assert!(SandboxDriverKind::Wasm.guarantees_network_off(&normal));
+
+    // MicroVm: operator firecracker config controls the NIC — never asserted.
+    assert!(!SandboxDriverKind::MicroVm.guarantees_network_off(&gate));
+    assert!(!SandboxDriverKind::MicroVm.guarantees_network_off(&normal));
+}
 
 fn manifest(agent_id: &str, sandbox: &str) -> AgentManifest {
     AgentManifest {
@@ -81,15 +102,26 @@ fn all_promotion_verdict_roles_isolated_on_bubblewrap() {
 }
 
 #[test]
-fn non_isolating_drivers_keep_predeny_for_promotion_roles() {
-    // docker/microvm/wasm do not honor force_network_off, so the
-    // deterministic-without-network pre-deny (P-3.10) must be preserved.
-    for driver in ["docker", "microvm", "wasm"] {
+fn drivers_that_guarantee_offline_also_run_isolated() {
+    // docker (`--network none`) and wasm (WASI, no sockets) are always offline,
+    // so promotion-verdict roles on them must ALSO run rather than be pre-denied.
+    for driver in ["docker", "wasm"] {
         assert!(
-            !promotion_run_is_network_isolated(&manifest("unit_test_runner.default", driver)),
-            "driver {driver} cannot guarantee network-off; pre-deny must be kept"
+            promotion_run_is_network_isolated(&manifest("unit_test_runner.default", driver)),
+            "driver {driver} guarantees network-off; the suite must run, not be pre-denied"
         );
     }
+}
+
+#[test]
+fn microvm_keeps_predeny_for_promotion_roles() {
+    // microvm's NIC is controlled by the operator firecracker --config-file; the
+    // gateway cannot assert it is offline, so the deterministic-without-network
+    // pre-deny (P-3.10) must be preserved.
+    assert!(
+        !promotion_run_is_network_isolated(&manifest("unit_test_runner.default", "microvm")),
+        "microvm cannot guarantee network-off; pre-deny must be kept"
+    );
 }
 
 #[test]

--- a/autonoetic-gateway/tests/promotion_gate_network_isolation_decision.rs
+++ b/autonoetic-gateway/tests/promotion_gate_network_isolation_decision.rs
@@ -1,0 +1,103 @@
+//! Promotion-gate network-isolation decision (P-3.10).
+//!
+//! A promotion-verdict role (e.g. `unit_test_runner.default`) that runs on a
+//! driver enforcing `force_network_off` must NOT be statically pre-denied just
+//! because `RemoteAccessAnalyzer` detects a network import (e.g. `import urllib`).
+//! The deterministic suite runs inside the physically network-isolated sandbox:
+//! a suite that mocks the HTTP caller passes; a suite that genuinely reaches the
+//! network fails at runtime and the role reports `unable_to_evaluate`.
+//!
+//! These tests pin the decision predicate so the false-deny regression (a
+//! mocked service importing `urllib` blocked from promotion) cannot return.
+//! They are pure (no sandbox), so they run in CI without bubblewrap.
+
+use autonoetic_gateway::runtime::tools::artifact_exec::promotion_run_is_network_isolated;
+use autonoetic_types::agent::{AgentIdentity, AgentManifest, RuntimeDeclaration};
+use autonoetic_types::capability::Capability;
+
+fn manifest(agent_id: &str, sandbox: &str) -> AgentManifest {
+    AgentManifest {
+        version: "1.0".to_string(),
+        runtime: RuntimeDeclaration {
+            engine: "autonoetic".to_string(),
+            gateway_version: "0.1.0".to_string(),
+            sdk_version: "0.1.0".to_string(),
+            runtime_type: "stateful".to_string(),
+            sandbox: sandbox.to_string(),
+            runtime_lock: "runtime.lock".to_string(),
+        },
+        agent: AgentIdentity {
+            id: agent_id.to_string(),
+            name: agent_id.to_string(),
+            description: "Test agent".to_string(),
+        },
+        capabilities: vec![Capability::CodeExecution {
+            patterns: vec!["*".to_string()],
+            commands: vec![],
+        }],
+        llm_overrides: None,
+        llm_preset: None,
+        llm_config: None,
+        limits: None,
+        background: None,
+        disclosure: None,
+        io: None,
+        middleware: None,
+        execution_mode: Default::default(),
+        script_entry: None,
+        script_input_mode: Default::default(),
+        gateway_url: None,
+        gateway_token: None,
+        allowed_tool_tiers: vec![],
+        agentskills_import: None,
+        compression: None,
+        sandbox_network: autonoetic_types::agent::SandboxNetworkPolicy::default(),
+    }
+}
+
+#[test]
+fn unit_test_runner_on_bubblewrap_runs_isolated_not_predenied() {
+    // The mocked-urllib false-deny case: unit_test_runner on bubblewrap is
+    // physically network-off, so detections are informational, not a pre-deny.
+    assert!(
+        promotion_run_is_network_isolated(&manifest("unit_test_runner.default", "bubblewrap")),
+        "unit_test_runner on bubblewrap must run in the isolated sandbox, not be pre-denied"
+    );
+}
+
+#[test]
+fn all_promotion_verdict_roles_isolated_on_bubblewrap() {
+    for role in [
+        "unit_test_runner.default",
+        "sealed_evaluator.default",
+        "static_evaluator.default",
+        "auditor.default",
+    ] {
+        assert!(
+            promotion_run_is_network_isolated(&manifest(role, "bubblewrap")),
+            "{role} must run network-isolated on bubblewrap"
+        );
+    }
+}
+
+#[test]
+fn non_isolating_drivers_keep_predeny_for_promotion_roles() {
+    // docker/microvm/wasm do not honor force_network_off, so the
+    // deterministic-without-network pre-deny (P-3.10) must be preserved.
+    for driver in ["docker", "microvm", "wasm"] {
+        assert!(
+            !promotion_run_is_network_isolated(&manifest("unit_test_runner.default", driver)),
+            "driver {driver} cannot guarantee network-off; pre-deny must be kept"
+        );
+    }
+}
+
+#[test]
+fn non_promotion_role_is_not_treated_as_isolated_promotion_run() {
+    // A plain executor is not a promotion-verdict role: this predicate is false
+    // (its network handling goes through the normal operator-approval path).
+    assert!(
+        !promotion_run_is_network_isolated(&manifest("executor.default", "bubblewrap")),
+        "non-promotion roles are not promotion-isolated runs"
+    );
+}


### PR DESCRIPTION
## Problem

A service that uses a remote URL writes unit tests that **mock** the HTTP caller — deterministic and correct. The tests pass. But `RemoteAccessAnalyzer` detected the `urllib` import, so the promotion gate **statically pre-denied** the test run before it ever executed (`promotion_gate_network_denied` → `unable_to_evaluate`). Good tests could not pass, and the planner looped with no winning move (asking the operator for approval doesn't help — the sandbox is offline by design).

## Root cause

`unit_test_runner` (and the other promotion-verdict roles) already run in a **physically network-isolated** sandbox: `promotion_gate_overrides()` sets `force_network_off`. The static pre-deny in `artifact_exec.rs` — keyed on *import detection* (`requires_approval = !patterns.is_empty()`, which fires on a bare `import urllib`) — was therefore both **redundant** (the run is already offline) and **harmful** (it blocks mocked, deterministic suites).

## Fix

- Centralized the per-driver guarantee into one source of truth, `SandboxDriverKind::guarantees_network_off(overrides)`:

  | driver | offline guaranteed? | why |
  |---|---|---|
  | bubblewrap | iff `force_network_off` | `--unshare-all`, no `--share-net` |
  | docker | **always** | `--network none` hardcoded |
  | wasm | **always** | WASI preview1, no sockets |
  | microvm | **no** | NIC controlled by operator firecracker `--config-file` |

- `promotion_run_is_network_isolated` routes through it. For promotion-verdict roles on a driver that guarantees offline, the gate **does not** pre-deny — it runs the deterministic suite in the isolated sandbox:
  - mocked tests **pass** → `pass`;
  - tests that genuinely reach the network fail at runtime (`ConnectionError`) → role reports `unable_to_evaluate` (existing `apply_network_isolation_failure_to_result` path).
- Detected patterns are surfaced as **informational** (`network_isolated_run` / `detected_patterns`), not a block.
- **microvm keeps** the deterministic-without-network pre-deny (P-3.10), since its network can't be asserted offline.
- `unit_test_runner` SKILL updated to judge from the **runtime outcome** rather than pre-judging `unable_to_evaluate` from detected imports.

## Tests

- `promotion_gate_network_isolation_decision.rs` (CI-safe, no sandbox): per-driver truth table + decision (bubblewrap/docker/wasm isolated; microvm pre-denied; non-promotion role excluded).
- `promotion_gate_mocked_network_e2e.rs` — **`#[ignore]`'d** full-sandbox e2e (requires `bwrap`, not in CI): builds an artifact and runs it through the real `artifact_exec` tool — mocked-urllib suite runs offline and **passes**; a real network call **fails** offline. **Verified passing locally against bubblewrap 0.9.0.** Documented in CLAUDE.md (`### Tests`) with the run command.
- Existing `constitution_promotion_no_network`, `constitution_p_2_26_unit_test_runner_gate`, `artifact_exec_lifecycle_integration` still green.

## Note / possible follow-up

microvm is the one driver that keeps the pre-deny. To remove the false-deny there too, the gateway would need to **assert** the firecracker `--config-file` declares no NIC for promotion runs (validate or strip it) — operator-environment-specific work, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
