### PR TITLE
fix(llm): fail-fast per-request timeout (300s→120s) + bounded timeout-aware retries

### DIFF
--- a/autonoetic-gateway/src/llm/anthropic.rs
+++ b/autonoetic-gateway/src/llm/anthropic.rs
@@ -120,29 +120,39 @@ impl LlmDriver for AnthropicDriver {
         let body = self.build_body(req, false);
 
         const MAX_RETRIES: u32 = 3;
-        const COMPLETE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+        let complete_timeout = crate::llm::request_timeout();
+        // Bound total wall-clock so a slow endpoint can't multiply the
+        // per-request timeout across retries.
+        let retry_deadline = complete_timeout.saturating_mul(2);
+        let loop_start = std::time::Instant::now();
         for attempt in 0..=MAX_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&self.provider.base_url)
-                    .timeout(COMPLETE_TIMEOUT)
+                    .timeout(complete_timeout)
                     .header("Content-Type", "application/json")
                     .json(&body),
             );
             let response = match builder.send().await {
                 Ok(r) => r,
-                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < MAX_RETRIES => {
-                    let wait_ms = crate::llm::connection_retry_backoff_ms(attempt);
-                    tracing::warn!(
+                Err(e) => {
+                    if let Some(wait_ms) = crate::llm::next_connection_retry_wait(
+                        &e,
                         attempt,
-                        wait_ms,
-                        error = %e,
-                        "Anthropic connection error, retrying"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-                    continue;
+                        loop_start.elapsed(),
+                        retry_deadline,
+                    ) {
+                        tracing::warn!(
+                            attempt,
+                            wait_ms,
+                            error = %e,
+                            "Anthropic connection error, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                        continue;
+                    }
+                    return Err(e.into());
                 }
-                Err(e) => return Err(e.into()),
             };
             let status = response.status().as_u16();
 

--- a/autonoetic-gateway/src/llm/anthropic.rs
+++ b/autonoetic-gateway/src/llm/anthropic.rs
@@ -119,13 +119,12 @@ impl LlmDriver for AnthropicDriver {
     async fn complete(&self, req: &CompletionRequest) -> anyhow::Result<CompletionResponse> {
         let body = self.build_body(req, false);
 
-        const MAX_RETRIES: u32 = 3;
         let complete_timeout = crate::llm::request_timeout();
         // Bound total wall-clock so a slow endpoint can't multiply the
         // per-request timeout across retries.
         let retry_deadline = complete_timeout.saturating_mul(2);
         let loop_start = std::time::Instant::now();
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=crate::llm::MAX_CONNECTION_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&self.provider.base_url)
@@ -157,13 +156,13 @@ impl LlmDriver for AnthropicDriver {
             let status = response.status().as_u16();
 
             if status == 429 || status == 529 {
-                if attempt < MAX_RETRIES {
+                if attempt < crate::llm::MAX_CONNECTION_RETRIES {
                     let wait_ms = (attempt + 1) as u64 * 2000;
                     tracing::warn!(status, attempt, wait_ms, "Anthropic rate limited, retrying");
                     tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                     continue;
                 }
-                anyhow::bail!("Anthropic rate limited after {} retries", MAX_RETRIES);
+                anyhow::bail!("Anthropic rate limited after {} retries", crate::llm::MAX_CONNECTION_RETRIES);
             }
 
             if !reqwest::StatusCode::from_u16(status)
@@ -223,8 +222,7 @@ impl LlmDriver for AnthropicDriver {
         use futures::StreamExt;
 
         let body = self.build_body(req, true);
-        const MAX_RETRIES: u32 = 3;
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=crate::llm::MAX_CONNECTION_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&self.provider.base_url)
@@ -233,7 +231,7 @@ impl LlmDriver for AnthropicDriver {
             );
             let response = match builder.send().await {
                 Ok(r) => r,
-                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < MAX_RETRIES => {
+                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < crate::llm::MAX_CONNECTION_RETRIES => {
                     let wait_ms = crate::llm::connection_retry_backoff_ms(attempt);
                     tracing::warn!(
                         attempt,
@@ -249,7 +247,7 @@ impl LlmDriver for AnthropicDriver {
             let status = response.status().as_u16();
 
             if status == 429 || status == 529 {
-                if attempt < MAX_RETRIES {
+                if attempt < crate::llm::MAX_CONNECTION_RETRIES {
                     let wait_ms = (attempt + 1) as u64 * 2000;
                     tracing::warn!(
                         status,
@@ -260,7 +258,7 @@ impl LlmDriver for AnthropicDriver {
                     tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                     continue;
                 }
-                anyhow::bail!("Anthropic rate limited after {} retries", MAX_RETRIES);
+                anyhow::bail!("Anthropic rate limited after {} retries", crate::llm::MAX_CONNECTION_RETRIES);
             }
 
             if !reqwest::StatusCode::from_u16(status)

--- a/autonoetic-gateway/src/llm/gemini.rs
+++ b/autonoetic-gateway/src/llm/gemini.rs
@@ -170,13 +170,12 @@ impl LlmDriver for GeminiDriver {
         let body = self.build_body(req);
         let url = self.url();
 
-        const MAX_RETRIES: u32 = 3;
         let complete_timeout = crate::llm::request_timeout();
         // Bound total wall-clock so a slow endpoint can't multiply the
         // per-request timeout across retries.
         let retry_deadline = complete_timeout.saturating_mul(2);
         let loop_start = std::time::Instant::now();
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=crate::llm::MAX_CONNECTION_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&url)
@@ -220,13 +219,13 @@ impl LlmDriver for GeminiDriver {
                     );
                 }
                 if status == 429 {
-                    if attempt < MAX_RETRIES {
+                    if attempt < crate::llm::MAX_CONNECTION_RETRIES {
                         let wait_ms = (attempt + 1) as u64 * 2000;
                         tracing::warn!(status, attempt, wait_ms, "Gemini rate limited, retrying");
                         tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                         continue;
                     }
-                    anyhow::bail!("Gemini rate limited after {} retries", MAX_RETRIES);
+                    anyhow::bail!("Gemini rate limited after {} retries", crate::llm::MAX_CONNECTION_RETRIES);
                 }
                 tracing::warn!(
                     target: "autonoetic::llm::gemini",

--- a/autonoetic-gateway/src/llm/gemini.rs
+++ b/autonoetic-gateway/src/llm/gemini.rs
@@ -171,29 +171,39 @@ impl LlmDriver for GeminiDriver {
         let url = self.url();
 
         const MAX_RETRIES: u32 = 3;
-        const COMPLETE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+        let complete_timeout = crate::llm::request_timeout();
+        // Bound total wall-clock so a slow endpoint can't multiply the
+        // per-request timeout across retries.
+        let retry_deadline = complete_timeout.saturating_mul(2);
+        let loop_start = std::time::Instant::now();
         for attempt in 0..=MAX_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&url)
-                    .timeout(COMPLETE_TIMEOUT)
+                    .timeout(complete_timeout)
                     .header("Content-Type", "application/json")
                     .json(&body),
             );
             let response = match builder.send().await {
                 Ok(r) => r,
-                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < MAX_RETRIES => {
-                    let wait_ms = crate::llm::connection_retry_backoff_ms(attempt);
-                    tracing::warn!(
+                Err(e) => {
+                    if let Some(wait_ms) = crate::llm::next_connection_retry_wait(
+                        &e,
                         attempt,
-                        wait_ms,
-                        error = %e,
-                        "Gemini connection error, retrying"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-                    continue;
+                        loop_start.elapsed(),
+                        retry_deadline,
+                    ) {
+                        tracing::warn!(
+                            attempt,
+                            wait_ms,
+                            error = %e,
+                            "Gemini connection error, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                        continue;
+                    }
+                    return Err(e.into());
                 }
-                Err(e) => return Err(e.into()),
             };
             let status = response.status().as_u16();
 

--- a/autonoetic-gateway/src/llm/mod.rs
+++ b/autonoetic-gateway/src/llm/mod.rs
@@ -27,7 +27,10 @@ pub mod provider;
 /// - `tcp_keepalive`: 30 s — detect dead TCP connections proactively.
 /// - **No global request timeout** — LLM streams can run for minutes; a blanket
 ///   `timeout()` would kill legitimate long-running responses. Instead, each
-///   non-streaming `complete()` call applies a per-request timeout (5 min).
+///   non-streaming `complete()` call applies a per-request timeout
+///   ([`request_timeout`], default 120s, env `AUTONOETIC_LLM_REQUEST_TIMEOUT_SECS`)
+///   with a fail-fast, wall-clock-bounded retry policy
+///   ([`next_connection_retry_wait`]).
 pub fn build_llm_client() -> reqwest::Client {
     reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(15))
@@ -61,8 +64,83 @@ pub fn is_transient_connection_error(err: &reqwest::Error) -> bool {
 
 pub const MAX_CONNECTION_RETRIES: u32 = 3;
 
+/// A *timeout* already consumed a full per-request budget; retrying it with
+/// another full-length attempt is how a degraded endpoint compounds into many
+/// minutes of wasted wall-clock. So timeouts retry at most once (fast-failing
+/// connection errors like refused/reset keep [`MAX_CONNECTION_RETRIES`]).
+pub const MAX_TIMEOUT_RETRIES: u32 = 1;
+
+/// Default per-request timeout for a non-streaming `complete()` call.
+/// Lowered from a previous 300s: 5 minutes per attempt let a slow/overloaded
+/// endpoint burn ~20 min/turn (timeout × retries) before failing. Override with
+/// `AUTONOETIC_LLM_REQUEST_TIMEOUT_SECS`.
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 120;
+
+/// The per-request completion timeout, from `AUTONOETIC_LLM_REQUEST_TIMEOUT_SECS`
+/// (clamped to a sane floor) or [`DEFAULT_REQUEST_TIMEOUT_SECS`].
+pub fn request_timeout() -> std::time::Duration {
+    let secs = std::env::var("AUTONOETIC_LLM_REQUEST_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|s| *s >= 5)
+        .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
 pub fn connection_retry_backoff_ms(attempt: u32) -> u64 {
     (attempt as u64) * 1000
+}
+
+/// Retry decision for a transient connection error on an LLM call.
+///
+/// Returns `Some(wait_ms)` to retry after a backoff, or `None` to stop. It
+/// fail-fasts on two axes the old "retry up to N times" logic ignored:
+/// - **wall-clock deadline**: once `elapsed >= deadline` (typically 2× the
+///   per-request timeout), stop — a persistently slow endpoint must not
+///   multiply the timeout across retries.
+/// - **timeout vs blip**: a request timeout (`is_timeout`) retries at most
+///   [`MAX_TIMEOUT_RETRIES`]; fast-failing connection errors retry up to
+///   [`MAX_CONNECTION_RETRIES`].
+pub fn next_connection_retry_wait(
+    err: &reqwest::Error,
+    attempt: u32,
+    elapsed: std::time::Duration,
+    deadline: std::time::Duration,
+) -> Option<u64> {
+    let is_timeout = err.is_timeout() || err.to_string().to_lowercase().contains("timed out");
+    retry_wait_decision(
+        is_transient_connection_error(err),
+        is_timeout,
+        attempt,
+        elapsed,
+        deadline,
+    )
+}
+
+/// Pure decision core of [`next_connection_retry_wait`], split out so it can be
+/// unit-tested without fabricating a `reqwest::Error`.
+pub(crate) fn retry_wait_decision(
+    is_transient: bool,
+    is_timeout: bool,
+    attempt: u32,
+    elapsed: std::time::Duration,
+    deadline: std::time::Duration,
+) -> Option<u64> {
+    if !is_transient {
+        return None;
+    }
+    if elapsed >= deadline {
+        return None;
+    }
+    let cap = if is_timeout {
+        MAX_TIMEOUT_RETRIES
+    } else {
+        MAX_CONNECTION_RETRIES
+    };
+    if attempt >= cap {
+        return None;
+    }
+    Some(connection_retry_backoff_ms(attempt))
 }
 
 /// Check whether a non-success status / body indicates a context-overflow error

--- a/autonoetic-gateway/src/llm/mod.rs
+++ b/autonoetic-gateway/src/llm/mod.rs
@@ -140,7 +140,14 @@ pub(crate) fn retry_wait_decision(
     if attempt >= cap {
         return None;
     }
-    Some(connection_retry_backoff_ms(attempt))
+    let wait_ms = connection_retry_backoff_ms(attempt);
+    // Don't sleep past the deadline: if the backoff itself would push us to/over
+    // the cap, stop now rather than sleep and then start an attempt that's
+    // already late. (Keeps the cumulative wall-clock honest.)
+    if elapsed.saturating_add(std::time::Duration::from_millis(wait_ms)) >= deadline {
+        return None;
+    }
+    Some(wait_ms)
 }
 
 /// Check whether a non-success status / body indicates a context-overflow error

--- a/autonoetic-gateway/src/llm/openai.rs
+++ b/autonoetic-gateway/src/llm/openai.rs
@@ -234,30 +234,40 @@ impl LlmDriver for OpenAiDriver {
         }
 
         const MAX_RETRIES: u32 = 3;
-        const COMPLETE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+        let complete_timeout = crate::llm::request_timeout();
+        // Bound total wall-clock so a slow endpoint can't multiply the
+        // per-request timeout across retries.
+        let retry_deadline = complete_timeout.saturating_mul(2);
+        let loop_start = std::time::Instant::now();
         for attempt in 0..=MAX_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&self.provider.base_url)
-                    .timeout(COMPLETE_TIMEOUT)
+                    .timeout(complete_timeout)
                     .header("Content-Type", "application/json")
                     .json(&body),
             );
 
             let response = match builder.send().await {
                 Ok(r) => r,
-                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < MAX_RETRIES => {
-                    let wait_ms = crate::llm::connection_retry_backoff_ms(attempt);
-                    tracing::warn!(
+                Err(e) => {
+                    if let Some(wait_ms) = crate::llm::next_connection_retry_wait(
+                        &e,
                         attempt,
-                        wait_ms,
-                        error = %e,
-                        "LLM connection error, retrying"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-                    continue;
+                        loop_start.elapsed(),
+                        retry_deadline,
+                    ) {
+                        tracing::warn!(
+                            attempt,
+                            wait_ms,
+                            error = %e,
+                            "LLM connection error, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                        continue;
+                    }
+                    return Err(e.into());
                 }
-                Err(e) => return Err(e.into()),
             };
             let status = response.status();
 

--- a/autonoetic-gateway/src/llm/openai.rs
+++ b/autonoetic-gateway/src/llm/openai.rs
@@ -233,13 +233,12 @@ impl LlmDriver for OpenAiDriver {
             }
         }
 
-        const MAX_RETRIES: u32 = 3;
         let complete_timeout = crate::llm::request_timeout();
         // Bound total wall-clock so a slow endpoint can't multiply the
         // per-request timeout across retries.
         let retry_deadline = complete_timeout.saturating_mul(2);
         let loop_start = std::time::Instant::now();
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=crate::llm::MAX_CONNECTION_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&self.provider.base_url)
@@ -272,7 +271,7 @@ impl LlmDriver for OpenAiDriver {
             let status = response.status();
 
             if status.as_u16() == 429 || status.as_u16() == 529 {
-                if attempt < MAX_RETRIES {
+                if attempt < crate::llm::MAX_CONNECTION_RETRIES {
                     let wait_ms = (attempt + 1) as u64 * 2000;
                     tracing::warn!(
                         status = status.as_u16(),
@@ -283,7 +282,7 @@ impl LlmDriver for OpenAiDriver {
                     tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                     continue;
                 }
-                anyhow::bail!("OpenAI API rate limited after {} retries", MAX_RETRIES);
+                anyhow::bail!("OpenAI API rate limited after {} retries", crate::llm::MAX_CONNECTION_RETRIES);
             }
 
             if !status.is_success() {
@@ -347,8 +346,7 @@ impl LlmDriver for OpenAiDriver {
 
         let body = self.build_body(req, true);
 
-        const MAX_RETRIES: u32 = 3;
-        for attempt in 0..=MAX_RETRIES {
+        for attempt in 0..=crate::llm::MAX_CONNECTION_RETRIES {
             let builder = self.apply_auth(
                 self.client
                     .post(&self.provider.base_url)
@@ -359,7 +357,7 @@ impl LlmDriver for OpenAiDriver {
 
             let response = match builder.send().await {
                 Ok(r) => r,
-                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < MAX_RETRIES => {
+                Err(e) if crate::llm::is_transient_connection_error(&e) && attempt < crate::llm::MAX_CONNECTION_RETRIES => {
                     let wait_ms = crate::llm::connection_retry_backoff_ms(attempt);
                     tracing::warn!(
                         attempt,

--- a/autonoetic-gateway/src/llm/tests.rs
+++ b/autonoetic-gateway/src/llm/tests.rs
@@ -743,5 +743,20 @@ mod tests {
         fn default_timeout_is_two_minutes() {
             assert_eq!(DEFAULT_REQUEST_TIMEOUT_SECS, 120);
         }
+
+        #[test]
+        fn backoff_that_would_cross_deadline_stops_now() {
+            // attempt 2 still has connection budget (cap 3) and elapsed (239.5s)
+            // is under the 240s deadline — but the attempt-2 backoff (2000ms)
+            // would push us past it, so we must NOT sleep-then-retry late.
+            assert_eq!(
+                retry_wait_decision(true, false, 2, Duration::from_millis(239_500), DEADLINE),
+                None
+            );
+            // Comfortably under the deadline: attempt 1 at 10s elapsed retries.
+            assert!(
+                retry_wait_decision(true, false, 1, Duration::from_secs(10), DEADLINE).is_some()
+            );
+        }
     }
 }

--- a/autonoetic-gateway/src/llm/tests.rs
+++ b/autonoetic-gateway/src/llm/tests.rs
@@ -678,4 +678,70 @@ mod tests {
             assert!(!is_context_overflow_error(500, "internal server error"));
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Fail-fast retry policy — retry_wait_decision / default timeout
+    // -----------------------------------------------------------------------
+    mod retry_policy {
+        use crate::llm::{
+            retry_wait_decision, DEFAULT_REQUEST_TIMEOUT_SECS, MAX_CONNECTION_RETRIES,
+            MAX_TIMEOUT_RETRIES,
+        };
+        use std::time::Duration;
+
+        const DEADLINE: Duration = Duration::from_secs(240);
+
+        #[test]
+        fn non_transient_never_retries() {
+            assert_eq!(
+                retry_wait_decision(false, false, 0, Duration::ZERO, DEADLINE),
+                None
+            );
+        }
+
+        #[test]
+        fn timeout_retries_at_most_once() {
+            assert_eq!(MAX_TIMEOUT_RETRIES, 1);
+            // attempt 0 retries…
+            assert!(retry_wait_decision(true, true, 0, Duration::ZERO, DEADLINE).is_some());
+            // …attempt 1 stops.
+            assert_eq!(
+                retry_wait_decision(true, true, 1, Duration::ZERO, DEADLINE),
+                None
+            );
+        }
+
+        #[test]
+        fn fast_connection_error_retries_up_to_max() {
+            assert_eq!(MAX_CONNECTION_RETRIES, 3);
+            for attempt in 0..MAX_CONNECTION_RETRIES {
+                assert!(
+                    retry_wait_decision(true, false, attempt, Duration::ZERO, DEADLINE).is_some(),
+                    "attempt {attempt} should retry"
+                );
+            }
+            assert_eq!(
+                retry_wait_decision(true, false, MAX_CONNECTION_RETRIES, Duration::ZERO, DEADLINE),
+                None
+            );
+        }
+
+        #[test]
+        fn wall_clock_deadline_stops_retries_even_with_budget() {
+            // attempt 0 (budget remains) but elapsed past the deadline → stop.
+            assert_eq!(
+                retry_wait_decision(true, false, 0, Duration::from_secs(241), DEADLINE),
+                None
+            );
+            assert_eq!(
+                retry_wait_decision(true, true, 0, Duration::from_secs(241), DEADLINE),
+                None
+            );
+        }
+
+        #[test]
+        fn default_timeout_is_two_minutes() {
+            assert_eq!(DEFAULT_REQUEST_TIMEOUT_SECS, 120);
+        }
+    }
 }

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -551,10 +551,15 @@ turn for many minutes.
 | connect timeout | `15s` | Fail fast on unreachable endpoints (vs ~2min OS TCP timeout). |
 | retries — fast connection errors (refused/reset) | up to `3` | Quick backoff; these fail in well under the timeout. |
 | retries — request **timeout** | at most `1` | A timeout already consumed a full attempt; retrying it is how a degraded endpoint compounds. |
-| overall retry deadline | `2 × per-request timeout` | Stops retrying once cumulative wall-clock exceeds this — caps worst case at ~one timeout + one retry. |
+| overall retry deadline | `2 × per-request timeout` | Stops retrying once cumulative wall-clock (incl. the next backoff) would reach this — caps the *request-timeout* worst case at ~one timeout + one retry. |
 
 Worst case for a hung endpoint is therefore ~`2 × timeout` (≈4 min at the
 default), not the previous ~`4 × 300s` (≈20 min).
+
+> The deadline bounds *request timeouts*. The `connect timeout` (15s, fixed) is
+> separate: at very low `request_timeout` settings (near the 5s floor) a single
+> connect attempt can exceed `2 × timeout`. The deadline still caps the number
+> of retries; it does not shorten an in-flight connect attempt.
 
 ## LLM Presets
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -539,6 +539,23 @@ rules:
 
 ---
 
+## LLM request timeout & retries
+
+Each non-streaming `complete()` call applies a **per-request timeout** and a
+bounded, fail-fast retry policy so a slow or overloaded endpoint cannot stall a
+turn for many minutes.
+
+| Setting | Value | Notes |
+|---|---|---|
+| per-request timeout | `120s` default | Override with env `AUTONOETIC_LLM_REQUEST_TIMEOUT_SECS` (floor 5s). |
+| connect timeout | `15s` | Fail fast on unreachable endpoints (vs ~2min OS TCP timeout). |
+| retries — fast connection errors (refused/reset) | up to `3` | Quick backoff; these fail in well under the timeout. |
+| retries — request **timeout** | at most `1` | A timeout already consumed a full attempt; retrying it is how a degraded endpoint compounds. |
+| overall retry deadline | `2 × per-request timeout` | Stops retrying once cumulative wall-clock exceeds this — caps worst case at ~one timeout + one retry. |
+
+Worst case for a hung endpoint is therefore ~`2 × timeout` (≈4 min at the
+default), not the previous ~`4 × 300s` (≈20 min).
+
 ## LLM Presets
 
 Unified registry for all LLM configurations. Each preset is either **fixed** (concrete provider/model) or **routing** (dynamic selection from fixed presets at call time).


### PR DESCRIPTION
## Problem (the ~80-min dominant cost in the analyzed session)

A slow/overloaded LLM endpoint could stall a single turn for ~20 minutes:
- the per-request timeout was a hardcoded **300s**, and
- `is_transient_connection_error` returns **true for `is_timeout()`**, so a timeout was *retried* up to `MAX_RETRIES = 3` → **up to 4 × 300s ≈ 20 min** on one call.

In the weather-agent session this burned ~80 min across three children (researcher 24m, executor 37m, architect 22m), each ending in `error sending request for url (http://infradai01:9878/...)`.

## Fix (all in `llm/`, applied to openai / gemini / anthropic)

- **Lower + centralize the timeout:** default `300s → 120s`, as `DEFAULT_REQUEST_TIMEOUT_SECS` (was a `const` duplicated in all three drivers), overridable via env `AUTONOETIC_LLM_REQUEST_TIMEOUT_SECS` (floor 5s).
- **Bounded, timeout-aware retries** via new `next_connection_retry_wait` (pure core `retry_wait_decision`):
  - a request **timeout** retries **at most once** — it already consumed a full attempt; retrying it is how a degraded endpoint compounds;
  - fast-failing connection errors (refused/reset) still retry **up to 3×** (they fail in well under the timeout);
  - an **overall wall-clock deadline** (`2 × timeout`) stops retries regardless.

**Worst case for a hung endpoint: ~20 min → ~4 min** (2 × 120s). A healthy-but-slow call still completes; a truly dead endpoint fails fast via the 15s connect-timeout + a few quick retries.

## Decisions
Default timeout **120s** and **retry-once-on-timeout within deadline** (per maintainer's call).

## Tests
`llm::tests::retry_policy` — non-transient never retries; timeout retries ≤1; fast connection error retries up to 3; wall-clock deadline stops retries even with budget; default timeout is 120s. (Decision logic extracted to a pure helper since a `reqwest::Error` can't be fabricated in a unit test.)

## Out of scope (Phase 2, optional)
A per-endpoint circuit-breaker — after K consecutive timeouts, short-circuit that endpoint for a cooldown + surface an operator signal — so a degraded server doesn't cost *every* agent a full timeout each. Only worth it if the slowness recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
