### PR TITLE
fix(reaper): don't reap children parked at an approval gate (stops install retry storm)

### DIFF
--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -717,6 +717,31 @@ pub async fn reap_orphaned_sessions(
     for (idx, (child_session_id, parent_session_id, root_session_id, agent_id)) in
         orphans.into_iter().enumerate()
     {
+        // A child parked at an approval gate is NOT an orphan. The async-spawn
+        // pattern legitimately ends the immediate parent's turn (transcript
+        // status `completed`) while the child stays suspended awaiting an
+        // operator decision — coordinated by the still-alive root. Reaping it
+        // here would discard committed work (e.g. a just-created revision) and
+        // drive the parent to retry, producing a cancel→retry→collision storm.
+        // Leave approval-suspended children to the operator and the gate-timeout
+        // lifecycle (P-2.11) instead.
+        match crate::scheduler::approval::pending_approval_requests_for_session(
+            &config,
+            Some(store.as_ref()),
+            &child_session_id,
+        ) {
+            Ok(pending) if !pending.is_empty() => {
+                tracing::info!(
+                    child_session_id = %child_session_id,
+                    parent_session_id = %parent_session_id,
+                    pending_approvals = pending.len(),
+                    "Orphan-child reaper (R+12): skipping child parked at an approval gate"
+                );
+                continue;
+            }
+            _ => {}
+        }
+
         tracing::info!(
             child_session_id = %child_session_id,
             parent_session_id = %parent_session_id,

--- a/autonoetic-gateway/src/scheduler.rs
+++ b/autonoetic-gateway/src/scheduler.rs
@@ -698,6 +698,30 @@ pub async fn reap_orphaned_sessions(
         return Ok(());
     }
 
+    // A child parked at an approval gate is NOT an orphan. The async-spawn
+    // pattern legitimately ends the immediate parent's turn (transcript status
+    // `completed`) while the child stays suspended awaiting an operator
+    // decision — coordinated by the still-alive root. Reaping it would discard
+    // committed work (e.g. a just-created revision) and drive the parent to
+    // retry, producing a cancel→retry→collision storm. Leave such children to
+    // the operator and the gate-timeout lifecycle (P-2.11).
+    //
+    // Load pending approvals ONCE into a set of parked session ids — cheap
+    // versus re-querying per orphan (O(orphans × pending)). If approval state
+    // cannot be determined, be conservative and skip this whole reap cycle
+    // rather than risk cancelling a parked child; the next cycle retries.
+    let approval_parked_sessions: std::collections::HashSet<String> =
+        match store.get_pending_approvals() {
+            Ok(pending) => pending.into_iter().map(|a| a.session_id).collect(),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Orphan-child reaper (R+12): could not load pending approvals — skipping this reap cycle (conservative)"
+                );
+                return Ok(());
+            }
+        };
+
     let config = execution.config();
     let now = chrono::Utc::now();
     let now_rfc = now.to_rfc3339();
@@ -717,29 +741,15 @@ pub async fn reap_orphaned_sessions(
     for (idx, (child_session_id, parent_session_id, root_session_id, agent_id)) in
         orphans.into_iter().enumerate()
     {
-        // A child parked at an approval gate is NOT an orphan. The async-spawn
-        // pattern legitimately ends the immediate parent's turn (transcript
-        // status `completed`) while the child stays suspended awaiting an
-        // operator decision — coordinated by the still-alive root. Reaping it
-        // here would discard committed work (e.g. a just-created revision) and
-        // drive the parent to retry, producing a cancel→retry→collision storm.
-        // Leave approval-suspended children to the operator and the gate-timeout
-        // lifecycle (P-2.11) instead.
-        match crate::scheduler::approval::pending_approval_requests_for_session(
-            &config,
-            Some(store.as_ref()),
-            &child_session_id,
-        ) {
-            Ok(pending) if !pending.is_empty() => {
-                tracing::info!(
-                    child_session_id = %child_session_id,
-                    parent_session_id = %parent_session_id,
-                    pending_approvals = pending.len(),
-                    "Orphan-child reaper (R+12): skipping child parked at an approval gate"
-                );
-                continue;
-            }
-            _ => {}
+        // Skip children parked at an approval gate (see note above the
+        // `approval_parked_sessions` set).
+        if approval_parked_sessions.contains(&child_session_id) {
+            tracing::info!(
+                child_session_id = %child_session_id,
+                parent_session_id = %parent_session_id,
+                "Orphan-child reaper (R+12): skipping child parked at an approval gate"
+            );
+            continue;
         }
 
         tracing::info!(

--- a/autonoetic-gateway/tests/constitution_lifecycle_orphan_reaper.rs
+++ b/autonoetic-gateway/tests/constitution_lifecycle_orphan_reaper.rs
@@ -284,3 +284,111 @@ async fn orphan_reaper_does_not_reap_suspended_parent() {
         "child with suspended parent should NOT be reaped"
     );
 }
+
+/// A child parked at an approval gate must NOT be reaped even when its
+/// immediate parent transcript is terminal: in the async-spawn pattern the
+/// parent legitimately ends its turn while the child stays suspended awaiting
+/// an operator decision (coordinated by the still-alive root). Reaping it would
+/// discard committed work and drive the parent to retry (cancel→retry→collision
+/// storm). It is left to the operator / gate-timeout (P-2.11).
+#[tokio::test]
+async fn orphan_reaper_skips_child_parked_at_approval() {
+    use autonoetic_types::background::{
+        ApprovalLevel, ApprovalRequest, ScheduledAction,
+    };
+
+    let ws = TestWorkspace::new().unwrap();
+    let gateway_dir = ws.agents_dir.join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+
+    let store = std::sync::Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+
+    let root_id = "root-session-003";
+    let parent_id = "root-session-003/agent-factory.default-aaaa1111";
+    let child_id =
+        "root-session-003/agent-factory.default-aaaa1111/specialized_builder.default-bbbb2222";
+
+    // Root alive, immediate parent's turn ended (completed), child still active.
+    store
+        .upsert_session_transcript(&make_transcript(root_id, root_id, "planner.default", "active"))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(
+            parent_id,
+            root_id,
+            "agent-factory.default",
+            "completed",
+        ))
+        .unwrap();
+    store
+        .upsert_session_transcript(&make_transcript(
+            child_id,
+            root_id,
+            "specialized_builder.default",
+            "active",
+        ))
+        .unwrap();
+
+    // The child is parked at a pending operator approval (e.g. a promotion gate).
+    let mut approval = ApprovalRequest {
+        request_id: "apr-parked-001".to_string(),
+        agent_id: "specialized_builder.default".to_string(),
+        session_id: child_id.to_string(),
+        action: ScheduledAction::SandboxExec {
+            command: "install".to_string(),
+            dependencies: None,
+            requires_approval: true,
+            evidence_ref: None,
+            detected_hosts: None,
+        },
+        approval_level: ApprovalLevel::Operator,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        reason: None,
+        evidence_ref: None,
+        workflow_id: None,
+        task_id: None,
+        root_session_id: Some(root_id.to_string()),
+        status: None,
+        decided_at: None,
+        decided_by: None,
+        decision_reason: None,
+        similar_to_request_id: None,
+        similarity_score: None,
+        min_dwell_ms: None,
+        confirm_phrase: None,
+        code_excerpts: None,
+        risk_summary: None,
+    };
+    store.create_approval(&mut approval).unwrap();
+    assert!(
+        store
+            .get_pending_approvals()
+            .unwrap()
+            .iter()
+            .any(|a| a.request_id == "apr-parked-001"),
+        "approval should be pending"
+    );
+
+    let config = ws.gateway_config();
+    let execution = std::sync::Arc::new(GatewayExecutionService::new(config, Some(store.clone())));
+
+    reap_orphaned_sessions(execution)
+        .await
+        .expect("reaper should succeed");
+
+    let child = store
+        .find_transcript_by_session_id(child_id)
+        .unwrap()
+        .expect("child should exist");
+    assert_eq!(
+        child.status, "active",
+        "child parked at an approval gate must NOT be reaped"
+    );
+
+    // And no parent_terminated reap event was emitted for it.
+    let events = store.search_causal_events(Some(child_id), None, 100).unwrap();
+    assert!(
+        !events.iter().any(|e| e.action == "parent_terminated"),
+        "no reap event should be emitted for an approval-parked child"
+    );
+}


### PR DESCRIPTION
## Problem (from a real session: 1h36m to build one weather agent, never finished)

The orphan-child reaper (R+12 / P-7.16) flags a child as orphaned whenever its **immediate parent transcript is `completed`/`failed`**. But in the async-spawn orchestration pattern, a parent legitimately ends its *turn* (status `completed`) while its child stays **suspended awaiting an operator approval**, coordinated by the still-alive root planner.

The reaper then cancelled the parked child, which:
- **discarded committed work** — the `specialized_builder` had already created the agent revision before parking at the promotion approval;
- **drove `agent-factory` to retry**, and the retry collided with the already-created revision (`"Agent 'weather-agent' already has an active revision"`).

Net: a cancel→retry→collision storm — 3 × `agent-factory` + 3 × `specialized_builder` over ~30 min, ending `BlockedApproval` without ever completing the install.

## Fix

In `reap_orphaned_sessions`, skip any orphan candidate whose session has a **pending approval** (`pending_approval_requests_for_session`). A child parked at an approval gate is not an orphan — it is intentionally suspended awaiting an operator decision and is owned by the gate-timeout lifecycle (**P-2.11**). It's left to the operator / gate timeout, not killed mid-flight.

This addresses the storm at its root: no reap → no `agent-factory` retry → no revision collision.

## Test

`orphan_reaper_skips_child_parked_at_approval` — root active, immediate parent `completed`, child `active` with a pending approval → child stays `active` (not reaped), and no `parent_terminated` event is emitted. The existing reaper tests (genuine orphan still reaped; active parent ignored) still pass.

## Follow-up proposed separately (not in this PR)

Idempotent install as defense-in-depth: `agent_revision_create_from_intent` returns a `fatal` when an active revision already exists (`agent_revision.rs:~1332`). For an exact-same-`artifact_ref` retry it could return the existing candidate (idempotent) so the caller proceeds straight to promote. That flips a **fail-closed** guard in the promotion pipeline (P-2.25), so it deserves its own review rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
