### PR TITLE
fix(llm): classify "Context size has been exceeded" 500 as context overflow (enables recovery)

### DIFF
--- a/autonoetic-gateway/src/llm/mod.rs
+++ b/autonoetic-gateway/src/llm/mod.rs
@@ -111,6 +111,15 @@ pub fn is_context_overflow_error(status: u16, body: &str) -> bool {
                     || lc.contains("maximum context length")
                     || lc.contains("context window")
                         && (lc.contains("exceed") || lc.contains("too long"))
+                    // General catch for OpenAI-compatible servers that phrase it
+                    // differently (e.g. llama.cpp / vLLM "Context size has been
+                    // exceeded."). Any error mentioning "context" together with an
+                    // overflow verb is treated as overflow so the aggressive-governor
+                    // retry fires instead of failing the turn terminally.
+                    || lc.contains("context")
+                        && (lc.contains("exceed")
+                            || lc.contains("too long")
+                            || lc.contains("too many tokens"))
                 {
                     return true;
                 }

--- a/autonoetic-gateway/src/llm/mod.rs
+++ b/autonoetic-gateway/src/llm/mod.rs
@@ -105,21 +105,28 @@ pub fn is_context_overflow_error(status: u16, body: &str) -> bool {
             //    OpenAI-compatible server that doesn't use a standard code/type.
             if let Some(msg) = err.get("message").and_then(|m| m.as_str()) {
                 let lc = msg.to_lowercase();
+                let has_overflow_verb = lc.contains("exceed")
+                    || lc.contains("too long")
+                    || lc.contains("too many tokens");
+                // A size/length/window/token hint distinguishes a *context size*
+                // overflow from unrelated "context" errors that merely share the
+                // word — most importantly "context deadline exceeded" (a timeout,
+                // NOT an overflow), which must not be routed into overflow recovery.
+                let has_size_hint = lc.contains("size")
+                    || lc.contains("length")
+                    || lc.contains("window")
+                    || lc.contains("token");
                 if lc.contains("exceeds the available context")
                     || lc.contains("exceeds the context")
                     || lc.contains("context length exceeded")
                     || lc.contains("maximum context length")
-                    || lc.contains("context window")
-                        && (lc.contains("exceed") || lc.contains("too long"))
+                    || (lc.contains("context window") && has_overflow_verb)
                     // General catch for OpenAI-compatible servers that phrase it
                     // differently (e.g. llama.cpp / vLLM "Context size has been
-                    // exceeded."). Any error mentioning "context" together with an
-                    // overflow verb is treated as overflow so the aggressive-governor
-                    // retry fires instead of failing the turn terminally.
-                    || lc.contains("context")
-                        && (lc.contains("exceed")
-                            || lc.contains("too long")
-                            || lc.contains("too many tokens"))
+                    // exceeded."). Requires "context" + an overflow verb + a
+                    // size/length/window/token hint, so timeouts like
+                    // "context deadline exceeded" are NOT misclassified.
+                    || (lc.contains("context") && has_overflow_verb && has_size_hint)
                 {
                     return true;
                 }

--- a/autonoetic-gateway/src/llm/tests.rs
+++ b/autonoetic-gateway/src/llm/tests.rs
@@ -603,6 +603,25 @@ mod tests {
         }
 
         #[test]
+        fn context_size_has_been_exceeded_500() {
+            // Observed from a local OpenAI-compatible server: HTTP 500 with a
+            // non-standard "Context size has been exceeded." message and a
+            // generic server_error type. Previously unrecognized → terminal
+            // failure instead of an aggressive-governor retry.
+            let body = r#"{"error":{"code":500,"message":"Context size has been exceeded.","type":"server_error"}}"#;
+            assert!(is_context_overflow_error(500, body));
+        }
+
+        #[test]
+        fn unrelated_context_error_without_overflow_verb_is_not_overflow() {
+            // Guard against the general "context" catch over-matching: an error
+            // mentioning context but no overflow verb must NOT be treated as
+            // overflow.
+            let body = r#"{"error":{"message":"invalid context id provided","type":"invalid_request_error"}}"#;
+            assert!(!is_context_overflow_error(400, body));
+        }
+
+        #[test]
         fn n_prompt_tokens_and_n_ctx_keys_alone_are_enough() {
             // Defensive: if the server reports both counters, it's an overflow
             // even if the message wording is unusual.

--- a/autonoetic-gateway/src/llm/tests.rs
+++ b/autonoetic-gateway/src/llm/tests.rs
@@ -622,6 +622,16 @@ mod tests {
         }
 
         #[test]
+        fn context_deadline_exceeded_timeout_is_not_overflow() {
+            // "context deadline exceeded" is a timeout/cancellation (Go/gRPC),
+            // NOT a context-size overflow. It has "context" + "exceed" but no
+            // size/length/window/token hint, so it must NOT route into
+            // overflow recovery (trimming context wouldn't help a timeout).
+            let body = r#"{"error":{"message":"context deadline exceeded","type":"server_error"}}"#;
+            assert!(!is_context_overflow_error(500, body));
+        }
+
+        #[test]
         fn n_prompt_tokens_and_n_ctx_keys_alone_are_enough() {
             // Defensive: if the server reports both counters, it's an overflow
             // even if the message wording is unusual.


### PR DESCRIPTION
## Problem (from the 1h36m session analysis)

Two agents (`planner.collaborative`, `agent-factory`) hit:
```
OpenAI API error 500 Internal Server Error: {"error":{"code":500,"message":"Context size has been exceeded.","type":"server_error"}}
```
and **failed terminally**. The gateway *has* an overflow-recovery path — `overflow_classifier::is_context_overflow` → retry once with the aggressive governor pipeline — but it never engaged here, because the LLM driver only tags an error `context_overflow:` when `is_context_overflow_error` recognizes the response, and this server's wording matched **none** of the patterns:

- ✗ "Context size has been exceeded." — not "maximum context length", not "exceeds the (available) context", not "context length exceeded", not "context window … exceed".
- Status 500 (the classifier handles any non-zero status, so that wasn't the blocker — the message wording was).

So a recoverable condition surfaced as a hard turn failure.

## Fix

Broaden the message-text signal in `is_context_overflow_error` with a general catch: any error mentioning **"context"** together with an **overflow verb** (`exceed` / `too long` / `too many tokens`) is classified as overflow. This makes the existing aggressive-governor retry fire for this (and similar) OpenAI-compatible servers instead of failing the turn.

Kept narrow enough to avoid false positives — a guard test confirms `"invalid context id provided"` (context, but no overflow verb) is **not** classified as overflow.

## Tests
- `context_size_has_been_exceeded_500` — the exact observed body is now recognized.
- `unrelated_context_error_without_overflow_verb_is_not_overflow` — over-match guard.
- All 14 `context_overflow` classifier tests pass.

## Note — this is the recovery layer, not full prevention
This turns a terminal failure into an automatic recovery. Two **prevention** follow-ups remain (governor-side, proposed separately): (a) on `GovernorResult::Overflow` the lifecycle currently logs and **sends the oversized prompt anyway** — it should instead trigger recovery proactively rather than guaranteeing a 500; (b) the effective context window falls back to a **32K guess** when the local model's window is unknown — wiring the local-model context probe / preset `context_window_tokens` would make prevention accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
