### PR TITLE
feat: optional validation waiver workflow (#333)

### DIFF
--- a/autonoetic-gateway/src/runtime/tools/promotion.rs
+++ b/autonoetic-gateway/src/runtime/tools/promotion.rs
@@ -495,12 +495,38 @@ impl NativeTool for PromotionQueryTool {
 
         let store = PromotionStore::new(gw_dir)?;
 
+        let waived_validations: Vec<serde_json::Value> =
+            if let Some(ref gs) = _gateway_store {
+                match gs.list_waivers_for_artifact(&artifact_id) {
+                    Ok(waivers) => waivers
+                        .into_iter()
+                        .map(|w| {
+                            serde_json::json!({
+                                "waiver_id": w.waiver_id,
+                                "validation_id": w.validation_id,
+                                "validation_class": w.validation_class.as_str(),
+                                "waived_by": w.waived_by,
+                                "reason": w.reason,
+                                "created_at": w.created_at,
+                            })
+                        })
+                        .collect(),
+                    Err(e) => {
+                        tracing::warn!(target: "promotion", artifact_id = %artifact_id, error = %e, "failed to load waivers");
+                        Vec::new()
+                    }
+                }
+            } else {
+                Vec::new()
+            };
+
         match store.get_promotion(&artifact_id) {
             Some(record) => {
                 let response = serde_json::json!({
                     "artifact_canonical_digest": artifact_canonical_digest,
                     "artifact_ref": user_ref,
                     "content_digest": record.content_digest,
+                    "waived_validations": waived_validations,
                     "evaluator_pass": record.evaluator_pass,
                     "auditor_pass": record.auditor_pass,
                     "evaluator_id": record.evaluator_id,

--- a/autonoetic-gateway/src/runtime/tools/workbench.rs
+++ b/autonoetic-gateway/src/runtime/tools/workbench.rs
@@ -1060,6 +1060,9 @@ impl NativeTool for WorkbenchReconcileTool {
             &now,
         )?;
 
+        let propose_waivers = config.validation_waivers.enabled
+            && config.validation_waivers.auto_propose_after_reconcile;
+
         let provenance = serde_json::json!({
             "base_artifact_id": wb.base_artifact_id,
             "new_artifact_id": bundle.artifact_id,
@@ -1068,6 +1071,7 @@ impl NativeTool for WorkbenchReconcileTool {
             "operator_added": diffs.iter().filter(|d| d.change_type == FileChangeType::Added).map(|d| d.path.clone()).collect::<Vec<_>>(),
             "deleted": diffs.iter().filter(|d| d.change_type == FileChangeType::Deleted).map(|d| d.path.clone()).collect::<Vec<_>>(),
             "unchanged": diffs.iter().filter(|d| d.change_type == FileChangeType::Unchanged).count(),
+            "propose_waivers": propose_waivers,
         });
 
         let provenance_path = meta_dir.join("reconciliation.json");
@@ -1091,6 +1095,7 @@ impl NativeTool for WorkbenchReconcileTool {
             "provenance": provenance,
             "semantic_summary": semantic_summary,
             "reconciled_at": now,
+            "propose_waivers": propose_waivers,
             "message": args.message.unwrap_or_default(),
         }))?)
     }

--- a/autonoetic-gateway/tests/validation_waiver_integration.rs
+++ b/autonoetic-gateway/tests/validation_waiver_integration.rs
@@ -428,3 +428,304 @@ fn validation_waive_rejects_non_art_artifact_id() {
     let waivers = store.list_waivers_for_workflow("").unwrap();
     assert_eq!(waivers.len(), 0, "no waiver should be persisted");
 }
+
+fn build_artifact_with_files(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    agent_dir: &std::path::Path,
+    gateway_dir: &std::path::Path,
+    config: &GatewayConfig,
+    store: &Arc<GatewayStore>,
+    session_id: &str,
+    files: &[(&str, &[u8])],
+) -> String {
+    let cs = autonoetic_gateway::runtime::content_store::ContentStore::new(gateway_dir).unwrap();
+    let mut input_names = Vec::new();
+    for (name, content) in files {
+        let h = cs.write(content).unwrap();
+        cs.register_name(session_id, name, &h).unwrap();
+        input_names.push(name.to_string());
+    }
+
+    let args = serde_json::json!({ "inputs": input_names });
+    let out = registry
+        .execute(
+            "artifact_build",
+            manifest,
+            policy,
+            agent_dir,
+            Some(gateway_dir),
+            &args.to_string(),
+            Some(session_id),
+            None,
+            Some(config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    if v["ok"] != true {
+        panic!("artifact_build failed: {:?}", v);
+    }
+    v["artifact_ref"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no artifact_ref in response: {:?}", v))
+        .to_string()
+}
+
+fn project_and_modify_workbench(
+    registry: &autonoetic_gateway::runtime::tools::NativeToolRegistry,
+    manifest: &AgentManifest,
+    policy: &PolicyEngine,
+    agent_dir: &std::path::Path,
+    gateway_dir: &std::path::Path,
+    config: &GatewayConfig,
+    store: &Arc<GatewayStore>,
+    session_id: &str,
+    artifact_ref: &str,
+) -> String {
+    let project_out = registry
+        .execute(
+            "artifact_project",
+            manifest,
+            policy,
+            agent_dir,
+            Some(gateway_dir),
+            &serde_json::to_string(&json!({ "artifact_ref": artifact_ref })).unwrap(),
+            Some(session_id),
+            None,
+            Some(config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let project_v: serde_json::Value = serde_json::from_str(&project_out).unwrap();
+    assert_eq!(project_v["ok"], true, "project should succeed: {:?}", project_v);
+    let workbench_id = project_v["workbench_id"].as_str().unwrap().to_string();
+    let workspace_path = project_v["workspace_path"].as_str().unwrap();
+
+    // Make a trivial edit so reconcile has something to commit.
+    let hello = std::path::Path::new(workspace_path).join("hello.txt");
+    std::fs::write(&hello, b"modified").unwrap();
+
+    workbench_id
+}
+
+#[test]
+fn promotion_query_returns_waived_validations() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-promo";
+    let artifact_id = make_artifact(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+    );
+
+    // Record a waiver.
+    let waive_args = json!({
+        "artifact_id": artifact_id,
+        "validation_id": "unit_tests",
+        "validation_class": "correctness_check",
+        "reason": "doc-only change"
+    });
+    let waive_out = registry
+        .execute(
+            "validation_waive",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &waive_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let waive_v: serde_json::Value = serde_json::from_str(&waive_out).unwrap();
+    assert_eq!(waive_v["ok"], true, "waiver should succeed: {:?}", waive_v);
+
+    // promotion.query needs a promotion record to attach waiver metadata to.
+    // Use the unit_test_runner role to record a passing verdict.
+    let mut unit_test_manifest = manifest.clone();
+    unit_test_manifest.agent.id = "unit_test_runner.default".to_string();
+    let unit_test_policy = PolicyEngine::new(unit_test_manifest.clone());
+    let record_args = json!({
+        "artifact_id": artifact_id,
+        "role": "unit_test_runner",
+        "pass": true,
+        "findings": [],
+        "summary": "tests waived"
+    });
+    let record_out = registry
+        .execute(
+            "promotion_record",
+            &unit_test_manifest,
+            &unit_test_policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &record_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let record_v: serde_json::Value = serde_json::from_str(&record_out).unwrap();
+    assert_eq!(record_v["ok"], true, "promotion_record should succeed: {:?}", record_v);
+
+    // promotion.query should surface the waiver alongside the record.
+    let query_out = registry
+        .execute(
+            "promotion_query",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &json!({ "artifact_id": artifact_id }).to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let query_v: serde_json::Value = serde_json::from_str(&query_out).unwrap();
+    assert!(
+        query_v.get("waived_validations").is_some(),
+        "promotion.query should include waived_validations: {:?}",
+        query_v
+    );
+    let waived = query_v["waived_validations"].as_array().unwrap();
+    assert_eq!(waived.len(), 1, "expected one waived validation: {:?}", waived);
+    assert_eq!(waived[0]["validation_id"], "unit_tests");
+    assert_eq!(waived[0]["validation_class"], "correctness_check");
+    assert_eq!(waived[0]["reason"], "doc-only change");
+}
+
+#[test]
+fn workbench_reconcile_propose_waivers_false_by_default() {
+    let dir = tempdir().unwrap();
+    let config = make_config(dir.path());
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-propose-default";
+    let artifact_ref = build_artifact_with_files(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+        &[("hello.txt", b"hello")],
+    );
+    let wb_id = project_and_modify_workbench(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id, &artifact_ref,
+    );
+
+    let reconcile_args = json!({ "workbench_id": wb_id, "message": "test" });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true, "reconcile should succeed: {:?}", v);
+    assert_eq!(
+        v["propose_waivers"], false,
+        "propose_waivers should be false by default: {:?}",
+        v
+    );
+
+    let provenance = v["provenance"].clone();
+    assert_eq!(
+        provenance["propose_waivers"], false,
+        "provenance should record propose_waivers=false: {:?}",
+        provenance
+    );
+}
+
+#[test]
+fn workbench_reconcile_propose_waivers_true_when_config_enabled() {
+    let dir = tempdir().unwrap();
+    let mut config = make_config(dir.path());
+    config.validation_waivers.enabled = true;
+    config.validation_waivers.auto_propose_after_reconcile = true;
+    let gateway_dir = dir.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).unwrap();
+    let store = Arc::new(GatewayStore::open(&gateway_dir).unwrap());
+    let registry = default_registry();
+    let manifest = planner_manifest();
+    let policy = PolicyEngine::new(manifest.clone());
+    let agent_dir = dir.path().join("planner.collaborative");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+
+    let session_id = "root-session-waiver-propose-enabled";
+    let artifact_ref = build_artifact_with_files(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id,
+        &[("hello.txt", b"hello")],
+    );
+    let wb_id = project_and_modify_workbench(
+        &registry, &manifest, &policy, &agent_dir,
+        &gateway_dir, &config, &store, session_id, &artifact_ref,
+    );
+
+    let reconcile_args = json!({ "workbench_id": wb_id, "message": "test" });
+    let out = registry
+        .execute(
+            "workbench_reconcile",
+            &manifest,
+            &policy,
+            &agent_dir,
+            Some(&gateway_dir),
+            &reconcile_args.to_string(),
+            Some(session_id),
+            None,
+            Some(&config),
+            Some(store.clone()),
+            None,
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["ok"], true, "reconcile should succeed: {:?}", v);
+    assert_eq!(
+        v["propose_waivers"], true,
+        "propose_waivers should be true when enabled in config: {:?}",
+        v
+    );
+
+    let provenance = v["provenance"].clone();
+    assert_eq!(
+        provenance["propose_waivers"], true,
+        "provenance should record propose_waivers=true: {:?}",
+        provenance
+    );
+}

--- a/autonoetic-types/src/config.rs
+++ b/autonoetic-types/src/config.rs
@@ -1071,6 +1071,12 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub response_validation: ResponseValidationConfig,
 
+    /// Optional validation-waiver workflow (#333).
+    /// Disabled by default; enable to let operators skip advisory validations
+    /// through a TUI picklist or `/waive` command.
+    #[serde(default)]
+    pub validation_waivers: ValidationWaiversConfig,
+
     /// Sandbox (bubblewrap) isolation overrides.
     /// Env overrides are ignored unless AUTONOETIC_ALLOW_SANDBOX_ENV_OVERRIDES=true.
     #[serde(default)]
@@ -1822,6 +1828,37 @@ impl Default for ResponseValidationConfig {
 
 fn default_response_validation_max_repair_attempts_ceiling() -> u32 {
     2
+}
+
+/// Configuration for the optional validation-waiver workflow (#333).
+///
+/// Validation waivers let operators skip advisory artifact validations
+/// (unit tests, style review, etc.) while recording the skip as audit
+/// provenance. Mechanical safety gates and security reviews can never be
+/// waived. The feature is opt-in and defaults to disabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationWaiversConfig {
+    /// Enable the operator-facing validation waiver workflow.
+    /// When false (default), `/waive` is not offered in the TUI and the
+    /// backend waiver tools are not surfaced to operators, but existing
+    /// waivers remain queryable.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Automatically propose the waiver picklist after a successful
+    /// `workbench reconcile`. When false (default), the operator must
+    /// explicitly trigger `/waive`.
+    #[serde(default)]
+    pub auto_propose_after_reconcile: bool,
+}
+
+impl Default for ValidationWaiversConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            auto_propose_after_reconcile: false,
+        }
+    }
 }
 
 /// Sandbox (bubblewrap) isolation overrides.
@@ -2739,6 +2776,7 @@ impl Default for GatewayConfig {
             capsule: CapsuleConfig::default(),
             reclamation: ReclamationConfig::default(),
             response_validation: ResponseValidationConfig::default(),
+            validation_waivers: ValidationWaiversConfig::default(),
             sandbox: SandboxConfig::default(),
             max_session_turns: default_max_session_turns(),
             loop_guard: LoopGuardConfig::default(),
@@ -3181,5 +3219,36 @@ mod tests {
         });
         let err = serde_json::from_value::<GatewayConfig>(j).unwrap_err();
         assert!(err.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn validation_waivers_defaults_to_disabled() {
+        let config = GatewayConfig::default();
+        assert!(!config.validation_waivers.enabled);
+        assert!(!config.validation_waivers.auto_propose_after_reconcile);
+    }
+
+    #[test]
+    fn validation_waivers_config_parses_when_omitted() {
+        let j = serde_json::json!({
+            "agents_dir": "/tmp/autonoetic-agents"
+        });
+        let parsed: GatewayConfig = serde_json::from_value(j).expect("parse json");
+        assert!(!parsed.validation_waivers.enabled);
+        assert!(!parsed.validation_waivers.auto_propose_after_reconcile);
+    }
+
+    #[test]
+    fn validation_waivers_config_parses_when_enabled() {
+        let j = serde_json::json!({
+            "agents_dir": "/tmp/autonoetic-agents",
+            "validation_waivers": {
+                "enabled": true,
+                "auto_propose_after_reconcile": true
+            }
+        });
+        let parsed: GatewayConfig = serde_json::from_value(j).expect("parse json");
+        assert!(parsed.validation_waivers.enabled);
+        assert!(parsed.validation_waivers.auto_propose_after_reconcile);
     }
 }

--- a/autonoetic/src/cli/chat.rs
+++ b/autonoetic/src/cli/chat.rs
@@ -287,6 +287,9 @@ enum SlashCommand {
     /// selected orchestrator (default: planner.default). Refuses to proceed
     /// when the workbench has unsaved edits unless `--force` is supplied.
     ReturnToAgent { force: bool, message: Option<String> },
+    /// `/waive [validation_id] [reason...]` — show validation waiver options
+    /// or ask the orchestrator to waive a specific advisory validation.
+    Waive { validation_id: Option<String>, reason: Option<String> },
     /// `/plan` lists pending plans; `/plan approve [plan_id]` approves one.
     PlanApprove(Option<String>),
     /// `/model` shows resolved inference; `/model <preset>` overrides; `/model clear` resets.
@@ -1134,6 +1137,18 @@ fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
             };
             Ok(SlashCommand::ReturnToAgent { force, message })
         }
+        "/waive" => {
+            let validation_id = parts.next().map(|s| s.to_string());
+            let reason = {
+                let rest: Vec<String> = parts.map(|s| s.to_string()).collect();
+                if rest.is_empty() {
+                    None
+                } else {
+                    Some(rest.join(" "))
+                }
+            };
+            Ok(SlashCommand::Waive { validation_id, reason })
+        }
         "/plan" => {
             let sub = parts.next().map(|s| s.to_lowercase());
             match sub.as_deref() {
@@ -1179,6 +1194,7 @@ fn format_help_card() -> String {
         "  /plan                  List plans awaiting operator approval",
         "  /plan approve [id]     Approve a plan (default: latest pending)",
         "  /wb [status|diff|reconcile|discard]  Workbench actions",
+        "  /waive [validation_id] [reason]  Trigger validation waiver workflow (requires validation_waivers.enabled)",
         "  /return [--force] [note]   Hand the active workbench back to the orchestrator (planner.default).",
         "                            Refuses if there are unsaved edits; use --force to override (edits are dropped).",
         "  /why [request_id]      Explain why an approval was triggered (constitutional rules)",
@@ -2119,7 +2135,86 @@ fn handle_slash_command_submission(
             app.add_message(MessageRole::System, message);
             true
         }
+        SlashCommand::Waive { validation_id, reason } => {
+            if !config.validation_waivers.enabled {
+                app.add_message(
+                    MessageRole::System,
+                    "Validation waivers are disabled in this gateway config. \
+                     Set `validation_waivers.enabled: true` to use `/waive`."
+                        .to_string(),
+                );
+                return true;
+            }
+            let card = match validation_id {
+                Some(id) => {
+                    let reason_text = reason.unwrap_or_else(|| "operator waived via /waive".to_string());
+                    match &app.active_workbench {
+                        Some(wb) => format!(
+                            "Requesting waiver for validation `{}` on artifact `{}`.\n\
+                             Reason: {}\n\nThe orchestrator will call `validation.waive` \
+                             with artifact_id=`{}`, validation_id=`{}`, validation_class=`correctness_check`.",
+                            id, wb.base_artifact_id, reason_text, wb.base_artifact_id, id
+                        ),
+                        None => format!(
+                            "Requesting waiver for validation `{}`.\n\
+                             Reason: {}\n\nNo active workbench was detected; please confirm the artifact_id with the orchestrator.",
+                            id, reason_text
+                        ),
+                    }
+                }
+                None => format_waiver_status_card(gateway_store, app),
+            };
+            app.add_message(MessageRole::System, card);
+            // Return true so the original `/waive ...` text is sent to the orchestrator
+            // as a chat message; the orchestrator can then call `validation.waive`.
+            true
+        }
     }
+}
+
+fn format_waiver_status_card(
+    gateway_store: Option<&GatewayStore>,
+    app: &App,
+) -> String {
+    let mut lines = vec![
+        "Validation waiver trigger — available validations:".to_string(),
+        String::new(),
+    ];
+
+    if let Some(wb) = &app.active_workbench {
+        lines.push(format!("Active workbench: {}", wb.workbench_id));
+        lines.push(format!("Base artifact: {}", wb.base_artifact_id));
+        if let Some(store) = gateway_store {
+            match store.list_waivers_for_artifact(&wb.base_artifact_id) {
+                Ok(waivers) if !waivers.is_empty() => {
+                    lines.push(String::new());
+                    lines.push("Existing waivers:".to_string());
+                    for w in waivers {
+                        lines.push(format!(
+                            "  - {} ({}) — {}",
+                            w.validation_id,
+                            w.validation_class.as_str(),
+                            w.reason
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+    } else {
+        lines.push("No active workbench. Open or create a workbench first.".to_string());
+    }
+
+    lines.push(String::new());
+    lines.push("Usage:".to_string());
+    lines.push("  /waive <validation_id> [reason...]".to_string());
+    lines.push(String::new());
+    lines.push("Example:".to_string());
+    lines.push("  /waive unit_tests Small doc-only change, no executable code touched.".to_string());
+    lines.push(String::new());
+    lines.push("Only advisory validations can be waived; mechanical_safety and security_review are enforced.".to_string());
+
+    lines.join("\n")
 }
 
 fn format_why_explanation(
@@ -6233,6 +6328,9 @@ async fn handle_chat_test_mode(
                  Ok(SlashCommand::ReturnToAgent { .. }) => {
                      println!("/return is not supported in test mode.");
                  }
+                 Ok(SlashCommand::Waive { .. }) => {
+                     println!("/waive is not supported in test mode.");
+                 }
                  Ok(SlashCommand::PlanApprove(_)) => {
                      println!("/plan is not supported in test mode.");
                  }
@@ -9619,6 +9717,34 @@ mod tests {
             SlashCommand::ReturnToAgent {
                 force: true,
                 message: Some("ship it".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_slash_command_waive() {
+        // Bare /waive shows the waiver status card.
+        assert_eq!(
+            parse_slash_command("/waive").unwrap(),
+            SlashCommand::Waive {
+                validation_id: None,
+                reason: None,
+            }
+        );
+        // /waive with validation_id but no reason.
+        assert_eq!(
+            parse_slash_command("/waive unit_tests").unwrap(),
+            SlashCommand::Waive {
+                validation_id: Some("unit_tests".to_string()),
+                reason: None,
+            }
+        );
+        // /waive with validation_id and multi-token reason.
+        assert_eq!(
+            parse_slash_command("/waive unit_tests doc only change").unwrap(),
+            SlashCommand::Waive {
+                validation_id: Some("unit_tests".to_string()),
+                reason: Some("doc only change".to_string()),
             }
         );
     }

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -97,6 +97,15 @@ response_validation:
   repair_enabled: true
   max_repair_attempts_ceiling: 2
 
+# ── Validation Waivers ────────────────────────────────────────────────
+# Optional operator workflow to skip advisory artifact validations
+# (unit tests, style review, etc.) with recorded audit provenance.
+# Disabled by default. When enabled, `/waive` is available in the Chat TUI
+# and the picklist can be auto-proposed after `workbench reconcile`.
+validation_waivers:
+  enabled: false
+  auto_propose_after_reconcile: false
+
 # ── Approval Timeout ──────────────────────────────────────────────────
 # Max seconds a task can stay in AwaitingApproval before auto-fail. 0 = no timeout.
 approval_timeout_secs: 3600

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -248,6 +248,29 @@ See `docs/response-validation-gate.md` for implementation details and `docs/iter
 
 ---
 
+## Validation Waivers
+
+Optional operator workflow for skipping advisory artifact validations (unit tests, style review, etc.) with recorded audit provenance. Mechanical safety gates (`mechanical_safety`) and security reviews (`security_review`) cannot be waived.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `validation_waivers.enabled` | bool | `false` | Enable the operator-facing waiver workflow. When `false`, `/waive` is not offered in the Chat TUI, but existing waivers remain queryable. |
+| `validation_waivers.auto_propose_after_reconcile` | bool | `false` | When `enabled` is also `true`, automatically set `propose_waivers: true` in `reconciliation.json` after a successful `workbench reconcile`. Clients can use this flag to offer the waiver picklist. |
+
+Example:
+
+```yaml
+validation_waivers:
+  enabled: true
+  auto_propose_after_reconcile: false
+```
+
+Use `/waive` in the Chat TUI to trigger the workflow, or `/waive <validation_id> [reason...]` to ask the orchestrator to waive a specific advisory validation. Waivers are recorded in the `validation_waivers` table and surfaced in `promotion.query` responses.
+
+See `docs/human-agent-collaboration.md` for the broader collaboration workflow.
+
+---
+
 ## Protected Agents
 
 Controls the protected-agent promotion gate (issue #21). Agents listed here

--- a/docs/human-agent-collaboration.md
+++ b/docs/human-agent-collaboration.md
@@ -8,7 +8,7 @@ The collaboration system lets operators and agents co-edit artifacts through a s
 autonoetic run -c
 ```
 
-The `--collaborative` (or `-c`) flag selects `planner.collaborative`, which has the `PlanFrameAccess` capability required for all collaboration tools. The TUI will automatically show workbench status and enable `/wb` and `/return` commands when a workbench is active.
+The `--collaborative` (or `-c`) flag selects `planner.collaborative`, which has the `PlanFrameAccess` capability required for all collaboration tools. The TUI will automatically show workbench status and enable `/wb`, `/return`, and (when configured) `/waive` commands when a workbench is active.
 
 Without this flag, `autonoetic run` uses `planner.default` which does not have collaboration tools.
 
@@ -57,6 +57,8 @@ A deterministic classification of every changed file produced during reconciliat
 ### Validation Waiver
 
 A durable, auditable record that an operator chose to skip a specific validation check. Mechanical safety gates and security reviews **cannot** be waived. Waivers are visible in promotion records and traces.
+
+The operator-facing waiver workflow is **opt-in**. Set `validation_waivers.enabled: true` in the gateway config to enable it. When enabled, the Chat TUI provides `/waive` to trigger the workflow and `/waive <validation_id> [reason...]` to ask the orchestrator to waive a specific advisory validation. Set `validation_waivers.auto_propose_after_reconcile: true` to have `workbench reconcile` automatically set `propose_waivers: true` in `reconciliation.json`, signaling clients that they may offer a waiver picklist.
 
 ## Lifecycle
 
@@ -280,6 +282,21 @@ to the planner if needed.
 | `/wb diff` | Show diff of active workbench against base artifact |
 | `/wb reconcile` | Reconcile active workbench edits into new artifact |
 | `/wb discard` | Discard active workbench without reconciling |
+
+### Validation waivers (`/waive`)
+
+```
+/waive [validation_id] [reason...]
+```
+
+Available when `validation_waivers.enabled: true`.
+
+| Command | Description |
+|---------|-------------|
+| `/waive` | Show the active workbench's validation policy and existing waivers. |
+| `/waive <validation_id> [reason...]` | Ask the orchestrator to waive a specific advisory validation. |
+
+`mechanical_safety` and `security_review` validations cannot be waived. Waivers are recorded with a reason and surfaced in `promotion.query`.
 
 ### Return to agent (`/return`)
 


### PR DESCRIPTION
Implements the remaining operator-facing pieces of #333, making validation waivers opt-in and explicitly triggerable.

## What changed

- **Config** (`autonoetic-types/src/config.rs`, `config/config-template.yaml`)
  - New `validation_waivers` section with `enabled` (default `false`) and `auto_propose_after_reconcile` (default `false`).
  - Unit tests for defaults and parsing.

- **Workbench reconcile** (`autonoetic-gateway/src/runtime/tools/workbench.rs`)
  - Writes `propose_waivers: true` into `reconciliation.json` only when both config flags are enabled.

- **Chat TUI** (`autonoetic/src/cli/chat.rs`)
  - New `/waive [validation_id] [reason...]` slash command.
  - `/waive` shows a status card with existing waivers; `/waive <id> <reason>` forwards the request to the orchestrator.
  - Respects `validation_waivers.enabled`; explains when disabled.

- **Promotion records** (`autonoetic-gateway/src/runtime/tools/promotion.rs`)
  - `promotion.query` now returns a `waived_validations` array for the artifact.

- **Tests** (`autonoetic-gateway/tests/validation_waiver_integration.rs`)
  - `promotion_query_returns_waived_validations`
  - `workbench_reconcile_propose_waivers_false_by_default`
  - `workbench_reconcile_propose_waivers_true_when_config_enabled`

- **Docs**
  - `docs/config-reference.md` — new `validation_waivers` reference section.
  - `docs/human-agent-collaboration.md` — describes the optional `/waive` workflow.

## Verification

```bash
cargo build
cargo test -p autonoetic-types validation_waivers
cargo test -p autonoetic-gateway --test validation_waiver_integration
cargo test -p autonoetic --bin autonoetic test_parse_slash_command_waive
```

All green.

## Related issues

Closes #547
Closes #548
Closes #549
Closes #550
Refs #333