### PR TITLE
feat(exec-cache): operator CLI to list + revoke approved exec entries (#380)

### DIFF
--- a/autonoetic-gateway/src/runtime/approved_exec_cache.rs
+++ b/autonoetic-gateway/src/runtime/approved_exec_cache.rs
@@ -99,6 +99,39 @@ impl ApprovedExecCache {
         entries.get(fingerprint).cloned()
     }
 
+    /// Returns all cached entries (cloned), sorted by `approved_at`. For
+    /// operator inspection / revocation tooling (#380).
+    pub fn all(&self) -> Vec<ApprovedExecEntry> {
+        let entries = self.entries.lock().unwrap();
+        let mut out: Vec<ApprovedExecEntry> = entries.values().cloned().collect();
+        out.sort_by(|a, b| a.approved_at.cmp(&b.approved_at));
+        out
+    }
+
+    /// Removes a cached approval by fingerprint, persisting the change. Returns
+    /// `true` if an entry was removed (#380). Revoking forces the next matching
+    /// exec back through approval.
+    pub fn remove(&self, fingerprint: &str) -> anyhow::Result<bool> {
+        let mut entries = self.entries.lock().unwrap();
+        let removed = entries.remove(fingerprint).is_some();
+        if removed {
+            self.flush(&entries)?;
+        }
+        Ok(removed)
+    }
+
+    /// Removes all cached approvals, persisting the change. Returns the number
+    /// removed (#380).
+    pub fn clear(&self) -> anyhow::Result<usize> {
+        let mut entries = self.entries.lock().unwrap();
+        let n = entries.len();
+        if n > 0 {
+            entries.clear();
+            self.flush(&entries)?;
+        }
+        Ok(n)
+    }
+
     /// Updates the last_used_at timestamp for an entry.
     pub fn update_last_used(&self, fingerprint: &str) -> anyhow::Result<()> {
         let mut entries = self.entries.lock().unwrap();

--- a/autonoetic-gateway/src/runtime/approved_exec_cache.rs
+++ b/autonoetic-gateway/src/runtime/approved_exec_cache.rs
@@ -152,7 +152,12 @@ impl ApprovedExecCache {
             std::fs::create_dir_all(parent)?;
         }
         let json = serde_json::to_string_pretty(entries)?;
-        std::fs::write(&self.cache_path, json)?;
+        // Atomic write: write a temp file then rename, so a crash or a concurrent
+        // reader never sees a torn/partial index. (Full cross-process
+        // lost-update serialization is a separate follow-up — see #380.)
+        let tmp = self.cache_path.with_extension("json.tmp");
+        std::fs::write(&tmp, json)?;
+        std::fs::rename(&tmp, &self.cache_path)?;
         Ok(())
     }
 }

--- a/autonoetic-gateway/tests/approved_exec_cache_integration.rs
+++ b/autonoetic-gateway/tests/approved_exec_cache_integration.rs
@@ -203,6 +203,48 @@ fn test_cache_not_found() {
 }
 
 #[test]
+fn test_cache_all_remove_clear() {
+    // #380: operator-facing list + revoke over the exec cache.
+    let temp = tempdir().expect("tempdir should create");
+    let gateway_dir = temp.path();
+    let cache = ApprovedExecCache::new(gateway_dir).expect("cache should create");
+
+    let mk = |fp: &str, approved_at: &str| ApprovedExecEntry {
+        fingerprint: fp.to_string(),
+        agent_id: "test.agent".to_string(),
+        remote_targets: vec!["api.example.com".to_string()],
+        code_content: "code".to_string(),
+        approval_request_id: "apr".to_string(),
+        approved_at: approved_at.to_string(),
+        approved_by: "operator".to_string(),
+        last_used_at: approved_at.to_string(),
+    };
+    cache.record(mk("sha256:bbb", "2026-06-02T00:00:00Z")).unwrap();
+    cache.record(mk("sha256:aaa", "2026-06-01T00:00:00Z")).unwrap();
+
+    // all() returns every entry, sorted by approved_at.
+    let all = cache.all();
+    assert_eq!(all.len(), 2);
+    assert_eq!(all[0].fingerprint, "sha256:aaa");
+    assert_eq!(all[1].fingerprint, "sha256:bbb");
+
+    // remove() revokes one and persists; a no-op remove returns false.
+    assert!(cache.remove("sha256:aaa").unwrap());
+    assert!(!cache.remove("sha256:aaa").unwrap());
+    assert!(cache.find("sha256:aaa").is_none());
+    assert!(cache.find("sha256:bbb").is_some());
+
+    // Revocation survives reopen (persisted).
+    let reopened = ApprovedExecCache::new(gateway_dir).expect("reopen");
+    assert_eq!(reopened.len(), 1);
+
+    // clear() removes all and returns the count.
+    assert_eq!(reopened.clear().unwrap(), 1);
+    assert_eq!(reopened.len(), 0);
+    assert_eq!(reopened.clear().unwrap(), 0);
+}
+
+#[test]
 fn test_classify_coverage_url_only() {
     let patterns = vec![create_pattern(
         "url_literal",

--- a/autonoetic/src/cli/common.rs
+++ b/autonoetic/src/cli/common.rs
@@ -379,6 +379,11 @@ pub enum GatewayCommands {
         #[command(subcommand)]
         command: GatewayGrantCommands,
     },
+    /// Inspect or revoke cross-session approved sandbox-exec cache entries.
+    ExecCache {
+        #[command(subcommand)]
+        command: GatewayExecCacheCommands,
+    },
     /// Inspect or answer pending user interactions.
     Interactions {
         #[command(subcommand)]
@@ -630,6 +635,28 @@ pub enum GatewayApprovalCommands {
         /// Only include approvals since this time (e.g. `1h`, `24h`, `7d`).
         #[arg(long)]
         since: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum GatewayExecCacheCommands {
+    /// List cached approved sandbox-exec fingerprints with metadata.
+    List {
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Revoke a cached approval by fingerprint, or all of them.
+    Revoke {
+        /// The fingerprint (`sha256:…`) to revoke. Copy it from `exec-cache list`.
+        #[arg(conflicts_with = "all")]
+        fingerprint: Option<String>,
+        /// Revoke every cached exec approval.
+        #[arg(long)]
+        all: bool,
+        /// Reason for revocation (recorded in the causal audit trail).
+        #[arg(long)]
+        reason: Option<String>,
     },
 }
 

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -738,6 +738,128 @@ pub async fn handle_gateway_grants(
     Ok(())
 }
 
+pub async fn handle_gateway_exec_cache(
+    config_path: &Path,
+    command: &super::common::GatewayExecCacheCommands,
+) -> anyhow::Result<()> {
+    use super::common::GatewayExecCacheCommands;
+
+    let config = autonoetic_gateway::config::load_config(config_path)?;
+    let gateway_dir = autonoetic_gateway::execution::gateway_root_dir(&config);
+    let cache =
+        autonoetic_gateway::runtime::approved_exec_cache::ApprovedExecCache::new(&gateway_dir)?;
+
+    match command {
+        GatewayExecCacheCommands::List { json } => {
+            let entries = cache.all();
+            if *json {
+                println!("{}", serde_json::to_string_pretty(&entries)?);
+            } else if entries.is_empty() {
+                println!("No cached exec approvals.");
+            } else {
+                println!(
+                    "{:<22} {:<18} {:<20} {:<12} {}",
+                    "FINGERPRINT", "AGENT", "APPROVED_AT", "BY", "TARGETS"
+                );
+                for e in &entries {
+                    // Show a short, copyable prefix of the fingerprint.
+                    let short_fp = e.fingerprint.chars().take(21).collect::<String>();
+                    let approved = e.approved_at.chars().take(19).collect::<String>();
+                    println!(
+                        "{:<22} {:<18} {:<20} {:<12} {}",
+                        short_fp,
+                        e.agent_id,
+                        approved,
+                        e.approved_by,
+                        e.remote_targets.join(", ")
+                    );
+                }
+                println!(
+                    "\n{} entr{}. Revoke with: gateway exec-cache revoke <fingerprint>",
+                    entries.len(),
+                    if entries.len() == 1 { "y" } else { "ies" }
+                );
+            }
+        }
+        GatewayExecCacheCommands::Revoke {
+            fingerprint,
+            all,
+            reason,
+        } => {
+            if fingerprint.is_none() && !all {
+                anyhow::bail!("Specify a <fingerprint> or --all to revoke exec-cache approvals");
+            }
+            let reason_text = reason.as_deref().unwrap_or("Revoked by operator");
+
+            let (count, target) = if *all {
+                (cache.clear()?, None)
+            } else {
+                let fp = fingerprint.as_deref().unwrap();
+                // Accept a full `sha256:…` or a unique prefix copied from `list`.
+                let matches: Vec<String> = cache
+                    .all()
+                    .into_iter()
+                    .map(|e| e.fingerprint)
+                    .filter(|f| f == fp || f.starts_with(fp))
+                    .collect();
+                match matches.len() {
+                    0 => {
+                        println!("No cached exec approval matching '{}'.", fp);
+                        return Ok(());
+                    }
+                    1 => {
+                        let full = &matches[0];
+                        let removed = cache.remove(full)?;
+                        (usize::from(removed), Some(full.clone()))
+                    }
+                    n => {
+                        anyhow::bail!(
+                            "'{}' matches {} entries — use the full fingerprint from `exec-cache list`",
+                            fp,
+                            n
+                        );
+                    }
+                }
+            };
+
+            if count == 0 {
+                println!("No matching exec-cache approvals revoked.");
+                return Ok(());
+            }
+            println!(
+                "Revoked {} cached exec approval(s) (reason: {}). The next matching exec will require fresh approval.",
+                count, reason_text
+            );
+
+            // Best-effort audit event.
+            if let Ok(store) =
+                autonoetic_gateway::scheduler::gateway_store::GatewayStore::open(&gateway_dir)
+            {
+                let _ = store.create_causal_event(&autonoetic_types::causal_chain::CausalEventRecord {
+                    event_id: format!("exec-cache-revoke-{}", uuid::Uuid::new_v4()),
+                    agent_id: "gateway".to_string(),
+                    session_id: "operator".to_string(),
+                    turn_id: None,
+                    event_seq: 0,
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    category: "exec_cache_revocation".to_string(),
+                    action: if *all { "revoke_all" } else { "revoke" }.to_string(),
+                    status: "completed".to_string(),
+                    enforced_rules: autonoetic_types::causal_chain::default_enforced_rules(),
+                    target: target.clone(),
+                    payload: Some(
+                        serde_json::json!({ "reason": reason_text, "count": count }).to_string(),
+                    ),
+                    payload_ref: None,
+                    evidence_ref: None,
+                    reason: reason.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn run_interactive_approvals(
     config: &autonoetic_types::config::GatewayConfig,
     gateway_store: &autonoetic_gateway::scheduler::gateway_store::GatewayStore,

--- a/autonoetic/src/cli/gateway.rs
+++ b/autonoetic/src/cli/gateway.rs
@@ -753,29 +753,45 @@ pub async fn handle_gateway_exec_cache(
         GatewayExecCacheCommands::List { json } => {
             let entries = cache.all();
             if *json {
-                println!("{}", serde_json::to_string_pretty(&entries)?);
+                // Curated view: omit `code_content` (potentially large/sensitive
+                // approved source) so it isn't leaked into logs/pipelines.
+                let view: Vec<serde_json::Value> = entries
+                    .iter()
+                    .map(|e| {
+                        serde_json::json!({
+                            "fingerprint": e.fingerprint,
+                            "agent_id": e.agent_id,
+                            "remote_targets": e.remote_targets,
+                            "approval_request_id": e.approval_request_id,
+                            "approved_at": e.approved_at,
+                            "approved_by": e.approved_by,
+                            "last_used_at": e.last_used_at,
+                        })
+                    })
+                    .collect();
+                println!("{}", serde_json::to_string_pretty(&view)?);
             } else if entries.is_empty() {
                 println!("No cached exec approvals.");
             } else {
                 println!(
-                    "{:<22} {:<18} {:<20} {:<12} {}",
+                    "{:<22} {:<18} {:<26} {:<12} {}",
                     "FINGERPRINT", "AGENT", "APPROVED_AT", "BY", "TARGETS"
                 );
                 for e in &entries {
-                    // Show a short, copyable prefix of the fingerprint.
+                    // Short, copyable prefix of the fingerprint; full RFC3339
+                    // timestamp (keep the timezone — this is audit tooling).
                     let short_fp = e.fingerprint.chars().take(21).collect::<String>();
-                    let approved = e.approved_at.chars().take(19).collect::<String>();
                     println!(
-                        "{:<22} {:<18} {:<20} {:<12} {}",
+                        "{:<22} {:<18} {:<26} {:<12} {}",
                         short_fp,
                         e.agent_id,
-                        approved,
+                        e.approved_at,
                         e.approved_by,
                         e.remote_targets.join(", ")
                     );
                 }
                 println!(
-                    "\n{} entr{}. Revoke with: gateway exec-cache revoke <fingerprint>",
+                    "\n{} entr{}. Revoke with: autonoetic gateway exec-cache revoke <fingerprint>",
                     entries.len(),
                     if entries.len() == 1 { "y" } else { "ies" }
                 );

--- a/autonoetic/src/main.rs
+++ b/autonoetic/src/main.rs
@@ -147,6 +147,9 @@ async fn main() -> anyhow::Result<()> {
             cli::common::GatewayCommands::Grants { command } => {
                 cli::gateway::handle_gateway_grants(&config_path, command).await?;
             }
+            cli::common::GatewayCommands::ExecCache { command } => {
+                cli::gateway::handle_gateway_exec_cache(&config_path, command).await?;
+            }
             cli::common::GatewayCommands::Interactions { command } => {
                 cli::gateway::handle_gateway_interactions(&config_path, command).await?;
             }

--- a/docs/approved-resources-caching.md
+++ b/docs/approved-resources-caching.md
@@ -153,8 +153,10 @@ Do NOT add `resource.revoke` as a runtime tool. Revocation is handled via Phase 
 
 ## Out of Scope for Phase 1
 
-- Capability change detection (Phase 2)
-- Revocation CLI/API (Phase 2)
+- Capability change detection — **done** (#381): the capability set is folded
+  into the fingerprint, so a capability change forces re-approval.
+- Revocation CLI/API — **done** (#380): see "Revocation" under Future
+  Enhancements below (`gateway exec-cache list/revoke`).
 
 ## Phase 1.5: Session Approval Grants [COMPLETE]
 
@@ -216,6 +218,14 @@ resource_approval:
 - Separate approval class: "approve all URLs on host X"
 - More convenient but broader trust
 
-### Revocation
-- Gateway CLI: `autonoetic approvals revoke-cache <fingerprint>`
-- Or API endpoint for management UI
+### Revocation — implemented (#380)
+Operator CLI over the cross-session exec cache, mirroring `gateway grants`:
+- `autonoetic gateway exec-cache list [--json]` — list cached approvals with
+  fingerprint, agent, approved-at/by, and targets.
+- `autonoetic gateway exec-cache revoke <fingerprint>` — revoke one (accepts a
+  full `sha256:…` or a unique prefix from `list`); `--all` revokes every entry;
+  `--reason` is recorded. Revocation persists and emits an
+  `exec_cache_revocation` causal event; the next matching exec re-requests
+  approval.
+
+(A management-UI API endpoint remains a possible future addition.)


### PR DESCRIPTION
## Problem (#380)

Session approval grants have `gateway grants revoke`, but the **cross-session approved-exec cache** (`approved_exec_cache.rs`) had no operator way to inspect or invalidate a cached approval. A stale or over-broad cached approval couldn't be revoked — it just persisted and kept skipping re-approval until the fingerprint changed.

## What this adds

**Cache API** (`ApprovedExecCache`):
- `all()` — every entry, sorted by `approved_at`.
- `remove(fingerprint)` — revoke one, persisted; returns whether an entry was removed.
- `clear()` — revoke all, returns the count.

**CLI** `gateway exec-cache` (mirrors `gateway grants`):
- `list [--json]` — fingerprint, agent, approved-at/by, targets, with a hint to revoke.
- `revoke <fingerprint> | --all [--reason]` — accepts a full `sha256:…` **or a unique prefix** from `list` (ambiguous prefix → error). Persists the change and emits an `exec_cache_revocation` causal event. The next matching exec re-requests approval.

Completes the revocation story for the cache hardened in #381 (capability-aware fingerprints).

## Tests
`test_cache_all_remove_clear` — list ordering, `remove` + no-op `remove`, persistence across reopen, `clear`. CLI help verified (`list`/`revoke` subcommands render). Build clean.

## Docs
`docs/approved-resources-caching.md`: filled in the Revocation section with the real command shape and marked the Phase-2 "Revocation CLI" + "Capability change detection" (#381) items done.

Closes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
