### PR TITLE
fix(sentinel): make repetition-entropy advisory + warm-up (stop researcher false divergence gate)

### DIFF
--- a/autonoetic-gateway/src/runtime/trajectory_monitor.rs
+++ b/autonoetic-gateway/src/runtime/trajectory_monitor.rs
@@ -145,7 +145,7 @@ impl TrajectoryMonitor {
             }
         }
         if toggles.repetition_entropy {
-            if let Some(s) = self.repetition_entropy_signal() {
+            if let Some(s) = self.repetition_entropy_signal(turn_counter) {
                 signals.push(s);
             }
         }
@@ -229,45 +229,51 @@ impl TrajectoryMonitor {
         }
     }
 
-    fn repetition_entropy_signal(&self) -> Option<DivergenceSignal> {
+    fn repetition_entropy_signal(&self, turn_counter: u64) -> Option<DivergenceSignal> {
         let cfg = &self.config.repetition_entropy;
+        // Warm-up: divergence is a trajectory property, not a single-turn one.
+        // I/O-heavy agents (e.g. `researcher.default`) legitimately fire many
+        // similar calls in their opening turns — fetching pages, re-querying.
+        // Don't judge tool-call repetition before `min_turns` so that burst
+        // does not trip the signal at turn 1.
+        if turn_counter < cfg.min_turns {
+            return None;
+        }
         if self.fingerprint_window.len() < cfg.min_observations.max(1) {
             return None;
         }
         let entropy = shannon_entropy_bits(&self.fingerprint_window);
-        if entropy <= cfg.critical_bits {
-            Some(
-                DivergenceSignal::new(
-                    DivergenceSignalKind::RepetitionEntropy,
-                    SignalSeverity::Critical,
-                    entropy,
-                    cfg.critical_bits,
-                )
-                .with_evidence(format!(
-                    "tool-fingerprint entropy {:.2} bits over last {} calls (critical ≤ {:.2})",
-                    entropy,
-                    self.fingerprint_window.len(),
-                    cfg.critical_bits
-                )),
-            )
-        } else if entropy <= cfg.warn_bits {
-            Some(
-                DivergenceSignal::new(
-                    DivergenceSignalKind::RepetitionEntropy,
-                    SignalSeverity::Warn,
-                    entropy,
-                    cfg.warn_bits,
-                )
-                .with_evidence(format!(
-                    "tool-fingerprint entropy {:.2} bits over last {} calls (warn ≤ {:.2})",
-                    entropy,
-                    self.fingerprint_window.len(),
-                    cfg.warn_bits
-                )),
-            )
-        } else {
-            None
+        if entropy > cfg.warn_bits {
+            return None;
         }
+        // Repetition entropy is ADVISORY: it caps at `Warn` and never escalates
+        // a session to `Critical` on its own, so it never raises the operator
+        // divergence gate. Repeating a tool call is weak evidence of being
+        // stuck — a researcher fetching many URLs is doing its job. The
+        // gate-worthy `Critical` verdicts come from the loop guard's semantic
+        // no-progress (P-7.19) and the error-burst signal. The evidence still
+        // records how low the entropy is (`critical_bits` band) so the
+        // divergence event stays informative.
+        let band = if entropy <= cfg.critical_bits {
+            "critically low"
+        } else {
+            "low"
+        };
+        Some(
+            DivergenceSignal::new(
+                DivergenceSignalKind::RepetitionEntropy,
+                SignalSeverity::Warn,
+                entropy,
+                cfg.warn_bits,
+            )
+            .with_evidence(format!(
+                "tool-fingerprint entropy {:.2} bits over last {} calls ({}, warn ≤ {:.2}) — advisory, not gating",
+                entropy,
+                self.fingerprint_window.len(),
+                band,
+                cfg.warn_bits
+            )),
+        )
     }
 
     fn error_burst_signal(&self) -> Option<DivergenceSignal> {
@@ -476,10 +482,13 @@ mod tests {
     // ── Per-signal extraction ───────────────────────────────────────────
 
     #[test]
-    fn repetition_entropy_zero_for_repeated_fingerprint() {
-        // Send the same fingerprint enough times to reach min_observations.
+    fn repetition_entropy_is_advisory_warn_never_critical() {
+        // Repeated identical fingerprints (entropy ≈ 0) must surface a Warn
+        // advisory — NOT a Critical signal — so a repetitive I/O agent never
+        // raises the operator divergence gate on repetition alone.
         let mut mon = TrajectoryMonitor::new(cfg());
         let fp = 42;
+        // Tick past the warm-up (min_turns = 3) and min_observations (4).
         for turn in 1..=4 {
             let _ = mon.tick(
                 turn,
@@ -488,23 +497,67 @@ mod tests {
                 &quiet_guard_state(),
             );
         }
-        // Entropy ≈ 0 → critical band.
         let r = mon.tick(
             5,
             &[ToolObservation { fingerprint: fp, failed: false }],
             None,
             &quiet_guard_state(),
         );
-        let has_entropy_critical = r
+        let entropy_signals: Vec<_> = r
             .health
             .signals()
             .iter()
-            .any(|s| s.kind == DivergenceSignalKind::RepetitionEntropy && s.severity == SignalSeverity::Critical);
+            .filter(|s| s.kind == DivergenceSignalKind::RepetitionEntropy)
+            .collect();
         assert!(
-            has_entropy_critical,
-            "expected entropy=critical signal, got health={:?}",
+            !entropy_signals.is_empty(),
+            "expected an entropy advisory signal, got health={:?}",
             r.health
         );
+        assert!(
+            entropy_signals
+                .iter()
+                .all(|s| s.severity == SignalSeverity::Warn),
+            "repetition entropy must cap at Warn, got {:?}",
+            entropy_signals
+        );
+        // …and it must not, by itself, drive the session to Critical.
+        assert!(
+            !matches!(r.health, TrajectoryHealth::Critical { .. }),
+            "entropy alone must not reach Critical, got {:?}",
+            r.health
+        );
+    }
+
+    #[test]
+    fn repetition_entropy_warmup_suppresses_early_turns() {
+        // Even with identical fingerprints meeting min_observations, the signal
+        // stays silent before min_turns (default 3) — an opening burst of
+        // similar calls (researcher fetching many URLs in turn 1) is fine.
+        let mut mon = TrajectoryMonitor::new(cfg());
+        for turn in 1..=2 {
+            let r = mon.tick(
+                turn,
+                &[
+                    ToolObservation { fingerprint: 9, failed: false },
+                    ToolObservation { fingerprint: 9, failed: false },
+                    ToolObservation { fingerprint: 9, failed: false },
+                    ToolObservation { fingerprint: 9, failed: false },
+                ],
+                None,
+                &quiet_guard_state(),
+            );
+            let has_entropy = r
+                .health
+                .signals()
+                .iter()
+                .any(|s| s.kind == DivergenceSignalKind::RepetitionEntropy);
+            assert!(
+                !has_entropy,
+                "entropy fired during warm-up at turn {} (health={:?})",
+                turn, r.health
+            );
+        }
     }
 
     #[test]

--- a/autonoetic-gateway/tests/trajectory_monitor_integration.rs
+++ b/autonoetic-gateway/tests/trajectory_monitor_integration.rs
@@ -124,7 +124,10 @@ fn signal_toggles_prevent_individual_signal_triggers() {
 fn fingerprint_entropy_detects_repetition() {
     let mut mon = TrajectoryMonitor::new(cfg());
 
-    // 4 identical fingerprints → entropy near 0 → critical.
+    // 4 identical fingerprints → entropy near 0. Repetition entropy is
+    // ADVISORY: it surfaces as a Warn signal, never Critical, so a repetitive
+    // I/O agent (e.g. researcher fetching many URLs) is not gated on
+    // repetition alone. Tick past the warm-up (min_turns = 3) first.
     let fp = 42u64;
     for turn in 1u64..=4 {
         let _ = mon.tick(
@@ -141,12 +144,30 @@ fn fingerprint_entropy_detects_repetition() {
         &quiet_guard_state(),
     );
 
-    let has_entropy_critical = r.health.signals().iter().any(|s| {
-        s.kind == DivergenceSignalKind::RepetitionEntropy && s.severity == SignalSeverity::Critical
-    });
-    assert!(has_entropy_critical, "expected entropy=critical signal from repetition");
+    let entropy_signals: Vec<_> = r
+        .health
+        .signals()
+        .iter()
+        .filter(|s| s.kind == DivergenceSignalKind::RepetitionEntropy)
+        .collect();
+    assert!(
+        !entropy_signals.is_empty(),
+        "expected an entropy advisory signal from repetition"
+    );
+    assert!(
+        entropy_signals
+            .iter()
+            .all(|s| s.severity == SignalSeverity::Warn),
+        "repetition entropy must be advisory (Warn), never Critical: {entropy_signals:?}"
+    );
+    // Entropy alone must not drive the session to Critical (the operator gate).
+    assert!(
+        !matches!(r.health, TrajectoryHealth::Critical { .. }),
+        "entropy alone must not reach Critical: {:?}",
+        r.health
+    );
 
-    // Payload must carry signals.
+    // Payload must still carry signals (advisory divergence is recorded).
     let payload = build_event_payload(&r.health).unwrap();
     assert!(payload["signals"].as_array().map(|a| a.len() > 0).unwrap_or(false));
 }

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -2496,6 +2496,14 @@ pub struct TrajectoryRepetitionEntropyConfig {
     /// repeating itself.
     #[serde(default = "default_repetition_entropy_warn_bits")]
     pub warn_bits: f32,
+    /// Entropy at or below this (in bits) is labelled "critically low" in the
+    /// divergence evidence. The repetition-entropy signal is **advisory**: it
+    /// caps at `Warn` severity and never escalates a session to `Critical` on
+    /// its own (so it never raises the operator divergence gate). Tool-call
+    /// repetition is weak evidence of being stuck — an I/O agent such as
+    /// `researcher.default` legitimately repeats fetch/search calls. The
+    /// gate-worthy `Critical` verdicts come from the loop guard's semantic
+    /// no-progress (P-7.19) and the error-burst signal.
     #[serde(default = "default_repetition_entropy_critical_bits")]
     pub critical_bits: f32,
     /// Minimum number of tool calls in the window before the signal is
@@ -2503,6 +2511,12 @@ pub struct TrajectoryRepetitionEntropyConfig {
     /// two calls observed.
     #[serde(default = "default_repetition_entropy_min_observations")]
     pub min_observations: usize,
+    /// Warm-up: the signal is not evaluated until the session reaches this
+    /// turn. Divergence is a trajectory property, not a single-turn one — an
+    /// agent's opening burst of similar calls (e.g. a researcher fetching many
+    /// pages in turn 1) must not trip it.
+    #[serde(default = "default_repetition_entropy_min_turns")]
+    pub min_turns: u64,
 }
 
 fn default_repetition_entropy_warn_bits() -> f32 {
@@ -2514,6 +2528,9 @@ fn default_repetition_entropy_critical_bits() -> f32 {
 fn default_repetition_entropy_min_observations() -> usize {
     4
 }
+fn default_repetition_entropy_min_turns() -> u64 {
+    3
+}
 
 impl Default for TrajectoryRepetitionEntropyConfig {
     fn default() -> Self {
@@ -2521,6 +2538,7 @@ impl Default for TrajectoryRepetitionEntropyConfig {
             warn_bits: default_repetition_entropy_warn_bits(),
             critical_bits: default_repetition_entropy_critical_bits(),
             min_observations: default_repetition_entropy_min_observations(),
+            min_turns: default_repetition_entropy_min_turns(),
         }
     }
 }

--- a/docs/design/divergence-sentinel-design.md
+++ b/docs/design/divergence-sentinel-design.md
@@ -161,7 +161,7 @@ It is rule-based, cheap, and has no LLM cost.
 | `failure_pressure` | max over tools of `failures / max_tool_failures` | warn ≥ 0.8 |
 | `child_failure_pressure` | `child_failures / max_child_failures` | warn ≥ 0.66 |
 | `digest_stall` | turns since last new causal event category | warn ≥ 5 |
-| `repetition_entropy` | Shannon entropy of last-N tool fingerprints (low = repetitive) | warn ≤ 1.2 |
+| `repetition_entropy` | Shannon entropy of last-N tool fingerprints (low = repetitive). **Advisory-only**: caps at `Warn` severity — never escalates to `Critical` on its own (repeating a tool call is weak evidence of being stuck; the gate-worthy `Critical` verdicts belong to the loop guard's semantic no-progress and the error-burst signal). Evidence still records how low entropy is (`"critically low"` below `critical_bits`); planner is still notified. Requires `min_turns` (default 3) warm-up before evaluation to avoid tripping on an agent's opening burst of similar calls. | warn ≤ 1.2, advisory (max Warn) |
 | `error_burst` | error events in last-N turns | warn ≥ 5 |
 | `context_pressure` | already exists in `budget_tracker.rs` | warn ≥ 0.8 |
 


### PR DESCRIPTION
## Problem

`researcher.default` (and any NetworkAccess/I-O-heavy agent) trips the divergence sentinel's **`RepetitionEntropy`** signal at **Critical on turn 1**, raising the operator clarification gate:

```
Critical divergence in 'researcher.default' turn 1: tool-fingerprint entropy 0.00 bits over last 4 calls (critical ≤ 0.50)
```

**Why:** the per-call fingerprint is `hash(tool_name, arguments)` with the `intent` field stripped. A researcher's repeated fetch/search calls (retries, same query, paginated reads) collapse to one fingerprint → ~0-bit entropy. With `min_observations: 4` and no warm-up, that fires on the very first turn, and `RepetitionEntropy` was rated **Critical** — the only health level that raises the operator gate.

## Fix (per maintainer decision: demote + warm-up)

- **Advisory severity:** `RepetitionEntropy` now caps at **`Warn`** and never escalates a session to `Critical` on its own, so it never raises the operator divergence gate. Repeating a tool call is weak evidence of being stuck; the gate-worthy `Critical` verdicts belong to the loop guard's semantic no-progress (**P-7.19**) and the error-burst signal. The divergence **evidence still records** how low the entropy is (`"critically low"` below `critical_bits`) and the **planner is still notified** — it's demoted, not silenced.
- **Warm-up:** new `repetition_entropy.min_turns` (default **3**). The signal isn't evaluated before that turn, so an agent's opening burst of similar calls can't trip it.

## Tests

- `repetition_entropy_is_advisory_warn_never_critical` — repeated identical fingerprints surface a `Warn` advisory, never `Critical`, and don't drive health to Critical.
- `repetition_entropy_warmup_suppresses_early_turns` — silent before `min_turns` even when `min_observations` is met.
- Updated the integration test's entropy assertion to the advisory semantics.

## Not in scope (pre-existing, unrelated)

The remaining `trajectory_monitor` failures — `progression_healthy_to_watching_to_diverging_to_critical`, `digest_stall_fires_…`, `error_burst_fires_…` (unit) and `looping_session_produces_divergence_event_sequence` (integration) — fail on `main` independent of this change. They're **loop-pressure / threshold** issues (e.g. `current_loops` 4/5 = 0.80 not producing `Watching`), driven by `&[]` observations with no entropy involved. Tracked with the broader test-triage cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
