### PR TITLE
fix(governor): don't send an over-window prompt on Overflow — recover pre-send

### DIFF
--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -105,6 +105,33 @@ impl ExecuteLoopTermination {
     }
 }
 
+/// Pre-send overflow guard. When the context governor is exhausted
+/// (`GovernorResult::Overflow`), decide whether the post-reduction prompt would
+/// still exceed the model's assumed context window (`effective_limit + margin`).
+///
+/// Returns a `context_overflow:`-tagged error (so the scheduler's recovery
+/// retries with the aggressive pipeline instead of sending a doomed request)
+/// when the estimate exceeds the window; `None` when the prompt is still under
+/// the window (only within the safety margin) and may be sent.
+fn overflow_presend_block(
+    estimated_tokens: usize,
+    effective_limit: usize,
+    margin: usize,
+) -> Option<anyhow::Error> {
+    let assumed_window = effective_limit.saturating_add(margin);
+    if estimated_tokens > assumed_window {
+        Some(anyhow::anyhow!(
+            "context_overflow: context governor exhausted — estimated {} tokens exceeds model context window ~{} (effective_limit {} + margin {}); not sending",
+            estimated_tokens,
+            assumed_window,
+            effective_limit,
+            margin
+        ))
+    } else {
+        None
+    }
+}
+
 fn build_critical_divergence_interaction(
     session_id: &str,
     root_session_id: String,
@@ -1774,38 +1801,35 @@ impl AgentExecutor {
                             "ContextGovernor exhausted — all strategies failed"
                         );
                         // Don't knowingly send a prompt that exceeds the model's
-                        // context window. `effective_limit` already subtracts the
-                        // safety margin, so the assumed window is
-                        // `effective_limit + margin`. If, even after exhausting
-                        // every reduction strategy, the estimate still exceeds the
-                        // window, sending is a guaranteed provider context-overflow
-                        // error. Surface a `context_overflow:`-tagged error here so
-                        // the scheduler's recovery retries with the aggressive
-                        // pipeline (and, if that is also exhausted, fails fast)
-                        // instead of paying a round-trip for a 500 we can already
-                        // predict. Prompts only within the safety margin (still
-                        // under the window) fall through and are sent as before.
-                        let assumed_window = effective_limit.saturating_add(margin);
-                        if budget_breakdown.total_tokens > assumed_window {
+                        // context window. Use the POST-governor estimate
+                        // (`ctx.breakdown.total_tokens`, after every reduction
+                        // strategy ran) — not the pre-governor `budget_breakdown`.
+                        // If it still exceeds the assumed window
+                        // (`effective_limit + margin`), sending is a guaranteed
+                        // provider context-overflow, so surface a
+                        // `context_overflow:`-tagged error here to route into the
+                        // scheduler's recovery (retry once with the aggressive
+                        // pipeline; a second overflow is terminal) instead of
+                        // paying a round-trip for a 500 we can already predict.
+                        // Prompts only within the safety margin (still under the
+                        // window) fall through and are sent as before.
+                        let post_governor_tokens = ctx.breakdown.total_tokens;
+                        if let Some(err) =
+                            overflow_presend_block(post_governor_tokens, effective_limit, margin)
+                        {
                             let _ = tracer.log_event(
                                 "context_governor",
                                 "overflow_blocked_send",
                                 autonoetic_types::causal_chain::EntryStatus::Error,
                                 Some(serde_json::json!({
-                                    "estimated_tokens": budget_breakdown.total_tokens,
-                                    "assumed_window": assumed_window,
+                                    "estimated_tokens": post_governor_tokens,
+                                    "assumed_window": effective_limit.saturating_add(margin),
                                     "effective_limit": effective_limit,
                                     "margin_tokens": margin,
                                     "overflow_recovery": self.overflow_recovery,
                                 })),
                             );
-                            return Err(anyhow::anyhow!(
-                                "context_overflow: context governor exhausted — estimated {} tokens exceeds model context window ~{} (effective_limit {} + margin {}); not sending",
-                                budget_breakdown.total_tokens,
-                                assumed_window,
-                                effective_limit,
-                                margin
-                            ));
+                            return Err(err);
                         }
                     }
                     Ok(GovernorResult::WithinBudget) => {
@@ -3295,6 +3319,36 @@ fn waiting_for_child_yield_reason(
 mod tests {
     use super::*;
     use autonoetic_types::agent::SessionState;
+
+    // -- overflow_presend_block ------------------------------------------------
+
+    #[test]
+    fn overflow_presend_block_errors_with_context_overflow_tag_when_over_window() {
+        // effective_limit 30000 + margin 2000 → assumed window 32000.
+        let err = overflow_presend_block(33_000, 30_000, 2_000)
+            .expect("over-window estimate must block");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("context_overflow:"),
+            "blocked error must be tagged for the scheduler's overflow recovery: {msg}"
+        );
+    }
+
+    #[test]
+    fn overflow_presend_block_allows_send_within_safety_margin() {
+        // 31000 is over effective_limit (30000) but under the window (32000) —
+        // only within the safety margin, so it is NOT blocked (sent as before).
+        assert!(overflow_presend_block(31_000, 30_000, 2_000).is_none());
+    }
+
+    #[test]
+    fn overflow_presend_block_boundary_at_window_is_allowed() {
+        // Exactly at the assumed window is not "exceeds" — allowed.
+        assert!(overflow_presend_block(32_000, 30_000, 2_000).is_none());
+        // One token over the window blocks.
+        assert!(overflow_presend_block(32_001, 30_000, 2_000).is_some());
+    }
+
     use crate::llm::{
         CompletionRequest, CompletionResponse, LlmDriver, StopReason, TokenUsage, ToolCall,
         ToolDefinition,

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -1773,6 +1773,40 @@ impl AgentExecutor {
                             diagnostic = ?diag,
                             "ContextGovernor exhausted — all strategies failed"
                         );
+                        // Don't knowingly send a prompt that exceeds the model's
+                        // context window. `effective_limit` already subtracts the
+                        // safety margin, so the assumed window is
+                        // `effective_limit + margin`. If, even after exhausting
+                        // every reduction strategy, the estimate still exceeds the
+                        // window, sending is a guaranteed provider context-overflow
+                        // error. Surface a `context_overflow:`-tagged error here so
+                        // the scheduler's recovery retries with the aggressive
+                        // pipeline (and, if that is also exhausted, fails fast)
+                        // instead of paying a round-trip for a 500 we can already
+                        // predict. Prompts only within the safety margin (still
+                        // under the window) fall through and are sent as before.
+                        let assumed_window = effective_limit.saturating_add(margin);
+                        if budget_breakdown.total_tokens > assumed_window {
+                            let _ = tracer.log_event(
+                                "context_governor",
+                                "overflow_blocked_send",
+                                autonoetic_types::causal_chain::EntryStatus::Error,
+                                Some(serde_json::json!({
+                                    "estimated_tokens": budget_breakdown.total_tokens,
+                                    "assumed_window": assumed_window,
+                                    "effective_limit": effective_limit,
+                                    "margin_tokens": margin,
+                                    "overflow_recovery": self.overflow_recovery,
+                                })),
+                            );
+                            return Err(anyhow::anyhow!(
+                                "context_overflow: context governor exhausted — estimated {} tokens exceeds model context window ~{} (effective_limit {} + margin {}); not sending",
+                                budget_breakdown.total_tokens,
+                                assumed_window,
+                                effective_limit,
+                                margin
+                            ));
+                        }
                     }
                     Ok(GovernorResult::WithinBudget) => {
                         // Emit a TUI-visible warning card when the estimated prompt


### PR DESCRIPTION
## Problem

When the context governor exhausted all reduction strategies (`GovernorResult::Overflow` — schema-compress → capsule → trim → demote, prompt still over the limit), the lifecycle just **logged a warning and proceeded to call the LLM with the oversized prompt** — a guaranteed provider context-overflow (the in-session `"Context size has been exceeded."` 500), paying a full round-trip before any recovery could engage. The governor *knew* it was over budget and sent anyway.

## Fix

On `Overflow`, if the estimate still exceeds the model's context window — `effective_limit + margin`, i.e. the window the governor itself assumed — the turn returns a **`context_overflow:`-tagged error instead of sending**. That routes straight into the existing scheduler recovery (retry once with the aggressive governor pipeline; a second overflow is terminal), proactively and without the predictable 500.

Prompts that are only within the **safety margin** (still under the actual window) fall through and are sent as before — so this doesn't over-trigger retries for prompts that would have fit.

## How it fits together

- **#540** (driver): recognizes the server's overflow message so a post-send 500 is *classified* and recovered.
- **This PR** (governor): never knowingly *sends* an over-window prompt — recover pre-send instead.

Together a context overflow is prevented pre-send or recovered post-500, never a terminal turn failure.

## On #2 (accurate window) — investigated, it's config

The 32K fallback only bites when the model's real window is unknown. Auto-detection **already exists and runs at gateway startup** (`warm_local_model_context` → `LocalModelContextCache::warm_from_config`, probing `/v1/models` `meta.n_ctx` or `/props` `default_generation_settings.n_ctx`) — but only for presets that declare a **`base_url`** (`is_probeable_preset`). So for an accurate window, the local model's preset should set `base_url` (+ `model`) so it gets probed, or set `context_window_tokens` directly. No code change needed there; with this PR + #540 the system is robust even when the window is mis-guessed.

## Testing note

The change is in the `execute_with_history` turn loop (Err propagation verified against the scheduler's `is_context_overflow` retry arm). The 21 `context_governor` unit tests pass; a full turn-loop overflow integration test would need a mock-LLM harness and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
