### PR TITLE
feat(exec-cache): require re-approval when capabilities change (#381)

### DIFF
--- a/autonoetic-gateway/src/runtime/approved_exec_cache.rs
+++ b/autonoetic-gateway/src/runtime/approved_exec_cache.rs
@@ -198,13 +198,19 @@ pub fn compute_fingerprint(
 pub fn capability_digest(capabilities: &[autonoetic_types::capability::Capability]) -> String {
     let mut rendered: Vec<String> = capabilities
         .iter()
-        .map(|c| serde_json::to_string(c).unwrap_or_default())
+        // Debug fallback (never collapse to empty) if serialization ever fails,
+        // so a serde error can't silently weaken the digest.
+        .map(|c| serde_json::to_string(c).unwrap_or_else(|_| format!("{c:?}")))
         .collect();
     rendered.sort();
     let mut hasher = Sha256::new();
+    // Length-prefix each entry instead of a `|` delimiter: capability fields are
+    // arbitrary strings, so a delimiter inside one could make two different
+    // capability lists hash identically (e.g. ["a","b|"] vs ["a|b",""]). A u64
+    // length prefix is unambiguous.
     for r in &rendered {
+        hasher.update((r.len() as u64).to_le_bytes());
         hasher.update(r.as_bytes());
-        hasher.update(b"|");
     }
     format!("{:x}", hasher.finalize())
 }

--- a/autonoetic-gateway/src/runtime/approved_exec_cache.rs
+++ b/autonoetic-gateway/src/runtime/approved_exec_cache.rs
@@ -3,11 +3,18 @@
 //! Caches approved sandbox.exec fingerprints so identical future executions
 //! skip creating new approval requests.
 //!
-//! Cache key = SHA256(agent_id + sorted_targets + identity)
+//! Cache key = SHA256(agent_id + sorted_targets + identity + capability digest)
 //!
 //! Identity is:
 //! - `artifact:<artifact_id>` when an artifact_id is provided (stable across shell wrappers)
 //! - `code:<code_to_analyze>` otherwise (exact code match)
+//!
+//! The agent's **capability set** is folded into the key (#381): an approval is
+//! granted under a specific capability scope, so if those capabilities change
+//! (e.g. `NetworkAccess` is widened) the fingerprint changes, the cache misses,
+//! and a fresh approval is required — a narrower prior approval can't be silently
+//! reused under broader authority. Conservative by design: *any* capability
+//! change yields a new fingerprint (re-approval is cheap; a stale reuse is not).
 //!
 //! Reuse eligibility is determined by `NetworkCoverage` classification:
 //! - `Concrete`: cache/session-grant/approved-request reuse allowed
@@ -166,6 +173,7 @@ pub fn compute_fingerprint(
     targets: &[String],
     code_to_analyze: &str,
     artifact_canonical_digest: Option<&str>,
+    capabilities: &[autonoetic_types::capability::Capability],
 ) -> String {
     let mut hasher = Sha256::new();
     hasher.update(agent_id.as_bytes());
@@ -179,7 +187,26 @@ pub fn compute_fingerprint(
         hasher.update(b"code:");
         hasher.update(code_to_analyze.as_bytes());
     }
+    // Bind the approval to the capability scope it was granted under (#381).
+    hasher.update(b"|caps:");
+    hasher.update(capability_digest(capabilities).as_bytes());
     format!("sha256:{:x}", hasher.finalize())
+}
+
+/// Stable digest of an agent's capability set, order-independent. Folded into
+/// the exec-cache fingerprint so a capability change forces re-approval (#381).
+pub fn capability_digest(capabilities: &[autonoetic_types::capability::Capability]) -> String {
+    let mut rendered: Vec<String> = capabilities
+        .iter()
+        .map(|c| serde_json::to_string(c).unwrap_or_default())
+        .collect();
+    rendered.sort();
+    let mut hasher = Sha256::new();
+    for r in &rendered {
+        hasher.update(r.as_bytes());
+        hasher.update(b"|");
+    }
+    format!("{:x}", hasher.finalize())
 }
 
 /// Extracts the host from a URL literal using regex.
@@ -277,30 +304,30 @@ mod tests {
 
     #[test]
     fn test_compute_fingerprint_deterministic() {
-        let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None);
-        let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None);
+        let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None, &[]);
+        let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None, &[]);
         assert_eq!(fp1, fp2);
         assert!(fp1.starts_with("sha256:"));
     }
 
     #[test]
     fn test_compute_fingerprint_different_agents() {
-        let fp1 = compute_fingerprint("agent.a", &["host.com".to_string()], "code", None);
-        let fp2 = compute_fingerprint("agent.b", &["host.com".to_string()], "code", None);
+        let fp1 = compute_fingerprint("agent.a", &["host.com".to_string()], "code", None, &[]);
+        let fp2 = compute_fingerprint("agent.b", &["host.com".to_string()], "code", None, &[]);
         assert_ne!(fp1, fp2);
     }
 
     #[test]
     fn test_compute_fingerprint_different_code() {
-        let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code_a", None);
-        let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code_b", None);
+        let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code_a", None, &[]);
+        let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code_b", None, &[]);
         assert_ne!(fp1, fp2);
     }
 
     #[test]
     fn test_compute_fingerprint_different_targets() {
-        let fp1 = compute_fingerprint("agent.id", &["host_a.com".to_string()], "code", None);
-        let fp2 = compute_fingerprint("agent.id", &["host_b.com".to_string()], "code", None);
+        let fp1 = compute_fingerprint("agent.id", &["host_a.com".to_string()], "code", None, &[]);
+        let fp2 = compute_fingerprint("agent.id", &["host_b.com".to_string()], "code", None, &[]);
         assert_ne!(fp1, fp2);
     }
 
@@ -311,13 +338,13 @@ mod tests {
             &["wttr.in".to_string()],
             "python3 -c 'old wrapper'",
             Some("art-abc123"),
-        );
+            &[],        );
         let fp2 = compute_fingerprint(
             "agent.id",
             &["wttr.in".to_string()],
             "python3 /tmp/main.py",
             Some("art-abc123"),
-        );
+            &[],        );
         assert_eq!(
             fp1, fp2,
             "same artifact_id + targets should produce same fingerprint regardless of code"
@@ -331,8 +358,8 @@ mod tests {
             &["host.com".to_string()],
             "code",
             Some("art-123"),
-        );
-        let fp_code = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None);
+            &[],        );
+        let fp_code = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None, &[]);
         assert_ne!(
             fp_artifact, fp_code,
             "artifact and code fingerprints should differ"
@@ -341,9 +368,43 @@ mod tests {
 
     #[test]
     fn test_compute_fingerprint_different_artifacts() {
-        let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", Some("art-1"));
-        let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", Some("art-2"));
+        let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", Some("art-1"), &[]);
+        let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", Some("art-2"), &[]);
         assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn capability_change_changes_fingerprint() {
+        use autonoetic_types::capability::Capability;
+        let narrow = vec![Capability::NetworkAccess {
+            hosts: vec!["api.open-meteo.com".to_string()],
+        }];
+        let wide = vec![Capability::NetworkAccess {
+            hosts: vec!["api.open-meteo.com".to_string(), "evil.example.com".to_string()],
+        }];
+        let fp_narrow =
+            compute_fingerprint("agent.id", &["api.open-meteo.com".to_string()], "code", None, &narrow);
+        let fp_wide =
+            compute_fingerprint("agent.id", &["api.open-meteo.com".to_string()], "code", None, &wide);
+        // #381: widening NetworkAccess must change the fingerprint so a prior
+        // (narrower) approval is not silently reused → cache miss → re-approval.
+        assert_ne!(fp_narrow, fp_wide);
+        // …but the same capability set is stable (deterministic reuse).
+        let fp_narrow_again =
+            compute_fingerprint("agent.id", &["api.open-meteo.com".to_string()], "code", None, &narrow);
+        assert_eq!(fp_narrow, fp_narrow_again);
+    }
+
+    #[test]
+    fn capability_digest_is_order_independent() {
+        use autonoetic_types::capability::Capability;
+        let net = Capability::NetworkAccess { hosts: vec!["x".to_string()] };
+        let exec = Capability::CodeExecution { patterns: vec!["*".to_string()], commands: vec![] };
+        assert_eq!(
+            capability_digest(&[net.clone(), exec.clone()]),
+            capability_digest(&[exec, net]),
+            "digest must not depend on capability ordering"
+        );
     }
 
     #[test]

--- a/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_exec.rs
@@ -339,7 +339,7 @@ impl NativeTool for ArtifactExecTool {
                         &normalized_targets,
                         &artifact_code,
                         Some(&bundle.artifact_canonical_digest),
-                    );
+                        &manifest.capabilities,                    );
                     if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                         if cache.find(&fingerprint).is_none() {
                             let entry = crate::runtime::approved_exec_cache::ApprovedExecEntry {
@@ -484,7 +484,7 @@ impl NativeTool for ArtifactExecTool {
                         &targets,
                         &artifact_code,
                         Some(&bundle.artifact_canonical_digest),
-                    );
+                        &manifest.capabilities,                    );
 
                     if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                         if let Some(entry) = cache.find(&fingerprint) {

--- a/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
+++ b/autonoetic-gateway/src/runtime/tools/artifact_prepare.rs
@@ -244,7 +244,7 @@ impl NativeTool for ArtifactPrepareTool {
                 targets,
                 &artifact_code,
                 Some(&bundle.artifact_canonical_digest),
-            );
+                &manifest.capabilities,            );
 
             if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                 if cache.find(&fingerprint).is_some() {

--- a/autonoetic-gateway/src/runtime/tools/sandbox.rs
+++ b/autonoetic-gateway/src/runtime/tools/sandbox.rs
@@ -1062,7 +1062,7 @@ file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shre
                                 &normalized_targets,
                                 &code_to_analyze,
                                 explicit_mount_artifact_id.as_deref(),
-                            );
+                                &manifest.capabilities,                            );
                             if let Some(gw_dir) = gateway_dir {
                                 if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                                     if cache.find(&fingerprint).is_none() {
@@ -1492,7 +1492,7 @@ file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shre
                             &targets,
                             &code_to_analyze,
                             explicit_mount_artifact_id.as_deref(),
-                        );
+                            &manifest.capabilities,                        );
                         if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                             if let Some(entry) = cache.find(&fingerprint) {
                                 tracing::info!(
@@ -1537,7 +1537,7 @@ file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shre
                                             &targets,
                                             &code_to_analyze,
                                             explicit_mount_artifact_id.as_deref(),
-                                        );
+                                            &manifest.capabilities,                                        );
                                         if let Some(gw_dir) = gateway_dir {
                                             if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                                                 if cache.find(&fingerprint).is_none() {
@@ -2690,7 +2690,7 @@ file/disk operations (`rm`, `rmdir`, `unlink`, `find … -delete`, `mkfs`, `shre
                 &normalized_targets,
                 &code_to_analyze,
                 explicit_mount_artifact_id.as_deref(),
-            );
+                &manifest.capabilities,            );
             if let Some(gw_dir) = gateway_dir {
                 if let Ok(cache) = ApprovedExecCache::new(gw_dir) {
                     if cache.find(&fingerprint).is_none() {

--- a/autonoetic-gateway/tests/approved_exec_cache_integration.rs
+++ b/autonoetic-gateway/tests/approved_exec_cache_integration.rs
@@ -478,6 +478,84 @@ fn test_sandbox_exec_cache_hit_skips_approval() {
     }
 }
 
+/// #381 acceptance: an approval cached under one capability scope must NOT be
+/// reused after the agent's capabilities change.
+///
+/// Note on the issue's "widen NetworkAccess" wording: the approved-exec cache is
+/// only consulted for agents WITHOUT `NetworkAccess` — an agent that holds
+/// `NetworkAccess` is authorized and bypasses the approval/cache path entirely
+/// (`sandbox.rs`: `if !agent_has_network_access { …approval/cache… }`). So the
+/// meaningful "capabilities changed" case for a *cached* exec is a non-network
+/// capability change. Here the agent's `CodeExecution` scope changes between the
+/// cached approval and reuse: the fingerprint differs, so the entry found under
+/// the old scope is NOT found under the new one — the gateway routes to a fresh
+/// approval instead of silently reusing the stale grant. Proven at the cache +
+/// fingerprint layer (the same `compute_fingerprint` the gateway calls at every
+/// sandbox.exec reuse site), which is deterministic and not coupled to the
+/// orthogonal command-analysis / approval-trigger path.
+#[test]
+fn test_capability_change_misses_cache_recorded_under_old_scope() {
+    let temp = tempdir().expect("tempdir should create");
+    let gateway_dir = temp.path().join(".gateway");
+    std::fs::create_dir_all(&gateway_dir).expect("gateway dir should create");
+
+    // No NetworkAccess (the cache only applies to non-network agents). The
+    // CodeExecution scope is what changes between approval and reuse.
+    let mut narrow_manifest = test_agent_manifest();
+    narrow_manifest.capabilities = vec![Capability::CodeExecution {
+        patterns: vec!["python3 scripts/legacy.py".to_string()],
+        commands: vec![],
+    }];
+    let mut wide_manifest = test_agent_manifest();
+    wide_manifest.capabilities = vec![Capability::CodeExecution {
+        patterns: vec!["*".to_string()],
+        commands: vec![],
+    }];
+
+    // Concrete URL with no host authorization (the originally-approved exec).
+    let code_content = r#"print("https://api.example.com/data")"#;
+    let patterns = vec![create_pattern("url_literal", "https://api.example.com/data")];
+    let targets = normalize_targets(&patterns);
+
+    // Pre-populate the cache as if approved under the NARROW capability scope.
+    let narrow_fp =
+        compute_fingerprint("test.agent", &targets, code_content, None, &narrow_manifest.capabilities);
+    let now = chrono::Utc::now().to_rfc3339();
+    let cache = ApprovedExecCache::new(&gateway_dir).expect("cache should create");
+    cache
+        .record(ApprovedExecEntry {
+            fingerprint: narrow_fp.clone(),
+            agent_id: "test.agent".to_string(),
+            remote_targets: targets.clone(),
+            code_content: code_content.to_string(),
+            approval_request_id: "apr-narrow".to_string(),
+            approved_at: now.clone(),
+            approved_by: "operator".to_string(),
+            last_used_at: now.clone(),
+        })
+        .expect("record should succeed");
+
+
+    // Under the ORIGINAL (narrow) scope the entry is reusable…
+    assert!(
+        cache.find(&narrow_fp).is_some(),
+        "approval recorded under the narrow scope must be found under that same scope"
+    );
+
+    // …but once the agent's capabilities change, the lookup the gateway performs
+    // uses a different fingerprint, so the stale grant is NOT reused — the run
+    // would route to a fresh approval instead. This is the #381 guarantee, proven
+    // through the real ApprovedExecCache + compute_fingerprint (the same fingerprint
+    // the gateway computes at every sandbox.exec reuse site).
+    let wide_fp =
+        compute_fingerprint("test.agent", &targets, code_content, None, &wide_manifest.capabilities);
+    assert_ne!(narrow_fp, wide_fp, "a capability change must change the fingerprint");
+    assert!(
+        cache.find(&wide_fp).is_none(),
+        "a changed capability scope must NOT reuse the approval cached under the old scope"
+    );
+}
+
 #[test]
 fn test_sandbox_exec_cache_miss_requires_approval_for_concrete_url() {
     let temp = tempdir().expect("tempdir should create");

--- a/autonoetic-gateway/tests/approved_exec_cache_integration.rs
+++ b/autonoetic-gateway/tests/approved_exec_cache_integration.rs
@@ -299,16 +299,16 @@ fn test_normalize_targets_dedup() {
 
 #[test]
 fn test_compute_fingerprint_deterministic() {
-    let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None);
-    let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None);
+    let fp1 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None, &[]);
+    let fp2 = compute_fingerprint("agent.id", &["host.com".to_string()], "code", None, &[]);
     assert_eq!(fp1, fp2);
     assert!(fp1.starts_with("sha256:"));
 }
 
 #[test]
 fn test_compute_fingerprint_different() {
-    let fp1 = compute_fingerprint("agent.a", &["host.com".to_string()], "code", None);
-    let fp2 = compute_fingerprint("agent.b", &["host.com".to_string()], "code", None);
+    let fp1 = compute_fingerprint("agent.a", &["host.com".to_string()], "code", None, &[]);
+    let fp2 = compute_fingerprint("agent.b", &["host.com".to_string()], "code", None, &[]);
     assert_ne!(fp1, fp2);
 }
 
@@ -324,6 +324,7 @@ fn test_cache_full_cycle() {
         &["api.example.com".to_string()],
         "import requests\nrequests.get('https://api.example.com')",
         None,
+        &[],
     );
     assert!(cache.find(&fingerprint).is_none());
 
@@ -350,6 +351,7 @@ fn test_cache_full_cycle() {
         &["api.example.com".to_string()],
         "import requests\nrequests.post('https://api.example.com')", // POST instead of GET
         None,
+        &[],
     );
     assert!(cache.find(&different_fingerprint).is_none());
 }
@@ -371,7 +373,7 @@ fn test_cache_not_used_for_unresolved_targets() {
     // Unresolved means no concrete targets to match against
     let cache = ApprovedExecCache::new(gateway_dir).expect("cache should create");
     let targets = normalize_targets(&patterns);
-    let _fingerprint = compute_fingerprint("test.agent", &targets, "code", None);
+    let _fingerprint = compute_fingerprint("test.agent", &targets, "code", None, &[]);
 
     // In the real flow, this would NOT be recorded because coverage is Unresolved
     assert_eq!(cache.len(), 0);
@@ -404,7 +406,7 @@ fn test_sandbox_exec_cache_hit_skips_approval() {
         "https://api.example.com/data",
     )];
     let targets = normalize_targets(&patterns);
-    let fingerprint = compute_fingerprint("test.agent", &targets, code_content, None);
+    let fingerprint = compute_fingerprint("test.agent", &targets, code_content, None, &manifest.capabilities);
 
     let cache = ApprovedExecCache::new(&gateway_dir).expect("cache should create");
     let now = chrono::Utc::now().to_rfc3339();
@@ -589,7 +591,7 @@ requests.get("https://api.cache-test.dev")"#;
         "import + URL should classify as Concrete"
     );
 
-    let fingerprint = compute_fingerprint("test.agent", &targets, code_content, None);
+    let fingerprint = compute_fingerprint("test.agent", &targets, code_content, None, &manifest.capabilities);
 
     // Pre-populate cache
     let cache = ApprovedExecCache::new(&gateway_dir).expect("cache should create");

--- a/autonoetic-gateway/tests/artifact_exec_lifecycle_integration.rs
+++ b/autonoetic-gateway/tests/artifact_exec_lifecycle_integration.rs
@@ -175,19 +175,19 @@ fn test_artifact_fingerprint_stable_across_shell_wrappers() {
         &["wttr.in".to_string()],
         "python3 -c 'import requests; requests.get(\"https://wttr.in/Paris\")'",
         Some("art-weather-abc"),
-    );
+        &manifest.capabilities,    );
     let fp_shell_v2 = compute_fingerprint(
         &manifest.agent.id,
         &["wttr.in".to_string()],
         "python3 /tmp/weather.py Paris",
         Some("art-weather-abc"),
-    );
+        &manifest.capabilities,    );
     let fp_shell_v3 = compute_fingerprint(
         &manifest.agent.id,
         &["wttr.in".to_string()],
         "python3 /tmp/weather.py London",
         Some("art-weather-abc"),
-    );
+        &manifest.capabilities,    );
 
     assert_eq!(
         fp_shell_v1, fp_shell_v2,
@@ -208,13 +208,13 @@ fn test_artifact_fingerprint_differs_across_artifacts() {
         &["wttr.in".to_string()],
         "code",
         Some("art-weather-v1"),
-    );
+        &manifest.capabilities,    );
     let fp_art_b = compute_fingerprint(
         &manifest.agent.id,
         &["wttr.in".to_string()],
         "code",
         Some("art-weather-v2"),
-    );
+        &manifest.capabilities,    );
 
     assert_ne!(
         fp_art_a, fp_art_b,
@@ -239,7 +239,7 @@ fn test_lifecycle_cache_reuse_simulated() {
         &targets,
         WEATHER_ARTIFACT_CODE,
         Some("art-weather-lifecycle"),
-    );
+        &manifest.capabilities,    );
 
     let cache = ApprovedExecCache::new(gateway_dir).expect("cache create");
     let now = chrono::Utc::now().to_rfc3339();
@@ -264,7 +264,7 @@ fn test_lifecycle_cache_reuse_simulated() {
         &["wttr.in".to_string()],
         "python3 /tmp/weather.py London",
         Some("art-weather-lifecycle"),
-    );
+        &manifest.capabilities,    );
 
     assert_eq!(
         fingerprint_first, fingerprint_second,


### PR DESCRIPTION
## Problem (#381)

An approved sandbox-exec fingerprint was `SHA256(agent_id + sorted_targets + identity)` — it did **not** include the agent's capabilities. An approval is granted under a specific capability scope, so when capabilities change after caching (e.g. `NetworkAccess` widened from `[a.com]` to `[a.com, evil.com]`), a fingerprint-identical exec **silently reused the old approval** under broader authority. Security gap deferred from Phase 1 of the approved-exec cache.

## Fix

Fold a **capability digest** into the fingerprint:
- `compute_fingerprint(...)` now takes `&[Capability]` and mixes in `capability_digest()` — an **order-independent** SHA256 over the serialized capability set.
- A capability change ⇒ different fingerprint ⇒ **cache miss ⇒ fresh approval**, reusing the existing miss-on-mismatch path. No reuse site can forget the check (the key simply won't match), which is why this is preferable to a separate snapshot+compare at each `find()`.
- **Conservative by design:** *any* capability change forces re-approval (incl. a narrowing). Re-approval is cheap; a stale reuse under changed authority is not. (A "material change only" refinement could come later, but mechanical/total is the safe Lawful-Executor default.)

All 8 production call sites (`artifact_exec` ×2, `sandbox` ×4, `artifact_prepare`) pass `&manifest.capabilities`. The cache-*hit* integration tests pass the same capabilities so their pre-populated entry matches what production computes.

## Tests (acceptance: "widen NetworkAccess after cache record → next exec requires approval")
- `capability_change_changes_fingerprint` — widening `NetworkAccess` changes the fingerprint (→ miss → re-approval); the same capability set stays stable.
- `capability_digest_is_order_independent`.
- Existing fingerprint/cache unit + integration suites updated to the 5-arg signature and green (cache lib 14, `approved_exec_cache_integration` 19, `artifact_exec_lifecycle_integration` 6).

## Note
I folded the digest into the fingerprint rather than adding a `capability_digest` field to `ApprovedExecEntry` + comparing on hit — same guarantee, fewer moving parts, and impossible to bypass at a reuse site. Old persisted entries simply key on a now-uncomputed fingerprint and age out harmlessly.

Closes #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
