### PR TITLE
feat(§O): emit O-1-tagged decider-obligation events + register §O (#399)

### DIFF
--- a/autonoetic-gateway/src/enforcement_register.rs
+++ b/autonoetic-gateway/src/enforcement_register.rs
@@ -39,6 +39,10 @@
 pub enum Binds {
     Agent,
     Gateway,
+    /// §O decider obligations bind whoever *decides* a gate (operator, an
+    /// agent-decider, or a policy engine) — the symmetric counterpart to the
+    /// agent's rule-duties and the gateway's right-duties (#359).
+    Decider,
 }
 
 impl Binds {
@@ -46,6 +50,7 @@ impl Binds {
         match self {
             Binds::Agent => "agent",
             Binds::Gateway => "gateway",
+            Binds::Decider => "decider",
         }
     }
 }
@@ -122,8 +127,42 @@ pub fn rights() -> &'static [Right] {
     ]
 }
 
-/// The enforcement register. P-7's four checks (P-7.5/7.7/7.19/7.20) plus one
-/// check per seeded right.
+/// A §O decider obligation — a duty binding whoever *decides* a gate. The
+/// symmetric counterpart to a [`Principle`] (agent) and a [`Right`] (gateway);
+/// modelled in the register the same way (#359 / #399).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Obligation {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub statement: &'static str,
+}
+
+/// Decider obligations (§O, bind the decider). Seeded with the two enacted
+/// clauses (O-1 motivation, O-2 attribution); O-3/O-4/O-5 enter by amendment as
+/// each becomes mechanically enforced (#399).
+pub fn obligations() -> &'static [Obligation] {
+    &[
+        Obligation {
+            id: "O-1",
+            title: "Motivated decision",
+            statement: "A decision owes a motivation, graduated by stakes. A rejection/abort, or \
+                        an approval of an elevated-authority or external/irreversible action, is \
+                        BLOCKING: it does not commit until a non-empty reason is recorded. Silent \
+                        rejection by a decider is as illegitimate as a gateway denial with no rule \
+                        ID (Ri-0.3).",
+        },
+        Obligation {
+            id: "O-2",
+            title: "Attributed decision",
+            statement: "Every decision is attributed to the deciding principal (id + kind) on the \
+                        causal chain and cannot be reattributed. The agent under decision can \
+                        always tell who decided and what kind of principal they are.",
+        },
+    ]
+}
+
+/// The enforcement register. P-7's four checks (P-7.5/7.7/7.19/7.20), one
+/// check per seeded right, plus §O decider obligations (O-1/O-2).
 pub fn enforcement_register() -> &'static [EnforcementEntry] {
     &[
         // ── P-7 (binds agent) ──
@@ -178,6 +217,26 @@ pub fn enforcement_register() -> &'static [EnforcementEntry] {
             test: "constitution_right_ri_0_14.rs::child_waiting_transition_emits_typed_parent_wakeup_event",
             config: Some("default_workflow_wait_secs"),
         },
+        // ── O-1 (binds decider) ──
+        EnforcementEntry {
+            clause_id: "O-1",
+            rule_id: "O-1",
+            check_id: "decider_obligation_motivation",
+            code: "scheduler/approval.rs::enforce_decider_motivation (classifier decision_is_blocking) \
+                   at the decide_request_with_options chokepoint; emits decider_obligation.refused/.satisfied",
+            test: "constitution_o_1_decider_motivation.rs + scheduler::approval::tests::decider_obligation_emits_tagged_o1_event",
+            config: Some("decider_obligations.enabled"),
+        },
+        // ── O-2 (binds decider) ──
+        EnforcementEntry {
+            clause_id: "O-2",
+            rule_id: "O-2",
+            check_id: "decider_attribution",
+            code: "decided_by + decided_by_kind on the approval (principal::decider_principal_kind, #361) \
+                   + actor bound into the causal-chain entry hash (causal_chain.rs)",
+            test: "constitution_o_1_decider_motivation.rs",
+            config: None,
+        },
     ]
 }
 
@@ -191,26 +250,36 @@ pub fn right(id: &str) -> Option<&'static Right> {
     rights().iter().find(|r| r.id == id)
 }
 
-/// True when `clause_id` resolves to a known principle or right.
-pub fn clause_exists(clause_id: &str) -> bool {
-    principle(clause_id).is_some() || right(clause_id).is_some()
+/// Look up a decider obligation by ID.
+pub fn obligation(id: &str) -> Option<&'static Obligation> {
+    obligations().iter().find(|o| o.id == id)
 }
 
-/// Human-readable title for a clause (principle *or* right). `None` if the
-/// clause is unknown.
+/// True when `clause_id` resolves to a known principle, right, or obligation.
+pub fn clause_exists(clause_id: &str) -> bool {
+    principle(clause_id).is_some()
+        || right(clause_id).is_some()
+        || obligation(clause_id).is_some()
+}
+
+/// Human-readable title for a clause (principle, right, *or* obligation).
+/// `None` if the clause is unknown.
 pub fn clause_title(clause_id: &str) -> Option<&'static str> {
     principle(clause_id)
         .map(|p| p.title)
         .or_else(|| right(clause_id).map(|r| r.title))
+        .or_else(|| obligation(clause_id).map(|o| o.title))
 }
 
 /// Bind direction for a clause: principles bind the agent, rights bind the
-/// gateway. `None` if the clause is unknown.
+/// gateway, obligations bind the decider. `None` if the clause is unknown.
 pub fn binds(clause_id: &str) -> Option<Binds> {
     if principle(clause_id).is_some() {
         Some(Binds::Agent)
     } else if right(clause_id).is_some() {
         Some(Binds::Gateway)
+    } else if obligation(clause_id).is_some() {
+        Some(Binds::Decider)
     } else {
         None
     }
@@ -303,10 +372,12 @@ pub fn render_register_markdown() -> String {
 
     out.push_str("## Bind-direction summary\n\n");
     out.push_str(&format!(
-        "{} principle(s) (bind the agent), {} right(s) (bind the gateway). \
+        "{} principle(s) (bind the agent), {} right(s) (bind the gateway), \
+         {} obligation(s) (bind the decider). \
          Counts are partial while migration (#303) is in progress — not the design ratio.\n\n",
         principles().len(),
         rights().len(),
+        obligations().len(),
     ));
 
     out.push_str("## Principles (bind: agent)\n\n");
@@ -321,6 +392,13 @@ pub fn render_register_markdown() -> String {
         out.push_str(&format!("### {} — {}\n\n", r.id, r.title));
         out.push_str(&format!("{}\n\n", r.statement));
         out.push_str(&render_entries_table(r.id));
+    }
+
+    out.push_str("## Obligations (bind: decider)\n\n");
+    for o in obligations() {
+        out.push_str(&format!("### {} — {}\n\n", o.id, o.title));
+        out.push_str(&format!("{}\n\n", o.statement));
+        out.push_str(&render_entries_table(o.id));
     }
     out
 }
@@ -378,6 +456,29 @@ mod tests {
                 r.id
             );
         }
+        for o in obligations() {
+            assert!(
+                entries_for(o.id).next().is_some(),
+                "obligation {} has no enforcement entries",
+                o.id
+            );
+        }
+    }
+
+    #[test]
+    fn decider_obligations_are_registered_and_attributable() {
+        // §O clauses resolve like principles/rights, and bind the decider.
+        assert!(clause_exists("O-1"));
+        assert!(clause_exists("O-2"));
+        assert_eq!(binds("O-1"), Some(Binds::Decider));
+        assert_eq!(clause_title("O-1"), Some("Motivated decision"));
+        // The O-1 motivation event (enforced_rules: ["O-1"]) attributes to its
+        // clause via contract-health — not dropped as `unattributed`.
+        let health = contract_health(["O-1", "O-1", "O-2"]);
+        assert_eq!(health.unattributed, 0);
+        assert!(health.by_clause.contains(&("O-1".to_string(), 2)));
+        assert!(health.by_clause.contains(&("O-2".to_string(), 1)));
+        assert_eq!(clause_of_rule("O-1"), Some("O-1"));
     }
 
     #[test]

--- a/autonoetic-gateway/src/scheduler/approval.rs
+++ b/autonoetic-gateway/src/scheduler/approval.rs
@@ -1346,15 +1346,27 @@ fn decision_is_blocking(
 /// Enforce the §O decider obligation: refuse a BLOCKING-tier decision with no
 /// motivation. Presence-only check (never judges the reason's quality —
 /// Lawful Executor). Disabled via `decider_obligations.enabled = false`.
+/// Outcome of the §O (O-1) decider-motivation check. `Refused` is conveyed as
+/// the `Err` of [`enforce_decider_motivation`]; the `Ok` variants distinguish a
+/// BLOCKING decision that satisfied its duty from one the obligation doesn't
+/// apply to (so the caller only emits a `satisfied` event for the former).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeciderObligationOutcome {
+    /// Not a BLOCKING-tier decision (or obligations disabled) — no duty owed.
+    NotApplicable,
+    /// BLOCKING decision that carried the required motivation.
+    Satisfied,
+}
+
 fn enforce_decider_motivation(
     config: &GatewayConfig,
     request: &ApprovalRequest,
     decided_by: &str,
     status: &ApprovalStatus,
     reason: Option<&str>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<DeciderObligationOutcome> {
     if !config.decider_obligations.enabled {
-        return Ok(());
+        return Ok(DeciderObligationOutcome::NotApplicable);
     }
     if decision_is_blocking(request, decided_by, status) {
         let has_reason = reason.map(|r| !r.trim().is_empty()).unwrap_or(false);
@@ -1367,8 +1379,52 @@ fn enforce_decider_motivation(
                 status.as_str()
             );
         }
+        return Ok(DeciderObligationOutcome::Satisfied);
     }
-    Ok(())
+    Ok(DeciderObligationOutcome::NotApplicable)
+}
+
+/// Emit an `O-1`-tagged causal event recording the §O motivation-obligation
+/// outcome (`decider_obligation.refused` / `…satisfied`), so contract-health
+/// (`enforcement_register::contract_health`) attributes it to clause O-1.
+/// Best-effort: a store/emit failure must not change the decision outcome.
+fn emit_decider_obligation_event(
+    gateway_store: Option<&crate::scheduler::gateway_store::GatewayStore>,
+    request: &ApprovalRequest,
+    decided_by: &str,
+    status: &ApprovalStatus,
+    action: &str,
+) {
+    let Some(store) = gateway_store else {
+        return;
+    };
+    let now = chrono::Utc::now();
+    let event = autonoetic_types::causal_chain::CausalEventRecord {
+        event_id: uuid::Uuid::new_v4().to_string(),
+        agent_id: request.agent_id.clone(),
+        session_id: request.session_id.clone(),
+        turn_id: None,
+        event_seq: now.timestamp_millis().max(0) as u64,
+        timestamp: now.to_rfc3339(),
+        category: "decider_obligation".to_string(),
+        action: action.to_string(),
+        status: if action == "refused" { "error" } else { "success" }.to_string(),
+        enforced_rules: vec!["O-1".to_string()],
+        target: Some(request.request_id.clone()),
+        payload: Some(
+            serde_json::json!({
+                "request_id": request.request_id,
+                "approval_level": request.approval_level.to_config(),
+                "status": status.as_str(),
+                "decided_by": decided_by,
+            })
+            .to_string(),
+        ),
+        payload_ref: None,
+        evidence_ref: None,
+        reason: Some(format!("§O (O-1) decider motivation {action}")),
+    };
+    let _ = store.create_causal_event(&event);
 }
 
 fn decide_request(
@@ -1421,7 +1477,24 @@ fn decide_request_with_options(
     // §O symmetric obligation (#359 / #395): a principal decider owes a
     // motivation for a BLOCKING-tier decision (reject/abort, or approval of an
     // elevated-authority / external-irreversible action). Checked before commit.
-    enforce_decider_motivation(config, &request, decided_by, &status, reason.as_deref())?;
+    // Either outcome is recorded as an O-1-tagged causal event (#399) so
+    // contract-health can attribute it.
+    match enforce_decider_motivation(config, &request, decided_by, &status, reason.as_deref()) {
+        Ok(DeciderObligationOutcome::Satisfied) => {
+            emit_decider_obligation_event(
+                gateway_store,
+                &request,
+                decided_by,
+                &status,
+                "satisfied",
+            );
+        }
+        Ok(DeciderObligationOutcome::NotApplicable) => {}
+        Err(e) => {
+            emit_decider_obligation_event(gateway_store, &request, decided_by, &status, "refused");
+            return Err(e);
+        }
+    }
 
     let decision = ApprovalDecision {
         request_id: request.request_id,
@@ -1717,6 +1790,66 @@ mod tests {
             ..Default::default()
         };
         assert!(super::enforce_decider_motivation(&cfg_off, &local, "operator", &ApprovalStatus::Rejected, None).is_ok());
+    }
+
+    #[test]
+    fn decider_obligation_emits_tagged_o1_event() {
+        use crate::enforcement_register::contract_health;
+        use crate::scheduler::gateway_store::GatewayStore;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = GatewayStore::open(tmp.path()).unwrap();
+
+        let request = ApprovalRequest {
+            request_id: "apr-o1".to_string(),
+            agent_id: "coder.default".to_string(),
+            session_id: "sess-o1".to_string(),
+            action: ScheduledAction::SandboxExec {
+                command: "x".to_string(),
+                dependencies: None,
+                requires_approval: true,
+                evidence_ref: None,
+                detected_hosts: None,
+            },
+            created_at: "2026-06-18T00:00:00Z".to_string(),
+            reason: None,
+            evidence_ref: None,
+            workflow_id: None,
+            task_id: None,
+            root_session_id: Some("sess-o1".to_string()),
+            status: None,
+            decided_at: None,
+            decided_by: None,
+            decision_reason: None,
+            approval_level: ApprovalLevel::Operator,
+            similar_to_request_id: None,
+            similarity_score: None,
+            min_dwell_ms: None,
+            confirm_phrase: None,
+            code_excerpts: None,
+            risk_summary: None,
+        };
+
+        super::emit_decider_obligation_event(
+            Some(&store),
+            &request,
+            "operator",
+            &ApprovalStatus::Rejected,
+            "refused",
+        );
+
+        let events = store.search_causal_events(Some("sess-o1"), None, 10).unwrap();
+        let ev = events
+            .iter()
+            .find(|e| e.category == "decider_obligation")
+            .expect("a decider_obligation event was emitted");
+        assert_eq!(ev.action, "refused");
+        assert_eq!(ev.enforced_rules, vec!["O-1".to_string()]);
+
+        // …and contract-health attributes it to clause O-1 (not unattributed).
+        let health = contract_health(ev.enforced_rules.iter());
+        assert_eq!(health.unattributed, 0);
+        assert!(health.by_clause.contains(&("O-1".to_string(), 1)));
     }
 
     #[test]

--- a/docs/constitution/enforcement-register.md
+++ b/docs/constitution/enforcement-register.md
@@ -4,7 +4,7 @@
 
 ## Bind-direction summary
 
-1 principle(s) (bind the agent), 2 right(s) (bind the gateway). Counts are partial while migration (#303) is in progress — not the design ratio.
+1 principle(s) (bind the agent), 2 right(s) (bind the gateway), 2 obligation(s) (bind the decider). Counts are partial while migration (#303) is in progress — not the design ratio.
 
 ## Principles (bind: agent)
 
@@ -36,4 +36,22 @@ When a child task reaches a terminal state or resolves a gate, the gateway wakes
 | rule id | check | code | test | config |
 |---|---|---|---|---|
 | `Ri-0.14` | `child_state_wakeup` | `scheduler/workflow_store.rs::update_task_run_status (send_child_state_notification) + scheduler/signal.rs + scheduler/task_notify.rs` | `constitution_right_ri_0_14.rs::child_waiting_transition_emits_typed_parent_wakeup_event` | `default_workflow_wait_secs` |
+
+## Obligations (bind: decider)
+
+### O-1 — Motivated decision
+
+A decision owes a motivation, graduated by stakes. A rejection/abort, or an approval of an elevated-authority or external/irreversible action, is BLOCKING: it does not commit until a non-empty reason is recorded. Silent rejection by a decider is as illegitimate as a gateway denial with no rule ID (Ri-0.3).
+
+| rule id | check | code | test | config |
+|---|---|---|---|---|
+| `O-1` | `decider_obligation_motivation` | `scheduler/approval.rs::enforce_decider_motivation (classifier decision_is_blocking) at the decide_request_with_options chokepoint; emits decider_obligation.refused/.satisfied` | `constitution_o_1_decider_motivation.rs + scheduler::approval::tests::decider_obligation_emits_tagged_o1_event` | `decider_obligations.enabled` |
+
+### O-2 — Attributed decision
+
+Every decision is attributed to the deciding principal (id + kind) on the causal chain and cannot be reattributed. The agent under decision can always tell who decided and what kind of principal they are.
+
+| rule id | check | code | test | config |
+|---|---|---|---|---|
+| `O-2` | `decider_attribution` | `decided_by + decided_by_kind on the approval (principal::decider_principal_kind, #361) + actor bound into the causal-chain entry hash (causal_chain.rs)` | `constitution_o_1_decider_motivation.rs` | — |
 


### PR DESCRIPTION
First follow-up from **#399** (§O decider-obligation follow-ups). Scoped to the first checklist item; the rest stay tracked on #399.

## Problem

`enforce_decider_motivation` correctly **refuses** unmotivated BLOCKING decisions (the §O / O-1 enforcement that shipped in the MVP), but it emitted **no `O-*`-tagged causal event** — so `contract_health` could not attribute §O to its clause the way it does for every principle/right. §O was enforced but invisible to the contract-health model.

## Changes

**Tagged events (the enforcement is now attributable):**
- `decide_request_with_options` emits a `decider_obligation.refused` / `…satisfied` causal event with `enforced_rules: ["O-1"]` on the BLOCKING path. Best-effort — a store/emit failure never changes the decision outcome.
- `enforce_decider_motivation` now returns a `DeciderObligationOutcome` (`NotApplicable` / `Satisfied`, with `refused` as the `Err`), so the caller emits `satisfied` only for a BLOCKING decision that carried its motivation — not for every approval.

**Model §O in the enforcement register like the rest:**
- New third bind direction **`Binds::Decider`** (§O binds the *decider* — the symmetric counterpart to principles binding the agent and rights binding the gateway, #359).
- `obligations()` clause set — **O-1** (motivated decision) and **O-2** (attributed decision) — wired into `clause_exists` / `clause_title` / `binds` / `obligation`, plus EnforcementEntry rows and an "Obligations (bind: decider)" section in the rendered register.
- `contract_health(["O-1"])` now attributes to clause **O-1** instead of counting it `unattributed`.
- Regenerated `docs/constitution/enforcement-register.md` (the drift guard passes).

## Tests
- `enforcement_register::tests::decider_obligations_are_registered_and_attributable` — clause lookups, `Binds::Decider`, and contract-health attribution for O-1/O-2.
- `scheduler::approval::tests::decider_obligation_emits_tagged_o1_event` — a refused decision writes an `O-1`-tagged `decider_obligation` causal event, and contract-health attributes it.
- Existing §O blocking test + the register doc-drift guard + `constitution_o_1_decider_motivation` (2/2) still green; approval lib suite 28/28.

## Still open on #399
Deferred-tier debt tracking, override-of-a-safe-default as a BLOCKING trigger, O-3/O-4/O-5 amendments (prepared unsigned → authority signs), client-side motivation UX for BLOCKING gates, operator-as-AI tier collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
