### PR TITLE
fix(sentinel): drop redundant "Continue" from divergence prompt (#500)

### DIFF
--- a/autonoetic-gateway/src/interaction_answer.rs
+++ b/autonoetic-gateway/src/interaction_answer.rs
@@ -456,11 +456,6 @@ mod tests {
                     value: "acknowledged".into(),
                 },
                 autonoetic_types::background::UserInteractionOption {
-                    id: "continue".into(),
-                    label: "Continue".into(),
-                    value: "continue".into(),
-                },
-                autonoetic_types::background::UserInteractionOption {
                     id: "stop".into(),
                     label: "Stop".into(),
                     value: "stop".into(),

--- a/autonoetic-gateway/src/runtime/lifecycle.rs
+++ b/autonoetic-gateway/src/runtime/lifecycle.rs
@@ -166,7 +166,7 @@ fn build_critical_divergence_interaction(
             agent_id, turn_counter, evidence
         ),
         None => format!(
-            "Critical trajectory divergence in agent '{}' at turn {}. Choose acknowledge, continue, stop, or enter a note.",
+            "Critical trajectory divergence in agent '{}' at turn {}. Choose acknowledge (dismiss — the session keeps running), stop, or enter a note.",
             agent_id, turn_counter
         ),
     };
@@ -187,16 +187,17 @@ fn build_critical_divergence_interaction(
                 signals_summary
             )
         }),
+        // Two distinct choices only. The prompt is non-blocking — the session
+        // keeps running while it's pending — so "Acknowledge" (dismiss/noted)
+        // and "Stop" (emergency-stop) are the only actions with different
+        // effects. A former third option, "Continue", behaved identically to
+        // "Acknowledge" (issue #500); "stop nagging me" is the agent's
+        // `sentinel.suppress` job, not a per-prompt operator action.
         options: vec![
             autonoetic_types::background::UserInteractionOption {
                 id: "ack".to_string(),
                 label: "Acknowledge".to_string(),
                 value: "acknowledged".to_string(),
-            },
-            autonoetic_types::background::UserInteractionOption {
-                id: "continue".to_string(),
-                label: "Continue".to_string(),
-                value: "continue".to_string(),
             },
             autonoetic_types::background::UserInteractionOption {
                 id: "stop".to_string(),
@@ -3533,11 +3534,11 @@ mod tests {
                 .contains("child_failure_pressure")
         );
         assert!(interaction.allow_freeform);
-        assert_eq!(interaction.options.len(), 3);
+        // Two distinct options only (issue #500 — "continue" was a no-op dup of "ack").
+        assert_eq!(interaction.options.len(), 2);
         assert_eq!(interaction.options[0].id, "ack");
-        assert_eq!(interaction.options[1].id, "continue");
-        assert_eq!(interaction.options[2].id, "stop");
-        assert_eq!(interaction.options[2].value, "stop");
+        assert_eq!(interaction.options[1].id, "stop");
+        assert_eq!(interaction.options[1].value, "stop");
         assert_eq!(interaction.workflow_id.as_deref(), Some("wf-1"));
         assert_eq!(interaction.task_id.as_deref(), Some("task-1"));
     }

--- a/autonoetic/src/cli/room/render.rs
+++ b/autonoetic/src/cli/room/render.rs
@@ -3042,7 +3042,6 @@ mod tests {
                 "context": "Signals:\n- loop_pressure (critical): 10 consecutive cycles without meaningful progress (limit 10)",
                 "options": [
                     {"id": "ack", "label": "Acknowledge"},
-                    {"id": "continue", "label": "Continue"},
                     {"id": "stop", "label": "Stop"},
                 ],
                 "allow_freeform": true,


### PR DESCRIPTION
## Problem (#500)

The critical-divergence operator prompt offered **Acknowledge / Continue / Stop**, but in `interaction_answer.rs` Acknowledge and Continue follow an **identical** path — only Stop differs (emergency-stop). The `answer_option_id` is logged but never branches behavior. So two of the three options are no-ops relative to each other, and the UI implies Continue does something Acknowledge doesn't.

## Fix

The prompt is **non-blocking** — the session keeps running while it's pending — so the only operator actions with distinct effects are "dismiss / keep running" and "halt". Collapse to two options:

- **Acknowledge** — dismiss/noted; the session continues (which it already is).
- **Stop** — emergency-stop the root session.

"Stop nagging me about this drift" is already the **agent's** `sentinel.suppress` job (bounded by `trajectory.suppress_max_turns`), not a per-prompt operator action — so I deliberately did **not** add a behavioral "Continue = suppress for N turns". (That would need new cross-session plumbing to reach the running session's suppress target from the out-of-band answer path; disproportionate for a non-blocking advisory prompt. Noted as a possible future enhancement.)

## Changes
- `build_critical_divergence_interaction` (`lifecycle.rs`): options `[ack, stop]`; question text updated.
- Updated the unit test (`options.len() == 2`) and two test fixtures (`interaction_answer.rs`, `room/render.rs`).
- No change to `interaction_answer.rs` logic — it already handled ack-vs-stop correctly; the bug was purely the redundant option.

Build clean; divergence + 83 room-render tests pass.

Closes #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
